### PR TITLE
feat: Batch 2 - Audio Separation Model Selection

### DIFF
--- a/backend/api/routes/file_upload.py
+++ b/backend/api/routes/file_upload.py
@@ -131,6 +131,10 @@ async def upload_and_create_job(
     lyrics_title: Optional[str] = Form(None, description="Override title for lyrics search"),
     lyrics_file: Optional[UploadFile] = File(None, description="User-provided lyrics file (TXT, DOCX, RTF)"),
     subtitle_offset_ms: int = Form(0, description="Subtitle timing offset in milliseconds (positive = delay)"),
+    # Audio separation model configuration
+    clean_instrumental_model: Optional[str] = Form(None, description="Model for clean instrumental separation (e.g., model_bs_roformer_ep_317_sdr_12.9755.ckpt)"),
+    backing_vocals_models: Optional[str] = Form(None, description="Comma-separated list of models for backing vocals separation"),
+    other_stems_models: Optional[str] = Form(None, description="Comma-separated list of models for other stems (bass, drums, guitar, etc.)"),
 ):
     """
     Upload an audio file and create a karaoke generation job with full style configuration.
@@ -244,6 +248,15 @@ async def upload_and_create_job(
         # Extract request metadata for tracking and filtering
         request_metadata = extract_request_metadata(request, created_from="upload")
         
+        # Parse comma-separated model lists into arrays
+        parsed_backing_vocals_models = None
+        if backing_vocals_models:
+            parsed_backing_vocals_models = [m.strip() for m in backing_vocals_models.split(',') if m.strip()]
+        
+        parsed_other_stems_models = None
+        if other_stems_models:
+            parsed_other_stems_models = [m.strip() for m in other_stems_models.split(',') if m.strip()]
+        
         # Create job first to get job_id
         job_create = JobCreate(
             artist=artist,
@@ -266,6 +279,10 @@ async def upload_and_create_job(
             lyrics_artist=lyrics_artist,
             lyrics_title=lyrics_title,
             subtitle_offset_ms=subtitle_offset_ms,
+            # Audio separation model configuration
+            clean_instrumental_model=clean_instrumental_model,
+            backing_vocals_models=parsed_backing_vocals_models,
+            other_stems_models=parsed_other_stems_models,
             # Request metadata for tracking and filtering
             request_metadata=request_metadata,
         )
@@ -377,6 +394,14 @@ async def upload_and_create_job(
             update_data['lyrics_file_gcs_path'] = lyrics_file_gcs_path
         if subtitle_offset_ms != 0:
             update_data['subtitle_offset_ms'] = subtitle_offset_ms
+        
+        # Audio separation model configuration
+        if clean_instrumental_model:
+            update_data['clean_instrumental_model'] = clean_instrumental_model
+        if parsed_backing_vocals_models:
+            update_data['backing_vocals_models'] = parsed_backing_vocals_models
+        if parsed_other_stems_models:
+            update_data['other_stems_models'] = parsed_other_stems_models
         
         job_manager.update_job(job_id, update_data)
         

--- a/backend/models/job.py
+++ b/backend/models/job.py
@@ -217,6 +217,11 @@ class Job(BaseModel):
     lyrics_file_gcs_path: Optional[str] = None   # GCS path to user-provided lyrics file
     subtitle_offset_ms: int = 0                  # Offset for subtitle timing (positive = delay)
     
+    # Audio separation model configuration
+    clean_instrumental_model: Optional[str] = None   # Model for clean instrumental separation
+    backing_vocals_models: Optional[List[str]] = None  # Models for backing vocals separation
+    other_stems_models: Optional[List[str]] = None     # Models for other stems (bass, drums, etc.)
+    
     # Processing state
     track_output_dir: Optional[str] = None       # Local output directory (temp)
     audio_hash: Optional[str] = None             # Hash for deduplication
@@ -384,6 +389,11 @@ class JobCreate(BaseModel):
     lyrics_title: Optional[str] = None           # Override title for lyrics search
     lyrics_file_gcs_path: Optional[str] = None   # GCS path to user-provided lyrics file
     subtitle_offset_ms: int = 0                  # Offset for subtitle timing (positive = delay)
+    
+    # Audio separation model configuration
+    clean_instrumental_model: Optional[str] = None   # Model for clean instrumental separation
+    backing_vocals_models: Optional[List[str]] = None  # Models for backing vocals separation
+    other_stems_models: Optional[List[str]] = None     # Models for other stems (bass, drums, etc.)
     
     # Request metadata (set by API endpoint from request headers)
     request_metadata: Dict[str, Any] = Field(default_factory=dict)

--- a/backend/tests/test_file_upload.py
+++ b/backend/tests/test_file_upload.py
@@ -427,6 +427,163 @@ class TestJobCreateLyricsFields:
         assert job_create.subtitle_offset_ms == 0
 
 
+class TestAudioModelConfigurationFields:
+    """Test that Job and JobCreate models support audio model configuration fields."""
+    
+    def test_job_has_clean_instrumental_model_field(self):
+        """Test that Job model has clean_instrumental_model field."""
+        from backend.models.job import Job
+        from datetime import datetime
+        
+        job = Job(
+            job_id="test123",
+            status=JobStatus.PENDING,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+            clean_instrumental_model="custom_model.ckpt"
+        )
+        
+        assert hasattr(job, 'clean_instrumental_model')
+        assert job.clean_instrumental_model == "custom_model.ckpt"
+    
+    def test_job_has_backing_vocals_models_field(self):
+        """Test that Job model has backing_vocals_models field."""
+        from backend.models.job import Job
+        from datetime import datetime
+        
+        job = Job(
+            job_id="test123",
+            status=JobStatus.PENDING,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+            backing_vocals_models=["model1.ckpt", "model2.ckpt"]
+        )
+        
+        assert hasattr(job, 'backing_vocals_models')
+        assert job.backing_vocals_models == ["model1.ckpt", "model2.ckpt"]
+    
+    def test_job_has_other_stems_models_field(self):
+        """Test that Job model has other_stems_models field."""
+        from backend.models.job import Job
+        from datetime import datetime
+        
+        job = Job(
+            job_id="test123",
+            status=JobStatus.PENDING,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+            other_stems_models=["htdemucs_6s.yaml"]
+        )
+        
+        assert hasattr(job, 'other_stems_models')
+        assert job.other_stems_models == ["htdemucs_6s.yaml"]
+    
+    def test_audio_model_fields_are_optional(self):
+        """Test that audio model fields default to None."""
+        from backend.models.job import Job
+        from datetime import datetime
+        
+        job = Job(
+            job_id="test123",
+            status=JobStatus.PENDING,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow()
+        )
+        
+        assert job.clean_instrumental_model is None
+        assert job.backing_vocals_models is None
+        assert job.other_stems_models is None
+    
+    def test_job_create_has_audio_model_fields(self):
+        """Test that JobCreate model has all audio model configuration fields."""
+        from backend.models.job import JobCreate
+        
+        job_create = JobCreate(
+            artist="Artist",
+            title="Title",
+            clean_instrumental_model="custom_clean.ckpt",
+            backing_vocals_models=["custom_bv.ckpt"],
+            other_stems_models=["custom_stems.yaml"]
+        )
+        
+        assert job_create.clean_instrumental_model == "custom_clean.ckpt"
+        assert job_create.backing_vocals_models == ["custom_bv.ckpt"]
+        assert job_create.other_stems_models == ["custom_stems.yaml"]
+    
+    def test_job_create_audio_model_fields_optional(self):
+        """Test that audio model fields are optional in JobCreate."""
+        from backend.models.job import JobCreate
+        
+        job_create = JobCreate(
+            artist="Artist",
+            title="Title"
+        )
+        
+        assert job_create.clean_instrumental_model is None
+        assert job_create.backing_vocals_models is None
+        assert job_create.other_stems_models is None
+    
+    def test_pydantic_includes_audio_model_fields_in_serialization(self):
+        """Test that Pydantic includes audio model fields in serialization."""
+        from backend.models.job import Job
+        from datetime import datetime
+        
+        job = Job(
+            job_id="test123",
+            status=JobStatus.PENDING,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+            clean_instrumental_model="custom.ckpt",
+            backing_vocals_models=["bv1.ckpt", "bv2.ckpt"],
+            other_stems_models=["stems.yaml"]
+        )
+        
+        job_dict = job.model_dump()
+        
+        assert "clean_instrumental_model" in job_dict
+        assert job_dict["clean_instrumental_model"] == "custom.ckpt"
+        assert "backing_vocals_models" in job_dict
+        assert job_dict["backing_vocals_models"] == ["bv1.ckpt", "bv2.ckpt"]
+        assert "other_stems_models" in job_dict
+        assert job_dict["other_stems_models"] == ["stems.yaml"]
+
+
+class TestCommaDelimitedModelParsing:
+    """Test parsing of comma-delimited model strings."""
+    
+    def test_parse_single_model(self):
+        """Test parsing a single model string."""
+        model_str = "model1.ckpt"
+        result = [m.strip() for m in model_str.split(',') if m.strip()]
+        assert result == ["model1.ckpt"]
+    
+    def test_parse_multiple_models(self):
+        """Test parsing multiple models."""
+        model_str = "model1.ckpt,model2.ckpt,model3.ckpt"
+        result = [m.strip() for m in model_str.split(',') if m.strip()]
+        assert result == ["model1.ckpt", "model2.ckpt", "model3.ckpt"]
+    
+    def test_parse_models_with_whitespace(self):
+        """Test parsing models with whitespace around commas."""
+        model_str = "model1.ckpt , model2.ckpt, model3.ckpt "
+        result = [m.strip() for m in model_str.split(',') if m.strip()]
+        assert result == ["model1.ckpt", "model2.ckpt", "model3.ckpt"]
+    
+    def test_parse_empty_string(self):
+        """Test parsing empty string."""
+        model_str = ""
+        result = [m.strip() for m in model_str.split(',') if m.strip()]
+        assert result == []
+    
+    def test_parse_none_returns_none(self):
+        """Test that None model string is handled correctly."""
+        model_str = None
+        result = None
+        if model_str:
+            result = [m.strip() for m in model_str.split(',') if m.strip()]
+        assert result is None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
 

--- a/backend/tests/test_workers.py
+++ b/backend/tests/test_workers.py
@@ -573,3 +573,164 @@ class TestDownloadHelpers:
             # Should have downloaded from GCS
             mock_storage.download_file.assert_called()
 
+
+class TestAudioWorkerModelConfiguration:
+    """Tests for audio worker model configuration parameters."""
+    
+    def test_create_audio_processor_with_defaults(self):
+        """Test creating AudioProcessor with default models."""
+        with patch('backend.workers.audio_worker.AudioProcessor') as mock_processor:
+            from backend.workers.audio_worker import create_audio_processor
+            
+            with tempfile.TemporaryDirectory() as temp_dir:
+                result = create_audio_processor(temp_dir)
+                
+                mock_processor.assert_called_once()
+                call_kwargs = mock_processor.call_args[1]
+                
+                # Should use default models
+                assert call_kwargs['clean_instrumental_model'] == "model_bs_roformer_ep_317_sdr_12.9755.ckpt"
+                assert call_kwargs['backing_vocals_models'] == ["mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956.ckpt"]
+                assert call_kwargs['other_stems_models'] == ["htdemucs_6s.yaml"]
+    
+    def test_create_audio_processor_with_custom_clean_model(self):
+        """Test creating AudioProcessor with custom clean instrumental model."""
+        with patch('backend.workers.audio_worker.AudioProcessor') as mock_processor:
+            from backend.workers.audio_worker import create_audio_processor
+            
+            with tempfile.TemporaryDirectory() as temp_dir:
+                result = create_audio_processor(
+                    temp_dir,
+                    clean_instrumental_model="custom_clean_model.ckpt"
+                )
+                
+                mock_processor.assert_called_once()
+                call_kwargs = mock_processor.call_args[1]
+                
+                # Should use custom clean model
+                assert call_kwargs['clean_instrumental_model'] == "custom_clean_model.ckpt"
+                # Other models should still be defaults
+                assert call_kwargs['backing_vocals_models'] == ["mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956.ckpt"]
+    
+    def test_create_audio_processor_with_custom_backing_models(self):
+        """Test creating AudioProcessor with custom backing vocals models."""
+        with patch('backend.workers.audio_worker.AudioProcessor') as mock_processor:
+            from backend.workers.audio_worker import create_audio_processor
+            
+            with tempfile.TemporaryDirectory() as temp_dir:
+                result = create_audio_processor(
+                    temp_dir,
+                    backing_vocals_models=["custom_bv1.ckpt", "custom_bv2.ckpt"]
+                )
+                
+                mock_processor.assert_called_once()
+                call_kwargs = mock_processor.call_args[1]
+                
+                # Should use custom backing vocals models
+                assert call_kwargs['backing_vocals_models'] == ["custom_bv1.ckpt", "custom_bv2.ckpt"]
+    
+    def test_create_audio_processor_with_custom_other_stems_models(self):
+        """Test creating AudioProcessor with custom other stems models."""
+        with patch('backend.workers.audio_worker.AudioProcessor') as mock_processor:
+            from backend.workers.audio_worker import create_audio_processor
+            
+            with tempfile.TemporaryDirectory() as temp_dir:
+                result = create_audio_processor(
+                    temp_dir,
+                    other_stems_models=["custom_demucs.yaml"]
+                )
+                
+                mock_processor.assert_called_once()
+                call_kwargs = mock_processor.call_args[1]
+                
+                # Should use custom other stems models
+                assert call_kwargs['other_stems_models'] == ["custom_demucs.yaml"]
+    
+    def test_create_audio_processor_with_all_custom_models(self):
+        """Test creating AudioProcessor with all custom models."""
+        with patch('backend.workers.audio_worker.AudioProcessor') as mock_processor:
+            from backend.workers.audio_worker import create_audio_processor
+            
+            with tempfile.TemporaryDirectory() as temp_dir:
+                result = create_audio_processor(
+                    temp_dir,
+                    clean_instrumental_model="custom_clean.ckpt",
+                    backing_vocals_models=["custom_bv.ckpt"],
+                    other_stems_models=["custom_stems.yaml"]
+                )
+                
+                mock_processor.assert_called_once()
+                call_kwargs = mock_processor.call_args[1]
+                
+                # All models should be custom
+                assert call_kwargs['clean_instrumental_model'] == "custom_clean.ckpt"
+                assert call_kwargs['backing_vocals_models'] == ["custom_bv.ckpt"]
+                assert call_kwargs['other_stems_models'] == ["custom_stems.yaml"]
+    
+    def test_job_model_fields_are_passed_to_processor(self):
+        """Test that job model fields can be passed to create_audio_processor."""
+        mock_job = Job(
+            job_id="test123",
+            status=JobStatus.PENDING,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+            artist="Test",
+            title="Test",
+            clean_instrumental_model="job_clean.ckpt",
+            backing_vocals_models=["job_bv.ckpt"],
+            other_stems_models=["job_stems.yaml"]
+        )
+        
+        with patch('backend.workers.audio_worker.AudioProcessor') as mock_processor:
+            from backend.workers.audio_worker import create_audio_processor
+            
+            with tempfile.TemporaryDirectory() as temp_dir:
+                # Simulate passing job model fields to create_audio_processor
+                result = create_audio_processor(
+                    temp_dir,
+                    clean_instrumental_model=mock_job.clean_instrumental_model,
+                    backing_vocals_models=mock_job.backing_vocals_models,
+                    other_stems_models=mock_job.other_stems_models
+                )
+                
+                mock_processor.assert_called_once()
+                call_kwargs = mock_processor.call_args[1]
+                
+                # Models from job should be used
+                assert call_kwargs['clean_instrumental_model'] == "job_clean.ckpt"
+                assert call_kwargs['backing_vocals_models'] == ["job_bv.ckpt"]
+                assert call_kwargs['other_stems_models'] == ["job_stems.yaml"]
+    
+    def test_none_model_values_use_defaults(self):
+        """Test that None model values fall back to defaults."""
+        mock_job = Job(
+            job_id="test123",
+            status=JobStatus.PENDING,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+            artist="Test",
+            title="Test",
+            clean_instrumental_model=None,  # Not specified
+            backing_vocals_models=None,     # Not specified
+            other_stems_models=None         # Not specified
+        )
+        
+        with patch('backend.workers.audio_worker.AudioProcessor') as mock_processor:
+            from backend.workers.audio_worker import create_audio_processor
+            
+            with tempfile.TemporaryDirectory() as temp_dir:
+                result = create_audio_processor(
+                    temp_dir,
+                    clean_instrumental_model=mock_job.clean_instrumental_model,
+                    backing_vocals_models=mock_job.backing_vocals_models,
+                    other_stems_models=mock_job.other_stems_models
+                )
+                
+                mock_processor.assert_called_once()
+                call_kwargs = mock_processor.call_args[1]
+                
+                # Should fall back to defaults
+                assert call_kwargs['clean_instrumental_model'] == "model_bs_roformer_ep_317_sdr_12.9755.ckpt"
+                assert call_kwargs['backing_vocals_models'] == ["mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956.ckpt"]
+                assert call_kwargs['other_stems_models'] == ["htdemucs_6s.yaml"]
+

--- a/backend/workers/audio_worker.py
+++ b/backend/workers/audio_worker.py
@@ -112,7 +112,12 @@ async def download_from_url(url: str, temp_dir: str, artist: str, title: str) ->
         return None
 
 
-def create_audio_processor(temp_dir: str) -> AudioProcessor:
+def create_audio_processor(
+    temp_dir: str,
+    clean_instrumental_model: Optional[str] = None,
+    backing_vocals_models: Optional[list] = None,
+    other_stems_models: Optional[list] = None
+) -> AudioProcessor:
     """
     Create an AudioProcessor instance configured for remote API processing.
     
