### PR TITLE
Fix YouTube duplicate checker returning videos from other channels

### DIFF
--- a/karaoke_gen/karaoke_finalise/karaoke_finalise.py
+++ b/karaoke_gen/karaoke_finalise/karaoke_finalise.py
@@ -424,6 +424,15 @@ class KaraokeFinalise:
         # Check if any videos were found
         if "items" in response and len(response["items"]) > 0:
             for item in response["items"]:
+                # YouTube search API sometimes returns results from other channels even with channelId filter
+                # Verify the video actually belongs to our channel
+                result_channel_id = item["snippet"]["channelId"]
+                if result_channel_id != channel_id:
+                    self.logger.debug(
+                        f"Skipping video from different channel: {item['snippet']['title']} (channel: {result_channel_id})"
+                    )
+                    continue
+
                 found_title = item["snippet"]["title"]
 
                 # In server-side mode, require an exact match to avoid false positives.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.71.68"
+version = "0.71.69"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"

--- a/tests/unit/test_karaoke_finalise/test_youtube_integration.py
+++ b/tests/unit/test_karaoke_finalise/test_youtube_integration.py
@@ -299,7 +299,7 @@ def test_check_if_video_title_exists_found_confirm(mock_input, mock_fuzz_ratio, 
     found_video_id = "existing_video_id"
     found_video_title = f"{ARTIST} - {TITLE} (Karaoke) Official"
     mock_youtube_service.search.return_value.list.return_value.execute.return_value = {
-        "items": [{"id": {"videoId": found_video_id}, "snippet": {"title": found_video_title}}]
+        "items": [{"id": {"videoId": found_video_id}, "snippet": {"title": found_video_title, "channelId": "UC_test_channel_id"}}]
     }
     mock_fuzz_ratio.return_value = 85 # High similarity
 
@@ -322,7 +322,7 @@ def test_check_if_video_title_exists_found_reject(mock_input, mock_fuzz_ratio, m
     found_video_id = "existing_video_id"
     found_video_title = f"{ARTIST} - {TITLE} (Karaoke) Official"
     mock_youtube_service.search.return_value.list.return_value.execute.return_value = {
-        "items": [{"id": {"videoId": found_video_id}, "snippet": {"title": found_video_title}}]
+        "items": [{"id": {"videoId": found_video_id}, "snippet": {"title": found_video_title, "channelId": "UC_test_channel_id"}}]
     }
     mock_fuzz_ratio.return_value = 85
 
@@ -344,7 +344,7 @@ def test_check_if_video_title_exists_low_similarity(mock_fuzz_ratio, mock_auth, 
     found_video_id = "existing_video_id"
     found_video_title = "Completely Different Title"
     mock_youtube_service.search.return_value.list.return_value.execute.return_value = {
-        "items": [{"id": {"videoId": found_video_id}, "snippet": {"title": found_video_title}}]
+        "items": [{"id": {"videoId": found_video_id}, "snippet": {"title": found_video_title, "channelId": "UC_test_channel_id"}}]
     }
     mock_fuzz_ratio.return_value = 30 # Low similarity
 
@@ -367,7 +367,7 @@ def test_check_if_video_title_exists_non_interactive(mock_input, mock_fuzz_ratio
     found_video_id = "existing_video_id"
     found_video_title = f"{ARTIST} - {TITLE} (Karaoke) Official"
     mock_youtube_service.search.return_value.list.return_value.execute.return_value = {
-        "items": [{"id": {"videoId": found_video_id}, "snippet": {"title": found_video_title}}]
+        "items": [{"id": {"videoId": found_video_id}, "snippet": {"title": found_video_title, "channelId": "UC_test_channel_id"}}]
     }
     mock_fuzz_ratio.return_value = 85
 
@@ -391,6 +391,63 @@ def test_check_if_video_title_exists_not_found(mock_auth, finaliser_for_yt, mock
     assert not hasattr(finaliser_for_yt, 'youtube_video_id')
     assert finaliser_for_yt.youtube_url is None # Check initial state remains None
     assert finaliser_for_yt.skip_notifications is False
+
+@patch.object(KaraokeFinalise, 'authenticate_youtube')
+@patch('thefuzz.fuzz.ratio')
+@patch('builtins.input')
+def test_check_if_video_title_exists_filters_other_channels(mock_input, mock_fuzz_ratio, mock_auth, finaliser_for_yt, mock_youtube_service):
+    """Test that videos from other channels are filtered out even if returned by search API.
+    
+    The YouTube search API sometimes returns results from other channels even when
+    channelId parameter is specified. This test verifies we filter those out.
+    """
+    mock_auth.return_value = mock_youtube_service
+    youtube_title = f"{ARTIST} - {TITLE} (Karaoke)"
+    
+    # Simulate YouTube API bug: returns videos from other channels despite channelId filter
+    mock_youtube_service.search.return_value.list.return_value.execute.return_value = {
+        "items": [
+            # Video from another channel - should be skipped
+            {"id": {"videoId": "other_channel_video_1"}, "snippet": {"title": f"{ARTIST} - {TITLE}", "channelId": "UC_other_channel_1"}},
+            {"id": {"videoId": "other_channel_video_2"}, "snippet": {"title": f"{ARTIST} - {TITLE} (Official)", "channelId": "UC_other_channel_2"}},
+            # Video from user's channel - should be matched
+            {"id": {"videoId": "my_channel_video"}, "snippet": {"title": f"{ARTIST} - {TITLE} (Karaoke)", "channelId": "UC_test_channel_id"}},
+        ]
+    }
+    mock_fuzz_ratio.return_value = 95
+    mock_input.return_value = 'y'
+
+    exists = finaliser_for_yt.check_if_video_title_exists_on_youtube_channel(youtube_title)
+
+    assert exists is True
+    # Should match the video from our channel, not the ones from other channels
+    assert finaliser_for_yt.youtube_video_id == "my_channel_video"
+    # fuzz.ratio should only be called for videos from our channel (1 video)
+    assert mock_fuzz_ratio.call_count == 1
+
+
+@patch.object(KaraokeFinalise, 'authenticate_youtube')
+@patch('thefuzz.fuzz.ratio')
+def test_check_if_video_title_exists_all_from_other_channels(mock_fuzz_ratio, mock_auth, finaliser_for_yt, mock_youtube_service):
+    """Test that if all returned videos are from other channels, no match is found."""
+    mock_auth.return_value = mock_youtube_service
+    youtube_title = f"{ARTIST} - {TITLE} (Karaoke)"
+    
+    # All results are from other channels
+    mock_youtube_service.search.return_value.list.return_value.execute.return_value = {
+        "items": [
+            {"id": {"videoId": "other_channel_video_1"}, "snippet": {"title": f"{ARTIST} - {TITLE}", "channelId": "UC_other_channel_1"}},
+            {"id": {"videoId": "other_channel_video_2"}, "snippet": {"title": f"{ARTIST} - {TITLE} (Official)", "channelId": "UC_other_channel_2"}},
+        ]
+    }
+
+    exists = finaliser_for_yt.check_if_video_title_exists_on_youtube_channel(youtube_title)
+
+    assert exists is False
+    # fuzz.ratio should never be called since all videos are filtered out
+    mock_fuzz_ratio.assert_not_called()
+    # Should log debug messages about skipping videos from other channels
+    assert finaliser_for_yt.logger.debug.call_count >= 2
 
 # --- Delete / Upload Tests ---
 


### PR DESCRIPTION
## Summary

Fixes a bug where the YouTube duplicate checker was showing videos from other channels, not just the user's channel.

## Problem

The YouTube Data API v3's `search().list()` endpoint has a known quirk where the `channelId` parameter doesn't always filter results correctly. It sometimes returns videos from other channels that match the search query, even when `channelId` is explicitly specified.

This caused the duplicate checker to show unrelated videos with similar titles (e.g., other people's uploads of the same song) and prompt the user to confirm if they were finalizing those videos:

```
Searching YouTube channel UCroMk5b4XILdeP7ZCGFicpw for title: Eyehategod - Trying to Crack the Hard Dollar (Karaoke)
Potential match found on YouTube channel with ID: fVLmPX91D7k and title: Eyehategod - Trying to Crack the Hard Dollar (similarity: 90%)
Is 'Eyehategod - Trying to Crack the Hard Dollar' the video you are finalising? (y/n): n
```

All those video IDs were from other channels, not the user's channel.

## Changes Made

- Added verification that each search result's `snippet.channelId` matches the user's channel ID before considering it as a potential match
- Videos from other channels are now skipped with a debug log message
- Added two new tests:
  - `test_check_if_video_title_exists_filters_other_channels` - verifies correct video is matched when API returns mixed results
  - `test_check_if_video_title_exists_all_from_other_channels` - verifies no match when all results are from other channels
- Updated existing tests to include `channelId` in mock responses

## Testing

- All existing unit tests pass
- Added new tests specifically for the channel filtering behavior
- Manually verified the fix addresses the reported issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YouTube video search accuracy by implementing channel ownership verification to ensure only videos from your authenticated channel are matched, reducing false positives from other channels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->