### PR TITLE
feat: Add admin UI for audio search cache management

### DIFF
--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -5,12 +5,13 @@ Handles:
 - Dashboard overview statistics
 - System-wide metrics
 - Admin-only operations
+- Audio search cache management
 """
 import logging
 from datetime import datetime, timedelta
-from typing import Tuple
+from typing import Tuple, List, Optional, Any, Dict
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from backend.api.dependencies import require_admin
@@ -196,4 +197,218 @@ async def get_admin_stats_overview(
         jobs_by_status=jobs_by_status,
         total_credits_issued_30d=total_credits_issued_30d,
         total_beta_testers=total_beta_testers,
+    )
+
+
+# =============================================================================
+# Audio Search Management Models
+# =============================================================================
+
+class AudioSearchResultSummary(BaseModel):
+    """Summary of a single audio search result."""
+    index: int
+    provider: str
+    artist: str
+    title: str
+    is_lossless: bool
+    quality: Optional[str] = None
+    seeders: Optional[int] = None
+
+
+class AudioSearchJobSummary(BaseModel):
+    """Summary of a job with audio search results."""
+    job_id: str
+    status: str
+    user_email: Optional[str] = None
+    audio_search_artist: Optional[str] = None
+    audio_search_title: Optional[str] = None
+    created_at: Optional[datetime] = None
+    results_count: int
+    results_summary: List[AudioSearchResultSummary]
+    has_lossless: bool
+    providers: List[str]
+
+
+class AudioSearchListResponse(BaseModel):
+    """Response for listing audio search jobs."""
+    jobs: List[AudioSearchJobSummary]
+    total: int
+
+
+class ClearSearchCacheResponse(BaseModel):
+    """Response for clearing search cache."""
+    status: str
+    job_id: str
+    message: str
+    previous_status: str
+    new_status: str
+    results_cleared: int
+
+
+# =============================================================================
+# Audio Search Management Endpoints
+# =============================================================================
+
+@router.get("/audio-searches", response_model=AudioSearchListResponse)
+async def list_audio_searches(
+    limit: int = 50,
+    status_filter: Optional[str] = None,
+    auth_data: Tuple[str, UserType, int] = Depends(require_admin),
+    user_service: UserService = Depends(get_user_service),
+):
+    """
+    List jobs with audio search results.
+
+    Returns jobs that have cached audio search results, useful for:
+    - Monitoring search activity
+    - Identifying stale cached results
+    - Clearing cache for specific jobs
+
+    Args:
+        limit: Maximum number of jobs to return (default 50)
+        status_filter: Optional filter by job status (e.g., 'awaiting_audio_selection')
+    """
+    from google.cloud.firestore_v1 import FieldFilter
+
+    db = user_service.db
+    jobs_collection = db.collection("jobs")
+
+    # Query jobs - we'll filter for those with audio_search_results in Python
+    # since Firestore can't query for existence of nested fields efficiently
+    query = jobs_collection.order_by("created_at", direction="DESCENDING").limit(500)
+
+    if status_filter:
+        query = jobs_collection.where(
+            filter=FieldFilter("status", "==", status_filter)
+        ).order_by("created_at", direction="DESCENDING").limit(500)
+
+    jobs_with_searches = []
+
+    for doc in query.stream():
+        data = doc.to_dict()
+        state_data = data.get("state_data", {})
+        audio_results = state_data.get("audio_search_results", [])
+
+        if not audio_results:
+            continue
+
+        # Compute has_lossless and providers from ALL results (not just first 10)
+        has_lossless = any(r.get("is_lossless", False) for r in audio_results)
+        providers = {r.get("provider", "Unknown") for r in audio_results}
+
+        # Build summary from first 10 results only
+        results_summary = []
+        for r in audio_results[:10]:
+            results_summary.append(AudioSearchResultSummary(
+                index=r.get("index", 0),
+                provider=r.get("provider", "Unknown"),
+                artist=r.get("artist", ""),
+                title=r.get("title", ""),
+                is_lossless=r.get("is_lossless", False),
+                quality=r.get("quality"),
+                seeders=r.get("seeders"),
+            ))
+
+        jobs_with_searches.append(AudioSearchJobSummary(
+            job_id=doc.id,
+            status=data.get("status", "unknown"),
+            user_email=data.get("user_email"),
+            audio_search_artist=data.get("audio_search_artist"),
+            audio_search_title=data.get("audio_search_title"),
+            created_at=data.get("created_at"),
+            results_count=len(audio_results),
+            results_summary=results_summary,
+            has_lossless=has_lossless,
+            providers=sorted(providers),
+        ))
+
+        if len(jobs_with_searches) >= limit:
+            break
+
+    return AudioSearchListResponse(
+        jobs=jobs_with_searches,
+        total=len(jobs_with_searches),
+    )
+
+
+@router.post("/audio-searches/{job_id}/clear-cache", response_model=ClearSearchCacheResponse)
+async def clear_audio_search_cache(
+    job_id: str,
+    auth_data: Tuple[str, UserType, int] = Depends(require_admin),
+    user_service: UserService = Depends(get_user_service),
+):
+    """
+    Clear the cached audio search results for a job.
+
+    This will:
+    1. Remove the cached search results from job.state_data
+    2. Reset the job status to 'pending' so a new search can be performed
+
+    Use this when:
+    - Cached results are stale (e.g., flacfetch was updated)
+    - User wants to search again with different terms
+    - Results appear incomplete or incorrect
+    """
+    job_manager = JobManager()
+    job = job_manager.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+
+    # Get current state
+    state_data = job.state_data or {}
+    audio_results = state_data.get("audio_search_results", [])
+    results_count = len(audio_results)
+    previous_status = job.status
+
+    if not audio_results:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Job {job_id} has no cached audio search results"
+        )
+
+    # Validate job status - only allow cache clear for appropriate states
+    # Don't allow clearing cache for jobs that are actively processing or complete
+    forbidden_statuses = {
+        "downloading", "downloading_audio", "searching_audio",
+        "separating_stage1", "separating_stage2", "transcribing", "correcting",
+        "generating_screens", "applying_padding", "rendering_video",
+        "generating_video", "encoding", "packaging", "uploading",
+        "complete", "prep_complete",
+    }
+    if previous_status in forbidden_statuses:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot clear cache for job in '{previous_status}' state. "
+            f"Only jobs in pending, awaiting_audio_selection, failed, or cancelled states can have cache cleared."
+        )
+
+    # Clear the cache by removing the keys
+    db = user_service.db
+    job_ref = db.collection("jobs").document(job_id)
+
+    from google.cloud.firestore_v1 import DELETE_FIELD
+
+    # Update job: clear cache and reset status
+    job_ref.update({
+        "state_data.audio_search_results": DELETE_FIELD,
+        "state_data.audio_search_count": DELETE_FIELD,
+        "state_data.remote_search_id": DELETE_FIELD,
+        "status": "pending",
+        "progress": 0,
+        "message": "Audio search cache cleared by admin. Ready for new search.",
+        "updated_at": datetime.utcnow(),
+    })
+
+    logger.info(
+        f"Admin {auth_data[0]} cleared audio search cache for job {job_id}. "
+        f"Cleared {results_count} results. Status changed from {previous_status} to pending."
+    )
+
+    return ClearSearchCacheResponse(
+        status="success",
+        job_id=job_id,
+        message=f"Cleared {results_count} cached search results. Job reset to pending.",
+        previous_status=previous_status,
+        new_status="pending",
+        results_cleared=results_count,
     )

--- a/docs/API.md
+++ b/docs/API.md
@@ -383,6 +383,68 @@ Authorization: Bearer ADMIN_TOKEN
 
 Admins can delete any job. Regular users can only delete their own jobs.
 
+### Audio Search Management (Admin)
+
+#### List Audio Searches
+
+```http
+GET /api/admin/audio-searches
+GET /api/admin/audio-searches?limit=50&status_filter=awaiting_audio_selection
+Authorization: Bearer ADMIN_TOKEN
+```
+
+Returns jobs with cached audio search results. Useful for:
+- Monitoring search activity
+- Identifying stale cached results (YouTube-only when lossless should be available)
+- Clearing cache for specific jobs
+
+Response:
+```json
+{
+  "jobs": [
+    {
+      "job_id": "abc123",
+      "status": "awaiting_audio_selection",
+      "user_email": "user@example.com",
+      "audio_search_artist": "Artist Name",
+      "audio_search_title": "Song Title",
+      "created_at": "2026-01-03T12:00:00Z",
+      "results_count": 5,
+      "has_lossless": false,
+      "providers": ["YouTube"],
+      "results_summary": [...]
+    }
+  ],
+  "total": 1
+}
+```
+
+#### Clear Audio Search Cache
+
+```http
+POST /api/admin/audio-searches/{job_id}/clear-cache
+Authorization: Bearer ADMIN_TOKEN
+```
+
+Clears cached search results and resets job to `pending` status, allowing a new search.
+
+Use when:
+- Cached results are stale (e.g., flacfetch was updated with new providers)
+- User wants to search again
+- Results appear incomplete (YouTube-only when lossless should exist)
+
+Response:
+```json
+{
+  "status": "success",
+  "job_id": "abc123",
+  "message": "Cleared 5 cached search results. Job reset to pending.",
+  "previous_status": "awaiting_audio_selection",
+  "new_status": "pending",
+  "results_cleared": 5
+}
+```
+
 ## Rate Limits
 
 No rate limits currently implemented.

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -789,6 +789,29 @@ result = job.state_data['search_results'][selection_index]
 
 **Lesson**: Design for stateless request handling. Any state that must survive between requests must be persisted externally.
 
+### Firestore Cache Has No Automatic Invalidation
+
+**Problem**: Audio search results are cached in Firestore (`job.state_data.audio_search_results`) with no expiration or invalidation. When a library like flacfetch is updated with new providers or bug fixes, existing cached results remain stale forever.
+
+**Symptoms**:
+- Job shows only 5 YouTube results when CLI shows 59 results including lossless sources
+- User cannot get better search results without admin intervention
+- No "re-search" option in the UI
+
+**Example**: Job `6ddbbef1` was searched when flacfetch had a bug returning only YouTube results. After flacfetch was fixed, the job still showed the old 5-result cache.
+
+**Solution**: Added admin endpoints and UI to manage cached searches:
+- `GET /api/admin/audio-searches` - List jobs with cached results
+- `POST /api/admin/audio-searches/{job_id}/clear-cache` - Clear cache and reset to pending
+- Admin UI at `/admin/searches` shows which jobs have YouTube-only results vs lossless
+
+**Future consideration**: Add automatic cache invalidation based on:
+- Time (TTL)
+- flacfetch version change
+- User-initiated "re-search" button
+
+**Lesson**: When caching external API results, consider how/when the cache should be invalidated. Permanent caches need admin tooling to manage stale data.
+
 ### GCS Downloads Preserve Directory Structure
 
 **Problem**: When downloading files from GCS, the directory structure is preserved. Code that uses non-recursive glob patterns won't find files in subdirectories.

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,8 @@
 
 ## Recent Changes
 
+- **Audio Search Cache Management** (2026-01-03): Added admin UI at `/admin/searches` to view and manage cached audio search results. Admins can clear stale caches (e.g., when flacfetch is updated with new providers) and allow users to re-search. Fixes issue where jobs showed only YouTube results when lossless sources should be available. See [API.md](API.md#audio-search-management-admin) and [LESSONS-LEARNED.md](LESSONS-LEARNED.md#firestore-cache-has-no-automatic-invalidation).
+
 - **User Database Separation** (2026-01-03): Migrated karaoke-gen users from shared `users` collection to dedicated `gen_users` collection. This separates karaoke-gen user data from karaoke-decide user data (both apps share the same GCP project/Firestore instance). Migration script in `scripts/migrate_users_to_gen_users.py`. See [ARCHITECTURE.md](ARCHITECTURE.md#firestore-collections) for collection details.
 
 - **Admin Dashboard** (2026-01-03): Added comprehensive admin dashboard at `/admin` with: stats overview (users, jobs, credits), user management (search, sort, add credits, toggle role, enable/disable), job browser (filter by status/user, view details, delete), and beta program monitoring. Query-param based routing for static export compatibility. See [API.md](API.md#admin-endpoints) for backend endpoints.

--- a/frontend/app/admin/layout.tsx
+++ b/frontend/app/admin/layout.tsx
@@ -46,6 +46,8 @@ function AdminBreadcrumb() {
             breadcrumbs.push({ label: "Jobs", href: "/admin/jobs" })
             breadcrumbs.push({ label: decodeURIComponent(segments[2]) })
           }
+        } else if (segments[1] === "searches") {
+          breadcrumbs.push({ label: "Audio Searches" })
         } else if (segments[1] === "beta") {
           breadcrumbs.push({ label: "Beta Program" })
         }

--- a/frontend/app/admin/searches/page.tsx
+++ b/frontend/app/admin/searches/page.tsx
@@ -1,0 +1,343 @@
+"use client"
+
+import { useEffect, useState, useCallback } from "react"
+import { adminApi, AudioSearchJobSummary } from "@/lib/api"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import {
+  RefreshCw,
+  Loader2,
+  Trash2,
+  Music,
+  CheckCircle,
+  XCircle,
+  ExternalLink,
+} from "lucide-react"
+import { useToast } from "@/hooks/use-toast"
+
+const statusOptions = [
+  { value: "all", label: "All Statuses" },
+  { value: "awaiting_audio_selection", label: "Awaiting Selection" },
+  { value: "pending", label: "Pending" },
+  { value: "complete", label: "Complete" },
+  { value: "failed", label: "Failed" },
+]
+
+export default function AdminSearchesPage() {
+  const { toast } = useToast()
+  const [searches, setSearches] = useState<AudioSearchJobSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [statusFilter, setStatusFilter] = useState("all")
+
+  // Clear cache dialog
+  const [clearDialogOpen, setClearDialogOpen] = useState(false)
+  const [jobToClear, setJobToClear] = useState<AudioSearchJobSummary | null>(null)
+  const [clearing, setClearing] = useState(false)
+
+  const loadSearches = useCallback(async () => {
+    try {
+      setLoading(true)
+      const data = await adminApi.listAudioSearches({
+        limit: 100,
+        status_filter: statusFilter !== "all" ? statusFilter : undefined,
+      })
+      setSearches(data.jobs)
+    } catch (err: any) {
+      console.error("Failed to load searches:", err)
+      toast({
+        title: "Error",
+        description: err.message || "Failed to load audio searches",
+        variant: "destructive",
+      })
+    } finally {
+      setLoading(false)
+    }
+  }, [statusFilter, toast])
+
+  useEffect(() => {
+    loadSearches()
+  }, [loadSearches])
+
+  const handleClearCache = async () => {
+    if (!jobToClear) return
+
+    try {
+      setClearing(true)
+      const result = await adminApi.clearAudioSearchCache(jobToClear.job_id)
+      toast({
+        title: "Cache Cleared",
+        description: result.message,
+      })
+      setClearDialogOpen(false)
+      setJobToClear(null)
+      loadSearches()
+    } catch (err: any) {
+      toast({
+        title: "Error",
+        description: err.message || "Failed to clear cache",
+        variant: "destructive",
+      })
+    } finally {
+      setClearing(false)
+    }
+  }
+
+  const getStatusVariant = (status: string) => {
+    if (status === "complete" || status === "prep_complete") return "default"
+    if (status === "failed") return "destructive"
+    if (status === "cancelled") return "outline"
+    if (status.includes("awaiting")) return "secondary"
+    return "secondary"
+  }
+
+  const formatDate = (dateStr?: string) => {
+    if (!dateStr) return "—"
+    return new Date(dateStr).toLocaleString()
+  }
+
+  const getProviderBadgeClass = (provider: string) => {
+    switch (provider.toLowerCase()) {
+      case "youtube":
+        return "bg-red-500/20 text-red-400 border-red-500/30"
+      case "red":
+        return "bg-red-600/30 text-red-300 border-red-500/30"
+      case "ops":
+        return "bg-blue-500/20 text-blue-400 border-blue-500/30"
+      default:
+        return "bg-slate-500/20 text-slate-400 border-slate-500/30"
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Audio Searches</h1>
+          <p className="text-muted-foreground">
+            View and manage cached audio search results
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={loadSearches} disabled={loading}>
+          <RefreshCw className={`w-4 h-4 mr-2 ${loading ? "animate-spin" : ""}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {/* Filters */}
+      <div className="flex gap-4">
+        <Select value={statusFilter} onValueChange={setStatusFilter}>
+          <SelectTrigger className="w-[200px]">
+            <SelectValue placeholder="Filter by status" />
+          </SelectTrigger>
+          <SelectContent>
+            {statusOptions.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Table */}
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Job ID</TableHead>
+              <TableHead>Search Query</TableHead>
+              <TableHead>Results</TableHead>
+              <TableHead>Providers</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>User</TableHead>
+              <TableHead>Created</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan={8} className="text-center py-8">
+                  <Loader2 className="w-6 h-6 animate-spin mx-auto text-muted-foreground" />
+                </TableCell>
+              </TableRow>
+            ) : searches.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={8} className="text-center py-8 text-muted-foreground">
+                  <Music className="w-8 h-8 mx-auto mb-2 opacity-50" />
+                  No audio searches found
+                </TableCell>
+              </TableRow>
+            ) : (
+              searches.map((search) => (
+                <TableRow key={search.job_id}>
+                  <TableCell className="font-mono text-xs">
+                    <a
+                      href={`/admin/jobs?id=${search.job_id}`}
+                      className="text-blue-500 hover:underline"
+                    >
+                      {search.job_id.slice(0, 8)}...
+                    </a>
+                  </TableCell>
+                  <TableCell>
+                    <div className="max-w-[200px]">
+                      <div className="font-medium truncate">
+                        {search.audio_search_artist || "—"}
+                      </div>
+                      <div className="text-sm text-muted-foreground truncate">
+                        {search.audio_search_title || "—"}
+                      </div>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium">{search.results_count}</span>
+                            {search.has_lossless ? (
+                              <CheckCircle className="w-4 h-4 text-green-500" />
+                            ) : (
+                              <XCircle className="w-4 h-4 text-red-400" />
+                            )}
+                          </div>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>{search.has_lossless ? "Has lossless sources" : "No lossless sources (YouTube only)"}</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex flex-wrap gap-1">
+                      {search.providers.map((provider) => (
+                        <Badge
+                          key={provider}
+                          variant="outline"
+                          className={`text-[10px] ${getProviderBadgeClass(provider)}`}
+                        >
+                          {provider}
+                        </Badge>
+                      ))}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={getStatusVariant(search.status)}>
+                      {search.status.replace(/_/g, " ")}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-xs text-muted-foreground">
+                    {search.user_email?.split("@")[0] || "—"}
+                  </TableCell>
+                  <TableCell className="text-xs text-muted-foreground">
+                    {formatDate(search.created_at)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8 text-orange-500 hover:text-orange-400 hover:bg-orange-500/10"
+                            onClick={() => {
+                              setJobToClear(search)
+                              setClearDialogOpen(true)
+                            }}
+                          >
+                            <Trash2 className="w-4 h-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>Clear cache & allow re-search</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Summary */}
+      {!loading && searches.length > 0 && (
+        <div className="text-sm text-muted-foreground">
+          Showing {searches.length} jobs with cached search results.
+          {searches.filter(s => !s.has_lossless).length > 0 && (
+            <span className="ml-2 text-orange-400">
+              {searches.filter(s => !s.has_lossless).length} have YouTube-only results (may need cache refresh).
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Clear Cache Dialog */}
+      <AlertDialog open={clearDialogOpen} onOpenChange={setClearDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Clear Search Cache?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will clear the cached search results for job{" "}
+              <span className="font-mono">{jobToClear?.job_id}</span> and reset it to pending
+              status, allowing a new search to be performed.
+              {jobToClear && !jobToClear.has_lossless && (
+                <span className="block mt-2 text-orange-400">
+                  This job only has YouTube results - clearing the cache may fix this if flacfetch has been updated.
+                </span>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleClearCache}
+              disabled={clearing}
+              className="bg-orange-600 hover:bg-orange-500"
+            >
+              {clearing ? (
+                <Loader2 className="w-4 h-4 animate-spin mr-2" />
+              ) : (
+                <Trash2 className="w-4 h-4 mr-2" />
+              )}
+              Clear Cache
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/frontend/components/admin/admin-sidebar.tsx
+++ b/frontend/components/admin/admin-sidebar.tsx
@@ -9,6 +9,7 @@ import {
   TestTube2,
   ArrowLeft,
   Settings,
+  Search,
 } from "lucide-react"
 
 import {
@@ -40,6 +41,11 @@ const navItems = [
     title: "Jobs",
     href: "/admin/jobs",
     icon: Briefcase,
+  },
+  {
+    title: "Audio Searches",
+    href: "/admin/searches",
+    icon: Search,
   },
   {
     title: "Beta Program",

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -782,6 +782,44 @@ export interface AdminJobListParams {
   limit?: number;
 }
 
+// Audio Search Admin Types
+export interface AudioSearchResultSummary {
+  index: number;
+  provider: string;
+  artist: string;
+  title: string;
+  is_lossless: boolean;
+  quality?: string;
+  seeders?: number;
+}
+
+export interface AudioSearchJobSummary {
+  job_id: string;
+  status: string;
+  user_email?: string;
+  audio_search_artist?: string;
+  audio_search_title?: string;
+  created_at?: string;
+  results_count: number;
+  results_summary: AudioSearchResultSummary[];
+  has_lossless: boolean;
+  providers: string[];
+}
+
+export interface AudioSearchListResponse {
+  jobs: AudioSearchJobSummary[];
+  total: number;
+}
+
+export interface ClearSearchCacheResponse {
+  status: string;
+  job_id: string;
+  message: string;
+  previous_status: string;
+  new_status: string;
+  results_cleared: number;
+}
+
 // Admin API namespace
 export const adminApi = {
   /**
@@ -930,6 +968,35 @@ export const adminApi = {
     const response = await fetch(
       `${API_BASE_URL}/api/jobs/${jobId}?delete_files=${deleteFiles}`,
       { method: 'DELETE', headers: getAuthHeaders() }
+    );
+    return handleResponse(response);
+  },
+
+  /**
+   * List jobs with audio search results
+   */
+  async listAudioSearches(params?: {
+    limit?: number;
+    status_filter?: string;
+  }): Promise<AudioSearchListResponse> {
+    const searchParams = new URLSearchParams();
+    if (params?.limit) searchParams.set('limit', String(params.limit));
+    if (params?.status_filter) searchParams.set('status_filter', params.status_filter);
+
+    const url = `${API_BASE_URL}/api/admin/audio-searches${searchParams.toString() ? '?' + searchParams.toString() : ''}`;
+    const response = await fetch(url, {
+      headers: getAuthHeaders()
+    });
+    return handleResponse(response);
+  },
+
+  /**
+   * Clear audio search cache for a job
+   */
+  async clearAudioSearchCache(jobId: string): Promise<ClearSearchCacheResponse> {
+    const response = await fetch(
+      `${API_BASE_URL}/api/admin/audio-searches/${jobId}/clear-cache`,
+      { method: 'POST', headers: getAuthHeaders() }
     );
     return handleResponse(response);
   },


### PR DESCRIPTION
## Summary

- Add admin UI at `/admin/searches` to view and manage cached audio search results
- Allow admins to clear stale caches when flacfetch is updated with new providers
- Fixes issue where jobs showed only YouTube results when lossless sources should be available

## Changes

- **Backend**: New admin endpoints `GET /api/admin/audio-searches` and `POST /api/admin/audio-searches/{job_id}/clear-cache`
- **Frontend**: New admin page with search results table, status indicators, and cache clear action
- **Safety**: Status validation prevents clearing cache on active/complete jobs
- **Docs**: Updated API.md, LESSONS-LEARNED.md, and README.md

## Testing

- [x] Backend module imports successfully
- [x] Frontend TypeScript compiles without errors
- [x] CodeRabbit CLI review completed and issues addressed

## Review

- [x] CodeRabbit CLI review completed locally (3 cycles)
- [x] Fixed: `has_lossless` now computed from ALL results, not just first 10
- [x] Fixed: Added status validation before cache clear
- [x] Noted (not fixed): Scalability optimization for large-scale - acceptable for admin tool

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)