@@ -120,10 +125,13 @@ def create_audio_processor(temp_dir: str) -> AudioProcessor:
     - Uses remote Modal API (via AUDIO_SEPARATOR_API_URL env var)
     - No local models needed (model_file_dir=None)
     - FLAC output format for quality
-    - Standard model configurations from karaoke-gen CLI
+    - Model configurations from job or CLI defaults
     
     Args:
         temp_dir: Temporary directory for processing
+        clean_instrumental_model: Model for clean instrumental separation (optional, uses default if not provided)
+        backing_vocals_models: List of models for backing vocals separation (optional, uses default if not provided)
+        other_stems_models: List of models for other stems separation (optional, uses default if not provided)
         
     Returns:
         Configured AudioProcessor instance
@@ -132,10 +140,10 @@ def create_audio_processor(temp_dir: str) -> AudioProcessor:
     audio_logger = logging.getLogger("karaoke_gen.audio_processor")
     audio_logger.setLevel(logging.INFO)
     
-    # Model configurations (same as CLI defaults)
-    clean_instrumental_model = "model_bs_roformer_ep_317_sdr_12.9755.ckpt"
-    backing_vocals_models = ["mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956.ckpt"]
-    other_stems_models = ["htdemucs_6s.yaml"]  # For 6-stem separation (bass, drums, etc.)
+    # Model configurations - use provided values or CLI defaults
+    effective_clean_model = clean_instrumental_model or "model_bs_roformer_ep_317_sdr_12.9755.ckpt"
+    effective_backing_models = backing_vocals_models or ["mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956.ckpt"]
+    effective_other_models = other_stems_models or ["htdemucs_6s.yaml"]  # For 6-stem separation (bass, drums, etc.)
     
     # FFmpeg command for combining audio files (must be a string, not a list)
     ffmpeg_base_command = "ffmpeg -hide_banner -loglevel error -nostats -y"
