### PR TITLE
fix: integrate instrumental review UI into local CLI workflow

### DIFF
--- a/karaoke_gen/utils/cli_args.py
+++ b/karaoke_gen/utils/cli_args.py
@@ -208,6 +208,11 @@ def create_parser(prog: str = "karaoke-gen") -> argparse.ArgumentParser:
         default="flac",
         help="Optional: format / file extension for instrumental track to use for remux (default: %(default)s). Example: --instrumental_format=mp3",
     )
+    audio_group.add_argument(
+        "--skip_instrumental_review",
+        action="store_true",
+        help="Optional: Skip the interactive instrumental review UI and use the old numeric selection. Example: --skip_instrumental_review",
+    )
 
     # Lyrics Configuration
     lyrics_group = parser.add_argument_group("Lyrics Configuration")

--- a/karaoke_gen/utils/gen_cli.py
+++ b/karaoke_gen/utils/gen_cli.py
@@ -14,10 +14,148 @@ import sys
 import json
 import asyncio
 import time
+import glob
 import pyperclip
 from karaoke_gen import KaraokePrep
 from karaoke_gen.karaoke_finalise import KaraokeFinalise
+from karaoke_gen.instrumental_review import (
+    AudioAnalyzer,
+    WaveformGenerator,
+    InstrumentalReviewServer,
+)
 from .cli_args import create_parser, process_style_overrides, is_url, is_file
+
+
+def run_instrumental_review(track: dict, logger: logging.Logger) -> str | None:
+    """
+    Run the instrumental review UI to let user select the best instrumental track.
+    
+    This analyzes the backing vocals, generates a waveform, and opens a browser
+    with an interactive UI for reviewing and selecting the instrumental.
+    
+    Args:
+        track: The track dictionary from KaraokePrep containing separated audio info
+        logger: Logger instance
+        
+    Returns:
+        Path to the selected instrumental file, or None to use the old numeric selection
+    """
+    track_dir = track.get("track_output_dir", ".")
+    artist = track.get("artist", "")
+    title = track.get("title", "")
+    base_name = f"{artist} - {title}"
+    
+    # Get separation results
+    separated = track.get("separated_audio", {})
+    if not separated:
+        logger.info("No separated audio found, skipping instrumental review UI")
+        return None
+    
+    # Find the backing vocals file
+    backing_vocals_path = None
+    backing_vocals_result = separated.get("backing_vocals", {})
+    for model, paths in backing_vocals_result.items():
+        if paths.get("backing_vocals"):
+            backing_vocals_path = paths["backing_vocals"]
+            break
+    
+    if not backing_vocals_path or not os.path.exists(backing_vocals_path):
+        logger.info("No backing vocals file found, skipping instrumental review UI")
+        return None
+    
+    # Find the clean instrumental file
+    clean_result = separated.get("clean_instrumental", {})
+    clean_instrumental_path = clean_result.get("instrumental")
+    
+    if not clean_instrumental_path or not os.path.exists(clean_instrumental_path):
+        logger.info("No clean instrumental file found, skipping instrumental review UI")
+        return None
+    
+    # Find the combined instrumental (with backing vocals) file - these have "(Padded)" suffix if padded
+    combined_result = separated.get("combined_instrumentals", {})
+    with_backing_path = None
+    for model, path in combined_result.items():
+        if path and os.path.exists(path):
+            with_backing_path = path
+            break
+    
+    try:
+        logger.info("=== Starting Instrumental Review ===")
+        logger.info(f"Analyzing backing vocals: {backing_vocals_path}")
+        
+        # Analyze backing vocals
+        analyzer = AudioAnalyzer()
+        analysis = analyzer.analyze(backing_vocals_path)
+        
+        logger.info(f"Analysis complete:")
+        logger.info(f"  Has audible content: {analysis.has_audible_content}")
+        logger.info(f"  Total duration: {analysis.total_duration_seconds:.1f}s")
+        logger.info(f"  Audible segments: {len(analysis.audible_segments)}")
+        logger.info(f"  Recommendation: {analysis.recommended_selection.value}")
+        
+        # Generate waveform
+        logger.info("Generating waveform visualization...")
+        waveform_generator = WaveformGenerator()
+        waveform_path = os.path.join(track_dir, f"{base_name} (Backing Vocals Waveform).png")
+        waveform_generator.generate(
+            audio_path=backing_vocals_path,
+            output_path=waveform_path,
+            audible_segments=analysis.audible_segments,
+        )
+        
+        # Start the review server
+        logger.info("Starting instrumental review UI...")
+        server = InstrumentalReviewServer(
+            output_dir=track_dir,
+            base_name=base_name,
+            analysis=analysis,
+            waveform_path=waveform_path,
+            backing_vocals_path=backing_vocals_path,
+            clean_instrumental_path=clean_instrumental_path,
+            with_backing_path=with_backing_path,
+        )
+        
+        # Start server and open browser, wait for selection
+        server.start_and_open_browser()
+        
+        logger.info("Waiting for instrumental selection in browser...")
+        logger.info("(Close the browser tab or press Ctrl+C to cancel)")
+        
+        try:
+            # Wait for user selection (blocking)
+            server._selection_event.wait()
+            selection = server.get_selection()
+            
+            logger.info(f"User selected: {selection}")
+            
+            # Stop the server
+            server.stop()
+            
+            # Return the selected instrumental path
+            if selection == "clean":
+                return clean_instrumental_path
+            elif selection == "with_backing":
+                return with_backing_path
+            elif selection == "custom":
+                custom_path = server.get_custom_instrumental_path()
+                if custom_path and os.path.exists(custom_path):
+                    return custom_path
+                else:
+                    logger.warning("Custom instrumental not found, falling back to clean")
+                    return clean_instrumental_path
+            else:
+                logger.warning(f"Unknown selection: {selection}, falling back to numeric selection")
+                return None
+                
+        except KeyboardInterrupt:
+            logger.info("Instrumental review cancelled by user")
+            server.stop()
+            return None
+            
+    except Exception as e:
+        logger.error(f"Error during instrumental review: {e}")
+        logger.info("Falling back to numeric selection")
+        return None
 
 
 async def async_main():
