### PR TITLE
Fix Unicode character encoding bug in filename sanitization

### DIFF
--- a/backend/workers/audio_worker.py
+++ b/backend/workers/audio_worker.py
@@ -405,10 +405,14 @@ async def download_audio(
         Path to downloaded audio file, or None if failed
     """
     try:
+        from karaoke_gen.utils import sanitize_filename
+
         # Case 1: File was uploaded to GCS
         if job.input_media_gcs_path:
             logger.info(f"Job {job_id}: Downloading uploaded file from GCS: {job.input_media_gcs_path}")
-            local_path = os.path.join(temp_dir, job.filename or "input.flac")
+            # Sanitize filename to handle Unicode chars that cause HTTP header encoding issues
+            safe_filename = sanitize_filename(job.filename) if job.filename else "input.flac"
+            local_path = os.path.join(temp_dir, safe_filename)
             storage.download_file(job.input_media_gcs_path, local_path)
             logger.info(f"Job {job_id}: Downloaded uploaded file to {local_path}")
             return local_path

--- a/karaoke_gen/utils/__init__.py
+++ b/karaoke_gen/utils/__init__.py
@@ -1,9 +1,35 @@
 import re
 
+# Unicode character replacements for ASCII-safe filenames
+# These characters cause issues with HTTP headers (latin-1 encoding) and some filesystems
+UNICODE_REPLACEMENTS = {
+    # Curly/smart quotes -> straight quotes
+    "\u2018": "'",  # LEFT SINGLE QUOTATION MARK
+    "\u2019": "'",  # RIGHT SINGLE QUOTATION MARK (the one causing the bug)
+    "\u201A": "'",  # SINGLE LOW-9 QUOTATION MARK
+    "\u201B": "'",  # SINGLE HIGH-REVERSED-9 QUOTATION MARK
+    "\u201C": '"',  # LEFT DOUBLE QUOTATION MARK
+    "\u201D": '"',  # RIGHT DOUBLE QUOTATION MARK
+    "\u201E": '"',  # DOUBLE LOW-9 QUOTATION MARK
+    "\u201F": '"',  # DOUBLE HIGH-REVERSED-9 QUOTATION MARK
+    # Other common problematic characters
+    "\u2013": "-",  # EN DASH
+    "\u2014": "-",  # EM DASH
+    "\u2026": "...",  # HORIZONTAL ELLIPSIS
+    "\u00A0": " ",  # NON-BREAKING SPACE
+}
+
+
 def sanitize_filename(filename):
     """Replace or remove characters that are unsafe for filenames."""
     if filename is None:
         return None
+
+    # First, normalize Unicode characters that cause HTTP header encoding issues
+    # (e.g., curly quotes from macOS/Word that can't be encoded in latin-1)
+    for unicode_char, ascii_replacement in UNICODE_REPLACEMENTS.items():
+        filename = filename.replace(unicode_char, ascii_replacement)
+
     # Replace problematic characters with underscores
     for char in ["\\", "/", ":", "*", "?", '"', "<", ">", "|"]:
         filename = filename.replace(char, "_")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.75.58"
+version = "0.75.59"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Fixes job failures when filenames contain Unicode characters like curly quotes (e.g., "Can't" with U+2019)
- The audio-separator Modal API requires latin-1 encoded HTTP headers, which can't represent these characters
- Added Unicode normalization to `sanitize_filename()` that converts problematic characters to ASCII equivalents

## Changes Made
- **karaoke_gen/utils/__init__.py**: Added `UNICODE_REPLACEMENTS` dictionary mapping curly quotes, smart quotes, en/em dashes, ellipsis, and non-breaking spaces to ASCII equivalents. Updated `sanitize_filename()` to apply these replacements.
- **backend/workers/audio_worker.py**: Applied `sanitize_filename()` to uploaded filenames before downloading from GCS, ensuring safe filenames are passed to the audio separation API.

## Test plan
- [x] All unit tests pass (739 passed)
- [x] E2E emulator tests pass (57 passed)
- [ ] Manual test: Upload a file with curly quotes in the filename via karaoke-gen-remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file handling to properly process special and Unicode characters in downloaded audio filenames, preventing encoding errors and system compatibility issues.

* **Chores**
  * Version bump to 0.75.59.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->