### PR TITLE
fix(agentic): Use gemini-2.0-flash instead of gemini-3-flash-preview

### DIFF
--- a/lyrics_transcriber_temp/lyrics_transcriber/correction/agentic/router.py
+++ b/lyrics_transcriber_temp/lyrics_transcriber/correction/agentic/router.py
@@ -5,8 +5,10 @@ from typing import Dict, Any
 
 from .providers.config import ProviderConfig
 
-# Default model for cloud deployments - Gemini 3 Flash via Vertex AI
-DEFAULT_CLOUD_MODEL = "vertexai/gemini-3-flash-preview"
+# Default model for cloud deployments - Gemini 2.0 Flash via Vertex AI
+# Note: gemini-3-flash-preview requires 'global' location, not us-central1
+# Using gemini-2.0-flash for broader regional availability
+DEFAULT_CLOUD_MODEL = "vertexai/gemini-2.0-flash"
 
 
 class ModelRouter:
@@ -19,7 +21,7 @@ class ModelRouter:
         """Choose appropriate model based on gap characteristics.
 
         Returns model identifier in format "provider/model" for LangChain:
-        - "vertexai/gemini-3-flash-preview" for Gemini via Vertex AI (default)
+        - "vertexai/gemini-2.0-flash" for Gemini via Vertex AI (default)
         - "ollama/llama3.2:latest" for local Ollama models
         - "openai/gpt-4" for OpenAI models
         - "anthropic/claude-3-sonnet-20240229" for Anthropic models
@@ -33,7 +35,7 @@ class ModelRouter:
         if self._config.privacy_mode:
             return "ollama/llama3.2:latest"
 
-        # Default to Gemini 3 Flash for all cases (fast, cost-effective)
+        # Default to Gemini 2.0 Flash for all cases (fast, cost-effective)
         return DEFAULT_CLOUD_MODEL
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.81.3"
+version = "0.81.4"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- **Root Cause**: `gemini-3-flash-preview` model was returning 404 errors because Gemini 3 preview models are only available in the `global` location, not `us-central1`
- **Fix**: Switch to `gemini-2.0-flash` which is a stable GA model available in all regional locations

## Error Observed

```
404 Publisher Model `projects/nomadkaraoke/locations/us-central1/publishers/google/models/gemini-3-flash-preview` was not found or your project does not have access to it.
```

## Files Changed

| File | Change |
|------|--------|
| `lyrics_transcriber_temp/.../agentic/router.py` | Changed `DEFAULT_CLOUD_MODEL` from `gemini-3-flash-preview` to `gemini-2.0-flash` |
| `pyproject.toml` | Version bump 0.81.3 → 0.81.4 |

## Test Plan

- [x] All backend tests pass (57 passed)
- [ ] Deploy and verify agentic correction completes for job 6e4815e2
- [ ] Verify Langfuse traces appear at https://us.cloud.langfuse.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default AI model to Gemini 2.0-Flash
  * Version bumped to 0.81.4

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->