@@ -146,9 +154,9 @@ def create_audio_processor(temp_dir: str) -> AudioProcessor:
         log_formatter=None,  # Not needed for our use case
         model_file_dir=None,  # No local models, using remote API
         lossless_output_format="FLAC",
-        clean_instrumental_model=clean_instrumental_model,
-        backing_vocals_models=backing_vocals_models,
-        other_stems_models=other_stems_models,
+        clean_instrumental_model=effective_clean_model,
+        backing_vocals_models=effective_backing_models,
+        other_stems_models=effective_other_models,
         ffmpeg_base_command=ffmpeg_base_command
     )
 
@@ -226,8 +234,21 @@ async def process_audio_separation(job_id: str) -> bool:
         })
         
         # Create AudioProcessor instance (reuses karaoke_gen code)
+        # Use model configuration from job if provided, otherwise use defaults
         job_log.info("Creating AudioProcessor instance...")
-        audio_processor = create_audio_processor(temp_dir)
+        if job.clean_instrumental_model:
+            job_log.info(f"  Using clean instrumental model: {job.clean_instrumental_model}")
+        if job.backing_vocals_models:
+            job_log.info(f"  Using backing vocals models: {job.backing_vocals_models}")
+        if job.other_stems_models:
+            job_log.info(f"  Using other stems models: {job.other_stems_models}")
+        
+        audio_processor = create_audio_processor(
+            temp_dir,
+            clean_instrumental_model=job.clean_instrumental_model,
+            backing_vocals_models=job.backing_vocals_models,
+            other_stems_models=job.other_stems_models
+        )
         
         # Format artist-title for file naming (matches CLI behavior)
         artist_title = f"{job.artist} - {job.title}"

