### PR TITLE
fix(ci): Add automatic disk space cleanup for self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,23 @@ jobs:
       needs.changes.outputs.frontend == 'true' &&
       contains(github.event.pull_request.labels.*.name, 'e2e')
     steps:
+      - name: Check disk space
+        run: |
+          echo "Checking disk space..."
+          USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+          echo "Current disk usage: ${USAGE}%"
+          if [ "$USAGE" -gt 70 ]; then
+            echo "Disk usage high, running cleanup..."
+            docker system prune -af || true
+            docker builder prune -af || true
+            USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+            echo "After cleanup: ${USAGE}%"
+          fi
+          if [ "$USAGE" -gt 85 ]; then
+            echo "::error::Disk usage ${USAGE}% exceeds 85% even after cleanup. Runner needs maintenance."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
 
       - name: Setup Node.js with caching
@@ -265,6 +282,23 @@ jobs:
     needs: changes
     if: github.ref != 'refs/heads/main' && (needs.changes.outputs.package == 'true' || needs.changes.outputs.deps == 'true')
     steps:
+      - name: Check disk space
+        run: |
+          echo "Checking disk space..."
+          USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+          echo "Current disk usage: ${USAGE}%"
+          if [ "$USAGE" -gt 70 ]; then
+            echo "Disk usage high, running cleanup..."
+            docker system prune -af || true
+            docker builder prune -af || true
+            USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+            echo "After cleanup: ${USAGE}%"
+          fi
+          if [ "$USAGE" -gt 85 ]; then
+            echo "::error::Disk usage ${USAGE}% exceeds 85% even after cleanup. Runner needs maintenance."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -323,6 +357,23 @@ jobs:
     needs: changes
     if: github.ref != 'refs/heads/main' && (needs.changes.outputs.package == 'true' || needs.changes.outputs.deps == 'true')
     steps:
+      - name: Check disk space
+        run: |
+          echo "Checking disk space..."
+          USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+          echo "Current disk usage: ${USAGE}%"
+          if [ "$USAGE" -gt 70 ]; then
+            echo "Disk usage high, running cleanup..."
+            docker system prune -af || true
+            docker builder prune -af || true
+            USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+            echo "After cleanup: ${USAGE}%"
+          fi
+          if [ "$USAGE" -gt 85 ]; then
+            echo "::error::Disk usage ${USAGE}% exceeds 85% even after cleanup. Runner needs maintenance."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -376,6 +427,23 @@ jobs:
       (needs.package-integration-tests.result == 'success' || needs.package-integration-tests.result == 'skipped') &&
       (needs.changes.outputs.package == 'true' || needs.changes.outputs.deps == 'true')
     steps:
+      - name: Check disk space
+        run: |
+          echo "Checking disk space..."
+          USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+          echo "Current disk usage: ${USAGE}%"
+          if [ "$USAGE" -gt 70 ]; then
+            echo "Disk usage high, running cleanup..."
+            docker system prune -af || true
+            docker builder prune -af || true
+            USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+            echo "After cleanup: ${USAGE}%"
+          fi
+          if [ "$USAGE" -gt 85 ]; then
+            echo "::error::Disk usage ${USAGE}% exceeds 85% even after cleanup. Runner needs maintenance."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -409,6 +477,23 @@ jobs:
     needs: changes
     if: github.ref != 'refs/heads/main' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.package == 'true' || needs.changes.outputs.deps == 'true')
     steps:
+      - name: Check disk space
+        run: |
+          echo "Checking disk space..."
+          USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+          echo "Current disk usage: ${USAGE}%"
+          if [ "$USAGE" -gt 70 ]; then
+            echo "Disk usage high, running cleanup..."
+            docker system prune -af || true
+            docker builder prune -af || true
+            USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+            echo "After cleanup: ${USAGE}%"
+          fi
+          if [ "$USAGE" -gt 85 ]; then
+            echo "::error::Disk usage ${USAGE}% exceeds 85% even after cleanup. Runner needs maintenance."
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -446,6 +531,23 @@ jobs:
     needs: changes
     if: github.ref != 'refs/heads/main' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.package == 'true' || needs.changes.outputs.deps == 'true')
     steps:
