### PR TITLE
docs: Document worker timeout fixes (PRs #153-155)

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -304,6 +304,32 @@ Default 5-minute timeout may not be enough for video encoding. Consider:
 - Breaking encoding into smaller chunks
 - Increasing timeout for specific operations
 
+### Cloud Tasks dispatch_deadline (Separate from Cloud Run Timeout)
+
+**Problem**: Cloud Tasks HTTP handlers have a separate `dispatch_deadline` (default 10 minutes, max 30 minutes) that controls how long Cloud Tasks waits for the HTTP response. This is DIFFERENT from Cloud Run's service timeout.
+
+**Symptom**: Worker killed silently after 10 minutes even though Cloud Run timeout was set to 30 minutes. Job appears stuck with no error.
+
+**Solution**: Set explicit `dispatch_deadline` when creating Cloud Tasks:
+```python
+from google.protobuf import duration_pb2
+
+task = {
+    "http_request": {...},
+    "dispatch_deadline": duration_pb2.Duration(seconds=1800),  # 30 min max
+}
+```
+
+**Key insight**: For tasks that might take >30 minutes, Cloud Tasks HTTP targets won't work. Use Cloud Run Jobs instead (supports up to 24-hour execution).
+
+| Timeout Type | Default | Max | What It Controls |
+|-------------|---------|-----|------------------|
+| Cloud Tasks `dispatch_deadline` | 10 min | 30 min | How long Cloud Tasks waits for HTTP response |
+| Cloud Run service timeout | 5 min | 60 min | How long a single HTTP request can run |
+| Cloud Run Jobs timeout | 10 min | 24 hr | How long a batch job execution can run |
+
+See `docs/archive/2026-01-01-worker-timeout-fixes.md` for full details.
+
 ### Two-Layer Timeout Pattern for Long-Running Loops
 
 **Problem**: A loop processing many items (e.g., 74 LLM calls at 15s each = 18+ minutes) can block indefinitely. Single outer timeout isn't enough because it may interrupt mid-operation and leave state inconsistent.

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,9 +30,10 @@
 ## Known Issues
 
 - CDG format generation requires additional style configuration
-- Long audio files (>10 min) may timeout on some workers
 
 ## Recent Changes
+
+- **Worker Timeout Fixes** (2026-01-01): Fixed 3 timeout issues blocking job completion: (1) Lyrics transcription timeout increased to 20 min (PR #153), (2) Cloud Tasks dispatch_deadline added for audio worker - default 10 min was killing Modal API calls (PR #154), (3) Enabled Cloud Run Jobs for video encoding - 1-hour timeout vs 30-min Cloud Run service limit (PR #155). Full E2E pipeline now verified working. See [archive/2026-01-01-worker-timeout-fixes.md](archive/2026-01-01-worker-timeout-fixes.md)
 
 - **Agentic Correction Timeout** (2025-12-31): Added 3-minute configurable timeout for agentic AI lyrics correction. Prevents stuck jobs when songs have many gaps (74+ gaps could take 30+ minutes). On timeout, skips correction and proceeds to human review with raw transcription. See [archive/2025-12-31-agentic-timeout-implementation.md](archive/2025-12-31-agentic-timeout-implementation.md)
 - **Job Failure Fixes** (2025-12-31): Fixed 4 critical issues causing job failures: (1) user_email not set on jobs - users couldn't see their jobs, (2) YouTube URL race condition - lyrics worker started before audio downloaded, (3) Audio search cache not persisting across Cloud Run instances, (4) Jobs stuck in downloading state - added 10min transcription timeout. See [archive/2024-12-31-job-failure-investigation.md](archive/2024-12-31-job-failure-investigation.md)

--- a/docs/archive/2026-01-01-worker-timeout-fixes.md
+++ b/docs/archive/2026-01-01-worker-timeout-fixes.md
@@ -1,0 +1,78 @@
+# Worker Timeout Fixes
+
+**Date**: 2026-01-01
+**PRs**: #153, #154, #155
+**Status**: Complete
+
+## Problem
+
+Jobs were failing at different stages due to worker timeouts:
+
+1. **Lyrics worker** - Timeout after 600 seconds (10 minutes) during transcription
+2. **Audio worker** - Killed after 10 minutes by Cloud Tasks default `dispatch_deadline`
+3. **Video worker** - Timeout after 30 minutes (Cloud Run service timeout)
+
+## Root Causes
+
+### Lyrics Transcription Timeout (PR #153)
+- `TRANSCRIPTION_TIMEOUT_SECONDS` was 600 (10 minutes)
+- AudioShake transcription + agentic correction can take 15+ minutes for complex songs
+- **Fix**: Increased to 1200 seconds (20 minutes)
+
+### Cloud Tasks dispatch_deadline (PR #154)
+- Cloud Tasks HTTP handlers have a default `dispatch_deadline` of 10 minutes
+- Audio separation via Modal API takes 15-20+ minutes
+- Worker was killed before Modal could complete, but no error surfaced
+- **Symptom**: Job stuck at `downloading` with `audio_complete: false`
+- **Fix**: Added explicit `dispatch_deadline` per worker type:
+  ```python
+  WORKER_DISPATCH_DEADLINES = {
+      "audio": 1800,       # 30 min
+      "lyrics": 1500,      # 25 min
+      "screens": 600,      # 10 min
+      "render-video": 1800,  # 30 min
+      "video": 1800,       # 30 min
+  }
+  ```
+
+### Video Encoding Timeout (PR #155)
+- Cloud Run service timeout is 1800 seconds (30 minutes)
+- `KaraokeFinalise.process()` takes 30-40+ minutes for average songs
+- Video encoding includes: 4 format encodings, CDG generation, TXT packages
+- **Symptom**: Job stuck at `encoding` with `updated_at` frozen
+- **Fix**: Enabled `USE_CLOUD_RUN_JOBS_FOR_VIDEO=true` in `cloudbuild.yaml`
+- Cloud Run Jobs support up to 1-hour execution (configured in `infrastructure/__main__.py`)
+
+## Key Insight: dispatch_deadline vs Cloud Run Timeout
+
+These are different timeouts:
+
+| Timeout | Default | Max | Controls |
+|---------|---------|-----|----------|
+| Cloud Tasks `dispatch_deadline` | 10 min | 30 min | How long Cloud Tasks waits for HTTP response |
+| Cloud Run service timeout | 5 min | 60 min | How long Cloud Run allows request to run |
+| Cloud Run Jobs timeout | 10 min | 24 hr | How long a batch job can run |
+
+For worker tasks that take >30 minutes, Cloud Tasks HTTP targets can't work. Use Cloud Run Jobs instead.
+
+## Verification
+
+Job `eb725b2c` completed successfully through the full pipeline:
+- Audio separation: Complete
+- Lyrics transcription: Complete
+- Video encoding: Complete
+- All 4 video formats generated
+- All stems, lyrics, and packages available
+
+## Files Changed
+
+- `backend/services/worker_service.py` - Added `dispatch_deadline` to Cloud Tasks
+- `cloudbuild.yaml` - Enabled `USE_CLOUD_RUN_JOBS_FOR_VIDEO=true`
+- `pyproject.toml` - Version bumps (0.86.4, 0.86.5)
+
+## Lessons Learned
+
+1. **Cloud Tasks dispatch_deadline is separate from Cloud Run timeout** - Both need to be configured for long-running workers
+2. **Default dispatch_deadline (10 min) is often insufficient** - Modal API, video encoding, and other heavy processing need more time
+3. **Cloud Run Jobs for truly long tasks** - For anything that might take >30 minutes, Cloud Tasks HTTP targets won't work
+4. **E2E tests reveal timeout issues** - Production E2E tests caught these issues that unit tests missed


### PR DESCRIPTION
## Summary

Documents the worker timeout fixes from PRs #153, #154, and #155 that resolved job failures:

- **Archive doc**: `docs/archive/2026-01-01-worker-timeout-fixes.md` - Full investigation and fix details
- **LESSONS-LEARNED**: Added Cloud Tasks `dispatch_deadline` insight (separate from Cloud Run timeout)
- **README**: Updated recent changes, removed outdated known issue

## Key Insights Documented

1. **Cloud Tasks dispatch_deadline** (default 10 min) is SEPARATE from Cloud Run service timeout
2. For tasks >30 minutes, Cloud Tasks HTTP targets won't work - use Cloud Run Jobs
3. Table comparing all three timeout types and their limits

## Test plan

- [x] Docs render correctly in markdown preview
- [x] Links to archive doc are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed known issue regarding long audio file timeouts
  * Added documentation on worker timeout improvements for audio, lyrics, and video processing
  * Documented new timeout handling patterns for long-running tasks

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->