### PR TITLE
Scale GitHub Actions runners from 10 to 20

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -262,7 +262,7 @@ Multiple GCP VMs run self-hosted GitHub Actions runners to:
 
 ### Specs
 
-- **Instances**: 10x e2-standard-4 (4 vCPU, 16GB RAM each)
+- **Instances**: 20x e2-standard-4 (4 vCPU, 16GB RAM each)
 - **Disk**: 200GB SSD per runner
 - **Pre-installed**: Docker, Python 3.13, Node.js 20, Java 21, Poetry, FFmpeg, gcloud CLI
 - **Labels**: `self-hosted`, `linux`, `x64`, `gcp`, `large-disk`
@@ -285,7 +285,7 @@ Multiple GCP VMs run self-hosted GitHub Actions runners to:
 
 4. Verify the runners registered:
    - Go to https://github.com/nomadkaraoke/karaoke-gen/settings/actions/runners
-   - You should see `gcp-runner-github-runner-1` through `gcp-runner-github-runner-10`
+   - You should see `gcp-runner-github-runner-1` through `gcp-runner-github-runner-20`
 
 ### Usage in Workflows
 
@@ -325,7 +325,7 @@ gcloud compute ssh github-runner-N --zone=us-central1-a -- \
 
 **List all runners:**
 ```bash
-for i in {1..10}; do
+for i in {1..20}; do
   echo "=== github-runner-$i ==="
   gcloud compute instances describe github-runner-$i --zone=us-central1-a --format='get(status)'
 done

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -1423,11 +1423,31 @@ docker system prune -af --filter "until=168h"
 CRON
 chmod +x /etc/cron.daily/docker-cleanup
 
+# ==================== Pre-warm Docker images ====================
+# Pre-fetch commonly used Docker images to speed up first CI runs
+echo "Pre-warming Docker images for faster CI builds..."
+
+# Configure Docker to authenticate with Artifact Registry
+gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+
+# Pull base images used by deploy-backend job (largest layers, most benefit from caching)
+echo "Pulling karaoke-backend-base image..."
+docker pull us-central1-docker.pkg.dev/nomadkaraoke/karaoke-repo/karaoke-backend-base:latest || true
+
+echo "Pulling karaoke-backend image..."
+docker pull us-central1-docker.pkg.dev/nomadkaraoke/karaoke-repo/karaoke-backend:latest || true
+
+# Pull GCS emulator image used by backend-emulator-tests job
+echo "Pulling fake-gcs-server image..."
+docker pull fsouza/fake-gcs-server:latest || true
+
+echo "Docker images pre-warmed"
+
 echo "Setup complete!"
 """
 
 # GitHub runner VM instances (multiple runners for parallel job execution)
-NUM_RUNNERS = 10
+NUM_RUNNERS = 20
 github_runner_vms = []
 
 for i in range(1, NUM_RUNNERS + 1):
@@ -1455,10 +1475,10 @@ for i in range(1, NUM_RUNNERS + 1):
         tags=["github-runner"],
         allow_stopping_for_update=True,
         # Ensure the secret exists before creating the VM
-        # For existing runners (1-5), ignore startup script changes to avoid replacement
+        # For existing runners (1-10), ignore startup script changes to avoid replacement
         opts=pulumi.ResourceOptions(
             depends_on=[github_runner_pat_secret],
-            ignore_changes=["metadataStartupScript"] if i <= 5 else None,
+            ignore_changes=["metadataStartupScript"] if i <= 10 else None,
         ),
     )
     github_runner_vms.append(vm)


### PR DESCRIPTION
## Summary
- Scale self-hosted GitHub Actions runners from 10 to 20 VMs
- Add Docker image pre-warming to startup script for faster first builds
- Protect existing runners (1-10) from startup script replacement

## Changes
- `infrastructure/__main__.py`:
  - `NUM_RUNNERS`: 10 → 20
  - `ignore_changes` protection: runners 1-5 → 1-10
  - Added Docker image pre-fetch to startup script (karaoke-backend-base, karaoke-backend, fake-gcs-server)
- `infrastructure/README.md`: Updated runner count documentation

## Test plan
- [ ] Run `pulumi preview` to verify 10 new runners will be created
- [ ] Run `pulumi up` to create runners 11-20
- [ ] Verify new runners appear in GitHub Actions settings
- [ ] Confirm Docker images are pre-warmed on new runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)