--- a/docs/00-current-plan/BACKEND-FEATURE-PARITY-PLAN.md
+++ b/docs/00-current-plan/BACKEND-FEATURE-PARITY-PLAN.md
@@ -1,7 +1,7 @@
 # Backend Feature Parity Plan
 
-**Last Updated:** 2024-12-10  
-**Status:** ✅ Core Feature Parity Achieved (v0.71.0) | Batch 1 Complete ✅
+**Last Updated:** 2024-12-11  
+**Status:** ✅ Core Feature Parity Achieved (v0.71.0) | Batch 1 ✅ | Batch 2 ✅
 
 This document tracks the progress toward complete feature parity between the local `karaoke-gen` CLI and the cloud backend, enabling the `karaoke-gen-remote` CLI to have equivalent functionality.
 
@@ -14,7 +14,7 @@ This document tracks the progress toward complete feature parity between the loc
 | Lyrics Configuration | 5 | 5 | **100%** | ✅ **Batch 1 Complete** (L1-L4) |
 | Style Configuration | 1 | 4 | **25%** | S2-S4 are MEDIUM priority |
 | Workflow Control | 0 | 3 | **0%** | W1/W2 HIGH, W7 MEDIUM (skip flags deferred) |
-| Audio Processing | 0 | 4 | **0%** | AP1-3, AP5 are HIGH priority |
+| Audio Processing | 3 | 4 | **75%** | ✅ **Batch 2 Complete** (AP1-AP3), AP5 remaining |
 | Input Modes | 1 | 3 | **33%** | P2, P3 are HIGH priority |
 | Audio Fetching | 0 | 1 | **0%** | A1 is HIGH priority |
 | Flags to Remove | - | - | - | I3-I6, AP6 (simplify codebase) |
