### PR TITLE
fix: Enable Cloud Tasks in deployment for scalable architecture

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -54,6 +54,7 @@ steps:
       - 'us-central1-docker.pkg.dev/$PROJECT_ID/karaoke-repo/karaoke-backend:latest'
 
   # Deploy to Cloud Run with version from pyproject.toml
+  # Uses Cloud Tasks for worker coordination (scalable architecture)
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: 'bash'
     args:
@@ -71,10 +72,10 @@ steps:
           --cpu-boost \
           --execution-environment gen2 \
           --timeout 1800 \
-          --concurrency 4 \
-          --max-instances 10 \
+          --concurrency 1 \
+          --max-instances 50 \
           --min-instances 0 \
-          --set-env-vars "GOOGLE_CLOUD_PROJECT=$PROJECT_ID,GCS_BUCKET_NAME=karaoke-gen-storage-$PROJECT_ID,FIRESTORE_COLLECTION=jobs,ENVIRONMENT=production,AUDIO_SEPARATOR_API_URL=https://nomadkaraoke--audio-separator-api.modal.run,KARAOKE_GEN_VERSION=$$VERSION,DEFAULT_DROPBOX_PATH=/MediaUnsynced/Karaoke/Tracks-Organized,DEFAULT_GDRIVE_FOLDER_ID=1laRKAyxo0v817SstfM5XkpbWiNKNAMSX" \
+          --set-env-vars "GOOGLE_CLOUD_PROJECT=$PROJECT_ID,GCS_BUCKET_NAME=karaoke-gen-storage-$PROJECT_ID,FIRESTORE_COLLECTION=jobs,ENVIRONMENT=production,AUDIO_SEPARATOR_API_URL=https://nomadkaraoke--audio-separator-api.modal.run,KARAOKE_GEN_VERSION=$$VERSION,DEFAULT_DROPBOX_PATH=/MediaUnsynced/Karaoke/Tracks-Organized,DEFAULT_GDRIVE_FOLDER_ID=1laRKAyxo0v817SstfM5XkpbWiNKNAMSX,ENABLE_CLOUD_TASKS=true,CLOUD_RUN_SERVICE_URL=https://api.nomadkaraoke.com,GCP_REGION=us-central1" \
           --set-secrets "AUDIOSHAKE_API_TOKEN=audioshake-api-key:latest,GENIUS_API_TOKEN=genius-api-key:latest,SPOTIFY_COOKIE_SP_DC=spotify-cookie:latest,RAPIDAPI_KEY=rapidapi-key:latest,DEFAULT_DISCORD_WEBHOOK_URL=discord-releases-webhook:latest,ADMIN_TOKENS=admin-tokens:latest"
 
 images:

--- a/docs/00-current-plan/SCALABLE-ARCHITECTURE-PLAN.md
+++ b/docs/00-current-plan/SCALABLE-ARCHITECTURE-PLAN.md
@@ -1,7 +1,7 @@
 # Scalable Architecture Plan
 
 **Last Updated:** 2025-12-11
-**Status:** Analysis Complete - Ready for Implementation
+**Status:** Phase 1 Complete - Cloud Tasks Enabled
 
 This document outlines the plan for evolving karaoke-gen's cloud backend to support **100+ concurrent jobs** with no performance degradation, while also achieving a clean, maintainable codebase with proper separation of concerns.
 
@@ -756,7 +756,11 @@ wait
 ## Success Criteria
 
 ### Phase 1 (Cloud Tasks)
-- [ ] 50 concurrent jobs complete without failures
+- [x] Cloud Tasks queues created and configured via Pulumi
+- [x] WorkerService updated to support Cloud Tasks mode
+- [x] Deployment configured with ENABLE_CLOUD_TASKS=true
+- [x] Container concurrency set to 1 for true isolation
+- [ ] 50 concurrent jobs complete without failures (to be validated)
 - [ ] Processing time per job unchanged (same as 1 job)
 - [ ] No resource contention (CPU/memory per job consistent)
 - [ ] Automatic retry on transient failures works

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.71.35"
+version = "0.71.36"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

The scalable architecture was deployed (Cloud Tasks queues, IAM permissions, infrastructure via Pulumi) but **never activated** in the Cloud Run deployment configuration. This PR completes the migration.

## Problem

Jobs were still running in the **old architecture**:
- `ENABLE_CLOUD_TASKS` was not set (defaulted to `false`)
- Workers ran via direct HTTP + BackgroundTasks in shared containers
- `containerConcurrency=4` allowed multiple jobs to compete for resources

## Changes

| Setting | Before | After |
|---------|--------|-------|
| `ENABLE_CLOUD_TASKS` | not set | `true` |
| `CLOUD_RUN_SERVICE_URL` | not set | `https://api.nomadkaraoke.com` |
| `GCP_REGION` | not set | `us-central1` |
| `--concurrency` | `4` | `1` |
| `--max-instances` | `10` | `50` |

## How It Works Now

1. Job uploaded → triggers workers via **Cloud Tasks queues**
2. Cloud Tasks delivers HTTP requests to Cloud Run
3. Cloud Run auto-scales, each request gets a **dedicated container** (concurrency=1)
4. No resource contention between jobs
5. Automatic retries on transient failures

## Testing

- [x] All 1121 tests pass
- [ ] Manual testing: Submit 3+ concurrent jobs, verify they process independently

## Related

- Architecture plan: `docs/00-current-plan/SCALABLE-ARCHITECTURE-PLAN.md`
- Infrastructure: `infrastructure/__main__.py` (Cloud Tasks queues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cloud Tasks job queuing system now enabled for improved asynchronous task processing and reliability.

* **Infrastructure Updates**
  * Cloud Run deployment configuration optimized for enhanced scalability with expanded instance capacity and refined concurrency settings.

* **Chores**
  * Version bumped to 0.71.36.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->