### PR TITLE
fix: Use correct Pulumi stack name in CI infrastructure deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1151,6 +1151,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Authenticate to Google Cloud (Workload Identity)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          version: "latest"
+
       - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
@@ -1178,7 +1189,7 @@ jobs:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
         run: |
           echo "🚀 Deploying infrastructure changes..."
-          pulumi up --yes --refresh --stack nomadkaraoke/karaoke-gen/prod
+          pulumi up --yes --refresh --stack nomadkaraoke/karaoke-gen-infrastructure/prod
 
       - name: Restart GCE Encoding Worker
         run: |


### PR DESCRIPTION
## Summary
- Fixed Pulumi stack reference from `nomadkaraoke/karaoke-gen/prod` to `nomadkaraoke/karaoke-gen-infrastructure/prod` (matches project name in `Pulumi.yaml`)
- Added GCP Workload Identity authentication for Pulumi deployment step

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, infrastructure deployment job succeeds

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)