### PR TITLE
Add GCS-backed cache for LyricsTranscriber to persist API responses

### DIFF
--- a/backend/services/lyrics_cache_service.py
+++ b/backend/services/lyrics_cache_service.py
@@ -1,0 +1,216 @@
+"""
+LyricsTranscriber cache synchronization with GCS.
+
+This service persists LyricsTranscriber's cache files to GCS so that
+cloud workers (Cloud Run instances) can share cache across containers.
+
+Cache files are stored flat in GCS under lyrics-transcriber-cache/ prefix:
+- Transcription: {provider}_{audio_hash}_raw.json, {provider}_{audio_hash}_converted.json
+- Lyrics: {provider}_{artist_title_hash}_raw.json, {provider}_{artist_title_hash}_converted.json
+
+Hash computation matches LyricsTranscriber's implementation exactly:
+- Audio hash: MD5 of audio file bytes
+- Lyrics hash: MD5 of "{artist.lower()}_{title.lower()}"
+"""
+import hashlib
+import logging
+import os
+from typing import Dict, List, Optional
+
+from backend.services.storage_service import StorageService
+
+logger = logging.getLogger(__name__)
+
+
+# Providers that use audio file hash as cache key
+TRANSCRIPTION_PROVIDERS = ["audioshake", "whisper", "localwhisper"]
+
+# Providers that use artist+title hash as cache key
+LYRICS_PROVIDERS = ["genius", "spotify", "lrclib", "musixmatch"]
+
+# Cache file suffixes
+CACHE_SUFFIXES = ["raw", "converted"]
+
+
+class LyricsCacheService:
+    """Service to sync LyricsTranscriber cache with GCS."""
+
+    GCS_CACHE_PREFIX = "lyrics-transcriber-cache/"
+
+    def __init__(self, storage: Optional[StorageService] = None):
+        """Initialize the cache service.
+
+        Args:
+            storage: StorageService instance. If None, creates a new one.
+        """
+        self.storage = storage or StorageService()
+
+    def compute_audio_hash(self, audio_path: str) -> str:
+        """Compute MD5 hash of audio file bytes.
+
+        This matches LyricsTranscriber's _get_file_hash() method exactly.
+
+        Args:
+            audio_path: Path to the audio file.
+
+        Returns:
+            MD5 hex digest of the file contents.
+        """
+        md5_hash = hashlib.md5()
+        with open(audio_path, "rb") as f:
+            for chunk in iter(lambda: f.read(4096), b""):
+                md5_hash.update(chunk)
+        return md5_hash.hexdigest()
+
+    def compute_lyrics_hash(self, artist: str, title: str) -> str:
+        """Compute MD5 hash of artist and title.
+
+        This matches LyricsTranscriber's _get_artist_title_hash() method exactly.
+
+        Args:
+            artist: Artist name.
+            title: Track title.
+
+        Returns:
+            MD5 hex digest of "{artist.lower()}_{title.lower()}".
+        """
+        combined = f"{artist.lower()}_{title.lower()}"
+        return hashlib.md5(combined.encode()).hexdigest()
+
+    def _get_cache_filenames(
+        self, providers: List[str], hash_value: str
+    ) -> List[str]:
+        """Generate list of possible cache filenames for given providers and hash.
+
+        Args:
+            providers: List of provider names (e.g., ["audioshake", "whisper"]).
+            hash_value: The hash to use in filenames.
+
+        Returns:
+            List of filenames like ["audioshake_abc123_raw.json", ...].
+        """
+        filenames = []
+        for provider in providers:
+            for suffix in CACHE_SUFFIXES:
+                filenames.append(f"{provider}_{hash_value}_{suffix}.json")
+        return filenames
+
+    def sync_cache_from_gcs(
+        self,
+        local_cache_dir: str,
+        audio_hash: str,
+        lyrics_hash: str,
+    ) -> Dict[str, int]:
+        """Download relevant cache files from GCS to local directory.
+
+        Downloads cache files for both transcription (audio hash) and
+        lyrics (artist+title hash) providers.
+
+        Args:
+            local_cache_dir: Local directory to download cache files to.
+            audio_hash: MD5 hash of audio file.
+            lyrics_hash: MD5 hash of artist+title.
+
+        Returns:
+            Dict with counts: {"downloaded": N, "not_found": M, "errors": E}
+        """
+        os.makedirs(local_cache_dir, exist_ok=True)
+
+        stats = {"downloaded": 0, "not_found": 0, "errors": 0}
+
+        # Get all possible cache filenames
+        transcription_files = self._get_cache_filenames(
+            TRANSCRIPTION_PROVIDERS, audio_hash
+        )
+        lyrics_files = self._get_cache_filenames(LYRICS_PROVIDERS, lyrics_hash)
+        all_files = transcription_files + lyrics_files
+
+        for filename in all_files:
+            gcs_path = f"{self.GCS_CACHE_PREFIX}{filename}"
+            local_path = os.path.join(local_cache_dir, filename)
+
+            try:
+                if self.storage.file_exists(gcs_path):
+                    self.storage.download_file(gcs_path, local_path)
+                    logger.info(f"Cache hit: downloaded {filename}")
+                    stats["downloaded"] += 1
+                else:
+                    logger.debug(f"Cache miss: {filename} not in GCS")
+                    stats["not_found"] += 1
+            except Exception as e:
+                logger.warning(f"Error downloading cache file {filename}: {e}")
+                stats["errors"] += 1
+
+        logger.info(
+            f"Cache sync from GCS complete: "
+            f"{stats['downloaded']} downloaded, "
+            f"{stats['not_found']} not found, "
+            f"{stats['errors']} errors"
+        )
+        return stats
+
+    def sync_cache_to_gcs(
+        self,
+        local_cache_dir: str,
+        audio_hash: str,
+        lyrics_hash: str,
+    ) -> Dict[str, int]:
+        """Upload new cache files from local directory to GCS.
+
+        Only uploads files that match expected cache patterns for the given
+        hashes and don't already exist in GCS.
+
+        Args:
+            local_cache_dir: Local directory with cache files.
+            audio_hash: MD5 hash of audio file.
+            lyrics_hash: MD5 hash of artist+title.
+
+        Returns:
+            Dict with counts: {"uploaded": N, "skipped": M, "errors": E}
+        """
+        stats = {"uploaded": 0, "skipped": 0, "errors": 0}
+
+        if not os.path.exists(local_cache_dir):
+            logger.warning(f"Local cache dir does not exist: {local_cache_dir}")
+            return stats
+
+        # Get all possible cache filenames we're interested in
+        transcription_files = self._get_cache_filenames(
+            TRANSCRIPTION_PROVIDERS, audio_hash
+        )
+        lyrics_files = self._get_cache_filenames(LYRICS_PROVIDERS, lyrics_hash)
+        expected_files = set(transcription_files + lyrics_files)
+
+        # Check each file in local cache dir
+        for filename in os.listdir(local_cache_dir):
+            # Only process files we expect (matching our hash patterns)
+            if filename not in expected_files:
+                continue
+
+            local_path = os.path.join(local_cache_dir, filename)
+            if not os.path.isfile(local_path):
+                continue
+
+            gcs_path = f"{self.GCS_CACHE_PREFIX}{filename}"
+
+            try:
+                # Skip if already exists in GCS (same hash = same content)
+                if self.storage.file_exists(gcs_path):
+                    logger.debug(f"Cache file already in GCS: {filename}")
+                    stats["skipped"] += 1
+                    continue
+
+                self.storage.upload_file(local_path, gcs_path)
+                logger.info(f"Uploaded cache file: {filename}")
+                stats["uploaded"] += 1
+            except Exception as e:
+                logger.warning(f"Error uploading cache file {filename}: {e}")
+                stats["errors"] += 1
+
+        logger.info(
+            f"Cache sync to GCS complete: "
+            f"{stats['uploaded']} uploaded, "
+            f"{stats['skipped']} skipped (already exist), "
+            f"{stats['errors']} errors"
+        )
+        return stats

