### PR TITLE
feat: Add email service config check and error handling

### DIFF
--- a/backend/api/routes/health.py
+++ b/backend/api/routes/health.py
@@ -8,6 +8,8 @@ from typing import Dict, Any, Optional
 
 from backend.version import VERSION
 from backend.services.flacfetch_client import get_flacfetch_client
+from backend.services.email_service import get_email_service
+from backend.services.stripe_service import get_stripe_service
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -103,23 +105,42 @@ async def check_flacfetch_service_status() -> Dict[str, Any]:
 async def detailed_health_check() -> Dict[str, Any]:
     """
     Detailed health check including dependencies.
-    
+
     Use this to debug issues with Transmission, flacfetch service, etc.
     """
     transmission_status = check_transmission_status()
     flacfetch_status = await check_flacfetch_service_status()
-    
+
+    # Check email service
+    email_service = get_email_service()
+    email_status = {
+        "configured": email_service.is_configured(),
+        "provider": type(email_service.provider).__name__,
+    }
+
+    # Check Stripe service
+    stripe_service = get_stripe_service()
+    stripe_status = {
+        "configured": stripe_service.is_configured(),
+    }
+
     # Log for debugging
     if not transmission_status.get("available"):
         logger.warning(f"Local Transmission not available: {transmission_status.get('error')}")
     else:
         logger.info(f"Local Transmission available at {transmission_status.get('host')}:{transmission_status.get('port')}")
-    
+
     if flacfetch_status.get("configured") and not flacfetch_status.get("available"):
         logger.warning(f"Remote flacfetch service not available: {flacfetch_status.get('error')}")
     elif flacfetch_status.get("available"):
         logger.info(f"Remote flacfetch service healthy: {flacfetch_status.get('status')}")
-    
+
+    if not email_status["configured"]:
+        logger.warning("Email service not configured - magic links will not work")
+
+    if not stripe_status["configured"]:
+        logger.warning("Stripe service not configured - payments will not work")
+
     return {
         "status": "healthy",
         "service": "karaoke-gen-backend",
@@ -127,6 +148,10 @@ async def detailed_health_check() -> Dict[str, Any]:
         "dependencies": {
             "transmission_local": transmission_status,
             "flacfetch_remote": flacfetch_status,
+        },
+        "services": {
+            "email": email_status,
+            "stripe": stripe_status,
         }
     }
 

--- a/backend/api/routes/users.py
+++ b/backend/api/routes/users.py
@@ -100,6 +100,14 @@ async def send_magic_link(
     The user will receive an email with a link that logs them in.
     Links expire after 15 minutes and can only be used once.
     """
+    # Check if email service is configured
+    if not email_service.is_configured():
+        logger.error("Email service not configured - cannot send magic links")
+        raise HTTPException(
+            status_code=503,
+            detail="Email service is not available. Please contact support."
+        )
+
     email = request.email.lower()
 
     # Get client info for security logging
@@ -396,6 +404,14 @@ async def enroll_beta_tester(
 
     Returns free credits and optionally a session token for new users.
     """
+    # Check if email service is configured
+    if not email_service.is_configured():
+        logger.error("Email service not configured - cannot send beta welcome emails")
+        raise HTTPException(
+            status_code=503,
+            detail="Email service is not available. Please contact support."
+        )
+
     email = request.email.lower()
 
     # Validate acceptance

--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -136,6 +136,10 @@ class EmailService:
             logger.warning("No email provider configured, using console logging")
             return ConsoleEmailProvider()
 
+    def is_configured(self) -> bool:
+        """Check if a real email provider is configured (not just console logging)."""
+        return isinstance(self.provider, SendGridEmailProvider)
+
     def send_magic_link(self, email: str, token: str) -> bool:
         """
         Send a magic link email for authentication.

--- a/docs/API.md
+++ b/docs/API.md
@@ -174,7 +174,7 @@ Common status codes:
 - `404` - Job not found
 - `500` - Server error
 
-## User Authentication (PR #90)
+## User Authentication
 
 ### Send Magic Link
 

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -225,6 +225,22 @@ Default 5-minute timeout may not be enough for video encoding. Consider:
 
 Cloud Run service account needs `Secret Manager Secret Accessor` role. This is managed via Pulumi in `infrastructure/`.
 
+### Cloud Run Secret Mounting
+
+**Problem**: Secrets created in Secret Manager aren't automatically available as environment variables in Cloud Run. The IAM role grants *access*, but secrets must be explicitly *mounted*.
+
+**Wrong assumption**: "I added the secret to Secret Manager and gave the service account access, so the secret is available."
+
+**Reality**: Cloud Run needs `--set-secrets` in the deploy command:
+```bash
+gcloud run deploy service-name \
+  --set-secrets "ENV_VAR_NAME=secret-name:latest"
+```
+
+**Symptoms of missing mount**: Service silently falls back to defaults (e.g., email service uses console logging instead of SendGrid).
+
+**Solution**: Add all required secrets to the CI deploy command (`.github/workflows/ci.yml`). Manual `gcloud run services update` fixes are overwritten on next deploy.
+
 ### Vertex AI Authentication
 
 For Gemini via Vertex AI, use Application Default Credentials (ADC) rather than API keys:

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,9 +20,9 @@
 | Instrumental selection | Working |
 | Multi-format encoding | Working |
 | Token-based auth | Working |
-| Magic link auth | In Progress (PR #90) |
-| Payment flow (Stripe) | In Progress (PR #90) |
-| Beta tester program | In Progress (PR #90) |
+| Magic link auth | Working |
+| Payment flow (Stripe) | Working |
+| Beta tester program | Working |
 | CI/CD self-hosted runner | Working (GCP) |
 
 ## Known Issues


### PR DESCRIPTION
## Summary
- Returns 503 error when email service isn't configured (instead of silently failing)
- Adds email/Stripe status to `/health/detailed` endpoint for debugging
- Updates docs to reflect merged payment flow

## Changes

### Backend
- `EmailService.is_configured()` - returns True only if SendGrid is configured
- Magic link endpoint returns 503 if email not configured
- Beta enrollment endpoint returns 503 if email not configured
- `/health/detailed` now shows email and Stripe configuration status

### Documentation
- Updated `docs/README.md` - magic link, Stripe, beta tester now marked "Working"
- Updated `docs/API.md` - removed "(PR #90)" reference
- Added `docs/LESSONS-LEARNED.md` - lesson about Cloud Run secret mounting

## Test plan
- [ ] Verify 503 returned when `SENDGRID_API_KEY` not set
- [ ] Verify `/health/detailed` shows service status
- [ ] Verify magic link works when secrets are properly configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)