### PR TITLE
Fix instrumental review UI path resolution after chdir

### DIFF
--- a/karaoke_gen/utils/gen_cli.py
+++ b/karaoke_gen/utils/gen_cli.py
@@ -26,6 +26,39 @@ from karaoke_gen.instrumental_review import (
 from .cli_args import create_parser, process_style_overrides, is_url, is_file
 
 
+def _resolve_path_for_cwd(path: str, track_dir: str) -> str:
+    """
+    Resolve a path that may have been created relative to the original working directory.
+    
+    After os.chdir(track_dir), paths like './TrackDir/stems/file.flac' become invalid.
+    This function converts such paths to work from the new current directory.
+    
+    Args:
+        path: The path to resolve (may be relative or absolute)
+        track_dir: The track directory we've chdir'd into
+        
+    Returns:
+        A path that's valid from the current working directory
+    """
+    if os.path.isabs(path):
+        return path
+    
+    # Normalize both paths for comparison
+    norm_path = os.path.normpath(path)
+    norm_track_dir = os.path.normpath(track_dir)
+    
+    # If path starts with track_dir, strip it to get the relative path from within track_dir
+    # e.g., './Four Lanes Male Choir - The White Rose/stems/file.flac' -> 'stems/file.flac'
+    if norm_path.startswith(norm_track_dir + os.sep):
+        return norm_path[len(norm_track_dir) + 1:]
+    elif norm_path.startswith(norm_track_dir):
+        return norm_path[len(norm_track_dir):].lstrip(os.sep) or '.'
+    
+    # If path doesn't start with track_dir, it might already be relative to track_dir
+    # or it's a path that doesn't need transformation
+    return path
+
+
 def run_instrumental_review(track: dict, logger: logging.Logger) -> str | None:
     """
     Run the instrumental review UI to let user select the best instrumental track.
@@ -52,11 +85,13 @@ def run_instrumental_review(track: dict, logger: logging.Logger) -> str | None:
         return None
     
     # Find the backing vocals file
+    # Note: Paths in separated_audio may be relative to the original working directory,
+    # but we've already chdir'd into track_dir. Use _resolve_path_for_cwd to fix paths.
     backing_vocals_path = None
     backing_vocals_result = separated.get("backing_vocals", {})
     for model, paths in backing_vocals_result.items():
         if paths.get("backing_vocals"):
-            backing_vocals_path = paths["backing_vocals"]
+            backing_vocals_path = _resolve_path_for_cwd(paths["backing_vocals"], track_dir)
             break
     
     if not backing_vocals_path or not os.path.exists(backing_vocals_path):
@@ -65,7 +100,8 @@ def run_instrumental_review(track: dict, logger: logging.Logger) -> str | None:
     
     # Find the clean instrumental file
     clean_result = separated.get("clean_instrumental", {})
-    clean_instrumental_path = clean_result.get("instrumental")
+    raw_clean_path = clean_result.get("instrumental")
+    clean_instrumental_path = _resolve_path_for_cwd(raw_clean_path, track_dir) if raw_clean_path else None
     
     if not clean_instrumental_path or not os.path.exists(clean_instrumental_path):
         logger.info("No clean instrumental file found, skipping instrumental review UI")
@@ -75,8 +111,9 @@ def run_instrumental_review(track: dict, logger: logging.Logger) -> str | None:
     combined_result = separated.get("combined_instrumentals", {})
     with_backing_path = None
     for model, path in combined_result.items():
-        if path and os.path.exists(path):
-            with_backing_path = path
+        resolved_path = _resolve_path_for_cwd(path, track_dir) if path else None
+        if resolved_path and os.path.exists(resolved_path):
+            with_backing_path = resolved_path
             break
     
     try:
@@ -94,9 +131,10 @@ def run_instrumental_review(track: dict, logger: logging.Logger) -> str | None:
         logger.info(f"  Recommendation: {analysis.recommended_selection.value}")
         
         # Generate waveform
+        # Note: We're already in track_dir after chdir, so use current directory
         logger.info("Generating waveform visualization...")
         waveform_generator = WaveformGenerator()
-        waveform_path = os.path.join(track_dir, f"{base_name} (Backing Vocals Waveform).png")
+        waveform_path = f"{base_name} (Backing Vocals Waveform).png"
         waveform_generator.generate(
             audio_path=backing_vocals_path,
             output_path=waveform_path,
@@ -104,9 +142,10 @@ def run_instrumental_review(track: dict, logger: logging.Logger) -> str | None:
         )
         
         # Start the review server
+        # Note: We're already in track_dir after chdir, so output_dir is "."
         logger.info("Starting instrumental review UI...")
         server = InstrumentalReviewServer(
-            output_dir=track_dir,
+            output_dir=".",
             base_name=base_name,
             analysis=analysis,
             waveform_path=waveform_path,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.71.41"
+version = "0.71.42"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"

--- a/tests/unit/test_gen_cli.py
+++ b/tests/unit/test_gen_cli.py
@@ -685,3 +685,78 @@ async def test_style_override_parsing(mock_kprep_class, mock_base_args):
         "end.video_duration": "10"
     }
     assert prep_kwargs["style_overrides"] == expected_overrides
+
+
+# --- Test _resolve_path_for_cwd helper function ---
+
+class TestResolvePathForCwd:
+    """Tests for the _resolve_path_for_cwd helper function.
+    
+    This function resolves paths that were created relative to the original working
+    directory after os.chdir(track_dir) has been called.
+    """
+    
+    def test_absolute_path_unchanged(self):
+        """Absolute paths should be returned unchanged."""
+        from karaoke_gen.utils.gen_cli import _resolve_path_for_cwd
+        
+        path = "/absolute/path/to/file.flac"
+        track_dir = "./Artist - Title"
+        result = _resolve_path_for_cwd(path, track_dir)
+        assert result == path
+    
+    def test_relative_path_starting_with_track_dir(self):
+        """Paths starting with track_dir should have track_dir stripped."""
+        from karaoke_gen.utils.gen_cli import _resolve_path_for_cwd
+        
+        path = "./Artist - Title/stems/file.flac"
+        track_dir = "./Artist - Title"
+        result = _resolve_path_for_cwd(path, track_dir)
+        assert result == "stems/file.flac"
+    
+    def test_relative_path_with_different_format(self):
+        """Paths without ./ prefix should also be handled."""
+        from karaoke_gen.utils.gen_cli import _resolve_path_for_cwd
+        
+        path = "Artist - Title/stems/file.flac"
+        track_dir = "Artist - Title"
+        result = _resolve_path_for_cwd(path, track_dir)
+        assert result == "stems/file.flac"
+    
+    def test_path_not_starting_with_track_dir(self):
+        """Paths not starting with track_dir should be returned unchanged."""
+        from karaoke_gen.utils.gen_cli import _resolve_path_for_cwd
+        
+        path = "different/path/to/file.flac"
+        track_dir = "./Artist - Title"
+        result = _resolve_path_for_cwd(path, track_dir)
+        assert result == path
+    
+    def test_path_with_complex_track_name(self):
+        """Test with a track name containing special characters."""
+        from karaoke_gen.utils.gen_cli import _resolve_path_for_cwd
+        
+        path = "./Four Lanes Male Choir - The White Rose/stems/backing_vocals.flac"
+        track_dir = "./Four Lanes Male Choir - The White Rose"
+        result = _resolve_path_for_cwd(path, track_dir)
+        assert result == "stems/backing_vocals.flac"
+    
+    def test_path_exactly_matching_track_dir(self):
+        """Test when path exactly matches track_dir (edge case)."""
+        from karaoke_gen.utils.gen_cli import _resolve_path_for_cwd
+        
+        path = "./Artist - Title"
+        track_dir = "./Artist - Title"
+        result = _resolve_path_for_cwd(path, track_dir)
+        assert result == "."
+    
+    def test_normalized_path_comparison(self):
+        """Test that path normalization works correctly."""
+        from karaoke_gen.utils.gen_cli import _resolve_path_for_cwd
+        
+        # Paths with extra slashes or dots should be normalized
+        path = "./Artist - Title//stems/./file.flac"
+        track_dir = "./Artist - Title/"
+        result = _resolve_path_for_cwd(path, track_dir)
+        # After normalization: "Artist - Title/stems/file.flac" vs "Artist - Title"
+        assert result == "stems/file.flac"


### PR DESCRIPTION
## Summary

- Fixes the instrumental review UI being skipped with "No backing vocals file found" when running `karaoke-gen` locally
- The issue was that file paths stored in `separated_audio` were relative to the original working directory, but `os.chdir(track_dir)` had already been called before the paths were checked

## Changes Made

1. Added `_resolve_path_for_cwd()` helper function to convert paths that were created relative to the original directory to work from the new current directory
2. Applied path resolution to `backing_vocals`, `clean_instrumental`, and `combined_instrumentals` paths in `run_instrumental_review()`
3. Updated waveform output path and `InstrumentalReviewServer` output_dir to use current directory since we're already inside `track_dir`
4. Added comprehensive unit tests for the new helper function

## Testing

- All existing tests pass (1323 passed)
- Added 7 new unit tests for `_resolve_path_for_cwd()` covering:
  - Absolute paths (unchanged)
  - Relative paths starting with track_dir (stripped)
  - Complex track names with spaces
  - Edge cases like exact match

## Related Issues

Fixes the issue observed in PRs #22 and #23 where the instrumental selection UI wasn't being triggered for local `karaoke-gen` runs, falling back to the old numbered file selection flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path resolution issues in the instrumental review workflow for backing vocals and clean instrumental audio files.
  * Improved working directory management to ensure output files are generated reliably, regardless of initial file path formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->