### PR TITLE
fix: correct _work directory ownership in runner startup script

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -1400,8 +1400,8 @@ cp -r /opt/pyenv/versions/3.13.0/* $TOOL_CACHE/Python/3.13.0/x64/
 # Create marker file that setup-python looks for
 touch $TOOL_CACHE/Python/3.13.0/x64.complete
 
-# Fix permissions
-chown -R runner:runner $TOOL_CACHE
+# Fix permissions - must own entire _work directory, not just _tool
+chown -R runner:runner /home/runner/actions-runner/_work
 
 echo "Python 3.13 added to tool cache"
 


### PR DESCRIPTION
## Summary

Fix permission denied error on self-hosted runners when jobs try to create `_temp` directory.

## Problem

The `_work` directory was being created by root (via `mkdir -p`) but the runner service runs as the `runner` user. This caused:
```
Access to the path '/home/runner/actions-runner/_work/_temp' is denied
```

## Fix

Change `chown -R runner:runner $TOOL_CACHE` to `chown -R runner:runner /home/runner/actions-runner/_work` to ensure the entire `_work` directory tree is owned by the runner user.

**Note**: Already manually fixed on all 5 running instances. This PR ensures future VM recreations won't have the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted Python tool cache and workspace file ownership permissions in the runner environment setup configuration. Extended the permission ownership scope from a specific internal subtree to the complete work directory, enabling improved access control and ensuring proper management of all cached tools and related workspace resources required for runner operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->