### PR TITLE
Fix stale exports in job/index.ts and add frontend build CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,31 @@ jobs:
           path: frontend/coverage/
           retention-days: 7
 
+  frontend-build:
+    name: "Frontend - Build"
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.frontend == 'true' || github.ref == 'refs/heads/main' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js with caching
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci --legacy-peer-deps
+
+      - name: Build frontend
+        working-directory: frontend
+        env:
+          NEXT_PUBLIC_API_URL: https://api.nomadkaraoke.com
+        run: npm run build
+
   # ============================================
   # PACKAGE TESTS (karaoke-gen Python CLI)
   # ============================================
@@ -425,13 +450,14 @@ jobs:
   ci-gate:
     name: "CI Gate"
     runs-on: ubuntu-latest
-    needs: [frontend-unit-tests, package-unit-tests, package-integration-tests, backend-unit-tests, backend-emulator-tests, backend-lint]
+    needs: [frontend-unit-tests, frontend-build, package-unit-tests, package-integration-tests, backend-unit-tests, backend-emulator-tests, backend-lint]
     if: always()
     steps:
       - name: Check results
         run: |
           results=(
             "${{ needs.frontend-unit-tests.result }}"
+            "${{ needs.frontend-build.result }}"
             "${{ needs.package-unit-tests.result }}"
             "${{ needs.package-integration-tests.result }}"
             "${{ needs.backend-unit-tests.result }}"
@@ -540,8 +566,8 @@ jobs:
   deploy-frontend:
     name: "Deploy - Frontend (GitHub Pages)"
     runs-on: ubuntu-latest
-    needs: [frontend-unit-tests]
-    if: ${{ always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && (needs.frontend-unit-tests.result == 'success' || needs.frontend-unit-tests.result == 'skipped') }}
+    needs: [frontend-unit-tests, frontend-build]
+    if: ${{ always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && (needs.frontend-unit-tests.result == 'success' || needs.frontend-unit-tests.result == 'skipped') && (needs.frontend-build.result == 'success' || needs.frontend-build.result == 'skipped') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/frontend/components/job/index.ts
+++ b/frontend/components/job/index.ts
@@ -1,6 +1,5 @@
-export { JobCard, StatusBadge } from "./JobCard"
+export { JobCard } from "./JobCard"
 export { JobActions } from "./JobActions"
 export { JobLogs } from "./JobLogs"
 export { OutputLinks } from "./OutputLinks"
-export { InstrumentalSelector } from "./InstrumentalSelector"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.76.19"
+version = "0.76.20"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Fixes the broken frontend deployment caused by stale exports in `frontend/components/job/index.ts`. Also adds a CI check to prevent this from happening again.

## Changes Made

- **Fixed** `frontend/components/job/index.ts` - Removed stale exports for `InstrumentalSelector` and `StatusBadge` that no longer exist
- **Added** `frontend-build` job to CI workflow - Runs `npm run build` on frontend changes to catch build failures before merge
- **Updated** `ci-gate` job to include `frontend-build` in required checks
- **Updated** `deploy-frontend` job to depend on `frontend-build` success

## Root Cause

PR #79 removed `InstrumentalSelector.tsx` but didn't update the barrel export file (`index.ts`). The unit tests passed because they mock the component, but the production build failed because it couldn't resolve the import.

## Prevention

The new `frontend-build` CI job will now run `npm run build` on any PR that touches frontend code. This will catch:
- Missing/broken imports
- TypeScript compilation errors  
- Any other build-time failures

## Testing

- [x] `npm run build` succeeds locally
- [x] `npm run test:unit` passes (138 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.76.20
  * Enhanced CI/CD pipeline with explicit frontend build step to improve deployment reliability and visibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->