### PR TITLE
feat: scale GitHub Actions runners from 5 to 10

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -262,7 +262,7 @@ Multiple GCP VMs run self-hosted GitHub Actions runners to:
 
 ### Specs
 
-- **Instances**: 5x e2-standard-4 (4 vCPU, 16GB RAM each)
+- **Instances**: 10x e2-standard-4 (4 vCPU, 16GB RAM each)
 - **Disk**: 200GB SSD per runner
 - **Pre-installed**: Docker, Python 3.13, Node.js 20, Java 21, Poetry, FFmpeg, gcloud CLI
 - **Labels**: `self-hosted`, `linux`, `x64`, `gcp`, `large-disk`
@@ -285,7 +285,7 @@ Multiple GCP VMs run self-hosted GitHub Actions runners to:
 
 4. Verify the runners registered:
    - Go to https://github.com/nomadkaraoke/karaoke-gen/settings/actions/runners
-   - You should see `gcp-runner-github-runner-1` through `gcp-runner-github-runner-5`
+   - You should see `gcp-runner-github-runner-1` through `gcp-runner-github-runner-10`
 
 ### Usage in Workflows
 
@@ -306,7 +306,7 @@ GitHub automatically distributes jobs across available runners.
 
 **Runner not appearing in GitHub:**
 ```bash
-# Check startup logs (replace N with runner number 1-3)
+# Check startup logs (replace N with runner number 1-10)
 gcloud compute ssh github-runner-N --zone=us-central1-a -- \
   "sudo cat /var/log/github-runner-startup.log"
 ```
@@ -325,7 +325,7 @@ gcloud compute ssh github-runner-N --zone=us-central1-a -- \
 
 **List all runners:**
 ```bash
-for i in 1 2 3 4 5; do
+for i in {1..10}; do
   echo "=== github-runner-$i ==="
   gcloud compute instances describe github-runner-$i --zone=us-central1-a --format='get(status)'
 done

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -1419,7 +1419,7 @@ echo "Setup complete!"
 """
 
 # GitHub runner VM instances (multiple runners for parallel job execution)
-NUM_RUNNERS = 5
+NUM_RUNNERS = 10
 github_runner_vms = []
 
 for i in range(1, NUM_RUNNERS + 1):
@@ -1447,7 +1447,11 @@ for i in range(1, NUM_RUNNERS + 1):
         tags=["github-runner"],
         allow_stopping_for_update=True,
         # Ensure the secret exists before creating the VM
-        opts=pulumi.ResourceOptions(depends_on=[github_runner_pat_secret]),
+        # For existing runners (1-5), ignore startup script changes to avoid replacement
+        opts=pulumi.ResourceOptions(
+            depends_on=[github_runner_pat_secret],
+            ignore_changes=["metadataStartupScript"] if i <= 5 else None,
+        ),
     )
     github_runner_vms.append(vm)
 


### PR DESCRIPTION
## Summary
- Increase self-hosted GitHub Actions runners from 5 to 10 for more parallel CI capacity
- Add `ignoreChanges` for existing runners (1-5) to prevent replacement during deployment
- Update infrastructure documentation to reflect 10 runners

## Test plan
- [x] Verified `pulumi preview` shows only 5 new runners being created (no replacements)
- [x] Successfully deployed with `pulumi up` - runners 6-10 created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Scaled GitHub Actions runner infrastructure from 5 to 10 instances to increase CI/CD capacity and throughput.

* **Documentation**
  * Updated infrastructure documentation to reflect the expanded runner configuration and updated verification procedures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->