### PR TITLE
fix: Handle GCE worker output_files as list of paths

### DIFF
--- a/backend/services/encoding_interface.py
+++ b/backend/services/encoding_interface.py
@@ -349,7 +349,29 @@ class GCEEncodingBackend(EncodingBackend):
             if not isinstance(result, dict):
                 self.logger.error(f"Unexpected GCE result type: {type(result)}")
                 result = {}
-            output_files = result.get("output_files", {})
+            raw_output_files = result.get("output_files", {})
+
+            # Convert output_files from list of paths to dict if needed
+            # GCE worker returns list like: ["path/output_4k_lossless.mp4", "path/output_720p.mp4"]
+            # We need dict like: {"mp4_4k_lossless": "path/...", "mp4_720p": "path/..."}
+            if isinstance(raw_output_files, list):
+                output_files = {}
+                for path in raw_output_files:
+                    if not isinstance(path, str):
+                        continue
+                    filename = path.split("/")[-1] if "/" in path else path
+                    # Map filename patterns to output format keys
+                    if "4k_lossless" in filename:
+                        output_files["mp4_4k_lossless"] = path
+                    elif "4k_lossy" in filename:
+                        output_files["mp4_4k_lossy"] = path
+                    elif "720p" in filename:
+                        output_files["mp4_720p"] = path
+                    elif filename.endswith(".mkv"):
+                        output_files["mkv_4k"] = path
+                self.logger.info(f"Converted output_files list to dict: {output_files}")
+            else:
+                output_files = raw_output_files if isinstance(raw_output_files, dict) else {}
 
             return EncodingOutput(
                 success=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.89.5"
+version = "0.89.6"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
Fix the actual root cause of `'list' object has no attribute 'get'` error in GCE encoding.

## Problem
The GCE encoding worker returns `output_files` as a **list of paths**:
```json
"output_files": [
    "jobs/501258e1/finals/output_4k_lossless.mp4",
    "jobs/501258e1/finals/output_4k_lossy.mp4",
    "jobs/501258e1/finals/output_720p.mp4"
]
```

But the code expected a **dict** with format keys:
```json
{"mp4_4k_lossless": "path/...", "mp4_4k_lossy": "path/...", ...}
```

This caused the error when calling `.get()` on the list.

## Solution
Added conversion logic to map the list of paths to the expected dict format by matching filename patterns (e.g., `output_4k_lossless.mp4` -> `mp4_4k_lossless`).

## Testing
- [x] Verified GCE worker response format
- [ ] Deploy and test with job 501258e1

## Notes
PR #191 fixed a similar issue in `wait_for_completion` where the entire `status` response could be a list. This PR fixes a different issue where `output_files` within the response is a list.

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)