### PR TITLE
fix: Handle both duration field names in instrumental review waveform

### DIFF
--- a/karaoke_gen/instrumental_review/static/index.html
+++ b/karaoke_gen/instrumental_review/static/index.html
@@ -786,8 +786,8 @@
                 
                 if (waveformRes.ok) {
                     waveformData = await waveformRes.json();
-                    // API returns duration_seconds, not duration
-                    duration = waveformData.duration_seconds || 0;
+                    // API may return duration_seconds (cloud) or duration (local)
+                    duration = waveformData.duration_seconds || waveformData.duration || 0;
                 }
                 
                 // Set initial selection based on recommendation


### PR DESCRIPTION
## Summary

- Fixed waveform click-to-seek not working in local CLI instrumental review UI
- The local `/api/jobs/local/waveform-data` endpoint returns `duration` but frontend only checked for `duration_seconds`
- Now handles both field names for compatibility with cloud and local APIs

## Root Cause

Field name mismatch between API response and frontend code:

| API returns | Frontend expected |
|-------------|-------------------|
| `{ "duration": 53.53, ... }` | `waveformData.duration_seconds` |

The global `duration` variable stayed at `0`, causing the click handler to early-return (guard against invalid duration) and preventing all seeking.

## Test plan

- [x] Verified fix with Playwright automated tests
- [x] Manual testing confirmed waveform clicking works in local CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duration detection to reliably handle both cloud and local API response formats, ensuring consistent playback information across different system configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->