### PR TITLE
fix: Add Noto fonts for full Unicode support in video rendering

### DIFF
--- a/backend/Dockerfile.base
+++ b/backend/Dockerfile.base
@@ -18,6 +18,23 @@ RUN apt-get update && apt-get install -y \
     xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
+# Install comprehensive font support for international lyrics and symbols
+# Noto fonts provide full Unicode coverage including:
+# - Latin, Greek, Cyrillic (core)
+# - CJK: Chinese, Japanese, Korean (~150MB)
+# - Arabic, Hebrew, Thai, Hindi, and other scripts (extra)
+# - Color emoji (limited support in libass, but available)
+# - Musical symbols (♪ ♫ etc.)
+# Note: This adds ~200-300MB to the image but ensures all languages render correctly
+RUN apt-get update && apt-get install -y \
+    fonts-noto-core \
+    fonts-noto-cjk \
+    fonts-noto-extra \
+    fonts-noto-color-emoji \
+    fontconfig \
+    && fc-cache -f \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install optimized static FFmpeg build (7.0.2) instead of Debian package (5.1.8)
 # John Van Sickle's builds are compiled with better optimizations for x86_64
 # This provides ~20-40% performance improvement for encoding tasks

--- a/backend/tests/test_routes_review.py
+++ b/backend/tests/test_routes_review.py
@@ -99,7 +99,7 @@ class TestStylesConfigRequirements:
             "karaoke": {
                 "background_color": "#000000",
                 "font_path": "",  # MUST be string, NOT None
-                "font": "Arial",
+                "font": "Noto Sans",
                 "ass_name": "Default",  # REQUIRED
                 "primary_color": "112, 112, 247, 255",
                 "secondary_color": "255, 255, 255, 255",
@@ -241,7 +241,7 @@ class TestPreviewStyleLoading:
                 "background_image": "/original/path/background.png",
                 "font_path": "/original/path/font.ttf",
                 "background_color": "#000000",
-                "font": "Arial",
+                "font": "Noto Sans",
                 "ass_name": "Default",
             }
         }
@@ -308,7 +308,7 @@ class TestPreviewStyleLoading:
         # Should have karaoke section with minimal/default values
         assert "karaoke" in result_styles
         assert result_styles["karaoke"]["background_color"] == "#000000"
-        assert result_styles["karaoke"]["font"] == "Arial"
+        assert result_styles["karaoke"]["font"] == "Noto Sans"
         # Minimal styles have background_image as None (default)
         assert result_styles["karaoke"].get("background_image") is None
     

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -633,6 +633,40 @@ See `docs/archive/2025-12-28-self-hosted-github-runner.md` for full details.
 - Pre-job checks provide fail-fast behavior with clear error messages
 - `docker builder prune -af` catches buildkit cache that `system prune` misses
 
