### PR TITLE
feat(frontend): add version display and improve UI

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -10,6 +10,7 @@ import { JobCard } from "@/components/job"
 import { JobSubmission } from "@/components/job/JobSubmission"
 import { AuthStatus } from "@/components/auth"
 import { AutoProcessor } from "@/components/AutoProcessor"
+import { VersionFooter } from "@/components/version-footer"
 import { useTheme } from "@/lib/theme"
 import {
   Tooltip,
@@ -229,17 +230,7 @@ export default function HomePage() {
         </div>
       </main>
 
-      {/* Footer */}
-      <footer className="border-t mt-12 py-6" style={{ borderColor: 'var(--card-border)' }}>
-        <div className="px-4 text-center text-sm" style={{ color: 'var(--text-muted)' }}>
-          <p>
-            Powered by{" "}
-            <a href="https://github.com/nomadkaraoke/karaoke-gen" className="text-amber-500 hover:underline">
-              karaoke-gen
-            </a>
-          </p>
-        </div>
-      </footer>
+      <VersionFooter />
     </div>
   )
 }

--- a/frontend/components/job/ColorOverrides.tsx
+++ b/frontend/components/job/ColorOverrides.tsx
@@ -31,14 +31,15 @@ function ColorField({ id, label, description, value, onChange, disabled }: Color
   return (
     <div className="space-y-1">
       <div className="flex items-center justify-between">
-        <Label htmlFor={id} className="text-sm text-slate-300">
+        <Label htmlFor={id} className="text-sm" style={{ color: 'var(--text)' }}>
           {label}
         </Label>
         {value && (
           <button
             type="button"
             onClick={() => onChange(undefined)}
-            className="text-xs text-slate-500 hover:text-slate-300"
+            className="text-xs"
+            style={{ color: 'var(--text-muted)' }}
             disabled={disabled}
           >
             Reset
@@ -47,8 +48,8 @@ function ColorField({ id, label, description, value, onChange, disabled }: Color
       </div>
       <div className="flex items-center gap-2">
         <div
-          className="w-8 h-8 rounded border border-slate-600 flex-shrink-0"
-          style={{ backgroundColor: value || "#333333" }}
+          className="w-8 h-8 rounded border flex-shrink-0"
+          style={{ backgroundColor: value || "#333333", borderColor: 'var(--card-border)' }}
         />
         <Input
           id={id}
@@ -64,7 +65,8 @@ function ColorField({ id, label, description, value, onChange, disabled }: Color
             }
           }}
           disabled={disabled}
-          className="bg-slate-800 border-slate-700 text-white placeholder:text-slate-500 font-mono text-sm"
+          className="font-mono text-sm"
+          style={{ backgroundColor: 'var(--secondary)', borderColor: 'var(--card-border)', color: 'var(--text)' }}
         />
         <Input
           type="color"
@@ -74,7 +76,7 @@ function ColorField({ id, label, description, value, onChange, disabled }: Color
           className="w-10 h-8 p-0 border-0 bg-transparent cursor-pointer"
         />
       </div>
-      <p className="text-xs text-slate-500">{description}</p>
+      <p className="text-xs" style={{ color: 'var(--text-muted)' }}>{description}</p>
     </div>
   )
 }
@@ -106,7 +108,8 @@ export function ColorOverridesPanel({ value, onChange, disabled }: ColorOverride
         <Button
           variant="ghost"
           type="button"
-          className="w-full justify-between px-3 py-2 h-auto text-slate-300 hover:text-white hover:bg-slate-700/50"
+          className="w-full justify-between px-3 py-2 h-auto"
+          style={{ color: 'var(--text)' }}
         >
           <span className="flex items-center gap-2">
             <Paintbrush className="w-4 h-4" />
@@ -126,9 +129,9 @@ export function ColorOverridesPanel({ value, onChange, disabled }: ColorOverride
       </CollapsibleTrigger>
 
       <CollapsibleContent className="mt-2">
-        <div className="space-y-4 p-4 rounded-lg border border-slate-700 bg-slate-800/50">
+        <div className="space-y-4 p-4 rounded-lg border" style={{ borderColor: 'var(--card-border)', backgroundColor: 'var(--secondary)' }}>
           <div className="flex items-center justify-between">
-            <p className="text-sm text-slate-400">
+            <p className="text-sm" style={{ color: 'var(--text-muted)' }}>
               Override theme colors (optional)
             </p>
             {hasAnyOverrides && (
@@ -138,7 +141,7 @@ export function ColorOverridesPanel({ value, onChange, disabled }: ColorOverride
                 size="sm"
                 onClick={handleResetAll}
                 disabled={disabled}
-                className="text-slate-400 hover:text-white"
+                style={{ color: 'var(--text-muted)' }}
               >
                 <RotateCcw className="w-3 h-3 mr-1" />
                 Reset All

--- a/frontend/components/job/JobSubmission.tsx
+++ b/frontend/components/job/JobSubmission.tsx
@@ -17,7 +17,7 @@ interface JobSubmissionProps {
 }
 
 export function JobSubmission({ onJobCreated }: JobSubmissionProps) {
-  const [activeTab, setActiveTab] = useState("upload")
+  const [activeTab, setActiveTab] = useState("search")
   const [error, setError] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
 
@@ -147,28 +147,31 @@ export function JobSubmission({ onJobCreated }: JobSubmissionProps) {
 
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab}>
-      <TabsList className="grid w-full grid-cols-3 bg-slate-800 h-auto">
-        <TabsTrigger value="upload" className="gap-1.5 sm:gap-2 py-3 min-h-[44px] text-xs sm:text-sm data-[state=active]:bg-slate-700">
+      <TabsList className="grid w-full grid-cols-3 h-auto" style={{ backgroundColor: 'var(--secondary)' }}>
+        <TabsTrigger value="search" className="gap-1.5 sm:gap-2 py-3 min-h-[44px] text-xs sm:text-sm" style={{ color: 'var(--text)' }}>
+          <Music className="w-4 h-4 shrink-0" />
+          <span className="truncate">Search</span>
+        </TabsTrigger>
+        <TabsTrigger value="upload" className="gap-1.5 sm:gap-2 py-3 min-h-[44px] text-xs sm:text-sm" style={{ color: 'var(--text)' }}>
           <Upload className="w-4 h-4 shrink-0" />
           <span className="truncate">Upload</span>
         </TabsTrigger>
-        <TabsTrigger value="url" className="gap-1.5 sm:gap-2 py-3 min-h-[44px] text-xs sm:text-sm data-[state=active]:bg-slate-700">
+        <TabsTrigger value="url" className="gap-1.5 sm:gap-2 py-3 min-h-[44px] text-xs sm:text-sm" style={{ color: 'var(--text)' }}>
           <Youtube className="w-4 h-4 shrink-0" />
           <span className="truncate">URL</span>
-        </TabsTrigger>
-        <TabsTrigger value="search" className="gap-1.5 sm:gap-2 py-3 min-h-[44px] text-xs sm:text-sm data-[state=active]:bg-slate-700">
-          <Music className="w-4 h-4 shrink-0" />
-          <span className="truncate">Search</span>
         </TabsTrigger>
       </TabsList>
 
       <TabsContent value="upload" className="mt-4">
         <form onSubmit={handleUploadSubmit} className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="audio-file" className="text-slate-200">Audio File</Label>
+            <Label htmlFor="audio-file" style={{ color: 'var(--text)' }}>Audio File</Label>
             <div
-              className={`relative border-2 border-dashed rounded-lg p-6 text-center transition-colors cursor-pointer
-                ${uploadFile ? "border-amber-500/50 bg-amber-500/5" : "border-slate-700 hover:border-slate-600 bg-slate-800/50"}`}
+              className="relative border-2 border-dashed rounded-lg p-6 text-center transition-colors cursor-pointer"
+              style={{
+                borderColor: uploadFile ? 'rgb(245 158 11 / 0.5)' : 'var(--card-border)',
+                backgroundColor: uploadFile ? 'rgb(245 158 11 / 0.05)' : 'var(--secondary)',
+              }}
             >
               <Input
                 id="audio-file"
@@ -178,16 +181,16 @@ export function JobSubmission({ onJobCreated }: JobSubmissionProps) {
                 className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
                 disabled={isSubmitting}
               />
-              <Upload className="w-8 h-8 mx-auto mb-2 text-slate-500" />
+              <Upload className="w-8 h-8 mx-auto mb-2" style={{ color: 'var(--text-muted)' }} />
               {uploadFile ? (
                 <div>
-                  <p className="font-medium text-white">{uploadFile.name}</p>
-                  <p className="text-sm text-slate-400">{(uploadFile.size / 1024 / 1024).toFixed(2)} MB</p>
+                  <p className="font-medium" style={{ color: 'var(--text)' }}>{uploadFile.name}</p>
+                  <p className="text-sm" style={{ color: 'var(--text-muted)' }}>{(uploadFile.size / 1024 / 1024).toFixed(2)} MB</p>
                 </div>
               ) : (
                 <div>
-                  <p className="font-medium text-slate-300 mb-1">Click to upload</p>
-                  <p className="text-sm text-slate-500">MP3, WAV, FLAC, M4A, or OGG</p>
+                  <p className="font-medium mb-1" style={{ color: 'var(--text)' }}>Click to upload</p>
+                  <p className="text-sm" style={{ color: 'var(--text-muted)' }}>MP3, WAV, FLAC, M4A, or OGG</p>
                 </div>
               )}
             </div>
@@ -195,31 +198,31 @@ export function JobSubmission({ onJobCreated }: JobSubmissionProps) {
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
             <div className="space-y-2">
-              <Label htmlFor="upload-artist" className="text-slate-200">Artist</Label>
+              <Label htmlFor="upload-artist" style={{ color: 'var(--text)' }}>Artist</Label>
               <Input
                 id="upload-artist"
                 placeholder="Artist name"
                 value={uploadArtist}
                 onChange={(e) => setUploadArtist(e.target.value)}
                 disabled={isSubmitting}
-                className="bg-slate-800 border-slate-700 text-white placeholder:text-slate-500"
+                style={{ backgroundColor: 'var(--secondary)', borderColor: 'var(--card-border)', color: 'var(--text)' }}
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="upload-title" className="text-slate-200">Title</Label>
+              <Label htmlFor="upload-title" style={{ color: 'var(--text)' }}>Title</Label>
               <Input
                 id="upload-title"
                 placeholder="Song title"
                 value={uploadTitle}
                 onChange={(e) => setUploadTitle(e.target.value)}
                 disabled={isSubmitting}
-                className="bg-slate-800 border-slate-700 text-white placeholder:text-slate-500"
+                style={{ backgroundColor: 'var(--secondary)', borderColor: 'var(--card-border)', color: 'var(--text)' }}
               />
             </div>
           </div>
 
           {/* Theme Selection */}
-          <div className="space-y-4 pt-4 border-t border-slate-700">
+          <div className="space-y-4 pt-4 border-t" style={{ borderColor: 'var(--card-border)' }}>
             <ThemeSelector
               value={selectedTheme}
               onChange={setSelectedTheme}
@@ -256,16 +259,17 @@ export function JobSubmission({ onJobCreated }: JobSubmissionProps) {
       <TabsContent value="url" className="mt-4">
         <form onSubmit={handleUrlSubmit} className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="youtube-url" className="text-slate-200">YouTube URL</Label>
+            <Label htmlFor="youtube-url" style={{ color: 'var(--text)' }}>YouTube URL</Label>
             <div className="relative">
-              <Youtube className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
+              <Youtube className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4" style={{ color: 'var(--text-muted)' }} />
               <Input
                 id="youtube-url"
                 type="url"
                 placeholder="https://youtube.com/watch?v=..."
                 value={youtubeUrl}
                 onChange={(e) => setYoutubeUrl(e.target.value)}
-                className="pl-10 bg-slate-800 border-slate-700 text-white placeholder:text-slate-500"
+                className="pl-10"
+                style={{ backgroundColor: 'var(--secondary)', borderColor: 'var(--card-border)', color: 'var(--text)' }}
                 disabled={isSubmitting}
               />
             </div>
@@ -273,31 +277,31 @@ export function JobSubmission({ onJobCreated }: JobSubmissionProps) {
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
             <div className="space-y-2">
-              <Label htmlFor="youtube-artist" className="text-slate-200">Artist (optional)</Label>
+              <Label htmlFor="youtube-artist" style={{ color: 'var(--text)' }}>Artist (optional)</Label>
               <Input
                 id="youtube-artist"
                 placeholder="Auto-detected"
                 value={youtubeArtist}
                 onChange={(e) => setYoutubeArtist(e.target.value)}
                 disabled={isSubmitting}
-                className="bg-slate-800 border-slate-700 text-white placeholder:text-slate-500"
+                style={{ backgroundColor: 'var(--secondary)', borderColor: 'var(--card-border)', color: 'var(--text)' }}
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="youtube-title" className="text-slate-200">Title (optional)</Label>
+              <Label htmlFor="youtube-title" style={{ color: 'var(--text)' }}>Title (optional)</Label>
               <Input
                 id="youtube-title"
                 placeholder="Auto-detected"
                 value={youtubeTitle}
                 onChange={(e) => setYoutubeTitle(e.target.value)}
                 disabled={isSubmitting}
-                className="bg-slate-800 border-slate-700 text-white placeholder:text-slate-500"
+                style={{ backgroundColor: 'var(--secondary)', borderColor: 'var(--card-border)', color: 'var(--text)' }}
               />
             </div>
           </div>
 
           {/* Theme Selection */}
-          <div className="space-y-4 pt-4 border-t border-slate-700">
+          <div className="space-y-4 pt-4 border-t" style={{ borderColor: 'var(--card-border)' }}>
             <ThemeSelector
               value={selectedTheme}
               onChange={setSelectedTheme}
@@ -335,31 +339,31 @@ export function JobSubmission({ onJobCreated }: JobSubmissionProps) {
         <form onSubmit={handleSearchSubmit} className="space-y-4">
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
             <div className="space-y-2">
-              <Label htmlFor="search-artist" className="text-slate-200">Artist</Label>
+              <Label htmlFor="search-artist" style={{ color: 'var(--text)' }}>Artist</Label>
               <Input
                 id="search-artist"
                 placeholder="Artist name"
                 value={searchArtist}
                 onChange={(e) => setSearchArtist(e.target.value)}
                 disabled={isSubmitting}
-                className="bg-slate-800 border-slate-700 text-white placeholder:text-slate-500"
+                style={{ backgroundColor: 'var(--secondary)', borderColor: 'var(--card-border)', color: 'var(--text)' }}
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="search-title" className="text-slate-200">Title</Label>
+              <Label htmlFor="search-title" style={{ color: 'var(--text)' }}>Title</Label>
               <Input
                 id="search-title"
                 placeholder="Song title"
                 value={searchTitle}
                 onChange={(e) => setSearchTitle(e.target.value)}
                 disabled={isSubmitting}
-                className="bg-slate-800 border-slate-700 text-white placeholder:text-slate-500"
+                style={{ backgroundColor: 'var(--secondary)', borderColor: 'var(--card-border)', color: 'var(--text)' }}
               />
             </div>
           </div>
 
           {/* Theme Selection */}
-          <div className="space-y-4 pt-4 border-t border-slate-700">
+          <div className="space-y-4 pt-4 border-t" style={{ borderColor: 'var(--card-border)' }}>
             <ThemeSelector
               value={selectedTheme}
               onChange={setSelectedTheme}

--- a/frontend/components/job/ThemeSelector.tsx
+++ b/frontend/components/job/ThemeSelector.tsx
@@ -6,7 +6,8 @@ import type { VideoThemeSummary } from "@/lib/video-themes"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Palette, AlertCircle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Palette, AlertCircle, Eye, EyeOff } from "lucide-react"
 
 interface ThemeSelectorProps {
   value?: string
@@ -18,6 +19,7 @@ export function ThemeSelector({ value, onChange, disabled }: ThemeSelectorProps)
   const [themes, setThemes] = useState<VideoThemeSummary[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [showPreview, setShowPreview] = useState(false)
 
   useEffect(() => {
     async function loadThemes() {
@@ -52,11 +54,11 @@ export function ThemeSelector({ value, onChange, disabled }: ThemeSelectorProps)
   if (loading) {
     return (
       <div className="space-y-2">
-        <Label className="text-slate-200 flex items-center gap-2">
+        <Label className="flex items-center gap-2" style={{ color: 'var(--text)' }}>
           <Palette className="w-4 h-4" />
           Video Theme
         </Label>
-        <Skeleton className="h-10 w-full bg-slate-700" />
+        <Skeleton className="h-10 w-full" style={{ backgroundColor: 'var(--secondary)' }} />
       </div>
     )
   }
@@ -64,7 +66,7 @@ export function ThemeSelector({ value, onChange, disabled }: ThemeSelectorProps)
   if (error || themes.length === 0) {
     return (
       <div className="space-y-2">
-        <Label className="text-slate-200 flex items-center gap-2">
+        <Label className="flex items-center gap-2" style={{ color: 'var(--text)' }}>
           <Palette className="w-4 h-4" />
           Video Theme
         </Label>
@@ -78,7 +80,7 @@ export function ThemeSelector({ value, onChange, disabled }: ThemeSelectorProps)
 
   return (
     <div className="space-y-2">
-      <Label htmlFor="theme-select" className="text-slate-200 flex items-center gap-2">
+      <Label htmlFor="theme-select" className="flex items-center gap-2" style={{ color: 'var(--text)' }}>
         <Palette className="w-4 h-4" />
         Video Theme
       </Label>
@@ -90,16 +92,16 @@ export function ThemeSelector({ value, onChange, disabled }: ThemeSelectorProps)
       >
         <SelectTrigger
           id="theme-select"
-          className="bg-slate-800 border-slate-700 text-white"
+          style={{ backgroundColor: 'var(--secondary)', borderColor: 'var(--card-border)', color: 'var(--text)' }}
         >
           <SelectValue placeholder="Select a theme..." />
         </SelectTrigger>
-        <SelectContent className="bg-slate-800 border-slate-700">
+        <SelectContent style={{ backgroundColor: 'var(--card)', borderColor: 'var(--card-border)' }}>
           {themes.map((theme) => (
             <SelectItem
               key={theme.id}
               value={theme.id}
-              className="text-white hover:bg-slate-700 focus:bg-slate-700"
+              style={{ color: 'var(--text)' }}
             >
               <div className="flex items-center gap-2">
                 <span>{theme.name}</span>
@@ -112,13 +114,26 @@ export function ThemeSelector({ value, onChange, disabled }: ThemeSelectorProps)
         </SelectContent>
       </Select>
 
-      {/* Theme description and preview */}
-      {selectedTheme && (
+      {/* Theme preview toggle */}
+      {selectedTheme?.thumbnail_url && (
         <div className="mt-2 space-y-2">
-          <p className="text-sm text-slate-400">{selectedTheme.description}</p>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setShowPreview(!showPreview)}
+            className="px-0"
+            style={{ color: 'var(--text-muted)' }}
+          >
+            {showPreview ? (
+              <><EyeOff className="w-4 h-4 mr-1.5" />Hide preview</>
+            ) : (
+              <><Eye className="w-4 h-4 mr-1.5" />Show preview</>
+            )}
+          </Button>
 
-          {selectedTheme.thumbnail_url && (
-            <div className="relative w-full aspect-video max-w-xs rounded-lg overflow-hidden border border-slate-700">
+          {showPreview && (
+            <div className="relative w-full aspect-video max-w-xs rounded-lg overflow-hidden border" style={{ borderColor: 'var(--card-border)' }}>
               <img
                 src={selectedTheme.thumbnail_url}
                 alt={`${selectedTheme.name} preview`}

--- a/frontend/components/version-footer.tsx
+++ b/frontend/components/version-footer.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+
+export function VersionFooter() {
+  const [backendVersion, setBackendVersion] = useState<string | null>(null);
+  // Frontend version is injected at build time from pyproject.toml
+  const frontendVersion = process.env.NEXT_PUBLIC_APP_VERSION || "dev";
+
+  useEffect(() => {
+    const fetchBackendVersion = async () => {
+      try {
+        const info = await api.getBackendInfo();
+        setBackendVersion(info.version);
+      } catch (error) {
+        console.error("Failed to fetch backend version:", error);
+        setBackendVersion(null);
+      }
+    };
+
+    fetchBackendVersion();
+  }, []);
+
+  return (
+    <footer className="border-t mt-12 py-6" style={{ borderColor: 'var(--card-border)' }}>
+      <div className="px-4 text-center text-sm" style={{ color: 'var(--text-muted)' }}>
+        <p>
+          Powered by{" "}
+          <a href="https://github.com/nomadkaraoke/karaoke-gen" className="text-amber-500 hover:underline">
+            karaoke-gen
+          </a>
+        </p>
+        <p className="mt-1 text-xs opacity-75">
+          Frontend: v{frontendVersion}
+          {backendVersion && (
+            <>
+              {" | "}
+              Backend: v{backendVersion}
+            </>
+          )}
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -517,6 +517,20 @@ export const api = {
     const data = await handleResponse<{ description: string | null }>(response);
     return data.description;
   },
+
+  // ==========================================================================
+  // Version API endpoint
+  // ==========================================================================
+
+  /**
+   * Get backend service info including version
+   */
+  async getBackendInfo(): Promise<{ service: string; version: string; status: string }> {
+    const response = await fetch(`${API_BASE_URL}/`, {
+      headers: getAuthHeaders()
+    });
+    return handleResponse(response);
+  },
 };
 
 export { ApiError };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "my-v0-project",
-  "version": "0.1.0",
+  "name": "karaoke-gen-frontend",
+  "version": "0.76.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "my-v0-project",
-      "version": "0.1.0",
+      "name": "karaoke-gen-frontend",
+      "version": "0.76.26",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "1.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "my-v0-project",
-  "version": "0.1.0",
+  "name": "karaoke-gen-frontend",
+  "version": "0.76.26",
   "private": true,
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
## Summary
- Add version footer showing frontend and backend versions (helps verify deployments)
- Make Search the default/first tab (reordered: Search, Upload, URL)
- Remove theme description text from selector
- Add "Show preview" button for theme thumbnails (prevents auto-download on page load)
- Fix light mode colors using CSS variables throughout all form components
- Sync frontend package.json version with pyproject.toml (0.76.26)

## Test plan
- [x] Unit tests pass (138/138)
- [ ] Verify version display shows correct frontend and backend versions
- [ ] Verify Search tab is now the default
- [ ] Verify theme preview only loads when button is clicked
- [ ] Test light mode - colors should be readable (no grey on grey)

🤖 Generated with [Claude Code](https://claude.com/claude-code)