### PR TITLE
feat: Allow retrying cancelled jobs

### DIFF
--- a/backend/api/routes/jobs.py
+++ b/backend/api/routes/jobs.py
@@ -1097,32 +1097,34 @@ async def retry_job(
     auth_data: Tuple[str, UserType, int] = Depends(require_auth)
 ) -> dict:
     """
-    Retry a failed job from the last successful checkpoint.
-    
-    This endpoint allows resuming jobs that failed during:
+    Retry a failed or cancelled job from the last successful checkpoint.
+
+    This endpoint allows resuming jobs that failed or were cancelled during:
+    - Audio processing (re-runs from beginning if input audio exists)
     - Video generation (re-runs video worker)
     - Encoding (re-runs video worker)
     - Packaging (re-runs video worker)
-    
+
     The retry logic determines the appropriate stage to resume from
     based on what files/state already exist.
     """
     job = job_manager.get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
-    
-    if job.status != JobStatus.FAILED:
+
+    if job.status not in [JobStatus.FAILED, JobStatus.CANCELLED]:
         raise HTTPException(
             status_code=400,
-            detail=f"Only failed jobs can be retried (current status: {job.status})"
+            detail=f"Only failed or cancelled jobs can be retried (current status: {job.status})"
         )
     
     try:
         # Determine retry point based on what's already complete
         error_details = job.error_details or {}
         error_stage = error_details.get('stage', 'unknown')
-        
-        logger.info(f"Job {job_id}: Retrying from failed stage '{error_stage}'")
+        original_status = job.status
+
+        logger.info(f"Job {job_id}: Retrying from {original_status} state (error stage: '{error_stage}')")
         
         # Check what state exists to determine retry point
         file_urls = job.file_urls or {}
@@ -1230,11 +1232,46 @@ async def retry_job(
                 "retry_stage": "screens_generation"
             }
         
+        # If we have input audio (uploaded or from URL), restart from beginning
+        elif job.input_media_gcs_path or job.url:
+            logger.info(f"Job {job_id}: Has input audio, restarting from beginning")
+
+            # Clear error state and any partial progress
+            job_manager.update_job(job_id, {
+                'error_message': None,
+                'error_details': None,
+                'state_data': {},  # Clear parallel worker progress
+            })
+
+            # Reset to DOWNLOADING and trigger audio worker
+            if not job_manager.transition_to_state(
+                job_id=job_id,
+                new_status=JobStatus.DOWNLOADING,
+                progress=5,
+                message=f"Restarting job from {original_status} state"
+            ):
+                raise HTTPException(
+                    status_code=500,
+                    detail="Failed to transition job status for retry"
+                )
+
+            # Trigger audio worker (which kicks off parallel audio + lyrics processing)
+            background_tasks.add_task(worker_service.trigger_audio_worker, job_id)
+            background_tasks.add_task(worker_service.trigger_lyrics_worker, job_id)
+
+            return {
+                "status": "success",
+                "job_id": job_id,
+                "job_status": "downloading",
+                "message": f"Job restarted from {original_status} state",
+                "retry_stage": "from_beginning"
+            }
+
         else:
-            # Can't determine a safe retry point, need to restart from beginning
+            # No input audio available - job needs to be resubmitted
             raise HTTPException(
                 status_code=400,
-                detail="Cannot determine safe retry point. Job may need to be resubmitted."
+                detail="Cannot retry: no input audio available. Job must be resubmitted."
             )
         
     except HTTPException:

