### PR TITLE
feat: Add hourly Docker image pre-warm cron to runners

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -1451,6 +1451,30 @@ docker system prune -af --filter "until=168h"
 CRON
 chmod +x /etc/cron.daily/docker-cleanup
 
+# ==================== Docker pre-warm cron ====================
+# Keep base images fresh by pulling hourly
+echo "Setting up Docker pre-warm cron..."
+cat > /etc/cron.hourly/docker-prewarm << 'CRON'
+#!/bin/bash
+# Pre-warm Docker images used by CI/CD
+# This ensures runners always have the latest base images cached
+
+# Log to syslog
+exec 1> >(logger -t docker-prewarm) 2>&1
+
+echo "Starting Docker image pre-warm..."
+
+# Configure Docker auth (uses instance service account)
+gcloud auth configure-docker us-central1-docker.pkg.dev --quiet 2>/dev/null
+
+# Pull latest images (|| true to not fail if network issues)
+docker pull us-central1-docker.pkg.dev/nomadkaraoke/karaoke-repo/karaoke-backend-base:latest || true
+docker pull us-central1-docker.pkg.dev/nomadkaraoke/karaoke-repo/karaoke-backend:latest || true
+
+echo "Docker image pre-warm complete"
+CRON
+chmod +x /etc/cron.hourly/docker-prewarm
+
 # ==================== Pre-warm Docker images ====================
 # Pre-fetch commonly used Docker images to speed up first CI runs
 echo "Pre-warming Docker images for faster CI builds..."


### PR DESCRIPTION
## Summary
- Adds an hourly cron job on each self-hosted runner to pull latest base images
- Ensures runners always have fresh images cached
- Complements the previous fix (#128) for instant local cache checks

## Changes
- Added `/etc/cron.hourly/docker-prewarm` to runner startup script
- Cron pulls `karaoke-backend-base:latest` and `karaoke-backend:latest` hourly
- Logs to syslog for debugging (`logger -t docker-prewarm`)

## Deployment
- **Already deployed**: Manually added cron job to all 20 existing runners
- **Future runners**: Will get cron job automatically via startup script

## Test plan
- [x] Cron job installed on all 20 runners
- [ ] Verify images stay fresh after next base image rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)