### PR TITLE
ci: use self-hosted runners for heavy CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
 
   package-unit-tests:
     name: "Package - Unit Tests (70% coverage)"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, gcp]
     needs: changes
     if: github.ref != 'refs/heads/main' && (needs.changes.outputs.package == 'true' || needs.changes.outputs.deps == 'true')
     steps:
@@ -186,7 +186,7 @@ jobs:
 
   package-integration-tests:
     name: "Package - Integration Tests"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, gcp]
     needs: changes
     if: github.ref != 'refs/heads/main' && (needs.changes.outputs.package == 'true' || needs.changes.outputs.deps == 'true')
     steps:
@@ -356,7 +356,7 @@ jobs:
 
   backend-lint:
     name: "Backend - Code Quality"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, gcp]
     needs: changes
     if: github.ref != 'refs/heads/main' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.package == 'true')
     steps:
@@ -429,7 +429,7 @@ jobs:
 
   package-build:
     name: "Package - Build"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, gcp]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Move disk-intensive CI jobs to self-hosted GCP runners to fix "No space left on device" errors
- Leverage our 10 powerful self-hosted runners (200GB SSD, 4 vCPU, 16GB RAM)
- Fixes failure from run [#20559390850](https://github.com/nomadkaraoke/karaoke-gen/actions/runs/20559390850/job/59047959760?pr=90)

## Changes
Jobs moved from `ubuntu-latest` to `[self-hosted, linux, gcp]`:
| Job | Reason |
|-----|--------|
| `backend-lint` | **Failed with disk space error** |
| `package-unit-tests` | Heavy - Poetry + spaCy model downloads |
| `package-integration-tests` | Heavy - Poetry + spaCy model downloads |
| `package-build` | Heavy - Poetry build during deploy |

Jobs kept on `ubuntu-latest` (lightweight):
- `changes` - Path filtering only
- `frontend-unit-tests` - npm install + tests
- `frontend-build` - npm build
- `ci-gate` - Just checks results
- `package-publish` - Downloads artifacts and publishes
- `deploy-frontend` - npm build for GitHub Pages

## Test plan
- [ ] CI workflow runs successfully on this PR
- [ ] Jobs execute on self-hosted runners (check runner labels in Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)