### PR TITLE
feat: scale to 5 self-hosted GitHub runners for parallel CI jobs

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -254,15 +254,16 @@ The function uses environment variables:
 
 Known gaps are configured in `main.py` and should match your local `validate_and_sync.py`.
 
-## Self-Hosted GitHub Actions Runner
+## Self-Hosted GitHub Actions Runners
 
-A dedicated GCP VM runs self-hosted GitHub Actions runners to solve disk space issues
-on GitHub-hosted runners (14GB vs 200GB).
+Multiple GCP VMs run self-hosted GitHub Actions runners to:
+- Solve disk space issues on GitHub-hosted runners (14GB vs 200GB)
+- Enable parallel job execution across multiple runners
 
 ### Specs
 
-- **Instance**: e2-standard-4 (4 vCPU, 16GB RAM)
-- **Disk**: 200GB SSD
+- **Instances**: 5x e2-standard-4 (4 vCPU, 16GB RAM each)
+- **Disk**: 200GB SSD per runner
 - **Pre-installed**: Docker, Python 3.13, Node.js 20, Java 21, Poetry, FFmpeg, gcloud CLI
 - **Labels**: `self-hosted`, `linux`, `x64`, `gcp`, `large-disk`
 
@@ -280,15 +281,15 @@ on GitHub-hosted runners (14GB vs 200GB).
      gcloud secrets versions add github-runner-pat --data-file=-
    ```
 
-3. Run `pulumi up` to create the runner VM
+3. Run `pulumi up` to create the runner VMs
 
-4. Verify the runner registered:
+4. Verify the runners registered:
    - Go to https://github.com/nomadkaraoke/karaoke-gen/settings/actions/runners
-   - You should see `gcp-runner-github-runner` with status "Idle"
+   - You should see `gcp-runner-github-runner-1` through `gcp-runner-github-runner-5`
 
 ### Usage in Workflows
 
-Jobs that need more disk space use the self-hosted runner:
+Jobs that need more disk space use the self-hosted runners:
 
 ```yaml
 jobs:
@@ -299,25 +300,35 @@ jobs:
       # ... rest of job
 ```
 
+GitHub automatically distributes jobs across available runners.
+
 ### Troubleshooting
 
 **Runner not appearing in GitHub:**
 ```bash
-# Check startup logs
-gcloud compute ssh github-runner --zone=us-central1-a -- \
+# Check startup logs (replace N with runner number 1-3)
+gcloud compute ssh github-runner-N --zone=us-central1-a -- \
   "sudo cat /var/log/github-runner-startup.log"
 ```
 
 **Re-register runner:**
 ```bash
 # Restart the VM to re-run startup script
-gcloud compute instances reset github-runner --zone=us-central1-a
+gcloud compute instances reset github-runner-N --zone=us-central1-a
 ```
 
 **Check runner service status:**
 ```bash
-gcloud compute ssh github-runner --zone=us-central1-a -- \
+gcloud compute ssh github-runner-N --zone=us-central1-a -- \
   "sudo systemctl status actions.runner.*"
+```
+
+**List all runners:**
+```bash
+for i in 1 2 3 4 5; do
+  echo "=== github-runner-$i ==="
+  gcloud compute instances describe github-runner-$i --zone=us-central1-a --format='get(status)'
+done
 ```
 
 ## Next Steps

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -1418,35 +1418,40 @@ chmod +x /etc/cron.daily/docker-cleanup
 echo "Setup complete!"
 """
 
-# GitHub runner VM instance
-github_runner_vm = gcp.compute.Instance(
-    "github-runner",
-    name="github-runner",
-    machine_type="e2-standard-4",  # 4 vCPU, 16GB RAM - good for Docker builds
-    zone="us-central1-a",
-    boot_disk=gcp.compute.InstanceBootDiskArgs(
-        initialize_params=gcp.compute.InstanceBootDiskInitializeParamsArgs(
-            image="debian-cloud/debian-12",
-            size=200,  # GB - plenty for Docker builds and caches
-            type="pd-ssd",  # SSD for faster I/O
+# GitHub runner VM instances (multiple runners for parallel job execution)
+NUM_RUNNERS = 5
+github_runner_vms = []
+
+for i in range(1, NUM_RUNNERS + 1):
+    vm = gcp.compute.Instance(
+        f"github-runner-{i}",
+        name=f"github-runner-{i}",
+        machine_type="e2-standard-4",  # 4 vCPU, 16GB RAM - good for Docker builds
+        zone="us-central1-a",
+        boot_disk=gcp.compute.InstanceBootDiskArgs(
+            initialize_params=gcp.compute.InstanceBootDiskInitializeParamsArgs(
+                image="debian-cloud/debian-12",
+                size=200,  # GB - plenty for Docker builds and caches
+                type="pd-ssd",  # SSD for faster I/O
+            ),
         ),
-    ),
-    network_interfaces=[gcp.compute.InstanceNetworkInterfaceArgs(
-        network="default",
-        access_configs=[gcp.compute.InstanceNetworkInterfaceAccessConfigArgs()],  # Ephemeral IP is fine
-    )],
-    service_account=gcp.compute.InstanceServiceAccountArgs(
-        email=github_runner_sa.email,
-        scopes=["cloud-platform"],
-    ),
-    metadata_startup_script=GITHUB_RUNNER_STARTUP_SCRIPT,
-    tags=["github-runner"],
-    allow_stopping_for_update=True,
-    # Ensure the secret exists before creating the VM
-    opts=pulumi.ResourceOptions(depends_on=[github_runner_pat_secret]),
-)
+        network_interfaces=[gcp.compute.InstanceNetworkInterfaceArgs(
+            network="default",
+            access_configs=[gcp.compute.InstanceNetworkInterfaceAccessConfigArgs()],  # Ephemeral IP is fine
+        )],
+        service_account=gcp.compute.InstanceServiceAccountArgs(
+            email=github_runner_sa.email,
+            scopes=["cloud-platform"],
+        ),
+        metadata_startup_script=GITHUB_RUNNER_STARTUP_SCRIPT,
+        tags=["github-runner"],
+        allow_stopping_for_update=True,
+        # Ensure the secret exists before creating the VM
+        opts=pulumi.ResourceOptions(depends_on=[github_runner_pat_secret]),
+    )
+    github_runner_vms.append(vm)
 
 # Export GitHub runner resources
-pulumi.export("github_runner_vm_name", github_runner_vm.name)
+pulumi.export("github_runner_vm_names", [vm.name for vm in github_runner_vms])
 pulumi.export("github_runner_service_account", github_runner_sa.email)
 


### PR DESCRIPTION
## Summary

- Replace single github-runner VM with 5 instances for parallel job execution
- Eliminates CI queue bottleneck when multiple PRs are open
- Each runner has identical specs: e2-standard-4, 200GB SSD

## Changes

- `infrastructure/__main__.py`: Loop to create 5 VMs instead of 1
- `infrastructure/README.md`: Updated docs for multiple runners

## Test plan

- [x] `pulumi preview` shows correct changes (delete 1, create 5)
- [ ] `pulumi up` successfully creates VMs
- [ ] All 5 runners appear in GitHub Actions settings
- [ ] Jobs distributed across runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)