### PR TITLE
fix: Skip slow docker pull when base image is cached locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -779,8 +779,19 @@ jobs:
           BASE_IMAGE="${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.BASE_IMAGE_NAME }}:latest"
 
           # Try to get the existing base image's hash label
+          # First check if image exists locally (fast, no network call)
+          # Only pull from registry if not cached locally
           EXISTING_HASH=""
-          if docker pull $BASE_IMAGE 2>/dev/null; then
+          if docker image inspect $BASE_IMAGE >/dev/null 2>&1; then
+            echo "✅ Base image found in local cache (skipping slow registry pull)"
+            EXISTING_HASH=$(docker inspect $BASE_IMAGE --format='{{index .Config.Labels "base.content.hash"}}' 2>/dev/null || echo "")
+            # Fallback to old label name for backwards compatibility
+            if [ -z "$EXISTING_HASH" ]; then
+              EXISTING_HASH=$(docker inspect $BASE_IMAGE --format='{{index .Config.Labels "poetry.lock.hash"}}' 2>/dev/null || echo "")
+            fi
+            echo "Existing base image hash: $EXISTING_HASH"
+          elif docker pull $BASE_IMAGE 2>/dev/null; then
+            echo "📥 Base image pulled from registry"
             EXISTING_HASH=$(docker inspect $BASE_IMAGE --format='{{index .Config.Labels "base.content.hash"}}' 2>/dev/null || echo "")
             # Fallback to old label name for backwards compatibility
             if [ -z "$EXISTING_HASH" ]; then


### PR DESCRIPTION
## Summary
- Fix 5+ minute delay in "Check if base image exists" CI step
- Use `docker image inspect` (instant) before falling back to `docker pull` (slow)
- Only affects self-hosted runners with pre-warmed Docker images

## Problem
The `docker pull` command was taking ~5 minutes even when the base image was already cached locally, because it contacts the registry and verifies all layers of the 15GB image.

## Solution
Check if image exists locally first with `docker image inspect` (no network call), only pull if not cached.

## Test plan
- [ ] CI passes on this PR
- [ ] Verify deploy job timing improves on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline efficiency through optimized resource management. The build process now prioritizes local cached resources before external requests, reducing network latency and accelerating build times. Fallback mechanisms ensure reliable builds when local resources are unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->