### PR TITLE
fix(admin): Fix impersonation button and remove Make Admin from detail page

### DIFF
--- a/frontend/app/admin/users/detail/page.tsx
+++ b/frontend/app/admin/users/detail/page.tsx
@@ -29,8 +29,6 @@ import {
   RefreshCw,
   Loader2,
   Plus,
-  Shield,
-  ShieldOff,
   UserX,
   UserCheck,
   CreditCard,
@@ -107,29 +105,6 @@ export default function AdminUserDetailPage() {
       toast({
         title: "Error",
         description: err.message || "Failed to add credits",
-        variant: "destructive",
-      })
-    } finally {
-      setActionLoading(false)
-    }
-  }
-
-  const handleToggleRole = async () => {
-    if (!user) return
-    const newRole = user.role === "admin" ? "user" : "admin"
-
-    try {
-      setActionLoading(true)
-      await adminApi.setUserRole(email, newRole)
-      toast({
-        title: "Role Updated",
-        description: `User is now ${newRole}`,
-      })
-      loadUser()
-    } catch (err: any) {
-      toast({
-        title: "Error",
-        description: err.message || "Failed to update role",
         variant: "destructive",
       })
     } finally {
@@ -236,23 +211,6 @@ export default function AdminUserDetailPage() {
         <Button onClick={() => setCreditDialogOpen(true)} disabled={actionLoading}>
           <Plus className="w-4 h-4 mr-2" />
           Add Credits
-        </Button>
-        <Button
-          variant="outline"
-          onClick={handleToggleRole}
-          disabled={actionLoading}
-        >
-          {user.role === "admin" ? (
-            <>
-              <ShieldOff className="w-4 h-4 mr-2" />
-              Remove Admin
-            </>
-          ) : (
-            <>
-              <Shield className="w-4 h-4 mr-2" />
-              Make Admin
-            </>
-          )}
         </Button>
         <Button
           variant={user.is_active ? "destructive" : "outline"}

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -3,7 +3,7 @@
 import { create } from "zustand"
 import { persist } from "zustand/middleware"
 import type { User, UserPublic } from "./types"
-import { api, setAccessToken, clearAccessToken, getAccessToken } from "./api"
+import { api, adminApi, setAccessToken, clearAccessToken, getAccessToken } from "./api"
 
 interface AuthStore {
   user: User | null
@@ -191,7 +191,7 @@ export const useAuth = create<AuthStore>()(
           }
 
           // Call API to get impersonation token
-          const response = await api.adminApi.impersonateUser(email)
+          const response = await adminApi.impersonateUser(email)
 
           // Switch to impersonation token
           setAccessToken(response.session_token)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.99.5"
+version = "0.99.6"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- Fix impersonate button not working in admin dashboard - clicking did nothing (no network request, no errors)
- Remove Make Admin/Remove Admin button from user detail page that should have been removed in #249

## Changes

- **auth.ts**: Fixed broken import - `adminApi` is a separate export from `api.ts`, not nested under the `api` object. `api.adminApi.impersonateUser()` was calling `undefined.impersonateUser()`
- **detail/page.tsx**: Removed Make Admin button, `handleToggleRole` function, and unused `Shield`/`ShieldOff` imports

## Test plan

- [x] Unit tests pass (150 tests)
- [x] E2E impersonation tests pass (4 tests)
- [ ] Manual: Click impersonate button on admin users list → should redirect to /app as that user
- [ ] Manual: Visit user detail page → Make Admin button should not appear

🤖 Generated with [Claude Code](https://claude.ai/code)

@coderabbitai ignore