### PR TITLE
feat: Add Transmission daemon for tracker downloads on Cloud Run

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -34,5 +34,26 @@ ENV PORT=8080
 # Expose port
 EXPOSE 8080
 
-# Run the application
-CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8080"]
+# Create startup script that launches Transmission daemon before the main app
+# Transmission is needed for flacfetch to download from music trackers (Redacted, OPS)
+RUN echo '#!/bin/bash\n\
+# Start Transmission daemon in background\n\
+echo "Starting Transmission daemon..."\n\
+transmission-daemon --foreground --config-dir /var/lib/transmission-daemon/.config/transmission-daemon &\n\
+TRANSMISSION_PID=$!\n\
+\n\
+# Wait for Transmission to be ready (up to 10 seconds)\n\
+for i in {1..20}; do\n\
+    if curl -s http://127.0.0.1:9091/transmission/rpc > /dev/null 2>&1; then\n\
+        echo "Transmission daemon ready"\n\
+        break\n\
+    fi\n\
+    sleep 0.5\n\
+done\n\
+\n\
+# Start the main application\n\
+exec uvicorn backend.main:app --host 0.0.0.0 --port 8080\n\
+' > /app/start.sh && chmod +x /app/start.sh
+
+# Run the startup script
+CMD ["/bin/bash", "/app/start.sh"]

--- a/backend/Dockerfile.base
+++ b/backend/Dockerfile.base
@@ -13,7 +13,31 @@ RUN apt-get update && apt-get install -y \
     libsox-dev \
     sox \
     build-essential \