+      - name: Check disk space
+        run: |
+          echo "Checking disk space..."
+          USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+          echo "Current disk usage: ${USAGE}%"
+          if [ "$USAGE" -gt 70 ]; then
+            echo "Disk usage high, running cleanup..."
+            docker system prune -af || true
+            docker builder prune -af || true
+            USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+            echo "After cleanup: ${USAGE}%"
+          fi
+          if [ "$USAGE" -gt 85 ]; then
+            echo "::error::Disk usage ${USAGE}% exceeds 85% even after cleanup. Runner needs maintenance."
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -493,6 +595,23 @@ jobs:
     needs: changes
     if: github.ref != 'refs/heads/main' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.package == 'true')
     steps:
+      - name: Check disk space
+        run: |
+          echo "Checking disk space..."
+          USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+          echo "Current disk usage: ${USAGE}%"
+          if [ "$USAGE" -gt 70 ]; then
+            echo "Disk usage high, running cleanup..."
+            docker system prune -af || true
+            docker builder prune -af || true
+            USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+            echo "After cleanup: ${USAGE}%"
+          fi
+          if [ "$USAGE" -gt 85 ]; then
+            echo "::error::Disk usage ${USAGE}% exceeds 85% even after cleanup. Runner needs maintenance."
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -568,6 +687,23 @@ jobs:
     runs-on: [self-hosted, linux, gcp]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
+      - name: Check disk space
+        run: |
+          echo "Checking disk space..."
+          USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+          echo "Current disk usage: ${USAGE}%"
+          if [ "$USAGE" -gt 70 ]; then
+            echo "Disk usage high, running cleanup..."
+            docker system prune -af || true
+            docker builder prune -af || true
+            USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+            echo "After cleanup: ${USAGE}%"
+          fi
+          if [ "$USAGE" -gt 85 ]; then
+            echo "::error::Disk usage ${USAGE}% exceeds 85% even after cleanup. Runner needs maintenance."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -778,6 +914,23 @@ jobs:
       BASE_IMAGE_NAME: karaoke-backend-base
       APP_IMAGE_NAME: karaoke-backend
     steps:
+      - name: Check disk space
+        run: |
+          echo "Checking disk space..."
+          USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+          echo "Current disk usage: ${USAGE}%"
+          if [ "$USAGE" -gt 70 ]; then
+            echo "Disk usage high, running cleanup..."
+            docker system prune -af || true
+            docker builder prune -af || true
+            USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+            echo "After cleanup: ${USAGE}%"
+          fi
+          if [ "$USAGE" -gt 85 ]; then
+            echo "::error::Disk usage ${USAGE}% exceeds 85% even after cleanup. Runner needs maintenance."
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -569,6 +569,51 @@ GitHub-hosted runners have ~14GB disk, which caused failures during Docker build
 
 See `docs/archive/2025-12-28-self-hosted-github-runner.md` for full details.
 
