### PR TITLE
feat: Add Stripe/SendGrid secrets to Pulumi and buy-site CI deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       package: ${{ steps.filter.outputs.package }}
       infra: ${{ steps.filter.outputs.infra }}
       deps: ${{ steps.filter.outputs.deps }}
+      buy_site: ${{ steps.filter.outputs.buy_site }}
     steps:
       - uses: actions/checkout@v4
 
@@ -50,6 +51,8 @@ jobs:
               - 'infrastructure/**'
             deps:
               - 'poetry.lock'
+            buy_site:
+              - 'buy-site/**'
 
       - name: Summary
         run: |
@@ -61,6 +64,7 @@ jobs:
           echo "| Package | ${{ steps.filter.outputs.package }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Infrastructure | ${{ steps.filter.outputs.infra }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Dependencies | ${{ steps.filter.outputs.deps }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Buy Site | ${{ steps.filter.outputs.buy_site }} |" >> $GITHUB_STEP_SUMMARY
 
   # ============================================
   # FRONTEND TESTS (PRs only - main skips tests)
@@ -623,6 +627,38 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  deploy-buy-site:
+    name: "Deploy - Buy Site (Cloudflare Pages)"
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js with caching
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: buy-site/package-lock.json
+
+      - name: Install dependencies
+        working-directory: buy-site
+        run: npm ci
+
+      - name: Build buy-site (Next.js static export)
+        working-directory: buy-site
+        env:
+          NEXT_PUBLIC_API_URL: https://api.nomadkaraoke.com
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy buy-site/out --project-name=nomadkaraoke-buy --branch=main
 
   deploy-backend:
     name: "Deploy - Backend (Cloud Run)"

--- a/docs/STRIPE-SETUP.md
+++ b/docs/STRIPE-SETUP.md
@@ -20,15 +20,17 @@ This guide walks you through setting up Stripe for the Nomad Karaoke payment sys
 
 ## 2. Store Keys in Google Cloud Secret Manager
 
-Store your Stripe keys securely in Secret Manager:
+The secret containers are already created via Pulumi (in `infrastructure/__main__.py`). You just need to add the secret values:
 
 ```bash
-# Store the secret key
-echo -n "sk_live_your_key_here" | gcloud secrets create stripe-secret-key --data-file=-
+# Store the Stripe secret key
+echo -n "sk_live_your_key_here" | gcloud secrets versions add stripe-secret-key --data-file=-
 
 # Store the webhook secret (after step 3)
-echo -n "whsec_your_webhook_secret" | gcloud secrets create stripe-webhook-secret --data-file=-
+echo -n "whsec_your_webhook_secret" | gcloud secrets versions add stripe-webhook-secret --data-file=-
 ```
+
+> **Note**: If running for the first time after Pulumi creates the secrets, use `gcloud secrets versions add` (not `gcloud secrets create`).
 
 ## 3. Set Up Webhook Endpoint
 
@@ -75,19 +77,15 @@ For sending magic link and purchase confirmation emails:
 
 1. Sign up for SendGrid: https://sendgrid.com
 2. Create an API key with "Mail Send" permissions
-3. Store it in Secret Manager:
+3. Store it in Secret Manager (secret container created by Pulumi):
 
 ```bash
-echo -n "SG.your_sendgrid_api_key" | gcloud secrets create sendgrid-api-key --data-file=-
+echo -n "SG.your_sendgrid_api_key" | gcloud secrets versions add sendgrid-api-key --data-file=-
 ```
 
-4. Set environment variables:
-
-```bash
-SENDGRID_API_KEY=SG.your_sendgrid_api_key
-EMAIL_FROM=noreply@nomadkaraoke.com
-EMAIL_FROM_NAME=Nomad Karaoke
-```
+4. The environment variables are configured in the Cloud Run deployment. Defaults:
+   - `EMAIL_FROM=noreply@nomadkaraoke.com`
+   - `EMAIL_FROM_NAME=Nomad Karaoke`
 
 ## 6. Test the Integration
 

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -612,6 +612,34 @@ ops_api_url_secret = secretmanager.Secret(
     ),
 )
 
+# ==================== Payment & Email Secrets ====================
+# Stripe API Secret Key (for checkout sessions and webhooks)
+stripe_secret_key = secretmanager.Secret(
+    "stripe-secret-key",
+    secret_id="stripe-secret-key",
+    replication=secretmanager.SecretReplicationArgs(
+        auto=secretmanager.SecretReplicationAutoArgs(),
+    ),
+)
+
+# Stripe Webhook Secret (for verifying webhook signatures)
+stripe_webhook_secret = secretmanager.Secret(
+    "stripe-webhook-secret",
+    secret_id="stripe-webhook-secret",
+    replication=secretmanager.SecretReplicationArgs(
+        auto=secretmanager.SecretReplicationAutoArgs(),
+    ),
+)
+
+# SendGrid API Key (for transactional emails: magic links, confirmations)
+sendgrid_api_key = secretmanager.Secret(
+    "sendgrid-api-key",
+    secret_id="sendgrid-api-key",
+    replication=secretmanager.SecretReplicationArgs(
+        auto=secretmanager.SecretReplicationAutoArgs(),
+    ),
+)
+
 # Create Cloud Run Domain Mapping
 # Maps api.nomadkaraoke.com to the karaoke-backend service
 domain_mapping = cloudrun.DomainMapping(


### PR DESCRIPTION
## Summary

- Adds Pulumi-managed secrets for Stripe and SendGrid (containers only, values added manually via gcloud)
- Adds buy-site deployment to CI workflow using Cloudflare Pages
- Updates STRIPE-SETUP.md to reference the Pulumi-managed secrets

## Changes

### Infrastructure (`infrastructure/__main__.py`)
- Add `stripe-secret-key` secret
- Add `stripe-webhook-secret` secret  
- Add `sendgrid-api-key` secret

### CI/CD (`.github/workflows/ci.yml`)
- Add `buy_site` to path detection filters
- Add `deploy-buy-site` job that:
  - Builds buy-site Next.js static export
  - Deploys to Cloudflare Pages (project: nomadkaraoke-buy)

### Documentation (`docs/STRIPE-SETUP.md`)
- Updated to reference Pulumi-managed secrets
- Changed `gcloud secrets create` to `gcloud secrets versions add`

## Pre-requisites for buy-site deployment

You'll need to add these GitHub secrets:
- `CLOUDFLARE_API_TOKEN` - Cloudflare API token with Pages edit permissions
- `CLOUDFLARE_ACCOUNT_ID` - Your Cloudflare account ID

And create the Cloudflare Pages project:
```bash
npx wrangler pages project create nomadkaraoke-buy
```

## Test plan

- [ ] Run `pulumi up` to create the new secrets
- [ ] Add secret values via gcloud
- [ ] Verify buy-site builds successfully in CI
- [ ] Verify buy-site deploys to Cloudflare Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)