### PR TITLE
fix: Include backend package in wheel for GCE worker LocalEncodingService

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,14 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.92.0"
+version = "0.93.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"
 readme = "README.md"
 packages = [
     { include = "karaoke_gen" },
-    { include = "lyrics_transcriber", from = "lyrics_transcriber_temp" }
+    { include = "lyrics_transcriber", from = "lyrics_transcriber_temp" },
+    { include = "backend" }
 ]
 include = [
     "karaoke_gen/instrumental_review/static/*",


### PR DESCRIPTION
## Summary

- Include `backend` package in pyproject.toml packages list for wheel distribution
- This enables the GCE encoding worker to import `LocalEncodingService`

## Problem

The GCE encoding worker failed with:
```
ERROR:__main__:LocalEncodingService not available: No module named 'backend'
```

The wheel was being installed correctly, but `backend/` wasn't included in the package.

## Changes

- Added `{ include = "backend" }` to packages list in pyproject.toml
- Bumped version to 0.93.0

## Test Plan

- [x] Verify pyproject.toml changes are correct
- [ ] CI builds wheel with backend included
- [ ] GCE worker downloads new wheel at job start
- [ ] E2E happy path test passes

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)