+    curl \
+    # Transmission daemon for torrent downloads (flacfetch tracker support)
+    transmission-daemon \
     && rm -rf /var/lib/apt/lists/*
+
+# Configure Transmission for headless operation
+# - Disable authentication (internal use only)
+# - Set download directory to /tmp/downloads
+# - Enable RPC on default port 9091
+RUN mkdir -p /var/lib/transmission-daemon/.config/transmission-daemon /tmp/downloads && \
+    echo '{ \
+        "download-dir": "/tmp/downloads", \
+        "incomplete-dir": "/tmp/downloads/.incomplete", \
+        "incomplete-dir-enabled": true, \
+        "rpc-authentication-required": false, \
+        "rpc-bind-address": "127.0.0.1", \
+        "rpc-enabled": true, \
+        "rpc-port": 9091, \
+        "rpc-whitelist-enabled": false, \
+        "speed-limit-down": 0, \
+        "speed-limit-down-enabled": false, \
+        "speed-limit-up": 0, \
+        "speed-limit-up-enabled": false, \
+        "umask": 2 \
+    }' > /var/lib/transmission-daemon/.config/transmission-daemon/settings.json
 
 # Set working directory
 WORKDIR /app

--- a/backend/api/routes/health.py
+++ b/backend/api/routes/health.py
@@ -1,10 +1,46 @@
 """
 Health check routes.
 """
+import os
+import logging
 from fastapi import APIRouter
-from typing import Dict
+from typing import Dict, Any
+
+from backend.version import VERSION
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+def check_transmission_status() -> Dict[str, Any]:
+    """Check if Transmission daemon is available and responsive."""
+    try:
+        import transmission_rpc
+        host = os.environ.get("TRANSMISSION_HOST", "localhost")
+        port = int(os.environ.get("TRANSMISSION_PORT", "9091"))
+        
+        client = transmission_rpc.Client(host=host, port=port, timeout=5)
+        stats = client.session_stats()
+        
+        return {
+            "available": True,
+            "host": host,
+            "port": port,
+            "download_dir": stats.download_dir if hasattr(stats, 'download_dir') else None,
+            "active_torrent_count": stats.active_torrent_count if hasattr(stats, 'active_torrent_count') else None,
+        }
+    except ImportError as e:
+        return {
+            "available": False,
+            "error": f"transmission_rpc not installed: {e}",
+        }
+    except Exception as e:
+        return {
+            "available": False,
+            "host": os.environ.get("TRANSMISSION_HOST", "localhost"),
+            "port": int(os.environ.get("TRANSMISSION_PORT", "9091")),
+            "error": str(e),
+        }
 
 
 @router.get("/health")
@@ -13,6 +49,31 @@ async def health_check() -> Dict[str, str]:
     return {
         "status": "healthy",
         "service": "karaoke-gen-backend"
+    }
+
+
+@router.get("/health/detailed")
+async def detailed_health_check() -> Dict[str, Any]:
+    """
+    Detailed health check including dependencies.
+    
+    Use this to debug issues with Transmission, etc.
+    """
+    transmission_status = check_transmission_status()
+    
+    # Log for debugging
+    if not transmission_status.get("available"):
+        logger.warning(f"Transmission not available: {transmission_status.get('error')}")
+    else:
+        logger.info(f"Transmission available at {transmission_status.get('host')}:{transmission_status.get('port')}")
+    
+    return {
+        "status": "healthy",
+        "service": "karaoke-gen-backend",
+        "version": VERSION,
+        "dependencies": {
+            "transmission": transmission_status,
+        }
     }
 
 

--- a/karaoke_gen/audio_fetcher.py
+++ b/karaoke_gen/audio_fetcher.py
@@ -270,6 +270,47 @@ class FlacFetchAudioFetcher(AudioFetcher):
         self._ops_api_key = ops_api_key or os.environ.get("OPS_API_KEY")
         self._provider_priority = provider_priority
         self._manager = None
+        self._transmission_available = None  # Cached result of Transmission check
+
+    def _check_transmission_available(self) -> bool:
+        """
+        Check if Transmission daemon is available for torrent downloads.
+        
+        This prevents adding tracker providers (Redacted/OPS) when Transmission
+        isn't running, which would result in search results that can't be downloaded.
+        
+        Returns:
+            True if Transmission is available and responsive, False otherwise.
+        """
+        if self._transmission_available is not None:
+            self.logger.info(f"[Transmission] Using cached status: available={self._transmission_available}")
+            return self._transmission_available
+        
+        host = os.environ.get("TRANSMISSION_HOST", "localhost")
+        port = int(os.environ.get("TRANSMISSION_PORT", "9091"))
+        self.logger.info(f"[Transmission] Checking availability at {host}:{port}")
+        
+        try:
+            import transmission_rpc
+            self.logger.info(f"[Transmission] transmission_rpc imported successfully")
+            
+            client = transmission_rpc.Client(host=host, port=port, timeout=5)
+            self.logger.info(f"[Transmission] Client created, calling session_stats()...")
+            
+            # Simple test to verify connection works
+            stats = client.session_stats()
+            self.logger.info(f"[Transmission] Connected! Download dir: {getattr(stats, 'download_dir', 'unknown')}")
+            
+            self._transmission_available = True
+        except ImportError as e:
+            self._transmission_available = False
+            self.logger.warning(f"[Transmission] transmission_rpc not installed: {e}")
+        except Exception as e:
+            self._transmission_available = False
+            self.logger.warning(f"[Transmission] Connection failed to {host}:{port}: {type(e).__name__}: {e}")
+        
+        self.logger.info(f"[Transmission] Final status: available={self._transmission_available}")
+        return self._transmission_available
 
     def _get_manager(self):
         """Lazily initialize and return the FetchManager."""
@@ -280,30 +321,46 @@ class FlacFetchAudioFetcher(AudioFetcher):
             from flacfetch.downloaders.youtube import YoutubeDownloader
 
             # Try to import TorrentDownloader (has optional dependencies)
+            TorrentDownloader = None
             try:
                 from flacfetch.downloaders.torrent import TorrentDownloader
             except ImportError:
-                TorrentDownloader = None
                 self.logger.debug("TorrentDownloader not available (missing dependencies)")
 
             self._manager = FetchManager()
 
+            # Only add tracker providers if we can actually download from them
+            # This requires both TorrentDownloader and a running Transmission daemon
+            has_torrent_downloader = TorrentDownloader is not None
+            transmission_available = self._check_transmission_available()
+            can_use_trackers = has_torrent_downloader and transmission_available
+            
+            self.logger.info(
+                f"[FlacFetcher] Provider setup: TorrentDownloader={has_torrent_downloader}, "
+                f"Transmission={transmission_available}, can_use_trackers={can_use_trackers}"
+            )
+            
+            if not can_use_trackers and (self._redacted_api_key or self._ops_api_key):
+                self.logger.warning(
+                    "[FlacFetcher] Tracker providers (Redacted/OPS) DISABLED: "
+                    f"TorrentDownloader={has_torrent_downloader}, Transmission={transmission_available}. "
+                    "Only YouTube sources will be used."
+                )
+
             # Add providers and downloaders based on available API keys
-            if self._redacted_api_key:
+            if self._redacted_api_key and can_use_trackers:
                 from flacfetch.providers.redacted import RedactedProvider
 
                 self._manager.add_provider(RedactedProvider(api_key=self._redacted_api_key))
-                if TorrentDownloader:
-                    self._manager.register_downloader("Redacted", TorrentDownloader())
-                self.logger.debug("Added Redacted provider")
+                self._manager.register_downloader("Redacted", TorrentDownloader())
+                self.logger.info("[FlacFetcher] Added Redacted provider with TorrentDownloader")
 
-            if self._ops_api_key:
+            if self._ops_api_key and can_use_trackers:
                 from flacfetch.providers.ops import OPSProvider
 
                 self._manager.add_provider(OPSProvider(api_key=self._ops_api_key))
-                if TorrentDownloader:
-                    self._manager.register_downloader("OPS", TorrentDownloader())
-                self.logger.debug("Added OPS provider")
+                self._manager.register_downloader("OPS", TorrentDownloader())
+                self.logger.info("[FlacFetcher] Added OPS provider with TorrentDownloader")
 
             # Always add YouTube as a fallback provider with its downloader
             self._manager.add_provider(YoutubeProvider())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.73.1"
+version = "0.73.2"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"

--- a/tests/unit/test_audio_fetcher.py
+++ b/tests/unit/test_audio_fetcher.py
@@ -917,17 +917,19 @@ class TestGetManagerIntegration:
         assert "YouTube" in manager._downloader_map, \
             "YouTube downloader must be registered to download from YouTube"
 
-    def test_get_manager_registers_redacted_with_api_key(self):
-        """Test that Redacted provider and downloader are registered when API key is provided."""
+    def test_get_manager_registers_redacted_with_api_key_and_transmission(self):
+        """Test that Redacted provider is registered when API key AND Transmission are available."""
         fetcher = FlacFetchAudioFetcher(redacted_api_key="test_key")
-        manager = fetcher._get_manager()
+        
+        # Mock Transmission as available
+        with patch.object(fetcher, '_check_transmission_available', return_value=True):
+            manager = fetcher._get_manager()
         
         # Verify Redacted provider is registered
         provider_names = [p.name for p in manager.providers]
         assert "Redacted" in provider_names
         
         # Verify Redacted downloader is registered (if TorrentDownloader is available)
-        # Note: TorrentDownloader may not be available in all environments
         try:
             from flacfetch.downloaders.torrent import TorrentDownloader
             assert "Redacted" in manager._downloader_map, \
@@ -936,10 +938,29 @@ class TestGetManagerIntegration:
             # TorrentDownloader not available, which is okay
             pass
 
-    def test_get_manager_registers_ops_with_api_key(self):
-        """Test that OPS provider and downloader are registered when API key is provided."""
+    def test_get_manager_skips_redacted_without_transmission(self):
+        """Test that Redacted provider is NOT registered when Transmission is unavailable."""
+        fetcher = FlacFetchAudioFetcher(redacted_api_key="test_key")
+        
+        # Mock Transmission as unavailable (the default on Cloud Run)
+        with patch.object(fetcher, '_check_transmission_available', return_value=False):
+            manager = fetcher._get_manager()
+        
+        # Verify Redacted provider is NOT registered (can't download from it)
+        provider_names = [p.name for p in manager.providers]
+        assert "Redacted" not in provider_names, \
+            "Redacted provider should NOT be registered when Transmission is unavailable"
+        
+        # YouTube should still be registered
+        assert "YouTube" in provider_names
+
+    def test_get_manager_registers_ops_with_api_key_and_transmission(self):
+        """Test that OPS provider is registered when API key AND Transmission are available."""
         fetcher = FlacFetchAudioFetcher(ops_api_key="test_key")
-        manager = fetcher._get_manager()
+        
+        # Mock Transmission as available
+        with patch.object(fetcher, '_check_transmission_available', return_value=True):
+            manager = fetcher._get_manager()
         
         # Verify OPS provider is registered
         provider_names = [p.name for p in manager.providers]
@@ -953,23 +974,121 @@ class TestGetManagerIntegration:
         except ImportError:
             pass
 
-    def test_get_manager_with_all_providers(self):
-        """Test manager setup with all providers configured."""
+    def test_get_manager_skips_ops_without_transmission(self):
+        """Test that OPS provider is NOT registered when Transmission is unavailable."""
+        fetcher = FlacFetchAudioFetcher(ops_api_key="test_key")
+        
+        # Mock Transmission as unavailable
+        with patch.object(fetcher, '_check_transmission_available', return_value=False):
+            manager = fetcher._get_manager()
+        
+        # Verify OPS provider is NOT registered
+        provider_names = [p.name for p in manager.providers]
+        assert "OPS" not in provider_names, \
+            "OPS provider should NOT be registered when Transmission is unavailable"
+        
+        # YouTube should still be registered
+        assert "YouTube" in provider_names
+
+    def test_get_manager_with_all_providers_and_transmission(self):
+        """Test manager setup with all providers configured when Transmission is available."""
         fetcher = FlacFetchAudioFetcher(
             redacted_api_key="red_key",
             ops_api_key="ops_key",
         )
-        manager = fetcher._get_manager()
+        
+        # Mock Transmission as available
+        with patch.object(fetcher, '_check_transmission_available', return_value=True):
+            manager = fetcher._get_manager()
         
         provider_names = [p.name for p in manager.providers]
         
-        # All three providers should be registered
+        # All three providers should be registered when Transmission is available
         assert "Redacted" in provider_names
         assert "OPS" in provider_names
         assert "YouTube" in provider_names
         
         # YouTube downloader should always be registered
         assert "YouTube" in manager._downloader_map
+
+    def test_get_manager_only_youtube_without_transmission(self):
+        """Test that only YouTube is registered when Transmission is unavailable."""
+        fetcher = FlacFetchAudioFetcher(
+            redacted_api_key="red_key",
+            ops_api_key="ops_key",
+        )
+        
+        # Mock Transmission as unavailable (simulates Cloud Run environment)
+        with patch.object(fetcher, '_check_transmission_available', return_value=False):
+            manager = fetcher._get_manager()
+        
+        provider_names = [p.name for p in manager.providers]
+        
+        # Only YouTube should be registered
+        assert "Redacted" not in provider_names
+        assert "OPS" not in provider_names
+        assert "YouTube" in provider_names
+        
+        # YouTube downloader should always be registered
+        assert "YouTube" in manager._downloader_map
+
+
+class TestTransmissionAvailabilityCheck:
+    """Tests for the Transmission daemon availability check."""
+
+    def test_check_transmission_available_returns_true_when_connected(self):
+        """Test that check returns True when Transmission is responsive."""
+        fetcher = FlacFetchAudioFetcher()
+        
+        mock_client = MagicMock()
+        mock_client.session_stats.return_value = {}  # Successful response
+        
+        with patch('transmission_rpc.Client', return_value=mock_client):
+            result = fetcher._check_transmission_available()
+        
+        assert result is True
+        # Result should be cached
+        assert fetcher._transmission_available is True
+
+    def test_check_transmission_available_returns_false_on_connection_error(self):
+        """Test that check returns False when Transmission connection fails."""
+        fetcher = FlacFetchAudioFetcher()
+        
+        with patch('transmission_rpc.Client', side_effect=Exception("Cannot connect")):
+            result = fetcher._check_transmission_available()
+        
+        assert result is False
+        # Result should be cached
+        assert fetcher._transmission_available is False
+
+    def test_check_transmission_available_caches_result(self):
+        """Test that Transmission availability is only checked once."""
+        fetcher = FlacFetchAudioFetcher()
+        
+        mock_client = MagicMock()
+        
+        with patch('transmission_rpc.Client', return_value=mock_client) as mock_constructor:
+            # First call - should connect
+            result1 = fetcher._check_transmission_available()
+            # Second call - should use cache
+            result2 = fetcher._check_transmission_available()
+        
+        # Should only create client once (cached after first call)
+        assert mock_constructor.call_count == 1
+        assert result1 == result2
+
+    def test_check_transmission_uses_environment_variables(self):
+        """Test that Transmission host/port can be configured via env vars."""
+        fetcher = FlacFetchAudioFetcher()
+        
+        mock_client = MagicMock()
+        
+        with patch.dict(os.environ, {'TRANSMISSION_HOST': 'custom-host', 'TRANSMISSION_PORT': '9999'}):
+            with patch('transmission_rpc.Client', return_value=mock_client) as mock_constructor:
+                fetcher._check_transmission_available()
+        
+        # Verify custom host/port were used
+        mock_constructor.assert_called_once_with(host='custom-host', port=9999, timeout=5)
 
 
 class TestFlacFetchReleaseModelCompatibility:


### PR DESCRIPTION
- Install transmission-daemon in base Docker image
- Add startup script to launch Transmission before uvicorn
- Add _check_transmission_available() to only enable tracker providers when Transmission is actually available (graceful fallback to YouTube)
- Add /api/health/detailed endpoint to check Transmission status
- Add comprehensive tests for Transmission availability checking
- Bump version to 0.73.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed health check endpoint exposing Transmission daemon status and dependency information.

* **Chores**
  * Version bumped to 0.73.2.
  * Improved application startup with Transmission daemon initialization and pre-configured settings.
  * Enhanced provider availability logic with environment-based health checks and graceful fallback to YouTube when unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->