### PR TITLE
fix: Double-escape backslashes in GCE embedded Python code

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -1386,9 +1386,10 @@ def run_preview_encoding(job_id: str, work_dir: Path, request: "EncodePreviewReq
         output_path = work_dir / "preview.mp4"
 
         # Escape special characters in path for FFmpeg filter syntax
-        # FFmpeg filter parsing requires escaping: \ : , [ ] ;
+        # FFmpeg filter parsing requires escaping: \\ : , [ ] ;
         def escape_ffmpeg_filter_path(path: str) -> str:
-            return path.replace("\\", "\\\\").replace(":", "\\:").replace(",", "\\,").replace("[", "\\[").replace("]", "\\]").replace(";", "\\;")
+            # Note: Extra escaping needed since this is inside a triple-quoted string in Pulumi
+            return path.replace("\\\\", "\\\\\\\\").replace(":", "\\\\:").replace(",", "\\\\,").replace("[", "\\\\[").replace("]", "\\\\]").replace(";", "\\\\;")
 
         escaped_ass_path = escape_ffmpeg_filter_path(str(ass_path))
 


### PR DESCRIPTION
## Summary
Fix syntax error in GCE encoding worker startup script caused by incorrect backslash escaping.

## Problem
The `escape_ffmpeg_filter_path` function in the GCE worker startup script had a syntax error:
```
SyntaxError: unexpected character after line continuation character
```

The issue was that backslashes in the embedded Python code weren't properly escaped for the triple-quoted string context in Pulumi.

## Solution
Double the backslashes in the Pulumi source:
- 4 backslashes in source → 2 in string value → 2 on VM (valid Python)

## Testing
- GCE encoding worker now starts successfully
- Health endpoint responds correctly
- Already deployed via `pulumi up` and verified working

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)