### PR TITLE
fix(infrastructure): Increase systemd startup timeout for wheel install

### DIFF
--- a/infrastructure/packer/scripts/provision.sh
+++ b/infrastructure/packer/scripts/provision.sh
@@ -148,6 +148,7 @@ ExecStartPre=/opt/encoding-worker/startup.sh
 ExecStart=/opt/encoding-worker/venv/bin/uvicorn backend.services.gce_encoding.main:app --host 0.0.0.0 --port 8080
 Restart=always
 RestartSec=10
+TimeoutStartSec=300
 Environment="GOOGLE_CLOUD_PROJECT=nomadkaraoke"
 EnvironmentFile=/opt/encoding-worker/env
 


### PR DESCRIPTION
## Summary

Fix encoding worker startup timeout issue discovered after #225 deployment.

## Problem

The ExecStartPre script that installs the karaoke-gen wheel can take 2+ minutes on first boot. The default systemd timeout (90s) caused multiple retries before eventually succeeding.

## Solution

Add `TimeoutStartSec=300` to the systemd service definition to allow up to 5 minutes for the startup script to complete.

## Test Plan

- [ ] Merge triggers Packer image rebuild
- [ ] New image has longer timeout configured
- [ ] Next VM recreation starts without timeout retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@coderabbitai ignore