--- a/backend/workers/lyrics_worker.py
+++ b/backend/workers/lyrics_worker.py
@@ -32,6 +32,7 @@ from backend.models.job import JobStatus
 from karaoke_gen.utils import sanitize_filename
 from backend.services.job_manager import JobManager
 from backend.services.storage_service import StorageService
+from backend.services.lyrics_cache_service import LyricsCacheService
 from backend.workers.worker_logging import create_job_logger, setup_job_logging, job_logging_context
 from backend.workers.style_helper import load_style_config
 from backend.services.tracing import job_span, add_span_event, add_span_attribute
@@ -229,7 +230,40 @@ async def process_lyrics_transcription(job_id: str) -> bool:
                         raise Exception("Failed to download audio file")
                     job_log.info(f"Audio downloaded: {os.path.basename(audio_path)}")
                     download_span.set_attribute("audio_file", os.path.basename(audio_path))
-                
+
+                # Set up LyricsTranscriber cache directory and sync from GCS
+                # This allows reusing cached AudioShake/lyrics API responses across Cloud Run instances
+                cache_dir = os.path.join(temp_dir, "lyrics-cache")
+                os.makedirs(cache_dir, exist_ok=True)
+                os.environ["LYRICS_TRANSCRIBER_CACHE_DIR"] = cache_dir
+                job_log.info(f"LyricsTranscriber cache dir: {cache_dir}")
+
+                # Sync cache from GCS (download any existing cached API responses)
+                # Note: Cache sync is best-effort - failures should not fail the job
+                cache_service = LyricsCacheService(storage)
+                audio_hash = None
+                lyrics_hash = None
+                with job_span("sync-cache-from-gcs", job_id):
+                    try:
+                        # Compute cache keys
+                        audio_hash = cache_service.compute_audio_hash(audio_path)
+                        # Use lyrics_artist/lyrics_title for lyrics hash (these are what LyricsTranscriber uses)
+                        lyrics_search_artist = getattr(job, 'lyrics_artist', None) or job.artist
+                        lyrics_search_title = getattr(job, 'lyrics_title', None) or job.title
+                        lyrics_hash = cache_service.compute_lyrics_hash(lyrics_search_artist, lyrics_search_title)
+
+                        job_log.info(f"Cache keys: audio_hash={audio_hash[:8]}..., lyrics_hash={lyrics_hash[:8]}...")
+                        add_span_attribute("audio_hash", audio_hash[:8])
+                        add_span_attribute("lyrics_hash", lyrics_hash[:8])
+
+                        # Download relevant cache files from GCS
+                        cache_stats = cache_service.sync_cache_from_gcs(cache_dir, audio_hash, lyrics_hash)
+                        job_log.info(f"Cache sync from GCS: {cache_stats['downloaded']} downloaded, {cache_stats['not_found']} not found")
+                        add_span_attribute("cache_hits", cache_stats["downloaded"])
+                    except Exception as e:
+                        job_log.warning(f"Cache sync from GCS failed (non-fatal): {e}", exc_info=True)
+                        add_span_attribute("cache_sync_error", str(e)[:100])
+
                 # Update progress using state_data (don't change status during parallel processing)
                 # The status is managed at a higher level - workers just track their progress
                 job_manager.update_state_data(job_id, 'lyrics_progress', {
@@ -380,7 +414,23 @@ async def process_lyrics_transcription(job_id: str) -> bool:
                 
                 job_log.info("All lyrics data uploaded successfully")
                 logger.info(f"[job:{job_id}] All lyrics data uploaded successfully")
-                
+
+                # Sync new cache files to GCS (upload any newly created cache entries)
+                # This persists cache across Cloud Run instances for future jobs
+                # Note: Cache upload is best-effort - failures should not fail the job
+                with job_span("sync-cache-to-gcs", job_id):
+                    try:
+                        if audio_hash and lyrics_hash:
+                            upload_stats = cache_service.sync_cache_to_gcs(cache_dir, audio_hash, lyrics_hash)
+                            job_log.info(f"Cache sync to GCS: {upload_stats['uploaded']} uploaded, {upload_stats['skipped']} already existed")
+                            add_span_attribute("cache_uploads", upload_stats["uploaded"])
+                        else:
+                            job_log.warning("Skipping cache upload: missing audio_hash or lyrics_hash")
+                            add_span_attribute("cache_upload_skipped", "missing_hashes")
+                    except Exception as e:
+                        job_log.warning(f"Cache upload to GCS failed (non-fatal): {e}")
+                        add_span_attribute("cache_upload_error", str(e)[:100])
+
                 # Update progress using state_data (don't change status during parallel processing)
                 job_manager.update_state_data(job_id, 'lyrics_progress', {
                     'stage': 'lyrics_complete',

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -629,6 +629,39 @@ result = job.state_data['search_results'][selection_index]
 
 **Lesson**: Design for stateless request handling. Any state that must survive between requests must be persisted externally.
 
+### Library Caches Need GCS Sync in Cloud Run
+
+**Problem**: Libraries like LyricsTranscriber cache API responses to local directories (e.g., `~/lyrics-transcriber-cache`). In Cloud Run, each container is ephemeral - the cache is lost on every restart or scale-up, causing redundant API calls.
+
+**Symptoms**:
+- Same song processed multiple times always hits external APIs
+- Higher API costs than expected (AudioShake charges per transcription)
+- Slower processing even for repeated jobs
+
+**Solution**: Sync library cache to/from GCS before/after each job:
+
+```python
+# Set cache dir via environment variable (library reads this)
+cache_dir = os.path.join(temp_dir, "lyrics-cache")
+os.environ["LYRICS_TRANSCRIBER_CACHE_DIR"] = cache_dir
+
+# Download relevant cache files from GCS before processing
+cache_service.sync_cache_from_gcs(cache_dir, audio_hash, lyrics_hash)
+
+# ... run processing ...
+
+# Upload new cache files to GCS after processing
+cache_service.sync_cache_to_gcs(cache_dir, audio_hash, lyrics_hash)
+```
+
+**Key design decisions**:
+1. Download only relevant files (by hash) - don't sync entire cache directory
+2. Skip files that already exist in GCS on upload (same input = same output)
+3. Use environment variable to configure library cache dir (avoids modifying library code)
+4. Cache indefinitely (no TTL) - API responses don't change for same inputs
+
+**Lesson**: When using third-party libraries with local caching in Cloud Run, check if they support configurable cache directories. If so, sync to GCS for persistence across instances.
+
 ### Sequential vs Parallel Worker Triggering
 
 **Problem**: For URL-based jobs (YouTube), triggering both audio and lyrics workers in parallel caused failures. Lyrics worker needs the audio file, but audio worker hadn't downloaded it yet.

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,8 @@
 
 ## Recent Changes
 
+- **LyricsTranscriber Cache Persistence** (2026-01-02): Added GCS-backed cache for LyricsTranscriber to avoid redundant API calls. AudioShake transcription and lyrics provider responses (Genius, Spotify, LRCLib, Musixmatch) are now cached to `gs://karaoke-gen-storage/lyrics-transcriber-cache/`. Cache is synced before/after each job, persisting across Cloud Run instances. Significantly reduces API costs and speeds up repeated processing of same songs.
+
 - **Worker Timeout Fixes** (2026-01-01): Fixed 3 timeout issues blocking job completion: (1) Lyrics transcription timeout increased to 20 min (PR #153), (2) Cloud Tasks dispatch_deadline added for audio worker - default 10 min was killing Modal API calls (PR #154), (3) Enabled Cloud Run Jobs for video encoding - 1-hour timeout vs 30-min Cloud Run service limit (PR #155). Full E2E pipeline now verified working. See [archive/2026-01-01-worker-timeout-fixes.md](archive/2026-01-01-worker-timeout-fixes.md)
 
 - **Agentic Correction Timeout** (2025-12-31): Added 3-minute configurable timeout for agentic AI lyrics correction. Prevents stuck jobs when songs have many gaps (74+ gaps could take 30+ minutes). On timeout, skips correction and proceeds to human review with raw transcription. See [archive/2025-12-31-agentic-timeout-implementation.md](archive/2025-12-31-agentic-timeout-implementation.md)

--- a/tests/unit/test_lyrics_cache_service.py
+++ b/tests/unit/test_lyrics_cache_service.py
@@ -1,0 +1,359 @@
+"""
+Unit tests for LyricsCacheService.
+
+Tests the GCS cache synchronization service for LyricsTranscriber.
+"""
+import hashlib
+import json
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.services.lyrics_cache_service import (
+    LyricsCacheService,
+    TRANSCRIPTION_PROVIDERS,
+    LYRICS_PROVIDERS,
+    CACHE_SUFFIXES,
+)
+
+
+class TestHashComputation:
+    """Tests for hash computation methods."""
+
+    def test_compute_audio_hash_matches_lyrics_transcriber(self, temp_dir):
+        """Audio hash should match LyricsTranscriber's _get_file_hash implementation."""
+        # Create a test audio file
+        audio_path = os.path.join(temp_dir, "test_audio.wav")
+        test_content = b"fake audio content for testing hash computation"
+        with open(audio_path, "wb") as f:
+            f.write(test_content)
+
+        # Compute hash using our service
+        mock_storage = MagicMock()
+        service = LyricsCacheService(storage=mock_storage)
+        computed_hash = service.compute_audio_hash(audio_path)
+
+        # Compute expected hash (same algorithm as LyricsTranscriber)
+        md5_hash = hashlib.md5()
+        with open(audio_path, "rb") as f:
+            for chunk in iter(lambda: f.read(4096), b""):
+                md5_hash.update(chunk)
+        expected_hash = md5_hash.hexdigest()
+
+        assert computed_hash == expected_hash
+
+    def test_compute_lyrics_hash_matches_lyrics_transcriber(self):
+        """Lyrics hash should match LyricsTranscriber's _get_artist_title_hash implementation."""
+        mock_storage = MagicMock()
+        service = LyricsCacheService(storage=mock_storage)
+
+        artist = "Test Artist"
+        title = "Test Song"
+
+        computed_hash = service.compute_lyrics_hash(artist, title)
+
+        # Expected hash (same algorithm as LyricsTranscriber)
+        combined = f"{artist.lower()}_{title.lower()}"
+        expected_hash = hashlib.md5(combined.encode()).hexdigest()
+
+        assert computed_hash == expected_hash
+
+    def test_compute_lyrics_hash_case_insensitive(self):
+        """Lyrics hash should be case-insensitive."""
+        mock_storage = MagicMock()
+        service = LyricsCacheService(storage=mock_storage)
+
+        hash1 = service.compute_lyrics_hash("Artist", "Title")
+        hash2 = service.compute_lyrics_hash("ARTIST", "TITLE")
+        hash3 = service.compute_lyrics_hash("artist", "title")
+
+        assert hash1 == hash2 == hash3
+
+
+class TestCacheFilenames:
+    """Tests for cache filename generation."""
+
+    def test_get_cache_filenames_transcription_providers(self):
+        """Should generate correct filenames for transcription providers."""
+        mock_storage = MagicMock()
+        service = LyricsCacheService(storage=mock_storage)
+
+        filenames = service._get_cache_filenames(TRANSCRIPTION_PROVIDERS, "abc123")
+
+        expected = []
+        for provider in TRANSCRIPTION_PROVIDERS:
+            for suffix in CACHE_SUFFIXES:
+                expected.append(f"{provider}_abc123_{suffix}.json")
+
+        assert sorted(filenames) == sorted(expected)
+
+    def test_get_cache_filenames_lyrics_providers(self):
+        """Should generate correct filenames for lyrics providers."""
+        mock_storage = MagicMock()
+        service = LyricsCacheService(storage=mock_storage)
+
+        filenames = service._get_cache_filenames(LYRICS_PROVIDERS, "def456")
+
+        expected = []
+        for provider in LYRICS_PROVIDERS:
+            for suffix in CACHE_SUFFIXES:
+                expected.append(f"{provider}_def456_{suffix}.json")
+
+        assert sorted(filenames) == sorted(expected)
+
+
+class TestSyncCacheFromGCS:
+    """Tests for downloading cache from GCS."""
+
+    def test_sync_cache_from_gcs_downloads_existing_files(self, temp_dir):
+        """Should download files that exist in GCS."""
+        mock_storage = MagicMock()
+        service = LyricsCacheService(storage=mock_storage)
+
+        # Configure mock to simulate some files exist in GCS
+        def file_exists(path):
+            # Simulate audioshake_abc123_raw.json exists
+            return "audioshake_abc123_raw.json" in path
+
+        mock_storage.file_exists.side_effect = file_exists
+
+        stats = service.sync_cache_from_gcs(
+            local_cache_dir=temp_dir,
+            audio_hash="abc123",
+            lyrics_hash="def456",
+        )
+
+        # Should have downloaded 1 file (audioshake_abc123_raw.json)
+        assert stats["downloaded"] == 1
+        # Should have not found the rest
+        assert stats["not_found"] > 0
+        assert stats["errors"] == 0
+
+        # Verify download_file was called for the existing file
+        mock_storage.download_file.assert_called_once()
+
+    def test_sync_cache_from_gcs_creates_directory(self, temp_dir):
+        """Should create the local cache directory if it doesn't exist."""
+        mock_storage = MagicMock()
+        mock_storage.file_exists.return_value = False
+        service = LyricsCacheService(storage=mock_storage)
+
+        cache_dir = os.path.join(temp_dir, "new_cache_dir")
+        assert not os.path.exists(cache_dir)
+
+        service.sync_cache_from_gcs(
+            local_cache_dir=cache_dir,
+            audio_hash="abc123",
+            lyrics_hash="def456",
+        )
+
+        assert os.path.exists(cache_dir)
+
+    def test_sync_cache_from_gcs_handles_errors(self, temp_dir):
+        """Should handle download errors gracefully."""
+        mock_storage = MagicMock()
+        mock_storage.file_exists.return_value = True
+        mock_storage.download_file.side_effect = Exception("Network error")
+        service = LyricsCacheService(storage=mock_storage)
+
+        stats = service.sync_cache_from_gcs(
+            local_cache_dir=temp_dir,
+            audio_hash="abc123",
+            lyrics_hash="def456",
+        )
+
+        # All files should have errors
+        assert stats["errors"] > 0
+        assert stats["downloaded"] == 0
+
+
+class TestSyncCacheToGCS:
+    """Tests for uploading cache to GCS."""
+
+    def test_sync_cache_to_gcs_uploads_new_files(self, temp_dir):
+        """Should upload files that don't exist in GCS."""
+        mock_storage = MagicMock()
+        mock_storage.file_exists.return_value = False
+        service = LyricsCacheService(storage=mock_storage)
+
+        # Create a cache file in temp_dir
+        cache_file = os.path.join(temp_dir, "audioshake_abc123_raw.json")
+        with open(cache_file, "w") as f:
+            json.dump({"test": "data"}, f)
+
+        stats = service.sync_cache_to_gcs(
+            local_cache_dir=temp_dir,
+            audio_hash="abc123",
+            lyrics_hash="def456",
+        )
+
+        assert stats["uploaded"] == 1
+        mock_storage.upload_file.assert_called_once()
+
+    def test_sync_cache_to_gcs_skips_existing_files(self, temp_dir):
+        """Should skip files that already exist in GCS."""
+        mock_storage = MagicMock()
+        mock_storage.file_exists.return_value = True
+        service = LyricsCacheService(storage=mock_storage)
+
+        # Create a cache file in temp_dir
+        cache_file = os.path.join(temp_dir, "audioshake_abc123_raw.json")
+        with open(cache_file, "w") as f:
+            json.dump({"test": "data"}, f)
+
+        stats = service.sync_cache_to_gcs(
+            local_cache_dir=temp_dir,
+            audio_hash="abc123",
+            lyrics_hash="def456",
+        )
+
+        assert stats["uploaded"] == 0
+        assert stats["skipped"] == 1
+        mock_storage.upload_file.assert_not_called()
+
+    def test_sync_cache_to_gcs_ignores_unexpected_files(self, temp_dir):
+        """Should ignore files that don't match expected cache patterns."""
+        mock_storage = MagicMock()
+        mock_storage.file_exists.return_value = False
+        service = LyricsCacheService(storage=mock_storage)
+
+        # Create an unexpected file
+        unexpected_file = os.path.join(temp_dir, "random_file.txt")
+        with open(unexpected_file, "w") as f:
+            f.write("not a cache file")
+
+        # Create a file with wrong hash
+        wrong_hash_file = os.path.join(temp_dir, "audioshake_wrong_hash_raw.json")
+        with open(wrong_hash_file, "w") as f:
+            json.dump({"test": "data"}, f)
+
+        stats = service.sync_cache_to_gcs(
+            local_cache_dir=temp_dir,
+            audio_hash="abc123",
+            lyrics_hash="def456",
+        )
+
+        # Should not upload any files
+        assert stats["uploaded"] == 0
+        mock_storage.upload_file.assert_not_called()
+
+    def test_sync_cache_to_gcs_handles_missing_directory(self, temp_dir):
+        """Should handle missing cache directory gracefully."""
+        mock_storage = MagicMock()
+        service = LyricsCacheService(storage=mock_storage)
+
+        stats = service.sync_cache_to_gcs(
+            local_cache_dir=os.path.join(temp_dir, "nonexistent"),
+            audio_hash="abc123",
+            lyrics_hash="def456",
+        )
+
+        assert stats["uploaded"] == 0
+        assert stats["skipped"] == 0
+        assert stats["errors"] == 0
+
+    def test_sync_cache_to_gcs_handles_upload_errors(self, temp_dir):
+        """Should handle upload errors gracefully."""
+        mock_storage = MagicMock()
+        mock_storage.file_exists.return_value = False
+        mock_storage.upload_file.side_effect = Exception("Upload failed")
+        service = LyricsCacheService(storage=mock_storage)
+
+        # Create a cache file
+        cache_file = os.path.join(temp_dir, "audioshake_abc123_raw.json")
+        with open(cache_file, "w") as f:
+            json.dump({"test": "data"}, f)
+
+        stats = service.sync_cache_to_gcs(
+            local_cache_dir=temp_dir,
+            audio_hash="abc123",
+            lyrics_hash="def456",
+        )
+
+        assert stats["errors"] == 1
+        assert stats["uploaded"] == 0
+
+
+class TestGCSPathStructure:
+    """Tests for GCS path structure."""
+
+    def test_gcs_cache_prefix(self):
+        """GCS cache prefix should be correct."""
+        assert LyricsCacheService.GCS_CACHE_PREFIX == "lyrics-transcriber-cache/"
+
+    def test_sync_uses_correct_gcs_paths(self, temp_dir):
+        """Should use correct GCS paths when downloading/uploading."""
+        mock_storage = MagicMock()
+        mock_storage.file_exists.return_value = True
+        service = LyricsCacheService(storage=mock_storage)
+
+        service.sync_cache_from_gcs(
+            local_cache_dir=temp_dir,
+            audio_hash="abc123",
+            lyrics_hash="def456",
+        )
+
+        # Check that file_exists was called with correct GCS path prefix
+        calls = mock_storage.file_exists.call_args_list
+        for call in calls:
+            gcs_path = call[0][0]
+            assert gcs_path.startswith("lyrics-transcriber-cache/")
+
+
+class TestEndToEnd:
+    """End-to-end tests for cache sync workflow."""
+
+    def test_round_trip_cache_sync(self, temp_dir):
+        """Test uploading and then downloading the same cache file."""
+        # We'll simulate this with two separate temp dirs
+        upload_dir = os.path.join(temp_dir, "upload")
+        download_dir = os.path.join(temp_dir, "download")
+        os.makedirs(upload_dir)
+        os.makedirs(download_dir)
+
+        # Create a test cache file
+        test_data = {"transcription": "test data", "words": [1, 2, 3]}
+        cache_filename = "audioshake_abc123_raw.json"
+        upload_path = os.path.join(upload_dir, cache_filename)
+        with open(upload_path, "w") as f:
+            json.dump(test_data, f)
+
+        # Create mock that tracks uploaded files
+        uploaded_files = {}
+
+        def mock_upload(local_path, gcs_path):
+            with open(local_path, "r") as f:
+                uploaded_files[gcs_path] = f.read()
+            return gcs_path
+
+        def mock_download(gcs_path, local_path):
+            if gcs_path in uploaded_files:
+                with open(local_path, "w") as f:
+                    f.write(uploaded_files[gcs_path])
+            return local_path
+
+        def mock_exists(gcs_path):
+            return gcs_path in uploaded_files
+
+        mock_storage = MagicMock()
+        mock_storage.upload_file.side_effect = mock_upload
+        mock_storage.download_file.side_effect = mock_download
+        mock_storage.file_exists.side_effect = mock_exists
+
+        service = LyricsCacheService(storage=mock_storage)
+
+        # Upload
+        upload_stats = service.sync_cache_to_gcs(upload_dir, "abc123", "def456")
+        assert upload_stats["uploaded"] == 1
+
+        # Download to new location
+        download_stats = service.sync_cache_from_gcs(download_dir, "abc123", "def456")
+        assert download_stats["downloaded"] == 1
+
+        # Verify downloaded content matches
+        downloaded_path = os.path.join(download_dir, cache_filename)
+        with open(downloaded_path, "r") as f:
+            downloaded_data = json.load(f)
+        assert downloaded_data == test_data


### PR DESCRIPTION
## Summary

- Add GCS-backed cache persistence for LyricsTranscriber to avoid redundant API calls
- AudioShake transcription and lyrics provider responses now cached across Cloud Run instances
- Significantly reduces API costs and speeds up repeated processing of same songs

## Changes

- **New:** `backend/services/lyrics_cache_service.py` - Service to sync cache files with GCS
  - Computes MD5 hashes matching LyricsTranscriber's algorithm
  - Downloads relevant cache files from GCS before processing
  - Uploads new cache files to GCS after processing
  - Best-effort with graceful error handling

- **Modified:** `backend/workers/lyrics_worker.py`
  - Sets `LYRICS_TRANSCRIBER_CACHE_DIR` environment variable
  - Syncs cache from GCS before transcription
  - Syncs cache to GCS after transcription
  - Error handling ensures cache failures don't fail jobs

- **New:** `tests/unit/test_lyrics_cache_service.py` - 16 unit tests
- **Updated:** `docs/README.md` and `docs/LESSONS-LEARNED.md`

## Cache Structure

| Type | Key | Files |
|------|-----|-------|
| Transcription | MD5(audio_file) | `audioshake_{hash}_raw.json`, `audioshake_{hash}_converted.json` |
| Lyrics | MD5(artist_title) | `genius_{hash}_raw.json`, `lrclib_{hash}_converted.json`, etc. |

Providers cached: `audioshake`, `whisper`, `genius`, `spotify`, `lrclib`, `musixmatch`

## Testing

- [x] All 16 new unit tests pass
- [x] All 57 existing tests pass (`make test`)
- [x] CodeRabbit CLI review completed locally

## Review

- [x] Local CodeRabbit review completed
- [x] Review feedback addressed (added error handling for cache operations)

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)