+### Fonts in Docker for Video Rendering
+
+**Problem**: Video rendering showed replacement characters (squares with question marks) for special Unicode symbols like `♪` in intro/instrumental screens.
+
+**Root cause**: The `python:3.11-slim` Docker base image has NO fonts installed. FFmpeg/libass falls back to whatever it can find, which often lacks support for musical symbols, emoji, or non-Latin scripts.
+
+**Symptoms**:
+- `♪ INTRO (19 seconds) ♪` displayed as `□ INTRO (19 seconds) □`
+- Unicode characters render as tofu (replacement boxes)
+- Only appears in cloud-generated videos, not local dev (which uses system fonts)
+
+**Solution**: Install comprehensive Noto fonts in the Docker base image:
+```dockerfile
+RUN apt-get update && apt-get install -y \
+    fonts-noto-core \
+    fonts-noto-cjk \
+    fonts-noto-extra \
+    fonts-noto-color-emoji \
+    fontconfig \
+    && fc-cache -f \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+**Package breakdown**:
+- `fonts-noto-core` (~10MB): Latin, Greek, Cyrillic, musical symbols
+- `fonts-noto-cjk` (~150MB): Chinese, Japanese, Korean
+- `fonts-noto-extra` (~50MB): Arabic, Hebrew, Thai, Hindi, other scripts
+- `fonts-noto-color-emoji` (~10MB): Color emoji (limited libass support)
+- `fontconfig`: Font configuration system (required for `fc-cache`)
+
+**Note on color emoji**: FFmpeg's libass subtitle renderer doesn't fully support color emoji fonts - it renders text as vectors and can't display color bitmap glyphs. Color emoji appears as monochrome outlines or may not render at all in ASS subtitles.
+
+**Lesson**: When building Docker images for video/subtitle rendering, install fonts explicitly. The default slim images have nothing, and font fallback behavior differs from local development machines.
+
 ## Performance Observations
 
 | Operation | Duration |

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,8 @@
 
 ## Recent Changes
 
+- **Full Unicode Font Support** (2026-01-03): Fixed rendering of musical symbols (♪) and added comprehensive international font support to Docker base image. Installed Noto fonts covering Latin, CJK (Chinese/Japanese/Korean), Arabic, Hebrew, Thai, and other scripts. Changed default karaoke font from Arial to Noto Sans. See [LESSONS-LEARNED.md](LESSONS-LEARNED.md#fonts-in-docker-for-video-rendering).
+
 - **Flacfetch Cache API Integration** (2026-01-03): Enhanced audio search cache management to also clear flacfetch's GCS cache. When admins clear a job's cache, both Firestore (job state) and flacfetch (GCS search results) are cleared simultaneously. Added "Clear All Cache" button and cache stats display to admin UI. New endpoints: `DELETE /api/admin/cache`, `GET /api/admin/cache/stats`. See [API.md](API.md#audio-search-management-admin).
 
 - **Audio Search Cache Management** (2026-01-03): Added admin UI at `/admin/searches` to view and manage cached audio search results. Admins can clear stale caches (e.g., when flacfetch is updated with new providers) and allow users to re-search. Fixes issue where jobs showed only YouTube results when lossless sources should be available. See [API.md](API.md#audio-search-management-admin) and [LESSONS-LEARNED.md](LESSONS-LEARNED.md#firestore-cache-has-no-automatic-invalidation).

--- a/karaoke_gen/style_loader.py
+++ b/karaoke_gen/style_loader.py
@@ -70,7 +70,9 @@ DEFAULT_KARAOKE_STYLE = {
     "background_color": "#000000",
     "background_image": None,
     # Font settings
-    "font": "Arial",
+    # Using "Noto Sans" for full Unicode support (CJK, Arabic, symbols, etc.)
+    # Requires fonts-noto-* packages installed in Docker image
+    "font": "Noto Sans",
     "font_path": "",  # Must be string, not None (for ASS generator)
     "ass_name": "Default",
     # Colors in "R, G, B, A" format (required by ASS)


### PR DESCRIPTION
## Summary

- Fixes rendering of musical symbols (♪) in INTRO/INSTRUMENTAL/OUTRO screens
- Adds comprehensive international font support for CJK and other scripts
- Changes default karaoke font from Arial to Noto Sans

## Changes

- **backend/Dockerfile.base**: Install Noto font packages (core, CJK, extra, color-emoji) with fontconfig
- **karaoke_gen/style_loader.py**: Change default font from "Arial" to "Noto Sans"
- **backend/tests/test_routes_review.py**: Update test assertions to match new default font
- **docs/LESSONS-LEARNED.md**: Add "Fonts in Docker for Video Rendering" section
- **docs/README.md**: Add "Full Unicode Font Support" to Recent Changes

## Testing

- [x] Tests pass locally (`make test`)
- [x] Manual review of changes completed

## Notes

- Adds ~200-300MB to Docker base image for comprehensive font coverage
- Color emoji has limited support in FFmpeg/libass (renders as monochrome)
- Requires base image rebuild to take effect

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)