### PR TITLE
fix(frontend): improve tab visibility and job card styling for light mode

### DIFF
--- a/frontend/components/job/JobActions.tsx
+++ b/frontend/components/job/JobActions.tsx
@@ -124,7 +124,8 @@ export function JobActions({ job, onRefresh, showLogs, onToggleLogs }: JobAction
         size="sm"
         variant="ghost"
         onClick={onToggleLogs}
-        className="text-xs text-slate-400 hover:text-white"
+        className="text-xs"
+        style={{ color: 'var(--text-muted)' }}
       >
         <FileText className="w-3 h-3 mr-1" />
         {showLogs ? "Hide" : "Show"} Logs

--- a/frontend/components/job/JobCard.tsx
+++ b/frontend/components/job/JobCard.tsx
@@ -60,7 +60,7 @@ function ProgressBar({ job }: { job: Job }) {
   const barColor = barColorMap[color] || "bg-blue-400"
 
   return (
-    <div className="w-full h-1 bg-slate-700/50 rounded-full mt-2 overflow-hidden">
+    <div className="w-full h-1 rounded-full mt-2 overflow-hidden" style={{ backgroundColor: 'var(--secondary)' }}>
       <div
         className={`h-full ${barColor} rounded-full transition-all duration-500 ease-out`}
         style={{ width: `${progressPercent}%` }}
@@ -190,18 +190,22 @@ export function JobCard({ job, onRefresh }: JobCardProps) {
 
   return (
     <div
-      className={`rounded-lg border p-3 transition-colors border-slate-700 bg-slate-800/30
+      className={`rounded-lg border p-3 transition-colors
         ${isComplete ? "border-green-500/30" : ""}
         ${isFailed ? "border-red-500/30" : ""}`}
+      style={{
+        borderColor: isComplete || isFailed ? undefined : 'var(--card-border)',
+        backgroundColor: 'var(--card)',
+      }}
     >
       {/* Header row with title */}
-      <p className="font-medium text-white truncate">
+      <p className="font-medium truncate" style={{ color: 'var(--text)' }}>
         {job.artist || "Unknown"} - {job.title || "Unknown"}
       </p>
 
       {/* Meta row: ID, date, status */}
-      <p className="text-xs text-slate-500 mt-1">
-        <span className="text-slate-600">ID:</span> {job.job_id} <span className="text-slate-600">•</span> {createdAt} <span className="text-slate-600">•</span> <StatusIndicator job={job} />
+      <p className="text-xs mt-1" style={{ color: 'var(--text-muted)' }}>
+        <span style={{ opacity: 0.7 }}>ID:</span> {job.job_id} <span style={{ opacity: 0.7 }}>•</span> {createdAt} <span style={{ opacity: 0.7 }}>•</span> <StatusIndicator job={job} />
       </p>
 
       {/* Progress bar for active jobs */}

--- a/frontend/components/job/JobLogs.tsx
+++ b/frontend/components/job/JobLogs.tsx
@@ -34,7 +34,7 @@ export function JobLogs({ jobId, limit = 50 }: JobLogsProps) {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-4 text-slate-400">
+      <div className="flex items-center justify-center py-4" style={{ color: 'var(--text-muted)' }}>
         <Loader2 className="w-4 h-4 animate-spin mr-2" />
         Loading logs...
       </div>
@@ -52,14 +52,14 @@ export function JobLogs({ jobId, limit = 50 }: JobLogsProps) {
 
   if (logs.length === 0) {
     return (
-      <div className="text-center py-4 text-slate-500 text-sm">
+      <div className="text-center py-4 text-sm" style={{ color: 'var(--text-muted)' }}>
         No logs available
       </div>
     )
   }
 
   return (
-    <div className="bg-slate-900 rounded border border-slate-700 p-3 max-h-64 overflow-y-auto">
+    <div className="rounded border p-3 max-h-64 overflow-y-auto" style={{ backgroundColor: 'var(--bg)', borderColor: 'var(--card-border)' }}>
       <div className="space-y-1 font-mono text-xs">
         {logs.map((log, index) => (
           <div
@@ -68,10 +68,11 @@ export function JobLogs({ jobId, limit = 50 }: JobLogsProps) {
               log.level === "ERROR" ? "text-red-400" :
               log.level === "WARNING" ? "text-yellow-400" :
               log.level === "INFO" ? "text-blue-400" :
-              "text-slate-400"
+              ""
             }`}
+            style={log.level !== "ERROR" && log.level !== "WARNING" && log.level !== "INFO" ? { color: 'var(--text-muted)' } : undefined}
           >
-            <span className="text-slate-600 shrink-0">
+            <span className="shrink-0" style={{ color: 'var(--text-muted)', opacity: 0.7 }}>
               {new Date(log.timestamp).toLocaleTimeString()}
             </span>
             <span className="shrink-0 font-semibold w-12">

--- a/frontend/components/job/JobSubmission.tsx
+++ b/frontend/components/job/JobSubmission.tsx
@@ -147,16 +147,28 @@ export function JobSubmission({ onJobCreated }: JobSubmissionProps) {
 
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab}>
-      <TabsList className="grid w-full grid-cols-3 h-auto" style={{ backgroundColor: 'var(--secondary)' }}>
-        <TabsTrigger value="search" className="gap-1.5 sm:gap-2 py-3 min-h-[44px] text-xs sm:text-sm" style={{ color: 'var(--text)' }}>
+      <TabsList className="grid w-full grid-cols-3 h-auto rounded-lg p-1" style={{ backgroundColor: 'var(--secondary)' }}>
+        <TabsTrigger
+          value="search"
+          className="gap-1.5 sm:gap-2 py-3 min-h-[44px] text-xs sm:text-sm rounded-md data-[state=active]:bg-amber-500 data-[state=active]:text-white data-[state=inactive]:opacity-70"
+          style={{ color: 'var(--text)' }}
+        >
           <Music className="w-4 h-4 shrink-0" />
           <span className="truncate">Search</span>
         </TabsTrigger>
-        <TabsTrigger value="upload" className="gap-1.5 sm:gap-2 py-3 min-h-[44px] text-xs sm:text-sm" style={{ color: 'var(--text)' }}>
+        <TabsTrigger
+          value="upload"
+          className="gap-1.5 sm:gap-2 py-3 min-h-[44px] text-xs sm:text-sm rounded-md data-[state=active]:bg-amber-500 data-[state=active]:text-white data-[state=inactive]:opacity-70"
+          style={{ color: 'var(--text)' }}
+        >
           <Upload className="w-4 h-4 shrink-0" />
           <span className="truncate">Upload</span>
         </TabsTrigger>
-        <TabsTrigger value="url" className="gap-1.5 sm:gap-2 py-3 min-h-[44px] text-xs sm:text-sm" style={{ color: 'var(--text)' }}>
+        <TabsTrigger
+          value="url"
+          className="gap-1.5 sm:gap-2 py-3 min-h-[44px] text-xs sm:text-sm rounded-md data-[state=active]:bg-amber-500 data-[state=active]:text-white data-[state=inactive]:opacity-70"
+          style={{ color: 'var(--text)' }}
+        >
           <Youtube className="w-4 h-4 shrink-0" />
           <span className="truncate">URL</span>
         </TabsTrigger>

--- a/frontend/components/job/OutputLinks.tsx
+++ b/frontend/components/job/OutputLinks.tsx
@@ -42,7 +42,7 @@ export function OutputLinks({ jobId }: OutputLinksProps) {
 
   if (isLoading) {
     return (
-      <div className="flex items-center gap-2 text-xs text-slate-400">
+      <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--text-muted)' }}>
         <Loader2 className="w-3 h-3 animate-spin" />
         Loading downloads...
       </div>
@@ -56,7 +56,7 @@ export function OutputLinks({ jobId }: OutputLinksProps) {
       {/* Combined Output Links */}
       {hasOutputs && (
         <div className="space-y-2">
-          <p className="text-xs text-slate-400 font-medium">Outputs:</p>
+          <p className="text-xs font-medium" style={{ color: 'var(--text-muted)' }}>Outputs:</p>
           <div className="flex flex-wrap gap-2">
             {/* Distribution Links */}
             {youtubeUrl && (
@@ -107,7 +107,7 @@ export function OutputLinks({ jobId }: OutputLinksProps) {
             {downloadUrls?.packages?.cdg_zip && (
               <a
                 href={api.getDownloadUrl(jobId, "packages", "cdg_zip")}
-                className="inline-flex items-center gap-1 text-xs px-2 py-1.5 rounded bg-slate-600 hover:bg-slate-500 text-white"
+                className="inline-flex items-center gap-1 text-xs px-2 py-1.5 rounded bg-gray-700 hover:bg-gray-600 text-white"
                 onClick={(e) => e.stopPropagation()}
               >
                 <Download className="w-3 h-3" />
@@ -117,7 +117,7 @@ export function OutputLinks({ jobId }: OutputLinksProps) {
             {downloadUrls?.packages?.txt_zip && (
               <a
                 href={api.getDownloadUrl(jobId, "packages", "txt_zip")}
-                className="inline-flex items-center gap-1 text-xs px-2 py-1.5 rounded bg-slate-600 hover:bg-slate-500 text-white"
+                className="inline-flex items-center gap-1 text-xs px-2 py-1.5 rounded bg-gray-700 hover:bg-gray-600 text-white"
                 onClick={(e) => e.stopPropagation()}
               >
                 <Download className="w-3 h-3" />
@@ -129,7 +129,7 @@ export function OutputLinks({ jobId }: OutputLinksProps) {
       )}
 
       {!hasOutputs && (
-        <p className="text-xs text-slate-500">No outputs available yet</p>
+        <p className="text-xs" style={{ color: 'var(--text-muted)' }}>No outputs available yet</p>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- Add amber background to active tab for clear visibility in both dark and light modes
- Fix job card backgrounds to use CSS variables instead of hardcoded slate colors
- Update OutputLinks, JobLogs, JobActions components with proper theme variables
- Progress bar now uses CSS variables for background

## Test plan
- [x] Unit tests pass (138/138)
- [ ] Verify active tab is clearly visible in dark mode (amber background)
- [ ] Verify active tab is clearly visible in light mode (amber background)
- [ ] Verify job cards have proper background in light mode (white, not grey)

🤖 Generated with [Claude Code](https://claude.com/claude-code)