### PR TITLE
Fix countdown serverless detection to include Cloud Run

### DIFF
--- a/karaoke_gen/lyrics_processor.py
+++ b/karaoke_gen/lyrics_processor.py
@@ -364,12 +364,16 @@ class LyricsProcessor:
         self.logger.info(f"  rapidapi_key: {env_config.get('rapidapi_key')[:3] + '...' if env_config.get('rapidapi_key') else 'None'}")
         self.logger.info(f"  lyrics_file: {self.lyrics_file}")
 
-        # Detect if we're running in a serverless environment (Modal)
-        # Modal sets specific environment variables we can check for
+        # Detect if we're running in a serverless/cloud environment (Modal or Cloud Run)
+        # In these environments, we defer countdown processing to Phase 2 (render_video_worker)
+        # so the review UI shows the original timing without the 3s shift
         is_serverless = (
-            os.getenv("MODAL_TASK_ID") is not None or 
+            # Modal environment detection
+            os.getenv("MODAL_TASK_ID") is not None or
             os.getenv("MODAL_FUNCTION_NAME") is not None or
-            os.path.exists("/.modal")  # Modal creates this directory in containers
+            os.path.exists("/.modal") or  # Modal creates this directory in containers
+            # Cloud Run environment detection
+            os.getenv("K_SERVICE") is not None  # Cloud Run always sets this
         )
         
         # In serverless environment, disable interactive review even if skip_transcription_review=False
@@ -377,17 +381,17 @@ class LyricsProcessor:
         enable_review_setting = not self.skip_transcription_review and not is_serverless
         
         if is_serverless and not self.skip_transcription_review:
-            self.logger.info("Detected serverless environment - disabling interactive review to prevent hanging")
+            self.logger.info("Detected cloud environment (Modal/Cloud Run) - disabling interactive review to prevent hanging")
         
         # In serverless environment, disable video generation during Phase 1 to save compute
         # Video will be generated in Phase 2 after human review
         serverless_render_video = render_video and not is_serverless
         
         if is_serverless and render_video:
-            self.logger.info("Detected serverless environment - deferring video generation until after review")
+            self.logger.info("Detected cloud environment (Modal/Cloud Run) - deferring video generation until after review")
 
         if is_serverless:
-            self.logger.info("Detected serverless environment - deferring countdown processing until after review")
+            self.logger.info("Detected cloud environment (Modal/Cloud Run) - deferring countdown processing until after review")
 
         output_config = OutputConfig(
             output_styles_json=self.style_params_json,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.76.2"
+version = "0.76.3"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Fixes countdown/lyrics sync mismatch in the review UI for Cloud Run deployments
- Adds Cloud Run environment detection (`K_SERVICE`) to `is_serverless` check in `lyrics_processor.py`
- Ensures countdown is deferred to Phase 2 (render_video_worker) when running on Cloud Run

## Root Cause
The `is_serverless` detection in `lyrics_processor.py` only checked for Modal environment variables:
- `MODAL_TASK_ID`
- `MODAL_FUNCTION_NAME`
- `/.modal` directory

However, the backend runs on Cloud Run, which sets `K_SERVICE` instead. This caused:
1. Countdown being added during Phase 1 (lyrics_worker)
2. A 3-second sync mismatch between lyrics and audio in the review UI
3. Users seeing "3... 2... 1..." countdown in review instead of original timing

## Changes Made
- Added `K_SERVICE` environment variable check to detect Cloud Run
- Updated log messages from "serverless environment" to "cloud environment (Modal/Cloud Run)" for clarity
- Bumped version to 0.76.3

## Testing
- All unit and backend tests pass (`make test`)
- Fix verified against the documented expected behavior in COUNTDOWN-PADDING.md

## Related Issues
This regression was introduced when the v0.76.1 fix only addressed Modal but not Cloud Run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded cloud environment detection to support Cloud Run platforms, ensuring proper handling of countdown processing and video rendering across additional cloud environments.

* **Chores**
  * Version bumped to 0.76.3.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->