@@ -461,6 +599,14 @@ async def async_main():
         logger.info(f"Changing to directory: {track_dir}")
         os.chdir(track_dir)
 
+        # Run instrumental review UI if not skipped
+        selected_instrumental_file = None
+        if not getattr(args, 'skip_instrumental_review', False):
+            selected_instrumental_file = run_instrumental_review(
+                track=track,
+                logger=logger,
+            )
+        
         # Load CDG styles if CDG generation is enabled
         cdg_styles = None
         if args.enable_cdg:
@@ -504,6 +650,7 @@ async def async_main():
             cdg_styles=cdg_styles,
             keep_brand_code=getattr(args, 'keep_brand_code', False),
             non_interactive=args.yes,
+            selected_instrumental_file=selected_instrumental_file,
         )
 
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.71.40"
+version = "0.71.41"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"

--- a/tests/unit/test_cli_feature_parity.py
+++ b/tests/unit/test_cli_feature_parity.py
@@ -206,3 +206,92 @@ class TestRemoteCLIAnalysisIntegration:
         from karaoke_gen.utils.remote_cli import JobMonitor
         
         assert hasattr(JobMonitor, 'handle_instrumental_selection')
+
+
+class TestLocalCLIIntegration:
+    """Verify local CLI actually integrates the instrumental review UI.
+    
+    These tests ensure the local CLI (gen_cli.py) actually uses the 
+    InstrumentalReviewServer to provide the interactive review experience,
+    not just that the classes exist.
+    """
+    
+    def test_gen_cli_has_run_instrumental_review_function(self):
+        """gen_cli.py should have run_instrumental_review function."""
+        from karaoke_gen.utils import gen_cli
+        
+        # The function should exist
+        assert hasattr(gen_cli, 'run_instrumental_review')
+        assert callable(gen_cli.run_instrumental_review)
+    
+    def test_gen_cli_imports_instrumental_review_components(self):
+        """gen_cli.py should import necessary instrumental review components."""
+        import karaoke_gen.utils.gen_cli as gen_cli
+        import inspect
+        
+        # Get the source of the module to verify imports
+        source = inspect.getsource(gen_cli)
+        
+        # Should import the key components
+        assert 'from karaoke_gen.instrumental_review import' in source
+        assert 'AudioAnalyzer' in source
+        assert 'WaveformGenerator' in source
+        assert 'InstrumentalReviewServer' in source
+    
+    def test_run_instrumental_review_uses_analyzer(self):
+        """run_instrumental_review should use AudioAnalyzer."""
+        import inspect
+        from karaoke_gen.utils.gen_cli import run_instrumental_review
+        
+        source = inspect.getsource(run_instrumental_review)
+        
+        # Should create and use analyzer
+        assert 'AudioAnalyzer()' in source or 'AudioAnalyzer(' in source
+        assert 'analyzer.analyze' in source or 'analysis = analyzer' in source
+    
+    def test_run_instrumental_review_uses_waveform_generator(self):
+        """run_instrumental_review should use WaveformGenerator."""
+        import inspect
+        from karaoke_gen.utils.gen_cli import run_instrumental_review
+        
+        source = inspect.getsource(run_instrumental_review)
+        
+        # Should create and use waveform generator
+        assert 'WaveformGenerator()' in source or 'WaveformGenerator(' in source
+        assert 'waveform_generator.generate' in source or 'generator.generate' in source
+    
+    def test_run_instrumental_review_uses_server(self):
+        """run_instrumental_review should use InstrumentalReviewServer."""
+        import inspect
+        from karaoke_gen.utils.gen_cli import run_instrumental_review
+        
+        source = inspect.getsource(run_instrumental_review)
+        
+        # Should create and use the review server
+        assert 'InstrumentalReviewServer(' in source
+        assert 'server.start_and_open_browser' in source
+        assert 'server.get_selection' in source
+    
+    def test_gen_cli_has_skip_instrumental_review_flag(self):
+        """gen_cli should support --skip_instrumental_review flag."""
+        from karaoke_gen.utils.cli_args import create_parser
+        
+        parser = create_parser(prog="test")
+        
+        # Parse with the flag
+        args = parser.parse_args(['--skip_instrumental_review', 'Test', 'Song'])
+        
+        assert hasattr(args, 'skip_instrumental_review')
+        assert args.skip_instrumental_review == True
+    
+    def test_gen_cli_skip_instrumental_review_defaults_false(self):
+        """skip_instrumental_review should default to False."""
+        from karaoke_gen.utils.cli_args import create_parser
+        
+        parser = create_parser(prog="test")
+        
+        # Parse without the flag
+        args = parser.parse_args(['Test', 'Song'])
+        
+        assert hasattr(args, 'skip_instrumental_review')
+        assert args.skip_instrumental_review == False


