### PR TITLE
fix: Upgrade github-runner storage role to objectAdmin

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -2260,11 +2260,11 @@ github_runner_logging_iam = gcp.projects.IAMMember(
     member=github_runner_sa.email.apply(lambda email: f"serviceAccount:{email}"),
 )
 
-# Grant runner service account storage write permissions (for uploading wheels to GCS)
+# Grant runner service account storage admin permissions (for uploading/overwriting wheels in GCS)
 github_runner_storage_iam = gcp.projects.IAMMember(
     "github-runner-storage-write",
     project=project_id,
-    role="roles/storage.objectCreator",
+    role="roles/storage.objectAdmin",
     member=github_runner_sa.email.apply(lambda email: f"serviceAccount:{email}"),
 )
 


### PR DESCRIPTION
## Summary

Wheel upload needs to overwrite existing files which requires `storage.objects.delete` permission. Changed from `objectCreator` to `objectAdmin` role.

## Previous Error
```
AccessDeniedException: 403 github-runner@nomadkaraoke.iam.gserviceaccount.com does not have storage.objects.delete access
```

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)