@@ -162,17 +162,19 @@ This section provides a comprehensive comparison of all CLI parameters between `
 
 | # | Parameter | Local | Remote | Description |
 |---|-----------|-------|--------|-------------|
-| AP1 | `--clean_instrumental_model` | ✅ | ❌ | **Stage 1 separation model.** AI model for initial vocal/instrumental separation. Default: `model_bs_roformer_ep_317_sdr_12.9755.ckpt`. Different models have different quality/speed tradeoffs. |
-| AP2 | `--backing_vocals_models` | ✅ | ❌ | **Stage 2 separation model(s).** AI model(s) for separating lead vocals from backing vocals. Default: `mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956.ckpt`. |
-| AP3 | `--other_stems_models` | ✅ | ❌ | **Multi-stem separation model.** AI model for separating drums, bass, guitar, piano, other. Default: `htdemucs_6s.yaml`. |
+| AP1 | `--clean_instrumental_model` | ✅ | ✅ | **Stage 1 separation model.** AI model for initial vocal/instrumental separation. Default: `model_bs_roformer_ep_317_sdr_12.9755.ckpt`. Different models have different quality/speed tradeoffs. |
+| AP2 | `--backing_vocals_models` | ✅ | ✅ | **Stage 2 separation model(s).** AI model(s) for separating lead vocals from backing vocals. Default: `mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956.ckpt`. |
+| AP3 | `--other_stems_models` | ✅ | ✅ | **Multi-stem separation model.** AI model for separating drums, bass, guitar, piano, other. Default: `htdemucs_6s.yaml`. |
 | AP4 | `--model_file_dir` | ✅ | N/A | **Model cache directory.** Where to store/load AI model files. Default: `/tmp/audio-separator-models/`. |
 | AP5 | `--existing_instrumental` | ✅ | ❌ | **Use pre-made instrumental.** Path to an existing instrumental file to use instead of running AI separation. Useful when you have a better instrumental from another source (official instrumental release, manual editing, etc.). Skips audio separation entirely. |
 | AP6 | `--instrumental_format` | 🗑️ | N/A | **REMOVE FROM LOCAL CLI.** FLAC is always fine, no need for format option. |
 
-**Remote Implementation Plan:**
-- **AP1-AP3 Model selection**: HIGH PRIORITY. All model options must work remotely! The Modal-hosted audio-separator API can download any model on demand and caches them. Just pass model name to API. Use case: A/B testing models, using newer models as they release.
+**Remote Implementation Status:** ✅ **BATCH 2 COMPLETE** (PR #9, v0.71.24)
+- **AP1 `--clean_instrumental_model`**: ✅ IMPLEMENTED. Sent as form field to backend. Audio worker passes to Modal API.
+- **AP2 `--backing_vocals_models`**: ✅ IMPLEMENTED. Sent as comma-separated list, parsed and passed to Modal API.
+- **AP3 `--other_stems_models`**: ✅ IMPLEMENTED. Sent as comma-separated list, parsed and passed to Modal API.
 - **AP4 `--model_file_dir`**: N/A for remote - Modal API handles model caching internally.
-- **AP5 `--existing_instrumental`**: HIGH PRIORITY. User uploads instrumental file with job. Backend STILL runs separation (for consistent stem outputs in download folder), but uses provided instrumental for karaoke remux and final video. **VALIDATION REQUIRED**: At job start, validate provided instrumental duration matches input audio duration (within 0.5 seconds tolerance) to ensure sync before proceeding.
+- **AP5 `--existing_instrumental`**: HIGH PRIORITY (Batch 3). User uploads instrumental file with job. Backend STILL runs separation (for consistent stem outputs in download folder), but uses provided instrumental for karaoke remux and final video. **VALIDATION REQUIRED**: At job start, validate provided instrumental duration matches input audio duration (within 0.5 seconds tolerance) to ensure sync before proceeding.
 - **AP6**: REMOVE from local CLI - FLAC is always fine.
 
 ---
@@ -320,19 +322,24 @@ Bump the patch version in `pyproject.toml` before committing.
 
 ---
 
-### Batch 2: Audio Separation Model Selection (HIGH)
+### Batch 2: Audio Separation Model Selection (HIGH) ✅ COMPLETE
 **Parameters:** AP1 `--clean_instrumental_model`, AP2 `--backing_vocals_models`, AP3 `--other_stems_models`
 
-**Scope:**
-- Remote CLI: Add 3 form fields to `submit_job()`
-- Backend: Add 3 Form parameters to upload endpoint
-- Backend: Store in job, pass to audio worker
-- Backend: Audio worker passes model names to Modal API (already supports any model)
+**Status:** ✅ **IMPLEMENTED** - PR #9 merged (v0.71.24)
 
-**Files to modify:**
-- `karaoke_gen/utils/remote_cli.py` - add to submit_job()
-- `backend/api/routes/file_upload.py` - add Form fields
-- `backend/workers/audio_worker.py` - pass model names to Modal API
+**Implementation Summary:**
+- Remote CLI: Added 3 form fields to `submit_job()`, sends models as comma-separated strings
+- Backend: Added 3 Form parameters to `/api/jobs/upload` endpoint, parses comma-separated lists
+- Backend: Job model stores model configuration as optional fields
+- Backend: Audio worker passes model names to AudioProcessor which uses Modal API
+
+**Files modified:**
+- `karaoke_gen/utils/remote_cli.py` - submit_job() with model params
+- `backend/api/routes/file_upload.py` - Form fields + comma parsing
+- `backend/models/job.py` - clean_instrumental_model, backing_vocals_models, other_stems_models fields
+- `backend/workers/audio_worker.py` - create_audio_processor() accepts model params from job
+
+**Tests added:** 15+ unit tests covering Job model fields, form parsing, AudioProcessor configuration
 
 **Complexity:** Low (Modal API already supports dynamic model selection)
 
@@ -496,7 +503,7 @@ Bump the patch version in `pyproject.toml` before committing.
 | Batch | Parameters | Priority | Complexity | Status |
 |-------|------------|----------|------------|--------|
 | 1 | L1-L4 (lyrics config) | HIGH | Low-Medium | ✅ **COMPLETE** (PR #8) |
-| 2 | AP1-AP3 (model selection) | HIGH | Low | ⏳ Pending |
+| 2 | AP1-AP3 (model selection) | HIGH | Low | ✅ **COMPLETE** (PR #9) |
 | 3 | AP5 (existing instrumental) | HIGH | Medium | ⏳ Pending |
 | 4 | P2 (YouTube URLs) | HIGH | Medium-High | ⏳ Pending |
 | 5 | P3, A1 (flacfetch search) | HIGH | High | ⏳ Pending |
@@ -506,7 +513,7 @@ Bump the patch version in `pyproject.toml` before committing.
 | 9 | W7 (edit-lyrics) | MEDIUM | Medium-High | ⏳ Pending |
 | 10 | F14, D2, D3, removals | LOW | Mixed | ⏳ Pending |
 
-**Recommended Order:** ~~1~~ → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 9 → 10
+**Recommended Order:** ~~1~~ → ~~2~~ → 3 → 4 → 5 → 6 → 7 → 8 → 9 → 10
 
 Batches 1-3 are quick wins that add significant value. Batches 4-6 are larger but high priority. Batches 7-10 can be done as time permits.
 
@@ -615,13 +622,13 @@ The karaoke-gen system supports multiple interfaces to the same core functionali
 
 | Feature | Version | PR | Notes |
 |---------|---------|-----|-------|
+|| Audio model selection | v0.71.24 | #9 | `--clean_instrumental_model`, `--backing_vocals_models`, `--other_stems_models` |
 | Lyrics override params | v0.71.22 | #8 | `--lyrics_artist`, `--lyrics_title`, `--lyrics_file`, `--subtitle_offset_ms` |
 
 ### ⏳ Not Yet Implemented
 
 | Feature | Priority | Notes |
 |---------|----------|-------|
-| Audio model selection | HIGH | `--clean_instrumental_model`, `--backing_vocals_models`, `--other_stems_models` |
 | Existing instrumental | HIGH | `--existing_instrumental` for re-processing |
 | Style override | MEDIUM | `--style_override` for quick tweaks |
 | Skip separation/transcription | MEDIUM | Workflow control for re-processing |
@@ -874,6 +881,16 @@ DEFAULT_DISCORD_WEBHOOK_URL=https://discord.com/...
 
 ## Recent Changes Log
 
+### 2024-12-11: v0.71.24 - Batch 2 Complete (Audio Model Selection)
+
+**PR #9: Audio Model Selection for Remote CLI**
+
+- ✅ `--clean_instrumental_model` - Custom Stage 1 separation model
+- ✅ `--backing_vocals_models` - Custom backing vocals separation models
+- ✅ `--other_stems_models` - Custom multi-stem separation models (bass, drums, etc.)
+- Added 15+ unit tests for new functionality
+- Files: `remote_cli.py`, `file_upload.py`, `job.py`, `audio_worker.py`
+
 ### 2024-12-10: v0.71.22 - Batch 1 Complete (Lyrics Configuration)
 
 **PR #8: Lyrics Configuration for Remote CLI**
@@ -936,12 +953,11 @@ DEFAULT_DISCORD_WEBHOOK_URL=https://discord.com/...
    - `--lyrics_artist`, `--lyrics_title`, `--lyrics_file`, `--subtitle_offset_ms`
    - PR #8, v0.71.22
 
-2. **Audio Model Selection** (Batch 2 - NEXT)
-   - Add `--clean_instrumental_model`, `--backing_vocals_models`, `--other_stems_models` support
-   - Files: `remote_cli.py`, `file_upload.py`, `audio_worker.py`
-   - Enables: A/B testing models, using newer models as they release
+2. ✅ **Audio Model Selection** (Batch 2 - COMPLETE)
+   - `--clean_instrumental_model`, `--backing_vocals_models`, `--other_stems_models`
+   - PR #9, v0.71.24
 
-3. **Existing Instrumental** (Batch 3)
+3. **Existing Instrumental** (Batch 3 - NEXT)
    - Add `--existing_instrumental` upload support
    - Files: `remote_cli.py`, `file_upload.py`, `audio_worker.py`, `render_worker.py`
    - Enables: Re-processing with better instrumentals

--- a/karaoke_gen/utils/remote_cli.py
+++ b/karaoke_gen/utils/remote_cli.py
@@ -204,6 +204,10 @@ class RemoteKaraokeClient:
         lyrics_title: Optional[str] = None,
         lyrics_file: Optional[str] = None,
         subtitle_offset_ms: int = 0,
+        # Audio separation model configuration
+        clean_instrumental_model: Optional[str] = None,
+        backing_vocals_models: Optional[list] = None,
+        other_stems_models: Optional[list] = None,
     ) -> Dict[str, Any]:
         """
         Submit a new karaoke generation job with optional style configuration.
@@ -226,6 +230,9 @@ class RemoteKaraokeClient:
             lyrics_title: Override title for lyrics search
             lyrics_file: Path to user-provided lyrics file
             subtitle_offset_ms: Subtitle timing offset in milliseconds
+            clean_instrumental_model: Model for clean instrumental separation
+            backing_vocals_models: List of models for backing vocals separation
+            other_stems_models: List of models for other stems (bass, drums, etc.)
         """
         file_path = Path(filepath)
         
@@ -320,6 +327,14 @@ class RemoteKaraokeClient:
                 data['lyrics_title'] = lyrics_title
             if subtitle_offset_ms != 0:
                 data['subtitle_offset_ms'] = str(subtitle_offset_ms)
+            
+            # Audio separation model configuration
+            if clean_instrumental_model:
+                data['clean_instrumental_model'] = clean_instrumental_model
+            if backing_vocals_models:
+                data['backing_vocals_models'] = ','.join(backing_vocals_models)
+            if other_stems_models:
+                data['other_stems_models'] = ','.join(other_stems_models)
             
             self.logger.info(f"Submitting job to {self.config.service_url}/api/jobs/upload")
             
@@ -1747,6 +1762,13 @@ def main():
         logger.info(f"Lyrics File: {args.lyrics_file}")
     if getattr(args, 'subtitle_offset_ms', 0):
         logger.info(f"Subtitle Offset: {args.subtitle_offset_ms}ms")
+    # Audio model configuration
+    if getattr(args, 'clean_instrumental_model', None):
+        logger.info(f"Clean Instrumental Model: {args.clean_instrumental_model}")
+    if getattr(args, 'backing_vocals_models', None):
+        logger.info(f"Backing Vocals Models: {args.backing_vocals_models}")
+    if getattr(args, 'other_stems_models', None):
+        logger.info(f"Other Stems Models: {args.other_stems_models}")
     logger.info(f"Service URL: {config.service_url}")
     logger.info(f"Review UI: {config.review_ui_url}")
     if config.non_interactive:
@@ -1785,6 +1807,10 @@ def main():
             lyrics_title=getattr(args, 'lyrics_title', None),
             lyrics_file=getattr(args, 'lyrics_file', None),
             subtitle_offset_ms=getattr(args, 'subtitle_offset_ms', 0) or 0,
+            # Audio separation model configuration
+            clean_instrumental_model=getattr(args, 'clean_instrumental_model', None),
+            backing_vocals_models=getattr(args, 'backing_vocals_models', None),
+            other_stems_models=getattr(args, 'other_stems_models', None),
         )
         job_id = result.get('job_id')
         style_assets = result.get('style_assets_uploaded', [])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.71.23"
+version = "0.71.24"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

This PR implements Batch 2 from the [BACKEND-FEATURE-PARITY-PLAN.md](docs/00-current-plan/BACKEND-FEATURE-PARITY-PLAN.md), adding support for custom audio separation models in the remote CLI:

- **AP1 `--clean_instrumental_model`**: Stage 1 separation model (default: `model_bs_roformer_ep_317_sdr_12.9755.ckpt`)
- **AP2 `--backing_vocals_models`**: Backing vocals separation models (default: `mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956.ckpt`)
- **AP3 `--other_stems_models`**: Multi-stem separation models for bass, drums, guitar, piano, other (default: `htdemucs_6s.yaml`)

## Changes Made

### Remote CLI (`karaoke_gen/utils/remote_cli.py`)
- Added 3 new parameters to `submit_job()`: `clean_instrumental_model`, `backing_vocals_models`, `other_stems_models`
- Sends models as comma-separated strings to backend
- Logs model configuration when submitting jobs

### Backend API (`backend/api/routes/file_upload.py`)
- Added 3 Form parameters for model configuration
- Parses comma-separated model strings into lists
- Stores model configuration in job and passes to update_data

### Job Model (`backend/models/job.py`)
- Added `clean_instrumental_model`, `backing_vocals_models`, `other_stems_models` fields to both `Job` and `JobCreate` models
- All fields are optional and default to `None` (backend uses CLI defaults when not specified)

### Audio Worker (`backend/workers/audio_worker.py`)
- Updated `create_audio_processor()` to accept optional model parameters
- Falls back to CLI defaults when job doesn't specify custom models
- Logs which models are being used for debugging

### Tests
- Added 15+ unit tests covering:
  - Job model field presence and serialization
  - JobCreate model fields
  - Comma-delimited model string parsing
  - AudioProcessor model configuration
  - Default value fallback behavior

### Documentation
- Updated `BACKEND-FEATURE-PARITY-PLAN.md` with Batch 2 completion status
- Updated Quick Parity Summary (Audio Processing: 75% → AP5 remaining)
- Added Recent Changes Log entry

## Testing

```bash
# Run all backend tests (382 passed)
python -m pytest backend/tests/ -v

# Run specific new tests
python -m pytest backend/tests/test_file_upload.py::TestAudioModelConfigurationFields -v
python -m pytest backend/tests/test_workers.py::TestAudioWorkerModelConfiguration -v
```

## Usage Example

```bash
# Use custom models
karaoke-gen-remote \
  --clean_instrumental_model="custom_roformer_model.ckpt" \
  --backing_vocals_models="custom_bv_model.ckpt" \
  --other_stems_models="htdemucs_ft.yaml" \
  ./song.flac "Artist" "Title"

# Uses defaults when not specified
karaoke-gen-remote ./song.flac "Artist" "Title"
```

## Related

- Part of the Backend Feature Parity effort
- See [BACKEND-FEATURE-PARITY-PLAN.md](docs/00-current-plan/BACKEND-FEATURE-PARITY-PLAN.md) for full context
- Follows Batch 1 (Lyrics Configuration) - PR #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now specify custom audio separation models for jobs, including clean instrumental, backing vocals, and other stems during upload.
  * Remote CLI now supports audio model configuration parameters for granular control over audio processing.

* **Tests**
  * Added comprehensive test coverage for audio model configuration functionality.

* **Chores**
  * Version bumped to 0.71.24.
  * Documentation updated to reflect feature completion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->