### PR TITLE
Add dispatch_deadline to Cloud Tasks to prevent audio worker timeout

### DIFF
--- a/backend/services/worker_service.py
+++ b/backend/services/worker_service.py
@@ -20,6 +20,7 @@ import os
 import json
 from typing import Optional
 import httpx
+from google.protobuf import duration_pb2
 
 from backend.config import get_settings
 from backend.services.tracing import inject_trace_context
@@ -36,6 +37,18 @@ WORKER_QUEUES = {
     "screens": "screens-worker-queue",
     "render-video": "render-worker-queue",
     "video": "video-worker-queue",
+}
+
+# Dispatch deadlines for each worker type (in seconds)
+# Cloud Tasks max is 1800s (30 min). These set how long Cloud Tasks waits
+# for the HTTP handler to respond before considering it failed.
+# Must be >= actual worker timeout + buffer for startup/upload.
+WORKER_DISPATCH_DEADLINES = {
+    "audio": 1800,       # 30 min - Modal separation can take 15-20 min
+    "lyrics": 1500,      # 25 min - TRANSCRIPTION_TIMEOUT_SECONDS is 1200s (20 min)
+    "screens": 600,      # 10 min - Screen generation is fast
+    "render-video": 1800,  # 30 min - Video encoding can be slow
+    "video": 1800,       # 30 min - Video encoding can be slow
 }
 
 
@@ -234,6 +247,9 @@ class WorkerService:
             # This allows worker spans to link back to the original request trace
             headers = inject_trace_context(headers)
             
+            # Get dispatch deadline for this worker type (how long Cloud Tasks waits for response)
+            dispatch_deadline_seconds = WORKER_DISPATCH_DEADLINES.get(worker_type, 600)
+
             # Build task payload
             task = {
                 "http_request": {
@@ -247,6 +263,10 @@ class WorkerService:
                         "service_account_email": f"karaoke-backend@{project}.iam.gserviceaccount.com",
                     },
                 },
+                # Set dispatch_deadline - how long Cloud Tasks waits for the handler to respond
+                # Default is 10 min, but audio separation can take 30+ min
+                # Max is 1800s (30 min) for Cloud Tasks
+                "dispatch_deadline": duration_pb2.Duration(seconds=dispatch_deadline_seconds),
             }
             
             # Create task
@@ -254,7 +274,8 @@ class WorkerService:
             # This prevents duplicate task errors on retries
             response = self.tasks_client.create_task(parent=parent, task=task)
             logger.info(
-                f"[job:{job_id}] Created Cloud Task for {worker_type} worker: {response.name}"
+                f"[job:{job_id}] Created Cloud Task for {worker_type} worker: {response.name} "
+                f"(dispatch_deadline={dispatch_deadline_seconds}s)"
             )
             return True
             

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.86.3"
+version = "0.86.4"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Add explicit `dispatch_deadline` configuration to Cloud Tasks for each worker type
- Audio worker gets 30 minutes (max) to accommodate Modal API separation times
- Lyrics worker gets 25 minutes for AudioShake + agentic correction
- This fixes the issue where audio workers were being killed after ~10 minutes (Cloud Tasks default) before Modal could complete

## Problem
The audio worker was being terminated before Modal API could complete audio separation:
1. Job created, audio task enqueued to Cloud Tasks
2. Cloud Tasks dispatches to Cloud Run, starts 10-minute default deadline timer
3. Audio worker submits to Modal API and waits
4. After 10 minutes, Cloud Tasks considers the dispatch failed
5. Cloud Run container gets killed, Modal task returns 404

## Solution
Set explicit `dispatch_deadline` for each worker type based on their expected execution time:
```python
WORKER_DISPATCH_DEADLINES = {
    "audio": 1800,       # 30 min - Modal separation can take 15-20 min
    "lyrics": 1500,      # 25 min - TRANSCRIPTION_TIMEOUT_SECONDS is 1200s (20 min)
    "screens": 600,      # 10 min - Screen generation is fast
    "render-video": 1800,  # 30 min - Video encoding can be slow
    "video": 1800,       # 30 min - Video encoding can be slow
}
```

## Test plan
- [x] All 57 backend tests pass
- [ ] Deploy and run E2E test to verify audio separation completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced task scheduling with optimized processing deadlines for different job types, improving system efficiency and reliability.

* **Chores**
  * Updated project version to 0.86.4.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->