### PR TITLE
fix: Use FFmpeg filter escaping instead of shell escaping for paths

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -222,9 +222,9 @@ escaped = filename.replace("'", "\\'")
 query = f"name='{escaped}' and '{parent_id}' in parents"
 ```
 
-### FFmpeg Filter Path Escaping
+### FFmpeg Filter Path Escaping (subprocess without shell)
 
-**Problem**: Song titles with apostrophes (e.g., "I'm With You") cause FFmpeg's ASS subtitle filter to fail because paths aren't escaped.
+**Problem**: Song titles with apostrophes (e.g., "I'm With You") cause FFmpeg's ASS subtitle filter to fail because paths aren't escaped correctly.
 
 ```python
 # BAD - FFmpeg strips the apostrophe, looks for wrong path
@@ -232,20 +232,31 @@ ass_filter = f"ass=./Avril Lavigne - I'm With You/cache/temp.ass"
 # FFmpeg error: Could not create a libass track when reading file './Avril Lavigne - Im With You/cache/temp.ass'
 ```
 
-FFmpeg filter syntax interprets `'`, `:`, and `\` as special characters. The path appears correct in logs but FFmpeg silently mangles it.
+**Wrong approach #1**: Simple backslash escaping like `\'` doesn't work because FFmpeg's filter parser requires more escaping.
 
