### PR TITLE
Enable YouTube upload by default for web service jobs

### DIFF
--- a/backend/api/routes/audio_search.py
+++ b/backend/api/routes/audio_search.py
@@ -424,12 +424,17 @@ async def search_audio(
         effective_dropbox_path = body.dropbox_path or settings.default_dropbox_path
         effective_gdrive_folder_id = body.gdrive_folder_id or settings.default_gdrive_folder_id
         effective_discord_webhook_url = body.discord_webhook_url or settings.default_discord_webhook_url
-        
+
+        # Apply defaults for YouTube/Dropbox distribution (for web service)
+        effective_enable_youtube_upload = body.enable_youtube_upload or settings.default_enable_youtube_upload
+        effective_brand_prefix = body.brand_prefix or settings.default_brand_prefix
+        effective_youtube_description = body.youtube_description or settings.default_youtube_description
+
         # Validate credentials if distribution services are requested
         invalid_services = []
         credential_manager = get_credential_manager()
-        
-        if body.enable_youtube_upload:
+
+        if effective_enable_youtube_upload:
             result = credential_manager.check_youtube_credentials()
             if result.status != CredentialStatus.VALID:
                 invalid_services.append(f"youtube ({result.message})")
@@ -463,10 +468,10 @@ async def search_audio(
             title=body.title,
             enable_cdg=body.enable_cdg,
             enable_txt=body.enable_txt,
-            brand_prefix=body.brand_prefix,
-            enable_youtube_upload=body.enable_youtube_upload,
-            youtube_description=body.youtube_description,
-            youtube_description_template=body.youtube_description,  # video_worker reads this field
+            brand_prefix=effective_brand_prefix,
+            enable_youtube_upload=effective_enable_youtube_upload,
+            youtube_description=effective_youtube_description,
+            youtube_description_template=effective_youtube_description,  # video_worker reads this field
             discord_webhook_url=effective_discord_webhook_url,
             dropbox_path=effective_dropbox_path,
             gdrive_folder_id=effective_gdrive_folder_id,

--- a/backend/config.py
+++ b/backend/config.py
@@ -69,6 +69,16 @@ class Settings(BaseSettings):
     default_discord_webhook_url: Optional[str] = (
         os.getenv("DEFAULT_DISCORD_WEBHOOK_URL", "").strip() or None
     )
+
+    # Default values for web service jobs (YouTube/Dropbox distribution)
+    default_enable_youtube_upload: bool = os.getenv("DEFAULT_ENABLE_YOUTUBE_UPLOAD", "false").lower() in ("true", "1", "yes")
+    default_brand_prefix: Optional[str] = os.getenv("DEFAULT_BRAND_PREFIX")
+    default_youtube_description: str = os.getenv(
+        "DEFAULT_YOUTUBE_DESCRIPTION",
+        "Karaoke video created with Nomad Karaoke (https://nomadkaraoke.com)\n\n"
+        "AI-powered vocal separation and synchronized lyrics.\n\n"
+        "#karaoke #music #singing #instrumental #lyrics"
+    )
     
     # Secret Manager cache
     _secret_cache: Dict[str, str] = {}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -75,7 +75,7 @@ steps:
           --concurrency 1 \
           --max-instances 50 \
           --min-instances 0 \
-          --set-env-vars "GOOGLE_CLOUD_PROJECT=$PROJECT_ID,GCS_BUCKET_NAME=karaoke-gen-storage-$PROJECT_ID,FIRESTORE_COLLECTION=jobs,ENVIRONMENT=production,AUDIO_SEPARATOR_API_URL=https://nomadkaraoke--audio-separator-api.modal.run,KARAOKE_GEN_VERSION=$$VERSION,DEFAULT_DROPBOX_PATH=/MediaUnsynced/Karaoke/Tracks-Organized,DEFAULT_GDRIVE_FOLDER_ID=1laRKAyxo0v817SstfM5XkpbWiNKNAMSX,ENABLE_CLOUD_TASKS=true,CLOUD_RUN_SERVICE_URL=https://api.nomadkaraoke.com,GCP_REGION=us-central1" \
+          --set-env-vars "GOOGLE_CLOUD_PROJECT=$PROJECT_ID,GCS_BUCKET_NAME=karaoke-gen-storage-$PROJECT_ID,FIRESTORE_COLLECTION=jobs,ENVIRONMENT=production,AUDIO_SEPARATOR_API_URL=https://nomadkaraoke--audio-separator-api.modal.run,KARAOKE_GEN_VERSION=$$VERSION,DEFAULT_DROPBOX_PATH=/MediaUnsynced/Karaoke/Tracks-Organized,DEFAULT_GDRIVE_FOLDER_ID=1laRKAyxo0v817SstfM5XkpbWiNKNAMSX,ENABLE_CLOUD_TASKS=true,CLOUD_RUN_SERVICE_URL=https://api.nomadkaraoke.com,GCP_REGION=us-central1,DEFAULT_ENABLE_YOUTUBE_UPLOAD=true,DEFAULT_BRAND_PREFIX=NOMAD" \
           --set-secrets "AUDIOSHAKE_API_TOKEN=audioshake-api-key:latest,GENIUS_API_TOKEN=genius-api-key:latest,SPOTIFY_COOKIE_SP_DC=spotify-cookie:latest,RAPIDAPI_KEY=rapidapi-key:latest,DEFAULT_DISCORD_WEBHOOK_URL=discord-releases-webhook:latest,ADMIN_TOKENS=admin-tokens:latest,RED_API_KEY=red-api-key:latest,RED_API_URL=red-api-url:latest,OPS_API_KEY=ops-api-key:latest,OPS_API_URL=ops-api-url:latest,FLACFETCH_API_URL=flacfetch-api-url:latest,FLACFETCH_API_KEY=flacfetch-api-key:latest"
 
 images:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.76.4"
+version = "0.76.5"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Fixed root cause of YouTube upload not happening: jobs were missing `youtube_description_template` field
- Add defaults for YouTube upload enablement, brand prefix, and description template
- Enable YouTube upload by default (`DEFAULT_ENABLE_YOUTUBE_UPLOAD=true`) for production

## Changes Made
- **backend/config.py**: Add `default_enable_youtube_upload`, `default_brand_prefix`, `default_youtube_description` settings
- **backend/api/routes/audio_search.py**: Apply defaults when creating jobs so `youtube_description_template` is always set
- **cloudbuild.yaml**: Add `DEFAULT_ENABLE_YOUTUBE_UPLOAD=true` and `DEFAULT_BRAND_PREFIX=NOMAD` environment variables

## Root Cause Analysis
Jobs created via the web UI were missing the `youtube_description_template` field. The video_worker checks:
```python
if youtube_credentials and getattr(job, 'youtube_description_template', None):
    # Enable YouTube upload
```

Without the template, YouTube upload was silently skipped even when credentials were configured.

## Testing
- [x] All backend unit tests pass (748 passed)
- [x] All E2E emulator tests pass (57 passed)
- [ ] Deploy and test full E2E flow with YouTube upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio search workflows now apply system-wide defaults for YouTube distribution settings (upload preferences, brand prefix, and video descriptions), streamlining job configuration.

* **Chores**
  * Updated version to 0.76.5.
  * Deployment environment updated with new default configuration values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->