### PR TITLE
Fix: Add theme support to /api/jobs/upload endpoint

### DIFF
--- a/backend/api/routes/file_upload.py
+++ b/backend/api/routes/file_upload.py
@@ -341,9 +341,12 @@ async def upload_and_create_job(
     style_cdg_instrumental_background: Optional[UploadFile] = File(None, description="CDG instrumental background"),
     style_cdg_title_background: Optional[UploadFile] = File(None, description="CDG title screen background"),
     style_cdg_outro_background: Optional[UploadFile] = File(None, description="CDG outro screen background"),
-    # Processing options (CDG/TXT require style config, disabled by default)
-    enable_cdg: bool = Form(False, description="Generate CDG+MP3 package (requires style config)"),
-    enable_txt: bool = Form(False, description="Generate TXT+MP3 package (requires style config)"),
+    # Theme configuration (use pre-made theme from GCS)
+    theme_id: Optional[str] = Form(None, description="Theme ID to use (e.g., 'nomad', 'default'). If set, CDG/TXT are enabled by default."),
+    color_overrides: Optional[str] = Form(None, description="JSON-encoded color overrides: artist_color, title_color, sung_lyrics_color, unsung_lyrics_color (hex #RRGGBB)"),
+    # Processing options (CDG/TXT require style config or theme, disabled by default unless theme is set)
+    enable_cdg: Optional[bool] = Form(None, description="Generate CDG+MP3 package. Default: True if theme_id set, False otherwise"),
+    enable_txt: Optional[bool] = Form(None, description="Generate TXT+MP3 package. Default: True if theme_id set, False otherwise"),
     # Finalisation options
     brand_prefix: Optional[str] = Form(None, description="Brand code prefix (e.g., NOMAD)"),
     enable_youtube_upload: bool = Form(False, description="Upload to YouTube"),
@@ -477,7 +480,35 @@ async def upload_and_create_job(
         
         # Extract request metadata for tracking and filtering
         request_metadata = extract_request_metadata(request, created_from="upload")
-        
+
+        # Parse color_overrides from JSON if provided
+        parsed_color_overrides: Dict[str, str] = {}
+        if color_overrides:
+            try:
+                parsed_color_overrides = json.loads(color_overrides)
+            except json.JSONDecodeError as e:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid color_overrides JSON: {e}"
+                )
+
+        # Resolve CDG/TXT defaults based on theme
+        resolved_cdg, resolved_txt = _resolve_cdg_txt_defaults(
+            theme_id, enable_cdg, enable_txt
+        )
+
+        # Check if any custom style files are being uploaded (overrides theme)
+        has_custom_style_files = any([
+            style_params,
+            style_intro_background,
+            style_karaoke_background,
+            style_end_background,
+            style_font,
+            style_cdg_instrumental_background,
+            style_cdg_title_background,
+            style_cdg_outro_background,
+        ])
+
         # Parse comma-separated model lists into arrays
         parsed_backing_vocals_models = None
         if backing_vocals_models:
@@ -492,8 +523,10 @@ async def upload_and_create_job(
             artist=artist,
             title=title,
             filename=file.filename,
-            enable_cdg=enable_cdg,
-            enable_txt=enable_txt,
+            theme_id=theme_id,
+            color_overrides=parsed_color_overrides,
+            enable_cdg=resolved_cdg,
+            enable_txt=resolved_txt,
             brand_prefix=brand_prefix,
             enable_youtube_upload=enable_youtube_upload,
             youtube_description=youtube_description,
@@ -521,9 +554,27 @@ async def upload_and_create_job(
         
         # Record job creation metric
         metrics.record_job_created(job_id, source="upload")
-        
+
         logger.info(f"Created job {job_id} for {artist} - {title}")
-        
+
+        # If theme is set and no custom style files are being uploaded, prepare theme style now
+        # This copies the theme's style_params.json to the job folder so LyricsTranscriber
+        # can access the style configuration for preview videos
+        theme_style_params_path = None
+        theme_style_assets = {}
+        theme_youtube_desc = None
+        if theme_id and not has_custom_style_files:
+            try:
+                theme_style_params_path, theme_style_assets, theme_youtube_desc = _prepare_theme_for_job(
+                    job_id, theme_id, parsed_color_overrides or None
+                )
+                logger.info(f"Applied theme '{theme_id}' to job {job_id}")
+            except HTTPException:
+                raise  # Re-raise validation errors (e.g., theme not found)
+            except Exception as e:
+                logger.warning(f"Failed to prepare theme '{theme_id}' for job {job_id}: {e}")
+                # Continue without theme - job can still be processed with defaults
+
         # Upload main audio file to GCS
         audio_gcs_path = f"uploads/{job_id}/audio/{file.filename}"
         logger.info(f"Uploading audio to GCS: {audio_gcs_path}")
@@ -592,21 +643,30 @@ async def upload_and_create_job(
         update_data = {
             'input_media_gcs_path': audio_gcs_path,
             'filename': file.filename,
-            'enable_cdg': enable_cdg,
-            'enable_txt': enable_txt,
+            'enable_cdg': resolved_cdg,
+            'enable_txt': resolved_txt,
         }
-        
+
+        # Handle style assets - either from custom uploads or from theme
         if style_assets:
+            # Custom style files uploaded
             update_data['style_assets'] = style_assets
             if 'style_params' in style_assets:
                 update_data['style_params_gcs_path'] = style_assets['style_params']
-        
+        elif theme_style_assets:
+            # Theme style assets (no custom uploads)
+            update_data['style_assets'] = theme_style_assets
+            if theme_style_params_path:
+                update_data['style_params_gcs_path'] = theme_style_params_path
+
         if brand_prefix:
             update_data['brand_prefix'] = brand_prefix
         if effective_discord_webhook_url:
             update_data['discord_webhook_url'] = effective_discord_webhook_url
-        if youtube_description:
-            update_data['youtube_description_template'] = youtube_description
+        # Use theme YouTube description if no custom one provided
+        effective_youtube_description = youtube_description or theme_youtube_desc
+        if effective_youtube_description:
+            update_data['youtube_description_template'] = effective_youtube_description
         
         # Native API distribution (use effective values which include defaults)
         if effective_dropbox_path:

--- a/backend/tests/test_file_upload.py
+++ b/backend/tests/test_file_upload.py
@@ -1606,5 +1606,133 @@ class TestIsUrlFunction:
         assert is_url("") is False
 
 
+class TestUploadEndpointThemeSupport:
+    """Test that /jobs/upload endpoint supports theme configuration.
+
+    CRITICAL: These tests verify that the /api/jobs/upload endpoint correctly handles
+    theme_id and color_overrides parameters, ensuring preview videos have themed
+    backgrounds instead of black backgrounds.
+
+    This addresses a bug where:
+    - The frontend sends theme_id and color_overrides when uploading files
+    - But the backend /api/jobs/upload endpoint was ignoring these parameters
+    - Result: Jobs created via file upload had black backgrounds instead of themed ones
+    """
+
+    def test_upload_endpoint_accepts_theme_id_parameter(self):
+        """Verify the upload endpoint has theme_id as a form parameter.
+
+        CRITICAL: The frontend sends theme_id when uploading files with a theme.
+        If this parameter is missing from the endpoint, the theme is silently ignored
+        and preview videos will have black backgrounds instead of themed ones.
+        """
+        from backend.api.routes import file_upload as file_upload_module
+
+        with open(file_upload_module.__file__, 'r') as f:
+            source_code = f.read()
+
+        has_theme_id_param = 'theme_id: Optional[str] = Form(' in source_code
+
+        assert has_theme_id_param, (
+            "file_upload.py /jobs/upload endpoint does not have theme_id as a Form parameter. "
+            "The frontend sends theme_id when uploading files with a theme, but the backend "
+            "ignores it. Add: theme_id: Optional[str] = Form(None, description='Theme ID...')"
+        )
+
+    def test_upload_endpoint_accepts_color_overrides_parameter(self):
+        """Verify the upload endpoint has color_overrides as a form parameter."""
+        from backend.api.routes import file_upload as file_upload_module
+
+        with open(file_upload_module.__file__, 'r') as f:
+            source_code = f.read()
+
+        has_color_overrides_param = 'color_overrides: Optional[str] = Form(' in source_code
+
+        assert has_color_overrides_param, (
+            "file_upload.py /jobs/upload endpoint does not have color_overrides as a Form parameter. "
+            "The frontend sends color_overrides when customizing theme colors."
+        )
+
+    def test_upload_endpoint_calls_prepare_theme_for_job(self):
+        """Verify the upload endpoint calls _prepare_theme_for_job when theme_id is set.
+
+        CRITICAL: When a job is created via the upload endpoint with a theme_id
+        (and no custom style files), the code must call _prepare_theme_for_job() to set:
+        1. style_params_gcs_path (pointing to the copied style_params.json)
+        2. style_assets (populated with asset mappings)
+
+        Without this, LyricsTranscriber won't have access to the theme's styles
+        and preview videos will have black backgrounds instead of themed ones.
+        """
+        from backend.api.routes import file_upload as file_upload_module
+
+        with open(file_upload_module.__file__, 'r') as f:
+            source_code = f.read()
+
+        # The function should be called in upload_and_create_job
+        has_theme_prep_call = '_prepare_theme_for_job(' in source_code
+
+        assert has_theme_prep_call, (
+            "file_upload.py does not call _prepare_theme_for_job(). "
+            "When theme_id is provided to /jobs/upload without custom style files, "
+            "the endpoint MUST call _prepare_theme_for_job() to copy the theme's "
+            "style_params.json to the job folder."
+        )
+
+    def test_upload_endpoint_uses_resolve_cdg_txt_defaults(self):
+        """Verify the upload endpoint uses _resolve_cdg_txt_defaults for theme-based defaults."""
+        from backend.api.routes import file_upload as file_upload_module
+
+        with open(file_upload_module.__file__, 'r') as f:
+            source_code = f.read()
+
+        has_resolve_call = '_resolve_cdg_txt_defaults(' in source_code
+
+        assert has_resolve_call, (
+            "file_upload.py does not call _resolve_cdg_txt_defaults(). "
+            "When theme_id is set, enable_cdg and enable_txt should default to True."
+        )
+
+    def test_upload_endpoint_has_optional_cdg_txt_params(self):
+        """Verify enable_cdg and enable_txt are Optional[bool] to support theme defaults.
+
+        CRITICAL: If enable_cdg/enable_txt are bool instead of Optional[bool],
+        they will default to False and override the theme-based defaults.
+        """
+        from backend.api.routes import file_upload as file_upload_module
+
+        with open(file_upload_module.__file__, 'r') as f:
+            source_code = f.read()
+
+        has_optional_cdg = 'enable_cdg: Optional[bool] = Form(' in source_code
+        has_optional_txt = 'enable_txt: Optional[bool] = Form(' in source_code
+
+        assert has_optional_cdg, (
+            "file_upload.py has enable_cdg as bool instead of Optional[bool]. "
+            "This prevents theme-based defaults from working."
+        )
+        assert has_optional_txt, (
+            "file_upload.py has enable_txt as bool instead of Optional[bool]. "
+            "This prevents theme-based defaults from working."
+        )
+
+    def test_job_create_includes_theme_id_and_color_overrides(self):
+        """Verify JobCreate is called with theme_id and color_overrides."""
+        from backend.api.routes import file_upload as file_upload_module
+
+        with open(file_upload_module.__file__, 'r') as f:
+            source_code = f.read()
+
+        has_theme_id_in_job_create = 'theme_id=theme_id,' in source_code
+        has_color_overrides_in_job_create = 'color_overrides=parsed_color_overrides' in source_code
+
+        assert has_theme_id_in_job_create, (
+            "file_upload.py does not pass theme_id to JobCreate."
+        )
+        assert has_color_overrides_in_job_create, (
+            "file_upload.py does not pass color_overrides to JobCreate."
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.76.25"
+version = "0.76.26"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- **Fix**: The `/api/jobs/upload` endpoint was missing `theme_id` and `color_overrides` parameters
- The frontend sends these when uploading files with a theme selected, but the backend was silently ignoring them
- Result: Jobs created via file upload had black backgrounds instead of themed backgrounds

## Root Cause

Looking at the two jobs you mentioned:
- **Job 47475700 (working)**: Created via Song Search (uses `/api/audio-search/search`) - PR #72 fixed theme support here
- **Job c9516773 (broken)**: Created via file upload (uses `/api/jobs/upload`) - this endpoint was never updated for theme support

The frontend API client at `frontend/lib/api.ts:247-252` correctly sends theme_id:
```typescript
if (options?.theme_id) {
  formData.append('theme_id', options.theme_id);
}
```

But the backend endpoint was not accepting this parameter, so it was silently ignored.

## Changes Made

1. **Add theme_id and color_overrides Form parameters** to `/jobs/upload` endpoint
2. **Change enable_cdg/enable_txt to Optional[bool]** for smart defaults (True when theme is set)
3. **Add _prepare_theme_for_job() call** when theme_id is set and no custom style files are uploaded
4. **Pass theme_id and color_overrides to JobCreate** so they're stored in the job document
5. **Use theme's YouTube description template** if no custom one provided

## Testing

- Added 6 regression tests to catch this issue in the future
- All 57 backend unit tests pass

## Files Changed

| File | Changes |
|------|---------|
| `backend/api/routes/file_upload.py` | Add theme parameters and preparation logic |
| `backend/tests/test_file_upload.py` | Add regression tests for theme support |
| `pyproject.toml` | Bump version 0.76.25 → 0.76.26 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)