### PR TITLE
feat: add /coderabbit-review slash command

### DIFF
--- a/.claude/commands/coderabbit-review.md
+++ b/.claude/commands/coderabbit-review.md
@@ -1,0 +1,109 @@
+---
+description: Review and address CodeRabbit comments on current PR
+allowed-tools: Read, Glob, Grep, Edit, Write, Bash, mcp__github__pull_request_read, mcp__github__get_me, mcp__github__list_pull_requests, mcp__github__add_issue_comment
+---
+
+# CodeRabbit Comment Review
+
+You are reviewing the current PR to address all CodeRabbit automated review comments.
+
+## Your Task
+
+### 1. Identify the Current PR
+
+First, determine the current branch and find the associated PR:
+```bash
+git branch --show-current
+```
+
+Then use GitHub tools to find the PR for this branch in the `nomadkaraoke/karaoke-gen` repository.
+
+### 2. Fetch CodeRabbit Comments
+
+Get all review comments and regular comments on the PR:
+
+**Review Comments (Potential Issues)**
+- Use `pull_request_read` with `method: "get_review_comments"` to get all review comment threads
+- Look for comments from the `coderabbitai` bot user
+- These are typically marked as "Potential issue" and MUST be resolved before merge
+
+**PR Comments (Including Nitpicks)**
+- Use `pull_request_read` with `method: "get_comments"` to get regular PR comments
+- CodeRabbit posts a summary comment that includes "Nitpick comments" section
+- These should also be reviewed and considered for action
+
+### 3. Analyze Each Comment
+
+For each CodeRabbit comment:
+1. Read the comment carefully to understand the concern
+2. Look at the referenced code location
+3. Decide if a code change is warranted:
+   - **Make changes** for: valid bugs, security issues, clear improvements, style violations
+   - **Skip changes** for: subjective preferences, false positives, already addressed, not applicable
+4. If skipping, note the reason
+
+### 4. Make Code Changes
+
+For each comment requiring action:
+1. Navigate to the file and line mentioned
+2. Understand the surrounding context
+3. Make the minimal change needed to address the concern
+4. Verify the change doesn't break anything obvious
+
+### 5. Commit and Push
+
+After making all changes:
+```bash
+# Stage all changes
+git add -A
+
+# Commit with descriptive message
+git commit -m "fix: address CodeRabbit review comments
+
+- [list each fix briefly]
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+
+# Push to the PR branch
+git push
+```
+
+### 6. Resolve Threads
+
+After pushing:
+- Reply to each CodeRabbit review thread indicating what was done
+- If a comment was addressed, reply with what was changed
+- If a comment was intentionally skipped, explain why
+- This helps mark threads as resolved so the PR can be merged
+
+## Output Format
+
+Provide a summary report:
+
+```
+## CodeRabbit Review Summary
+
+### Comments Addressed
+- [ ] File:line - Brief description of issue → What was changed
+
+### Comments Skipped (with reason)
+- [ ] File:line - Issue → Reason for skipping
+
+### Actions Taken
+- Committed: [commit hash]
+- Pushed to: [branch name]
+- Threads replied to: [count]
+
+### Status
+Ready for merge: Yes/No (if No, explain why)
+```
+
+## Guidelines
+
+- Focus on code quality improvements, not just making CodeRabbit happy
+- Don't blindly accept every suggestion - use judgment
+- Group related fixes into logical commits if needed
+- Keep changes minimal and focused on the specific issues raised
+- If a suggestion would require significant refactoring, note it for future work instead


### PR DESCRIPTION
## Summary
- Adds a new Claude Code slash command `/coderabbit-review` for reviewing and addressing CodeRabbit automated review comments on PRs
- Streamlines the workflow of addressing both "Potential issue" review threads and "Nitpick comments"
- Automates the fix → commit → push → resolve threads workflow

## Changes
- New file: `.claude/commands/coderabbit-review.md`

## Test plan
- [ ] Run `/coderabbit-review` on a PR with CodeRabbit comments
- [ ] Verify it fetches both review threads and PR comments
- [ ] Verify it makes appropriate code changes
- [ ] Verify it commits and pushes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)