### PR TITLE
feat(audio-search): Add display artist/title override for search

### DIFF
--- a/backend/api/routes/audio_search.py
+++ b/backend/api/routes/audio_search.py
@@ -107,6 +107,10 @@ class AudioSearchRequest(BaseModel):
     lyrics_artist: Optional[str] = Field(None, description="Override artist name for lyrics search")
     lyrics_title: Optional[str] = Field(None, description="Override title for lyrics search")
     subtitle_offset_ms: int = Field(0, description="Subtitle timing offset in milliseconds")
+
+    # Display overrides (optional - if empty, search values are used for display)
+    display_artist: Optional[str] = Field(None, description="Artist name for title screens/filenames. If empty, uses search artist.")
+    display_title: Optional[str] = Field(None, description="Title for title screens/filenames. If empty, uses search title.")
     
     # Audio separation model configuration
     clean_instrumental_model: Optional[str] = Field(None, description="Model for clean instrumental separation")
@@ -530,10 +534,16 @@ async def search_audio(
         # Use authenticated user's email
         effective_user_email = auth_result.user_email
 
+        # Determine display values - use display_* if provided, otherwise fall back to search values
+        # Display values are used for title screens, filenames, YouTube, etc.
+        # Search values (body.artist, body.title) are used for audio search
+        effective_display_artist = body.display_artist.strip() if body.display_artist else body.artist
+        effective_display_title = body.display_title.strip() if body.display_title else body.title
+
         # Create job
         job_create = JobCreate(
-            artist=body.artist,
-            title=body.title,
+            artist=effective_display_artist,  # Display value for title screens, filenames
+            title=effective_display_title,    # Display value for title screens, filenames
             theme_id=body.theme_id,
             color_overrides=body.color_overrides or {},
             enable_cdg=resolved_cdg,

--- a/docs/API.md
+++ b/docs/API.md
@@ -114,11 +114,52 @@ Content-Type: application/json
 
 ### Audio Search
 
+#### Search for Audio
+
 ```http
-GET /api/audio-search?q=song+name
+POST /api/audio-search/search
+Content-Type: application/json
+
+{
+  "artist": "Artist Name",
+  "title": "Song Title",
+  "auto_download": false,
+  "theme_id": "nomad",
+  "display_artist": "Display Artist (optional)",
+  "display_title": "Display Title (optional)"
+}
 ```
 
-Search for songs (flacfetch integration).
+Searches for audio sources (flacfetch integration). Creates a job and returns search results.
+
+**Key fields:**
+- `artist`, `title` - Used to search for audio on trackers
+- `display_artist`, `display_title` - Optional overrides for how artist/title appear on title screens and filenames. If omitted, search values are used.
+- `auto_download` - If true, automatically selects best result and starts processing
+- `theme_id` - Video theme to use
+
+**Use case:** Search for "Jeremy Kushnier" but display "Footloose (Broadway Cast)" on the karaoke video.
+
+#### Get Search Results
+
+```http
+GET /api/audio-search/{job_id}/results
+```
+
+Returns cached search results for a job awaiting audio selection.
+
+#### Select Audio Source
+
+```http
+POST /api/audio-search/{job_id}/select
+Content-Type: application/json
+
+{
+  "selection_index": 0
+}
+```
+
+Selects an audio source from the search results and starts processing.
 
 ### Themes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,8 @@
 
 ## Recent Changes
 
+- **Audio Search Display Override** (2026-01-06): Added optional "Display As" fields to audio search, allowing users to search for audio by one artist/title (e.g., "Jeremy Kushnier") but display a different artist/title on title screens and filenames (e.g., "Footloose (Broadway Cast)"). Useful for Broadway casts, covers, remixes where tracker metadata differs from desired display. See [API.md](API.md#audio-search).
+
 - **Infrastructure Modularization** (2026-01-06): Refactored `infrastructure/__main__.py` from 2,602 lines to 339 lines (87% reduction). Split into organized modules: `modules/` for core GCP resources, `compute/` for VMs and startup scripts, `config.py` for shared constants. Extracted embedded encoding worker Python app to `backend/services/gce_encoding/`. See `infrastructure/README.md` for new structure and `infrastructure/docs/PHASE5-PACKER-IMAGE-PLAN.md` for planned Packer image optimization.
 
 - **Email Notification System** (2026-01-06): Added automated email notifications for job completion and user action reminders. Features: GCS-backed HTML email templates with fallback defaults, SendGrid with CC support, auto-completion emails on job finish, idle reminder emails via Cloud Tasks (5-min delay for blocking states), admin UI buttons to copy message or send email manually. Endpoints: `GET /api/admin/jobs/{id}/completion-message`, `POST /api/admin/jobs/{id}/send-completion-email`. Feature flag `ENABLE_AUTO_EMAILS` (default: false). See [API.md](API.md#email-notifications-admin) and [ARCHITECTURE.md](ARCHITECTURE.md#video-worker-orchestrator).

--- a/frontend/components/job/JobSubmission.tsx
+++ b/frontend/components/job/JobSubmission.tsx
@@ -34,6 +34,9 @@ export function JobSubmission({ onJobCreated }: JobSubmissionProps) {
   // Audio search form
   const [searchArtist, setSearchArtist] = useState("")
   const [searchTitle, setSearchTitle] = useState("")
+  // Display As overrides (optional - if empty, search values used for display)
+  const [displayArtist, setDisplayArtist] = useState("")
+  const [displayTitle, setDisplayTitle] = useState("")
 
   // Theme selection (shared across all tabs)
   const [selectedTheme, setSelectedTheme] = useState<string | undefined>()
@@ -128,9 +131,14 @@ export function JobSubmission({ onJobCreated }: JobSubmissionProps) {
         theme_id: selectedTheme,
         color_overrides: cleanColorOverrides(colorOverrides),
         non_interactive: nonInteractive,
+        // Display overrides (empty string means use search values)
+        display_artist: displayArtist.trim() || undefined,
+        display_title: displayTitle.trim() || undefined,
       })
       setSearchArtist("")
       setSearchTitle("")
+      setDisplayArtist("")
+      setDisplayTitle("")
       onJobCreated()
     } catch (err) {
       if (err instanceof ApiError) {
@@ -407,33 +415,69 @@ export function JobSubmission({ onJobCreated }: JobSubmissionProps) {
 
       <TabsContent value="search" className="mt-4">
         <form onSubmit={handleSearchSubmit} className="space-y-4">
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="search-artist" style={{ color: 'var(--text)' }}>Artist</Label>
-              <Input
-                id="search-artist"
-                placeholder="Artist name"
-                value={searchArtist}
-                onChange={(e) => setSearchArtist(e.target.value)}
-                disabled={isSubmitting}
-                style={{ backgroundColor: 'var(--secondary)', borderColor: 'var(--card-border)', color: 'var(--text)' }}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="search-title" style={{ color: 'var(--text)' }}>Title</Label>
-              <Input
-                id="search-title"
-                placeholder="Song title"
-                value={searchTitle}
-                onChange={(e) => setSearchTitle(e.target.value)}
-                disabled={isSubmitting}
-                style={{ backgroundColor: 'var(--secondary)', borderColor: 'var(--card-border)', color: 'var(--text)' }}
-              />
+          {/* Search For section */}
+          <div className="space-y-2">
+            <Label style={{ color: 'var(--text)' }}>Search For</Label>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="search-artist" className="text-xs" style={{ color: 'var(--text-muted)' }}>Artist</Label>
+                <Input
+                  id="search-artist"
+                  placeholder="Artist name on trackers"
+                  value={searchArtist}
+                  onChange={(e) => setSearchArtist(e.target.value)}
+                  disabled={isSubmitting}
+                  style={{ backgroundColor: 'var(--secondary)', borderColor: 'var(--card-border)', color: 'var(--text)' }}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="search-title" className="text-xs" style={{ color: 'var(--text-muted)' }}>Title</Label>
+                <Input
+                  id="search-title"
+                  placeholder="Song title on trackers"
+                  value={searchTitle}
+                  onChange={(e) => setSearchTitle(e.target.value)}
+                  disabled={isSubmitting}
+                  style={{ backgroundColor: 'var(--secondary)', borderColor: 'var(--card-border)', color: 'var(--text)' }}
+                />
+              </div>
             </div>
           </div>
-          <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
-            <span className="text-amber-500 font-medium">Note:</span> Format these exactly as you want them on the title card and video filename.
-          </p>
+
+          {/* Display As section (optional) */}
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <Label style={{ color: 'var(--text)' }}>Display As</Label>
+              <span className="text-xs px-1.5 py-0.5 rounded" style={{ color: 'var(--text-muted)', backgroundColor: 'var(--secondary)' }}>optional</span>
+            </div>
+            <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+              Override how artist/title appear on the title card and filename. Leave empty to use search values.
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="display-artist" className="text-xs" style={{ color: 'var(--text-muted)' }}>Display Artist</Label>
+                <Input
+                  id="display-artist"
+                  placeholder="e.g., Footloose (Broadway Cast)"
+                  value={displayArtist}
+                  onChange={(e) => setDisplayArtist(e.target.value)}
+                  disabled={isSubmitting}
+                  style={{ backgroundColor: 'var(--secondary)', borderColor: 'var(--card-border)', color: 'var(--text)' }}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="display-title" className="text-xs" style={{ color: 'var(--text-muted)' }}>Display Title</Label>
+                <Input
+                  id="display-title"
+                  placeholder="e.g., I Can't Stand Still"
+                  value={displayTitle}
+                  onChange={(e) => setDisplayTitle(e.target.value)}
+                  disabled={isSubmitting}
+                  style={{ backgroundColor: 'var(--secondary)', borderColor: 'var(--card-border)', color: 'var(--text)' }}
+                />
+              </div>
+            </div>
+          </div>
 
           {/* Theme Selection */}
           <div className="space-y-4 pt-4 border-t" style={{ borderColor: 'var(--card-border)' }}>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -418,6 +418,9 @@ export const api = {
       theme_id?: string;
       color_overrides?: ColorOverrides;
       non_interactive?: boolean;
+      // Display overrides - if provided, these appear on title screens/filenames instead of search values
+      display_artist?: string;
+      display_title?: string;
     }
   ): Promise<AudioSearchResponse> {
     const body: Record<string, any> = { artist, title, auto_download: autoDownload };
@@ -428,6 +431,9 @@ export const api = {
     if (options?.theme_id) body.theme_id = options.theme_id;
     if (options?.color_overrides) body.color_overrides = options.color_overrides;
     if (options?.non_interactive !== undefined) body.non_interactive = options.non_interactive;
+    // Display overrides
+    if (options?.display_artist) body.display_artist = options.display_artist;
+    if (options?.display_title) body.display_title = options.display_title;
 
     const response = await fetch(`${API_BASE_URL}/api/audio-search/search`, {
       method: 'POST',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.94.0"
+version = "0.95.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Add optional "Display As" fields to audio search, allowing users to search for audio by one artist/title but display a different artist/title on title screens and filenames
- Useful for Broadway casts, covers, remixes where tracker metadata differs from desired display

## Changes
- Add `display_artist`/`display_title` fields to `AudioSearchRequest` model
- Update job creation to use display values for output (title screens, filenames, YouTube, distribution)
- Add "Display As" optional fields to frontend search UI
- Update API documentation

## Example Use Case
- **Search For**: Artist = "Jeremy Kushnier", Title = "I Can't Stand Still"
- **Display As**: Artist = "Footloose (Broadway Cast)"
- **Result**: Audio found using "Jeremy Kushnier", but title screen shows "Footloose (Broadway Cast) - I Can't Stand Still"

## Test plan
- [ ] Search with display override → verify title screen shows display values
- [ ] Search without display override → verify search values used (backwards compatible)
- [ ] Verify filenames use display values

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)