### PR TITLE
fix: Reset worker progress state on job retry

### DIFF
--- a/backend/api/routes/jobs.py
+++ b/backend/api/routes/jobs.py
@@ -1291,12 +1291,13 @@ async def retry_job(
             
             logger.info(f"Job {job_id}: Has rendered video and instrumental selection, retrying video generation")
             
-            # Clear error state
+            # Clear error state and reset worker progress for idempotency
             job_manager.update_job(job_id, {
                 'error_message': None,
                 'error_details': None,
             })
-            
+            job_manager.update_state_data(job_id, 'video_progress', {'stage': 'pending'})
+
             # Reset to INSTRUMENTAL_SELECTED and trigger video worker
             if not job_manager.transition_to_state(
                 job_id=job_id,
@@ -1324,13 +1325,14 @@ async def retry_job(
               file_urls.get('screens', {}).get('title')):
             
             logger.info(f"Job {job_id}: Has corrections and screens, retrying from render stage")
-            
-            # Clear error state
+
+            # Clear error state and reset worker progress for idempotency
             job_manager.update_job(job_id, {
                 'error_message': None,
                 'error_details': None,
             })
-            
+            job_manager.update_state_data(job_id, 'render_progress', {'stage': 'pending'})
+
             # Reset to REVIEW_COMPLETE and trigger render worker
             if not job_manager.transition_to_state(
                 job_id=job_id,
@@ -1358,13 +1360,14 @@ async def retry_job(
               file_urls.get('lyrics', {}).get('corrections')):
             
             logger.info(f"Job {job_id}: Has stems and corrections, retrying from screens stage")
-            
-            # Clear error state
+
+            # Clear error state and reset worker progress for idempotency
             job_manager.update_job(job_id, {
                 'error_message': None,
                 'error_details': None,
             })
-            
+            job_manager.update_state_data(job_id, 'screens_progress', {'stage': 'pending'})
+
             # Reset to a state before screens and trigger screens worker
             if not job_manager.transition_to_state(
                 job_id=job_id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.89.1"
+version = "0.89.2"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Fix job retry getting stuck because worker progress state wasn't reset
- When retrying, idempotency check saw `video_progress.stage = 'running'` from previous failed run
- Now properly resets progress state to 'pending' for video, render, and screens workers

## Changes
- `backend/api/routes/jobs.py` - Add `update_state_data` calls to reset progress

## Testing
- [x] Encoding tests pass locally
- [ ] Test with job `501258e1` after deployment

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)