### PR TITLE
fix: Allow explicit override of YouTube upload server default

### DIFF
--- a/backend/api/routes/audio_search.py
+++ b/backend/api/routes/audio_search.py
@@ -95,7 +95,7 @@ class AudioSearchRequest(BaseModel):
     
     # Finalisation options
     brand_prefix: Optional[str] = Field(None, description="Brand code prefix (e.g., NOMAD)")
-    enable_youtube_upload: bool = Field(False, description="Upload to YouTube")
+    enable_youtube_upload: Optional[bool] = Field(None, description="Upload to YouTube. None = use server default")
     youtube_description: Optional[str] = Field(None, description="YouTube video description text")
     discord_webhook_url: Optional[str] = Field(None, description="Discord webhook URL for notifications")
     
@@ -485,7 +485,8 @@ async def search_audio(
         effective_discord_webhook_url = body.discord_webhook_url or settings.default_discord_webhook_url
 
         # Apply defaults for YouTube/Dropbox distribution (for web service)
-        effective_enable_youtube_upload = body.enable_youtube_upload or settings.default_enable_youtube_upload
+        # Use explicit value if provided, otherwise fall back to server default
+        effective_enable_youtube_upload = body.enable_youtube_upload if body.enable_youtube_upload is not None else settings.default_enable_youtube_upload
         effective_brand_prefix = body.brand_prefix or settings.default_brand_prefix
         effective_youtube_description = body.youtube_description or settings.default_youtube_description
 

--- a/backend/api/routes/file_upload.py
+++ b/backend/api/routes/file_upload.py
@@ -69,7 +69,7 @@ class CreateJobFromUrlRequest(BaseModel):
 
     # Finalisation options
     brand_prefix: Optional[str] = Field(None, description="Brand code prefix (e.g., NOMAD)")
-    enable_youtube_upload: bool = Field(False, description="Upload to YouTube")
+    enable_youtube_upload: Optional[bool] = Field(None, description="Upload to YouTube. None = use server default")
     youtube_description: Optional[str] = Field(None, description="YouTube video description text")
     discord_webhook_url: Optional[str] = Field(None, description="Discord webhook URL for notifications")
     webhook_url: Optional[str] = Field(None, description="Generic webhook URL")
@@ -123,7 +123,7 @@ class CreateJobWithUploadUrlsRequest(BaseModel):
     
     # Finalisation options
     brand_prefix: Optional[str] = Field(None, description="Brand code prefix (e.g., NOMAD)")
-    enable_youtube_upload: bool = Field(False, description="Upload to YouTube")
+    enable_youtube_upload: Optional[bool] = Field(None, description="Upload to YouTube. None = use server default")
     youtube_description: Optional[str] = Field(None, description="YouTube video description text")
     discord_webhook_url: Optional[str] = Field(None, description="Discord webhook URL for notifications")
     webhook_url: Optional[str] = Field(None, description="Generic webhook URL")
@@ -406,7 +406,7 @@ async def upload_and_create_job(
     enable_txt: Optional[bool] = Form(None, description="Generate TXT+MP3 package. Default: True if theme_id set, False otherwise"),
     # Finalisation options
     brand_prefix: Optional[str] = Form(None, description="Brand code prefix (e.g., NOMAD)"),
-    enable_youtube_upload: bool = Form(False, description="Upload to YouTube"),
+    enable_youtube_upload: Optional[bool] = Form(None, description="Upload to YouTube. None = use server default"),
     youtube_description: Optional[str] = Form(None, description="YouTube video description text"),
     discord_webhook_url: Optional[str] = Form(None, description="Discord webhook URL for notifications"),
     webhook_url: Optional[str] = Form(None, description="Generic webhook URL"),
@@ -510,12 +510,19 @@ async def upload_and_create_job(
         if dist.brand_prefix and not brand_prefix:
             logger.info(f"Using default brand_prefix: {dist.brand_prefix}")
 
+        # Apply YouTube upload default from settings
+        # Use explicit value if provided, otherwise fall back to server default
+        settings = get_settings()
+        effective_enable_youtube_upload = enable_youtube_upload if enable_youtube_upload is not None else settings.default_enable_youtube_upload
+        if effective_enable_youtube_upload and enable_youtube_upload is None:
+            logger.info("Using default enable_youtube_upload: True (from env)")
+
         # Validate credentials for requested distribution services (including defaults)
         # This prevents accepting jobs that will fail later due to missing credentials
         invalid_services = []
         credential_manager = get_credential_manager()
 
-        if enable_youtube_upload:
+        if effective_enable_youtube_upload:
             result = credential_manager.check_youtube_credentials()
             if result.status != CredentialStatus.VALID:
                 invalid_services.append(f"youtube ({result.message})")
@@ -594,7 +601,7 @@ async def upload_and_create_job(
             enable_cdg=resolved_cdg,
             enable_txt=resolved_txt,
             brand_prefix=dist.brand_prefix,
-            enable_youtube_upload=enable_youtube_upload,
+            enable_youtube_upload=effective_enable_youtube_upload,
             youtube_description=youtube_description,
             discord_webhook_url=dist.discord_webhook_url,
             webhook_url=webhook_url,
@@ -815,11 +822,12 @@ async def upload_and_create_job(
                 "using_default": gdrive_folder_id is None,
             }
         
-        if enable_youtube_upload:
+        if effective_enable_youtube_upload:
             youtube_result = credential_manager.check_youtube_credentials()
             distribution_services["youtube"] = {
                 "enabled": True,
                 "credentials_valid": youtube_result.status == CredentialStatus.VALID,
+                "using_default": enable_youtube_upload is None,
             }
         
         if dist.discord_webhook_url:
@@ -908,7 +916,7 @@ class CreateFinaliseOnlyJobRequest(BaseModel):
     # Finalisation options
     brand_prefix: Optional[str] = Field(None, description="Brand code prefix (e.g., NOMAD)")
     keep_brand_code: Optional[str] = Field(None, description="Preserve existing brand code from folder name")
-    enable_youtube_upload: bool = Field(False, description="Upload to YouTube")
+    enable_youtube_upload: Optional[bool] = Field(None, description="Upload to YouTube. None = use server default")
     youtube_description: Optional[str] = Field(None, description="YouTube video description text")
     discord_webhook_url: Optional[str] = Field(None, description="Discord webhook URL for notifications")
     
@@ -1048,11 +1056,16 @@ async def create_job_with_upload_urls(
             brand_prefix=body.brand_prefix,
         )
 
+        # Apply YouTube upload default from settings
+        # Use explicit value if provided, otherwise fall back to server default
+        settings = get_settings()
+        effective_enable_youtube_upload = body.enable_youtube_upload if body.enable_youtube_upload is not None else settings.default_enable_youtube_upload
+
         # Validate credentials for requested distribution services
         invalid_services = []
         credential_manager = get_credential_manager()
 
-        if body.enable_youtube_upload:
+        if effective_enable_youtube_upload:
             result = credential_manager.check_youtube_credentials()
             if result.status != CredentialStatus.VALID:
                 invalid_services.append(f"youtube ({result.message})")
@@ -1105,7 +1118,7 @@ async def create_job_with_upload_urls(
             enable_cdg=resolved_cdg,
             enable_txt=resolved_txt,
             brand_prefix=dist.brand_prefix,
-            enable_youtube_upload=body.enable_youtube_upload,
+            enable_youtube_upload=effective_enable_youtube_upload,
             youtube_description=body.youtube_description,
             youtube_description_template=body.youtube_description,  # video_worker reads this field
             discord_webhook_url=dist.discord_webhook_url,
@@ -1466,11 +1479,16 @@ async def create_job_from_url(
             brand_prefix=body.brand_prefix,
         )
 
+        # Apply YouTube upload default from settings
+        # Use explicit value if provided, otherwise fall back to server default
+        settings = get_settings()
+        effective_enable_youtube_upload = body.enable_youtube_upload if body.enable_youtube_upload is not None else settings.default_enable_youtube_upload
+
         # Validate credentials for requested distribution services
         invalid_services = []
         credential_manager = get_credential_manager()
 
-        if body.enable_youtube_upload:
+        if effective_enable_youtube_upload:
             result = credential_manager.check_youtube_credentials()
             if result.status != CredentialStatus.VALID:
                 invalid_services.append(f"youtube ({result.message})")
@@ -1522,7 +1540,7 @@ async def create_job_from_url(
             enable_cdg=resolved_cdg,
             enable_txt=resolved_txt,
             brand_prefix=dist.brand_prefix,
-            enable_youtube_upload=body.enable_youtube_upload,
+            enable_youtube_upload=effective_enable_youtube_upload,
             youtube_description=body.youtube_description,
             discord_webhook_url=dist.discord_webhook_url,
             webhook_url=body.webhook_url,
@@ -1712,11 +1730,16 @@ async def create_finalise_only_job(
             brand_prefix=body.brand_prefix,
         )
 
+        # Apply YouTube upload default from settings
+        # Use explicit value if provided, otherwise fall back to server default
+        settings = get_settings()
+        effective_enable_youtube_upload = body.enable_youtube_upload if body.enable_youtube_upload is not None else settings.default_enable_youtube_upload
+
         # Validate distribution credentials if services are requested
         invalid_services = []
         credential_manager = get_credential_manager()
 
-        if body.enable_youtube_upload:
+        if effective_enable_youtube_upload:
             result = credential_manager.check_youtube_credentials()
             if result.status != CredentialStatus.VALID:
                 invalid_services.append(f"youtube ({result.message})")
@@ -1766,7 +1789,7 @@ async def create_finalise_only_job(
             enable_cdg=resolved_cdg,
             enable_txt=resolved_txt,
             brand_prefix=dist.brand_prefix,
-            enable_youtube_upload=body.enable_youtube_upload,
+            enable_youtube_upload=effective_enable_youtube_upload,
             youtube_description=body.youtube_description,
             discord_webhook_url=dist.discord_webhook_url,
             dropbox_path=dist.dropbox_path,

--- a/backend/api/routes/jobs.py
+++ b/backend/api/routes/jobs.py
@@ -87,6 +87,11 @@ async def create_job(
             user_email = request.user_email
             logger.info(f"Admin {auth_result.user_email} creating job on behalf of {user_email}")
 
+        # Apply YouTube upload default from settings
+        # Use explicit value if provided, otherwise fall back to server default
+        settings = get_settings()
+        effective_enable_youtube_upload = request.enable_youtube_upload if request.enable_youtube_upload is not None else settings.default_enable_youtube_upload
+
         # Create job with all preferences
         job_create = JobCreate(
             url=str(request.url),
@@ -94,7 +99,7 @@ async def create_job(
             title=request.title,
             enable_cdg=request.enable_cdg,
             enable_txt=request.enable_txt,
-            enable_youtube_upload=request.enable_youtube_upload,
+            enable_youtube_upload=effective_enable_youtube_upload,
             youtube_description=request.youtube_description,
             webhook_url=request.webhook_url,
             user_email=user_email

--- a/backend/models/requests.py
+++ b/backend/models/requests.py
@@ -14,7 +14,7 @@ class URLSubmissionRequest(BaseModel):
     # Optional preferences
     enable_cdg: bool = False  # Requires style config
     enable_txt: bool = False  # Requires style config
-    enable_youtube_upload: bool = False
+    enable_youtube_upload: Optional[bool] = None  # None = use server default
     youtube_description: Optional[str] = None
     webhook_url: Optional[str] = None
     user_email: Optional[str] = None
@@ -28,7 +28,7 @@ class UploadSubmissionRequest(BaseModel):
     # Optional preferences
     enable_cdg: bool = False  # Requires style config
     enable_txt: bool = False  # Requires style config
-    enable_youtube_upload: bool = False
+    enable_youtube_upload: Optional[bool] = None  # None = use server default
     youtube_description: Optional[str] = None
     webhook_url: Optional[str] = None
     user_email: Optional[str] = None

--- a/backend/tests/test_file_upload.py
+++ b/backend/tests/test_file_upload.py
@@ -1128,7 +1128,8 @@ class TestFinaliseOnlyModels:
         assert request.enable_txt is None
         assert request.brand_prefix is None
         assert request.keep_brand_code is None
-        assert request.enable_youtube_upload is False
+        # YouTube upload default is None (server applies default_enable_youtube_upload)
+        assert request.enable_youtube_upload is None
         assert request.dropbox_path is None
         assert request.gdrive_folder_id is None
 

--- a/backend/tests/test_requests.py
+++ b/backend/tests/test_requests.py
@@ -149,7 +149,8 @@ class TestUploadSubmissionRequest:
         # CDG/TXT disabled by default (requires style config)
         assert request.enable_cdg is False
         assert request.enable_txt is False
-        assert request.enable_youtube_upload is False
+        # YouTube upload default is None (use server default)
+        assert request.enable_youtube_upload is None
 
 
 class TestStartReviewRequest:

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -247,6 +247,43 @@ def _get_effective_distribution_settings(...) -> EffectiveDistributionSettings:
 
 **Lesson**: When you see the same logic repeated in multiple places, refactor into a helper function immediately. Otherwise bugs will be fixed in one place but not others.
 
+### Python `or` Operator Can't Override True Defaults with False
+
+**Problem**: Using Python's `or` operator for default logic prevents explicit `false` from overriding a `true` server default.
+
+```python
+# BAD - can't explicitly disable if server default is true
+effective_value = body.enable_feature or settings.default_enable_feature
+# When body.enable_feature=False and settings.default=True:
+# False or True = True  (ignores explicit False!)
+```
+
+**Symptoms**:
+- Feature can be enabled but never disabled via API
+- Works fine when server default is `false` but breaks when default is `true`
+- No errors - just ignores the explicit `false` value
+
+**Solution**: Use `Optional[bool] = None` with explicit `is not None` check:
+
+```python
+# Request model
+enable_feature: Optional[bool] = None  # None = use server default
+
+# Default logic
+effective_value = (
+    body.enable_feature
+    if body.enable_feature is not None
+    else settings.default_enable_feature
+)
+```
+
+This allows three states:
+- `None` (not specified) → use server default
+- `True` → explicitly enable
+- `False` → explicitly disable (overrides server default)
+
+**Lesson**: When a boolean field needs to support "use server default" behavior, use `Optional[bool] = None` instead of `bool = False`. The `or` operator conflates "not specified" with "explicitly false".
+
 ### Field Name Mismatches Between Endpoints
 
 **Problem**: Different endpoints setting different field names for the same logical value, where consumers check only one field name.

--- a/frontend/e2e/production/happy-path-real-user.spec.ts
+++ b/frontend/e2e/production/happy-path-real-user.spec.ts
@@ -154,6 +154,23 @@ test.describe('E2E Happy Path - Real User with Full UI Interactions', () => {
     // Only create email helper if we're doing the full signup flow
     const emailHelper = usePreConfiguredToken ? null : await createEmailHelper();
 
+    // Intercept API requests to disable YouTube upload for E2E tests
+    // This prevents test jobs from uploading to YouTube when server default is true
+    await page.route('**/api/audio-search/search', async (route) => {
+      const request = route.request();
+      if (request.method() === 'POST') {
+        const postData = request.postDataJSON();
+        // Explicitly disable YouTube upload for E2E test jobs
+        postData.enable_youtube_upload = false;
+        console.log('  [Request Intercept] Disabled YouTube upload for audio search');
+        await route.continue({
+          postData: JSON.stringify(postData),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
     try {
       // =========================================================================
       // STEP 1: Landing Page


### PR DESCRIPTION
## Summary
- Changed `enable_youtube_upload` from `bool=False` to `Optional[bool]=None` in request models
- Allows explicit `false` to override server default when `DEFAULT_ENABLE_YOUTUBE_UPLOAD=true`
- E2E tests now intercept requests to disable YouTube upload for test jobs

## Changes
- **Request models**: Changed to `Optional[bool] = None` to support three states (None/True/False)
- **API routes**: All job creation endpoints now compute effective value using `if is not None else` pattern
- **E2E test**: Added Playwright request interception to set `enable_youtube_upload=false` for test jobs
- **Tests**: Updated to expect `None` instead of `False` for request model defaults
- **Docs**: Added lesson learned about Python `or` operator gotcha with boolean defaults

## Testing
- [x] Backend tests pass (`make test`)
- [x] No TypeScript errors in frontend changes

## Review
- [x] CodeRabbit CLI review completed locally
- [x] No issues found

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)