### PR TITLE
Remove deployment tracking to fix PR banner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,9 +542,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [frontend-unit-tests]
     if: ${{ always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && (needs.frontend-unit-tests.result == 'success' || needs.frontend-unit-tests.result == 'skipped') }}
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Removes the `environment` block from the `deploy-frontend` job in CI workflow
- This prevents GitHub from creating deployment entries that cause the "This branch has not been deployed" banner on PRs

## Changes Made
- Removed lines 545-547 from `.github/workflows/ci.yml`:
  ```yaml
  environment:
    name: github-pages
    url: ${{ steps.deployment.outputs.page_url }}
  ```

## Testing
- The `actions/deploy-pages@v4` action will still deploy to GitHub Pages without the environment block
- Verified by checking GitHub Actions documentation - the environment block is optional and primarily used for deployment tracking/protection rules

## Context
The banner appeared because GitHub was tracking `github-pages` environment deployments. Every push to main created a deployment entry, causing PRs to show "not deployed" since they weren't deployed to that environment.

Also cleaned up ~500 existing deployments via the GitHub API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated frontend deployment configuration to streamline the deployment process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->