### PR DESCRIPTION
## Summary

The instrumental review UI was built (PR #22) but never integrated into the local CLI (`karaoke-gen`) workflow. Users running `karaoke-gen` locally were still seeing the old numeric selection prompt instead of the new interactive web UI.

This fix:
- Adds `run_instrumental_review()` function to `gen_cli.py` that analyzes backing vocals, generates waveform visualization, starts the review server, and opens a browser for interactive selection
- Integrates the review into the finalization loop before `KaraokeFinalise`
- Adds `--skip_instrumental_review` CLI flag for backwards compatibility
- Adds comprehensive tests that verify the integration exists (tests that would have caught this gap)

## Changes Made

- `karaoke_gen/utils/gen_cli.py`: Added `run_instrumental_review()` function and integration with finalization loop
- `karaoke_gen/utils/cli_args.py`: Added `--skip_instrumental_review` flag
- `tests/unit/test_cli_feature_parity.py`: Added `TestLocalCLIIntegration` class with 7 new tests

## Testing

- All 1316 tests pass
- Test coverage: 72.46% (above 70% minimum)
- New tests verify:
  - `gen_cli.py` has `run_instrumental_review` function
  - The function imports and uses `AudioAnalyzer`, `WaveformGenerator`, and `InstrumentalReviewServer`
  - The `--skip_instrumental_review` flag exists and defaults to False

## Root Cause

The original implementation marked the "local-cli-integration" TODO as complete when only the building blocks were created (classes and server), but the actual integration into the CLI flow was never done. The existing tests only verified that classes existed, not that they were actually used in the CLI workflow.

## Prevention

The new tests in `TestLocalCLIIntegration` use source code inspection to verify that the integration code actually exists, which would catch similar gaps in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive instrumental review UI for analyzing and selecting backing tracks
  * Added `--skip_instrumental_review` CLI flag to skip the new review interface

* **Tests**
  * Added instrumental review integration test coverage

* **Chores**
  * Version bumped to 0.71.41

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->