+### Docker Disk Space Management on Self-Hosted Runners
+
+**Problem**: Even with 200GB SSDs, self-hosted runners can fill up with Docker images. Each CI build creates new dangling images (~15GB each), and without aggressive cleanup, disk fills in days.
+
+**Symptoms**:
+- CI jobs fail with `No space left on device`
+- Jobs that require Docker (build, deploy, emulator tests) fail
+- Runners 11-20 at 100% while 1-10 at 30% (newer runners had less cleanup history)
+
+**Root cause**: Original cleanup cron used `docker system prune -af --filter "until=168h"` which only removes images older than 7 days. With frequent CI builds, most dangling images are < 7 days old and never get cleaned.
+
+**Solution** (two-layer approach):
+
+1. **Hourly threshold-based cleanup** (on runners):
+   ```bash
+   # /etc/cron.hourly/docker-cleanup
+   THRESHOLD=70
+   USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+   if [ "$USAGE" -gt "$THRESHOLD" ]; then
+       docker system prune -af  # No age filter!
+       docker builder prune -af
+   fi
+   ```
+
+2. **Pre-job disk check** (in CI workflow):
+   ```yaml
+   - name: Check disk space
+     run: |
+       USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+       if [ "$USAGE" -gt 70 ]; then
+         docker system prune -af || true
+         docker builder prune -af || true
+       fi
+       if [ "$USAGE" -gt 85 ]; then
+         echo "::error::Disk usage exceeds 85%. Runner needs maintenance."
+         exit 1
+       fi
+   ```
+
+**Key insights**:
+- Remove the age filter (`--filter "until=168h"`) - dangling images should always be cleaned
+- Threshold-based cleanup is better than time-based (don't clean if disk is fine)
+- Pre-job checks provide fail-fast behavior with clear error messages
+- `docker builder prune -af` catches buildkit cache that `system prune` misses
+
 ## Performance Observations
 
 | Operation | Duration |

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,8 @@
 
 ## Recent Changes
 
+- **Runner Disk Space Auto-Cleanup** (2026-01-03): Fixed CI failures caused by self-hosted runners filling up with Docker images. Changed cleanup from daily/7-day-old to hourly/threshold-based (70%). Added pre-job disk checks to all self-hosted CI jobs. See [LESSONS-LEARNED.md](LESSONS-LEARNED.md#docker-disk-space-management-on-self-hosted-runners)
+
 - **E2E Happy Path Test** (2026-01-02): Added comprehensive E2E test that validates the complete karaoke generation journey using ONLY browser UI interactions (no API shortcuts). Test covers all 12 steps from landing page through cleanup. Runs daily via GitHub Actions and takes ~38 minutes. See [E2E-HAPPY-PATH-TEST-SPEC.md](E2E-HAPPY-PATH-TEST-SPEC.md)
 
 - **LyricsTranscriber Cache Persistence** (2026-01-02): Added GCS-backed cache for LyricsTranscriber to avoid redundant API calls. AudioShake transcription and lyrics provider responses (Genius, Spotify, LRCLib, Musixmatch) are now cached to `gs://karaoke-gen-storage/lyrics-transcriber-cache/`. Cache is synced before/after each job, persisting across Cloud Run instances. Significantly reduces API costs and speeds up repeated processing of same songs.

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -1537,13 +1537,44 @@ echo "Python 3.13 added to tool cache"
 
 # ==================== Docker cleanup cron ====================
 # Prevent disk from filling up with old Docker images
+# Run hourly instead of daily, with threshold-based cleanup
 echo "Setting up Docker cleanup cron..."
-cat > /etc/cron.daily/docker-cleanup << 'CRON'
+cat > /etc/cron.hourly/docker-cleanup << 'CRON'
 #!/bin/bash
-# Clean up Docker resources older than 7 days
-docker system prune -af --filter "until=168h"
+# Docker disk space cleanup for GitHub Actions runners
+# Runs hourly, with aggressive cleanup when disk usage exceeds threshold
+
+# Log to syslog
+exec 1> >(logger -t docker-cleanup) 2>&1
+
+THRESHOLD=70  # Cleanup when disk usage exceeds this percentage
+
+# Get current disk usage percentage (remove % sign)
+USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+
+echo "Current disk usage: ${USAGE}%"
+
+if [ "$USAGE" -gt "$THRESHOLD" ]; then
+    echo "Disk usage ${USAGE}% exceeds threshold ${THRESHOLD}%, running cleanup..."
+
+    # Remove ALL unused images (not just old ones) - this is the key fix
+    # The previous 168h filter let recent images accumulate
+    docker system prune -af
+
+    # Also clean builder cache which can grow large
+    docker builder prune -af
+
+    # Report new usage
+    NEW_USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+    echo "Cleanup complete. Disk usage: ${NEW_USAGE}%"
+else
+    echo "Disk usage ${USAGE}% is below threshold ${THRESHOLD}%, skipping cleanup"
+fi
 CRON
-chmod +x /etc/cron.daily/docker-cleanup
+chmod +x /etc/cron.hourly/docker-cleanup
+
+# Remove old daily cleanup if it exists (migrating to hourly)
+rm -f /etc/cron.daily/docker-cleanup
 
 # ==================== Docker pre-warm cron ====================
 # Keep base images fresh by pulling hourly


### PR DESCRIPTION
## Summary

- Fixed CI failures caused by self-hosted runners (11-20) running out of disk space
- Changed Docker cleanup from daily/7-day-old to hourly/threshold-based (70%)
- Added pre-job disk checks to all 9 self-hosted CI jobs
- Deployed fix immediately to all 20 runners (emergency cleanup reclaimed ~57GB each)

## Problem

Runners 11-20 were at 98-100% disk usage causing jobs to fail with `No space left on device`. The existing cleanup cron only removed images older than 7 days, but CI builds create new dangling images (~15GB each) faster than cleanup could remove them.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Added disk check step to all 9 self-hosted jobs |
| `infrastructure/__main__.py` | Changed cleanup to hourly/threshold-based, removed age filter |
| `docs/LESSONS-LEARNED.md` | Added section on Docker disk space management |
| `docs/README.md` | Added recent change entry |

## Test plan

- [x] Verified all 20 runners now healthy (14-37% usage)
- [x] Deployed new cleanup script to all runners immediately
- [x] CI workflow YAML validates correctly
- [ ] CI jobs will run disk check on next execution

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)