### PR TITLE
fix: Admin dashboard improvements

### DIFF
--- a/backend/api/routes/users.py
+++ b/backend/api/routes/users.py
@@ -228,15 +228,34 @@ async def get_current_user(
     """
     Get the current user's profile.
 
-    Requires a valid session token.
+    Requires a valid session token or admin token.
     """
+    from backend.services.auth_service import get_auth_service
+
     if not authorization:
         raise HTTPException(status_code=401, detail="Not authenticated")
 
     # Extract token
     token = authorization.replace("Bearer ", "") if authorization.startswith("Bearer ") else authorization
 
-    # Validate session
+    # First try auth service (handles admin tokens and auth_tokens)
+    auth_service = get_auth_service()
+    auth_result = auth_service.validate_token_full(token)
+
+    if auth_result.is_valid and auth_result.user_email:
+        # Get or create user record for the authenticated email
+        user = user_service.get_or_create_user(auth_result.user_email)
+        user_public = UserPublic(
+            email=user.email,
+            role=user.role if not auth_result.is_admin else UserRole.ADMIN,
+            credits=user.credits,
+            display_name=user.display_name,
+            total_jobs_created=user.total_jobs_created,
+            total_jobs_completed=user.total_jobs_completed,
+        )
+        return UserProfileResponse(user=user_public, has_session=True)
+
+    # Fall back to session validation (for magic link sessions)
     valid, user, message = user_service.validate_session(token)
 
     if not valid or not user:

--- a/frontend/app/admin/users/page.tsx
+++ b/frontend/app/admin/users/page.tsx
@@ -245,7 +245,7 @@ export default function AdminUsersPage() {
                 <TableRow
                   key={user.email}
                   className="cursor-pointer hover:bg-muted/50"
-                  onClick={() => router.push(`/admin/users/${encodeURIComponent(user.email)}`)}
+                  onClick={() => router.push(`/admin/users/detail?email=${encodeURIComponent(user.email)}`)}
                 >
                   <TableCell className="font-medium">
                     {user.display_name || user.email}

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -92,6 +92,58 @@ firestore_index_magic_links = firestore.Index(
     opts=pulumi.ResourceOptions(depends_on=[firestore_db]),
 )
 
+# Users: query by is_active, order by created_at (for admin user list)
+firestore_index_users_active_created = firestore.Index(
+    "firestore-index-users-active-created",
+    project=project_id,
+    database=firestore_db.name,
+    collection="users",
+    fields=[
+        firestore.IndexFieldArgs(field_path="is_active", order="ASCENDING"),
+        firestore.IndexFieldArgs(field_path="created_at", order="DESCENDING"),
+    ],
+    opts=pulumi.ResourceOptions(depends_on=[firestore_db]),
+)
+
+# Users: query by is_active, order by last_login_at (for admin user list sorting)
+firestore_index_users_active_login = firestore.Index(
+    "firestore-index-users-active-login",
+    project=project_id,
+    database=firestore_db.name,
+    collection="users",
+    fields=[
+        firestore.IndexFieldArgs(field_path="is_active", order="ASCENDING"),
+        firestore.IndexFieldArgs(field_path="last_login_at", order="DESCENDING"),
+    ],
+    opts=pulumi.ResourceOptions(depends_on=[firestore_db]),
+)
+
+# Users: query by is_active, order by credits (for admin user list sorting)
+firestore_index_users_active_credits = firestore.Index(
+    "firestore-index-users-active-credits",
+    project=project_id,
+    database=firestore_db.name,
+    collection="users",
+    fields=[
+        firestore.IndexFieldArgs(field_path="is_active", order="ASCENDING"),
+        firestore.IndexFieldArgs(field_path="credits", order="DESCENDING"),
+    ],
+    opts=pulumi.ResourceOptions(depends_on=[firestore_db]),
+)
+
+# Users: query by is_active, order by email (for admin user list sorting)
+firestore_index_users_active_email = firestore.Index(
+    "firestore-index-users-active-email",
+    project=project_id,
+    database=firestore_db.name,
+    collection="users",
+    fields=[
+        firestore.IndexFieldArgs(field_path="is_active", order="ASCENDING"),
+        firestore.IndexFieldArgs(field_path="email", order="ASCENDING"),
+    ],
+    opts=pulumi.ResourceOptions(depends_on=[firestore_db]),
+)
+
 # Create Cloud Storage Bucket
 bucket = storage.Bucket(
     "karaoke-storage",
@@ -755,6 +807,10 @@ pulumi.export("firestore_index_jobs_user_email", firestore_index_jobs_user_email
 pulumi.export("firestore_index_jobs_status", firestore_index_jobs_status.name)
 pulumi.export("firestore_index_sessions_active", firestore_index_sessions_active.name)
 pulumi.export("firestore_index_magic_links", firestore_index_magic_links.name)
+pulumi.export("firestore_index_users_active_created", firestore_index_users_active_created.name)
+pulumi.export("firestore_index_users_active_login", firestore_index_users_active_login.name)
+pulumi.export("firestore_index_users_active_credits", firestore_index_users_active_credits.name)
+pulumi.export("firestore_index_users_active_email", firestore_index_users_active_email.name)
 pulumi.export("service_account_email", service_account.email)
 pulumi.export("artifact_repo_url", artifact_repo.name.apply(
     lambda name: f"us-central1-docker.pkg.dev/{project_id}/karaoke-repo"


### PR DESCRIPTION
## Summary
- Fix user detail page navigation (404 when clicking on user in admin panel)
- Add admin token support to `/api/users/me` endpoint (allows token-based login)
- Add Firestore composite indexes for admin user queries (fixes 500 errors)

## Changes
1. **Frontend**: Fixed navigation from `/admin/users/{email}` to `/admin/users/detail?email={email}`
2. **Backend**: Updated `/me` endpoint to accept admin tokens in addition to session tokens
3. **Infrastructure**: Added 4 Firestore indexes for `users` collection (already deployed via Pulumi)

## Test plan
- [ ] Navigate to `/admin/users` and click on a user - should load detail page
- [ ] Use admin token in "use access token instead" login - should authenticate as admin

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)