### PR TITLE
Fix instrumental UI authentication token not being passed in URL

### DIFF
--- a/frontend/components/__tests__/JobCard.test.tsx
+++ b/frontend/components/__tests__/JobCard.test.tsx
@@ -135,7 +135,7 @@ describe('JobCard', () => {
       const instrumentalJob = {
         ...mockJob,
         status: 'awaiting_instrumental_selection',
-        state_data: { instrumental_token: 'test-instrumental-token' }
+        instrumental_token: 'test-instrumental-token'
       }
       render(<JobCard job={instrumentalJob} onRefresh={mockOnRefresh} />)
 

--- a/frontend/components/job/JobCard.tsx
+++ b/frontend/components/job/JobCard.tsx
@@ -117,8 +117,8 @@ export function JobCard({ job, onRefresh }: JobCardProps) {
     const baseApiUrl = `${backendUrl}/api/jobs/${job.job_id}`
     const encodedApiUrl = encodeURIComponent(baseApiUrl)
     let url = `/instrumental/?baseApiUrl=${encodedApiUrl}`
-    if (job.state_data?.instrumental_token) {
-      url += `&instrumentalToken=${encodeURIComponent(job.state_data.instrumental_token)}`
+    if (job.instrumental_token) {
+      url += `&instrumentalToken=${encodeURIComponent(job.instrumental_token)}`
     }
     return url
   }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -63,6 +63,7 @@ export interface Job {
     message?: string;
   }>;
   review_token?: string;
+  instrumental_token?: string;
   audio_hash?: string;
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.76.21"
+version = "0.76.22"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Fixes 401 Unauthorized errors in the instrumental review UI deployed to the cloud
- The instrumental review UI was not receiving the authentication token because JobCard was looking in the wrong location

## Changes Made
- Added `instrumental_token` field to `Job` interface in `frontend/lib/api.ts`
- Fixed `getInstrumentalUrl()` in `frontend/components/job/JobCard.tsx` to use `job.instrumental_token` instead of `job.state_data?.instrumental_token`
- Updated test to use the correct token location

## Root Cause
The backend stores `instrumental_token` directly on the job document (same as `review_token`), but the frontend was incorrectly looking for it in `job.state_data.instrumental_token`.

## Testing
- [x] Frontend unit tests pass (138/138)
- [x] Fix matches the existing pattern used for `review_token` in lyrics review

🤖 Generated with [Claude Code](https://claude.com/claude-code)