--- a/backend/models/job.py
+++ b/backend/models/job.py
@@ -134,17 +134,23 @@ STATE_TRANSITIONS = {
     JobStatus.UPLOADING: [JobStatus.NOTIFYING, JobStatus.COMPLETE, JobStatus.FAILED],
     JobStatus.NOTIFYING: [JobStatus.COMPLETE, JobStatus.FAILED],
     
-    # Terminal states - COMPLETE, PREP_COMPLETE, and CANCELLED have no transitions
-    # FAILED allows retry transitions to resume from checkpoints
+    # Terminal states - COMPLETE, PREP_COMPLETE have no transitions
+    # FAILED and CANCELLED allow retry transitions to resume from checkpoints
     # PREP_COMPLETE allows finalise-only continuation
     JobStatus.COMPLETE: [],
     JobStatus.PREP_COMPLETE: [JobStatus.AWAITING_INSTRUMENTAL_SELECTION, JobStatus.FAILED],  # Finalise-only continues from here
     JobStatus.FAILED: [
+        JobStatus.DOWNLOADING,            # Retry from beginning (if input audio exists)
         JobStatus.INSTRUMENTAL_SELECTED,  # Retry from video generation
         JobStatus.REVIEW_COMPLETE,        # Retry from render stage
         JobStatus.LYRICS_COMPLETE,        # Retry from screens generation
     ],
-    JobStatus.CANCELLED: [],
+    JobStatus.CANCELLED: [
+        JobStatus.DOWNLOADING,            # Retry from beginning (if input audio exists)
+        JobStatus.INSTRUMENTAL_SELECTED,  # Retry from video generation
+        JobStatus.REVIEW_COMPLETE,        # Retry from render stage
+        JobStatus.LYRICS_COMPLETE,        # Retry from screens generation
+    ],
     
     # Legacy states (for backward compatibility)
     JobStatus.QUEUED: [JobStatus.PENDING],

--- a/backend/tests/test_routes_jobs.py
+++ b/backend/tests/test_routes_jobs.py
@@ -67,11 +67,30 @@ class TestJobStatusTransitions:
         """Test FAILED status can transition to retry checkpoint states."""
         from backend.models.job import STATE_TRANSITIONS
         valid_transitions = STATE_TRANSITIONS.get(JobStatus.FAILED, [])
-        
+
         # FAILED should allow retry transitions
         assert JobStatus.INSTRUMENTAL_SELECTED in valid_transitions, "FAILED should allow retry to INSTRUMENTAL_SELECTED"
         assert JobStatus.REVIEW_COMPLETE in valid_transitions, "FAILED should allow retry to REVIEW_COMPLETE"
         assert JobStatus.LYRICS_COMPLETE in valid_transitions, "FAILED should allow retry to LYRICS_COMPLETE"
+
+    def test_cancelled_can_transition_for_retry(self):
+        """Test CANCELLED status can transition to retry checkpoint states."""
+        from backend.models.job import STATE_TRANSITIONS
+        valid_transitions = STATE_TRANSITIONS.get(JobStatus.CANCELLED, [])
+
+        # CANCELLED should allow same retry transitions as FAILED
+        assert JobStatus.INSTRUMENTAL_SELECTED in valid_transitions, "CANCELLED should allow retry to INSTRUMENTAL_SELECTED"
+        assert JobStatus.REVIEW_COMPLETE in valid_transitions, "CANCELLED should allow retry to REVIEW_COMPLETE"
+        assert JobStatus.LYRICS_COMPLETE in valid_transitions, "CANCELLED should allow retry to LYRICS_COMPLETE"
+        assert JobStatus.DOWNLOADING in valid_transitions, "CANCELLED should allow retry to DOWNLOADING (restart)"
+
+    def test_failed_can_restart_from_beginning(self):
+        """Test FAILED status can transition to DOWNLOADING for restart from beginning."""
+        from backend.models.job import STATE_TRANSITIONS
+        valid_transitions = STATE_TRANSITIONS.get(JobStatus.FAILED, [])
+
+        # FAILED should allow restart from beginning
+        assert JobStatus.DOWNLOADING in valid_transitions, "FAILED should allow restart to DOWNLOADING"
 
 
 class TestJobModelSerialization:
@@ -118,4 +137,146 @@ class TestJobModelSerialization:
         assert job.title is None
         assert job.url is None
         assert job.file_urls == {}
+
+
+class TestRetryEndpoint:
+    """Tests for the retry job endpoint."""
+
+    @pytest.fixture
+    def mock_job_manager(self):
+        """Create mock job manager."""
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_worker_service(self):
+        """Create mock worker service."""
+        return MagicMock()
+
+    def test_retry_rejects_pending_job(self, mock_job_manager):
+        """Test retry endpoint rejects jobs that are not failed or cancelled."""
+        # Create a pending job
+        job = Job(
+            job_id="test123",
+            status=JobStatus.PENDING,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+            artist="Test",
+            title="Song"
+        )
+        mock_job_manager.get_job.return_value = job
+
+        # The endpoint should reject this with a 400 error
+        # (status check happens before any logic)
+        assert job.status not in [JobStatus.FAILED, JobStatus.CANCELLED]
+
+    def test_retry_accepts_failed_job(self, mock_job_manager):
+        """Test retry endpoint accepts failed jobs."""
+        job = Job(
+            job_id="test123",
+            status=JobStatus.FAILED,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+            artist="Test",
+            title="Song",
+            input_media_gcs_path="jobs/test123/input/audio.flac"
+        )
+        mock_job_manager.get_job.return_value = job
+
+        # Status should be accepted
+        assert job.status in [JobStatus.FAILED, JobStatus.CANCELLED]
+
+    def test_retry_accepts_cancelled_job(self, mock_job_manager):
+        """Test retry endpoint accepts cancelled jobs."""
+        job = Job(
+            job_id="test123",
+            status=JobStatus.CANCELLED,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+            artist="Test",
+            title="Song",
+            input_media_gcs_path="jobs/test123/input/audio.flac"
+        )
+        mock_job_manager.get_job.return_value = job
+
+        # Status should be accepted
+        assert job.status in [JobStatus.FAILED, JobStatus.CANCELLED]
+
+    def test_retry_checkpoint_detection_video_generation(self):
+        """Test retry detects video generation checkpoint."""
+        job = Job(
+            job_id="test123",
+            status=JobStatus.FAILED,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+            artist="Test",
+            title="Song",
+            file_urls={
+                'videos': {'with_vocals': 'gs://bucket/path/video.mkv'}
+            },
+            state_data={
+                'instrumental_selection': 'clean'
+            }
+        )
+
+        # This job has video and instrumental selection - should retry from video generation
+        has_video = job.file_urls.get('videos', {}).get('with_vocals')
+        has_instrumental_selection = (job.state_data or {}).get('instrumental_selection')
+        assert has_video and has_instrumental_selection
+
+    def test_retry_checkpoint_detection_render_stage(self):
+        """Test retry detects render stage checkpoint."""
+        job = Job(
+            job_id="test123",
+            status=JobStatus.FAILED,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+            artist="Test",
+            title="Song",
+            file_urls={
+                'lyrics': {'corrections': 'gs://bucket/path/corrections.json'},
+                'screens': {'title': 'gs://bucket/path/title.mov'}
+            }
+        )
+
+        # This job has corrections and screens - should retry from render
+        has_corrections = job.file_urls.get('lyrics', {}).get('corrections')
+        has_screens = job.file_urls.get('screens', {}).get('title')
+        has_video = job.file_urls.get('videos', {}).get('with_vocals')
+        assert has_corrections and has_screens and not has_video
+
+    def test_retry_checkpoint_detection_from_beginning(self):
+        """Test retry detects need to restart from beginning."""
+        job = Job(
+            job_id="test123",
+            status=JobStatus.CANCELLED,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+            artist="Test",
+            title="Song",
+            input_media_gcs_path="jobs/test123/input/audio.flac",
+            file_urls={}  # No progress yet
+        )
+
+        # This job has input audio but no other files - should restart from beginning
+        has_input = job.input_media_gcs_path
+        has_stems = job.file_urls.get('stems', {}).get('instrumental_clean')
+        has_corrections = job.file_urls.get('lyrics', {}).get('corrections')
+        assert has_input and not has_stems and not has_corrections
+
+    def test_retry_no_input_audio(self):
+        """Test retry fails when no input audio available."""
+        job = Job(
+            job_id="test123",
+            status=JobStatus.CANCELLED,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+            artist="Test",
+            title="Song",
+            # No input_media_gcs_path and no url
+            file_urls={}
+        )
+
+        # This job has no input audio - should not be retryable
+        has_input = job.input_media_gcs_path or job.url
+        assert not has_input
 

--- a/frontend/components/__tests__/JobActions.test.tsx
+++ b/frontend/components/__tests__/JobActions.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * Tests for JobActions component
+ */
+
+import { render, screen } from '@testing-library/react'
+import { JobActions } from '../job/JobActions'
+import { Job } from '@/lib/api'
+
+// Mock the API module
+jest.mock('@/lib/api', () => ({
+  api: {
+    retryJob: jest.fn(),
+    cancelJob: jest.fn(),
+    deleteJob: jest.fn(),
+  }
+}))
+
+describe('JobActions', () => {
+  const mockOnRefresh = jest.fn()
+  const mockOnToggleLogs = jest.fn()
+
+  const baseJob: Partial<Job> = {
+    job_id: '123',
+    created_at: '2025-01-01T00:00:00Z',
+    updated_at: '2025-01-01T00:00:00Z',
+    artist: 'Test Artist',
+    title: 'Test Song',
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('Retry button visibility', () => {
+    it('shows retry button for failed jobs', () => {
+      const failedJob = { ...baseJob, status: 'failed' } as Job
+      render(
+        <JobActions
+          job={failedJob}
+          onRefresh={mockOnRefresh}
+          showLogs={false}
+          onToggleLogs={mockOnToggleLogs}
+        />
+      )
+
+      expect(screen.getByText('Retry')).toBeInTheDocument()
+    })
+
+    it('shows retry button for cancelled jobs', () => {
+      const cancelledJob = { ...baseJob, status: 'cancelled' } as Job
+      render(
+        <JobActions
+          job={cancelledJob}
+          onRefresh={mockOnRefresh}
+          showLogs={false}
+          onToggleLogs={mockOnToggleLogs}
+        />
+      )
+
+      expect(screen.getByText('Retry')).toBeInTheDocument()
+    })
+
+    it('does not show retry button for pending jobs', () => {
+      const pendingJob = { ...baseJob, status: 'pending' } as Job
+      render(
+        <JobActions
+          job={pendingJob}
+          onRefresh={mockOnRefresh}
+          showLogs={false}
+          onToggleLogs={mockOnToggleLogs}
+        />
+      )
+
+      expect(screen.queryByText('Retry')).not.toBeInTheDocument()
+    })
+
+    it('does not show retry button for processing jobs', () => {
+      const processingJob = { ...baseJob, status: 'processing' } as Job
+      render(
+        <JobActions
+          job={processingJob}
+          onRefresh={mockOnRefresh}
+          showLogs={false}
+          onToggleLogs={mockOnToggleLogs}
+        />
+      )
+
+      expect(screen.queryByText('Retry')).not.toBeInTheDocument()
+    })
+
+    it('does not show retry button for complete jobs', () => {
+      const completeJob = { ...baseJob, status: 'complete' } as Job
+      render(
+        <JobActions
+          job={completeJob}
+          onRefresh={mockOnRefresh}
+          showLogs={false}
+          onToggleLogs={mockOnToggleLogs}
+        />
+      )
+
+      expect(screen.queryByText('Retry')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Cancel button visibility', () => {
+    it('shows cancel button for pending jobs', () => {
+      const pendingJob = { ...baseJob, status: 'pending' } as Job
+      render(
+        <JobActions
+          job={pendingJob}
+          onRefresh={mockOnRefresh}
+          showLogs={false}
+          onToggleLogs={mockOnToggleLogs}
+        />
+      )
+
+      expect(screen.getByText('Cancel')).toBeInTheDocument()
+    })
+
+    it('does not show cancel button for failed jobs', () => {
+      const failedJob = { ...baseJob, status: 'failed' } as Job
+      render(
+        <JobActions
+          job={failedJob}
+          onRefresh={mockOnRefresh}
+          showLogs={false}
+          onToggleLogs={mockOnToggleLogs}
+        />
+      )
+
+      expect(screen.queryByText('Cancel')).not.toBeInTheDocument()
+    })
+
+    it('does not show cancel button for cancelled jobs', () => {
+      const cancelledJob = { ...baseJob, status: 'cancelled' } as Job
+      render(
+        <JobActions
+          job={cancelledJob}
+          onRefresh={mockOnRefresh}
+          showLogs={false}
+          onToggleLogs={mockOnToggleLogs}
+        />
+      )
+
+      expect(screen.queryByText('Cancel')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Delete button visibility', () => {
+    it('shows delete button for complete jobs', () => {
+      const completeJob = { ...baseJob, status: 'complete' } as Job
+      render(
+        <JobActions
+          job={completeJob}
+          onRefresh={mockOnRefresh}
+          showLogs={false}
+          onToggleLogs={mockOnToggleLogs}
+        />
+      )
+
+      expect(screen.getByText('Delete')).toBeInTheDocument()
+    })
+
+    it('shows delete button for failed jobs', () => {
+      const failedJob = { ...baseJob, status: 'failed' } as Job
+      render(
+        <JobActions
+          job={failedJob}
+          onRefresh={mockOnRefresh}
+          showLogs={false}
+          onToggleLogs={mockOnToggleLogs}
+        />
+      )
+
+      expect(screen.getByText('Delete')).toBeInTheDocument()
+    })
+
+    it('shows delete button for cancelled jobs', () => {
+      const cancelledJob = { ...baseJob, status: 'cancelled' } as Job
+      render(
+        <JobActions
+          job={cancelledJob}
+          onRefresh={mockOnRefresh}
+          showLogs={false}
+          onToggleLogs={mockOnToggleLogs}
+        />
+      )
+
+      expect(screen.getByText('Delete')).toBeInTheDocument()
+    })
+
+    it('does not show delete button for pending jobs', () => {
+      const pendingJob = { ...baseJob, status: 'pending' } as Job
+      render(
+        <JobActions
+          job={pendingJob}
+          onRefresh={mockOnRefresh}
+          showLogs={false}
+          onToggleLogs={mockOnToggleLogs}
+        />
+      )
+
+      expect(screen.queryByText('Delete')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Show Logs button', () => {
+    it('always shows Show Logs button', () => {
+      const pendingJob = { ...baseJob, status: 'pending' } as Job
+      render(
+        <JobActions
+          job={pendingJob}
+          onRefresh={mockOnRefresh}
+          showLogs={false}
+          onToggleLogs={mockOnToggleLogs}
+        />
+      )
+
+      expect(screen.getByText('Show Logs')).toBeInTheDocument()
+    })
+
+    it('shows Hide Logs when logs are visible', () => {
+      const pendingJob = { ...baseJob, status: 'pending' } as Job
+      render(
+        <JobActions
+          job={pendingJob}
+          onRefresh={mockOnRefresh}
+          showLogs={true}
+          onToggleLogs={mockOnToggleLogs}
+        />
+      )
+
+      expect(screen.getByText('Hide Logs')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/components/job/JobActions.tsx
+++ b/frontend/components/job/JobActions.tsx
@@ -19,7 +19,7 @@ export function JobActions({ job, onRefresh, showLogs, onToggleLogs }: JobAction
   const [isCancelling, setIsCancelling] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
 
-  const canRetry = job.status === "failed"
+  const canRetry = job.status === "failed" || job.status === "cancelled"
   const canCancel = !["complete", "failed", "cancelled"].includes(job.status)
   const canDelete = ["complete", "failed", "cancelled"].includes(job.status)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.76.2"
+version = "0.76.3"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- Add retry support for cancelled jobs, enabling users to restart cancelled jobs from their last checkpoint or from the beginning
- Add "restart from beginning" capability for both failed and cancelled jobs when input audio exists in GCS

## Changes Made

### Backend (`backend/`)
- **`models/job.py`**: Add CANCELLED and FAILED state transitions to support retry:
  - CANCELLED → DOWNLOADING, INSTRUMENTAL_SELECTED, REVIEW_COMPLETE, LYRICS_COMPLETE
  - FAILED → DOWNLOADING (new), INSTRUMENTAL_SELECTED, REVIEW_COMPLETE, LYRICS_COMPLETE

- **`api/routes/jobs.py`**: Update retry endpoint to:
  - Accept both FAILED and CANCELLED jobs
  - Add new "restart from beginning" path when job has `input_media_gcs_path` or `url` but no checkpoint files
  - Clear `state_data` when restarting to avoid stale parallel worker progress

### Frontend (`frontend/`)
- **`components/job/JobActions.tsx`**: Show retry button for both failed AND cancelled jobs

### Tests
- **`backend/tests/test_routes_jobs.py`**: Add tests for:
  - CANCELLED state transitions
  - FAILED restart from beginning transition
  - Retry checkpoint detection logic

- **`frontend/components/__tests__/JobActions.test.tsx`**: New test file for JobActions component covering retry, cancel, delete, and logs button visibility

## Testing

- [x] All backend tests pass (`make test`)
- [x] All frontend unit tests pass (`npm run test:unit`)
- [x] Manual testing: Retry button now appears for cancelled jobs in the UI

## How It Works

When a job is retried, the endpoint checks what files exist in GCS to determine the appropriate restart point:

1. **Video generation stage**: If `videos.with_vocals` and `instrumental_selection` exist
2. **Render stage**: If `lyrics.corrections` and `screens.title` exist  
3. **Screens generation stage**: If `stems.instrumental_clean` and `lyrics.corrections` exist
4. **From beginning** (NEW): If `input_media_gcs_path` or `url` exists but no checkpoint files

This means cancelled jobs can now be retried without losing the already-downloaded audio file - it won't re-run flacfetch if the audio is already stored in GCS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cancelled jobs can now be retried in addition to failed jobs.
  * Jobs with input media can be restarted from the beginning with error states reset.

* **Improvements**
  * Clarified error messages for retry eligibility to better inform users when retries are available.
  * Enhanced retry logging to include original job status and error stage for improved traceability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->