### PR TITLE
fix: Handle list response in encoding service wait_for_completion

### DIFF
--- a/backend/services/encoding_service.py
+++ b/backend/services/encoding_service.py
@@ -177,6 +177,15 @@ class EncodingService:
                 raise TimeoutError(f"Encoding job {job_id} timed out after {timeout}s")
 
             status = await self.get_job_status(job_id)
+
+            # Handle case where GCE worker returns a list instead of dict
+            if isinstance(status, list):
+                logger.warning(f"[job:{job_id}] GCE returned list instead of dict: {status}")
+                status = status[0] if status and isinstance(status[0], dict) else {}
+            if not isinstance(status, dict):
+                logger.error(f"[job:{job_id}] Unexpected status type: {type(status)}")
+                status = {}
+
             job_status = status.get("status", "unknown")
             progress = status.get("progress", 0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.89.4"
+version = "0.89.5"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Fix `'list' object has no attribute 'get'` error in GCE encoding wait_for_completion
- The GCE encoding worker sometimes returns a list instead of a dict from the /status endpoint
- PR #186 added handling in encode(), but same issue occurs in wait_for_completion()

## Changes
- Added defensive handling to convert list responses to dicts in wait_for_completion()

## Testing
- [x] Code review
- [ ] Deploy and test with job 501258e1

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)