-**Wrong approach** (doesn't work): Simple backslash escaping like `\'` doesn't work because FFmpeg's filter parser consumes the backslash.
+**Wrong approach #2**: Shell-style escaping `'\''` (end quote, escaped quote, start quote) only works when passing through a shell. When using Python `subprocess` with a command list, there's no shell - arguments go directly to FFmpeg, so shell escaping patterns don't work.
 
-**Solution**: Wrap paths in single quotes and escape embedded quotes using `'\''`:
+**Solution**: Use FFmpeg filter escaping (for subprocess without shell):
 ```python
 def _escape_ffmpeg_filter_path(path: str) -> str:
-    # Escape single quotes: ' becomes '\'' (end quote, \', start quote)
-    escaped = path.replace("'", "'\\''")
-    # Wrap entire path in single quotes
-    return f"'{escaped}'"
+    """Escape a path for FFmpeg filter expressions (for subprocess without shell).
 
-# Result: "I'm With You" becomes "'I'\\''m With You'"
-# FFmpeg sees: 'I' + literal ' + 'm With You'
+    FFmpeg filter escaping rules:
+    - Backslashes: double them (\ -> \\)
+    - Single quotes/apostrophes: escape with three backslashes (' -> \\\')
+    - Spaces: escape with backslash ( -> \ )
+    """
+    # First escape existing backslashes (\ -> \\)
+    escaped = path.replace("\\", "\\\\")
+    # Escape single quotes (' -> \\\')
+    # In Python source: 6 backslashes + apostrophe = 3 backslashes + apostrophe in string
+    escaped = escaped.replace("'", "\\\\\\'")
+    # Escape spaces
+    escaped = escaped.replace(" ", "\\ ")
+    return escaped
+
+# Result: "I'm With You" becomes "I\\\'m\ With\ You"
+# FFmpeg correctly interprets this as: I'm With You
 ```
 
 **Symptoms**:
@@ -253,7 +264,9 @@ def _escape_ffmpeg_filter_path(path: str) -> str:
 - Error path is subtly different from the path in your code (missing apostrophe)
 - Works fine for songs without special characters
 
-**Lesson**: Any path passed to FFmpeg filter expressions (`-vf`, `-af`) needs single-quote wrapping. The `'\''` pattern (end quote, escaped quote, start quote) handles embedded quotes correctly.
+**Key insight**: FFmpeg filter escaping is different from shell escaping. When using `subprocess.run(cmd_list)` (no `shell=True`), there's no shell to interpret the arguments. FFmpeg receives the strings directly and applies its own filter expression parsing rules. The `'\''` shell idiom does NOT work in this context.
+
+**Lesson**: When debugging FFmpeg filter path issues, check whether you're using shell or subprocess. For subprocess without shell, escape spaces with `\ ` and apostrophes with `\\\'` (3 backslashes + quote in the actual string).
 
 ### Duplicate Code Leads to Inconsistent Behavior
 

--- a/lyrics_transcriber_temp/lyrics_transcriber/output/video.py
+++ b/lyrics_transcriber_temp/lyrics_transcriber/output/video.py
@@ -353,18 +353,27 @@ class VideoGenerator:
             raise
 
     def _escape_ffmpeg_filter_path(self, path: str) -> str:
-        """Escape a path for FFmpeg filter expressions using single-quote wrapping.
+        """Escape a path for FFmpeg filter expressions (for subprocess without shell).
 
-        FFmpeg filter syntax uses single quotes to protect special characters
-        like spaces, colons, and semicolons. Single quotes within the path
-        are escaped using the '\'' pattern (end quote, literal quote, start quote).
+        When using subprocess with a command list (no shell), FFmpeg receives the
+        filter string directly. FFmpeg's filter parser requires escaping:
+        - Backslashes: double them (\ -> \\)
+        - Single quotes/apostrophes: escape with three backslashes (' -> \\')
+        - Spaces: escape with backslash ( -> \ )
 
-        Example: "I'm With You" becomes "'I'\\''m With You'"
+        Note: This is different from shell escaping. The '\\'\\''' pattern used for
+        shell escaping does NOT work when subprocess passes args directly to FFmpeg.
+
+        Example: "I'm With You" becomes "I\\\\'m\\ With\\ You"
         """
-        # Escape single quotes: ' becomes '\'' (end quote, \', start quote)
-        escaped = path.replace("'", "'\\''")
-        # Wrap entire path in single quotes
-        return f"'{escaped}'"
+        # First escape existing backslashes (\ -> \\)
+        escaped = path.replace("\\", "\\\\")
+        # Escape single quotes (' -> \\')
+        # In the actual string we need 3 backslashes before the quote
+        escaped = escaped.replace("'", "\\\\\\'")
+        # Escape spaces
+        escaped = escaped.replace(" ", "\\ ")
+        return escaped
 
     def _build_ass_filter(self, ass_path: str) -> str:
         """Build ASS filter with font directory support."""

--- a/lyrics_transcriber_temp/tests/unit/output/test_video.py
+++ b/lyrics_transcriber_temp/tests/unit/output/test_video.py
@@ -210,7 +210,8 @@ def test_build_ass_filter_no_font_path(video_generator):
     """Test _build_ass_filter with no font path configured."""
     ass_path = "test.ass"
     result = video_generator._build_ass_filter(ass_path)
-    assert result == "ass='test.ass'"
+    # No special chars = no escaping needed
+    assert result == "ass=test.ass"
 
 
 def test_build_ass_filter_with_valid_font_path(video_generator, tmp_path):
@@ -226,8 +227,10 @@ def test_build_ass_filter_with_valid_font_path(video_generator, tmp_path):
 
     ass_path = "test.ass"
     result = video_generator._build_ass_filter(ass_path)
-    # Both paths should be wrapped in single quotes
-    expected = f"ass='test.ass':fontsdir='{str(font_dir)}'"
+    # Paths with no special chars don't need escaping
+    # But font_dir path from tmp_path may have spaces on some systems
+    escaped_font_dir = str(font_dir).replace("\\", "\\\\").replace("'", "\\\\'").replace(" ", "\\ ")
+    expected = f"ass=test.ass:fontsdir={escaped_font_dir}"
     assert result == expected
 
 
@@ -238,7 +241,8 @@ def test_build_ass_filter_with_invalid_font_path(video_generator):
 
     ass_path = "test.ass"
     result = video_generator._build_ass_filter(ass_path)
-    assert result == "ass='test.ass'"
+    # No special chars = no escaping
+    assert result == "ass=test.ass"
 
 
 def test_build_ass_filter_with_empty_font_path(video_generator):
@@ -248,7 +252,8 @@ def test_build_ass_filter_with_empty_font_path(video_generator):
 
     ass_path = "test.ass"
     result = video_generator._build_ass_filter(ass_path)
-    assert result == "ass='test.ass'"
+    # No special chars = no escaping
+    assert result == "ass=test.ass"
 
 
 def test_build_ass_filter_with_none_font_path(video_generator):
@@ -258,7 +263,8 @@ def test_build_ass_filter_with_none_font_path(video_generator):
 
     ass_path = "test.ass"
     result = video_generator._build_ass_filter(ass_path)
-    assert result == "ass='test.ass'"
+    # No special chars = no escaping
+    assert result == "ass=test.ass"
 
 
 def test_build_ass_filter_no_karaoke_section(tmp_path):
@@ -273,7 +279,8 @@ def test_build_ass_filter_no_karaoke_section(tmp_path):
 
     ass_path = "test.ass"
     result = generator._build_ass_filter(ass_path)
-    assert result == "ass='test.ass'"
+    # No special chars = no escaping
+    assert result == "ass=test.ass"
 
 
 def test_build_ass_filter_logging(video_generator, tmp_path, caplog):
@@ -299,30 +306,38 @@ def test_build_ass_filter_logging(video_generator, tmp_path, caplog):
 
 
 def test_escape_ffmpeg_filter_path(video_generator):
-    """Test _escape_ffmpeg_filter_path uses single-quote wrapping correctly."""
-    # Test simple path (wrapped in single quotes)
-    assert video_generator._escape_ffmpeg_filter_path("/path/to/file.ass") == "'/path/to/file.ass'"
+    """Test _escape_ffmpeg_filter_path uses FFmpeg filter escaping (not shell escaping).
+
+    FFmpeg filter escaping rules (for subprocess without shell):
+    - Backslashes: double them (\ -> \\)
+    - Single quotes/apostrophes: escape with three backslashes (' -> \\')
+    - Spaces: escape with backslash ( -> \ )
+    """
+    # Test simple path without special chars (no escaping needed)
+    assert video_generator._escape_ffmpeg_filter_path("/path/to/file.ass") == "/path/to/file.ass"
 
     # Test apostrophe escaping (fixes paths like "I'm With You")
-    # Single quote becomes '\'' (end quote, escaped quote, start quote)
-    assert video_generator._escape_ffmpeg_filter_path("./Avril Lavigne - I'm With You/file.ass") == "'./Avril Lavigne - I'\\''m With You/file.ass'"
+    # Apostrophe becomes \\\' (three backslashes + quote) in the actual string
+    result = video_generator._escape_ffmpeg_filter_path("./Avril Lavigne - I'm With You/file.ass")
+    assert result == "./Avril\\ Lavigne\\ -\\ I\\\\\\'m\\ With\\ You/file.ass"
 
-    # Test path with spaces (protected by single quotes)
-    assert video_generator._escape_ffmpeg_filter_path("/path/with spaces/file.ass") == "'/path/with spaces/file.ass'"
+    # Test path with spaces (escaped with backslash)
+    assert video_generator._escape_ffmpeg_filter_path("/path/with spaces/file.ass") == "/path/with\\ spaces/file.ass"
 
-    # Test path with colons (protected by single quotes)
-    assert video_generator._escape_ffmpeg_filter_path("C:/path/file.ass") == "'C:/path/file.ass'"
+    # Test path with colons (no escaping needed - colon is only special in filter options)
+    assert video_generator._escape_ffmpeg_filter_path("C:/path/file.ass") == "C:/path/file.ass"
 
     # Test multiple apostrophes
-    assert video_generator._escape_ffmpeg_filter_path("It's Bob's file.ass") == "'It'\\''s Bob'\\''s file.ass'"
+    result = video_generator._escape_ffmpeg_filter_path("It's Bob's file.ass")
+    assert result == "It\\\\\\'s\\ Bob\\\\\\'s\\ file.ass"
 
 
 def test_build_ass_filter_escapes_path_with_apostrophe(video_generator):
     """Test _build_ass_filter properly escapes paths containing apostrophes."""
     ass_path = "./Avril Lavigne - I'm With You/cache/temp.ass"
     result = video_generator._build_ass_filter(ass_path)
-    # Should wrap in single quotes and escape the apostrophe
-    assert result == "ass='./Avril Lavigne - I'\\''m With You/cache/temp.ass'"
+    # Spaces escaped with backslash, apostrophe escaped with \\\'
+    assert result == "ass=./Avril\\ Lavigne\\ -\\ I\\\\\\'m\\ With\\ You/cache/temp.ass"
 
 
 def test_build_ass_filter_escapes_font_dir_with_special_chars(video_generator, tmp_path):
@@ -340,5 +355,5 @@ def test_build_ass_filter_escapes_font_dir_with_special_chars(video_generator, t
     result = video_generator._build_ass_filter(ass_path)
     # Should have fontsdir with escaped path
     assert "fontsdir=" in result
-    # Apostrophe should be escaped using '\'' pattern
-    assert "'\\''s" in result
+    # Apostrophe should be escaped using \\\' pattern (3 backslashes + quote)
+    assert "\\\\\\'s" in result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.91.4"
+version = "0.91.5"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Fixes video generation for songs with apostrophes in titles (e.g., "I'm With You")
- PR #212 introduced shell-style escaping (`'\''`) which doesn't work with subprocess command lists
- Changed to FFmpeg's native filter escaping rules

## Test plan
- [x] All 22 video.py unit tests pass
- [x] All 68 backend tests pass  
- [x] End-to-end FFmpeg test with apostrophe in path succeeds
- [ ] Manual test with "Avril Lavigne - I'm With You"

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)