### PR TITLE
docs: Add E2E mock response type lesson, mark consolidation complete

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -205,6 +205,43 @@ def _get_effective_distribution_settings(...) -> EffectiveDistributionSettings:
 
 ## Testing Insights
 
+### E2E Mock Responses Must Match API Types Exactly
+
+**Problem**: E2E tests with mocked API responses were failing silently because mock response format didn't match the TypeScript type the app expected.
+
+The test mocked `/api/users/me` returning:
+```javascript
+{ body: { email: 'test@example.com', credits: 5 } }
+```
+
+But `UserProfileResponse` type expects:
+```typescript
+interface UserProfileResponse {
+  user: UserPublic;  // { email, credits, role }
+  has_session: boolean;
+}
+```
+
+**Symptoms**:
+- Tests passed initial auth check but `/api/jobs` was never called
+- Mock server showed only 2 of 4 endpoints being called
+- App redirected to `/` instead of loading job list
+- No error messages (silent failure)
+
+**Root cause**: The auth module's `fetchUser()` ran at page load and tried to access `response.user.email`. With the wrong mock format, this threw an error, the catch block called `clearAccessToken()`, and the app page saw no token and redirected.
+
+**Solution**: Mock must return the exact structure the TypeScript type expects:
+```javascript
+{
+  body: {
+    user: { email: 'test@example.com', credits: 5, role: 'user' },
+    has_session: true,
+  },
+}
+```
+
+**Lesson**: When writing E2E test mocks, check the TypeScript interface/type definition for the API response, not just what fields the UI displays. Silent failures from type mismatches are hard to debug.
+
 ### Emulator Tests Catch Real Bugs
 
 Unit tests with mocks didn't catch the `input_media_gcs_path` bug. Emulator integration tests did because they use real Firestore behavior.

--- a/docs/archive/2025-12-29-e2e-test-consolidation-plan.md
+++ b/docs/archive/2025-12-29-e2e-test-consolidation-plan.md
@@ -1,7 +1,7 @@
 # E2E Test Suite Consolidation Plan
 
 **Date**: December 29, 2025
-**Status**: Planning
+**Status**: Completed
 **Author**: Claude (with Andrew's direction)
 
 ---


### PR DESCRIPTION
## Summary

- Add "E2E Mock Responses Must Match API Types Exactly" lesson to LESSONS-LEARNED.md
- Update e2e-test-consolidation-plan.md status from Planning to Completed

## Details

Documents the lesson learned from debugging E2E test failures where mock responses didn't match TypeScript interface types. The mocks returned `{ email, credits }` but `UserProfileResponse` expects `{ user: { email, credits, role }, has_session: true }`. This caused silent auth failures and redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)