### PR TITLE
docs: Add zone availability notes for c4d instances

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -105,6 +105,8 @@ Audio separation and lyrics transcription run in parallel:
 
 **Important**: C4D instances require `hyperdisk-balanced` disk type, not `pd-balanced`.
 
+**Zone availability**: High-end C4D instances (e.g., c4d-highcpu-32) may not be available in all zones. During deployment, us-central1-a and us-central1-b failed with "does not have enough resources available" while us-central1-c succeeded. Added `ENCODING_WORKER_ZONE` config to explicitly specify zone instead of using the default region zone.
+
 **Scripts**: See `scripts/benchmark_candidates.sh` for multi-instance benchmarking orchestration.
 
 ## Common Gotchas

--- a/docs/archive/2026-01-08-performance-investigation.md
+++ b/docs/archive/2026-01-08-performance-investigation.md
@@ -1,7 +1,7 @@
 # Performance Investigation: Karaoke Generation Pipeline
 
 **Date**: 2026-01-08
-**Status**: Phase 2 In Progress - Encoding Infrastructure Benchmarking
+**Status**: Phase 2 Complete - Encoding Infrastructure Upgraded
 **Goal**: Reduce total karaoke generation time from ~30 minutes to ~10 minutes
 
 ## Executive Summary


### PR DESCRIPTION
## Summary
- Documents zone availability lesson learned during c4d-highcpu-32 deployment
- Updates performance investigation status to Phase 2 Complete

## Changes
- `docs/LESSONS-LEARNED.md`: Added note about c4d instance zone availability (us-central1-c works when us-central1-a/b have resource exhaustion)
- `docs/archive/2026-01-08-performance-investigation.md`: Updated status from "In Progress" to "Complete"

## Testing
- [x] Documentation only - no code changes

## Review
- [x] Docs-only change, no code review needed

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)