### PR TITLE
fix: allow @nomadkaraoke.com emails to access admin dashboard

### DIFF
--- a/frontend/app/admin/layout.tsx
+++ b/frontend/app/admin/layout.tsx
@@ -93,10 +93,13 @@ export default function AdminLayout({
       return
     }
 
-    // Check if user is admin
-    if (user && user.role !== "admin") {
-      router.replace("/app")
-      return
+    // Check if user is admin (either by role or @nomadkaraoke.com email)
+    if (user) {
+      const isAdmin = user.role === "admin" || user.email?.endsWith("@nomadkaraoke.com")
+      if (!isAdmin) {
+        router.replace("/app")
+        return
+      }
     }
 
     // If we have a token but no user yet, wait for auth to load


### PR DESCRIPTION
Updates AdminLayout to grant admin access to users with @nomadkaraoke.com email addresses, matching the admin validation logic in E2E tests.

Previously, only users with role="admin" could access /admin, causing users with @nomadkaraoke.com emails to be redirected to /app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced admin authorization to recognize users with specific email domain credentials in addition to admin role assignments, improving access management flexibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->