### PR TITLE
fix(ci): Move encoding worker restart to deploy-backend with correct zone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1017,7 +1017,14 @@ jobs:
           # Upload to GCS (GCE worker downloads latest at job start)
           gsutil cp "$WHEEL_FILE" gs://karaoke-gen-storage-${{ env.PROJECT_ID }}/wheels/
 
-          echo "✅ Wheel uploaded - GCE worker will pick up changes on next job"
+          echo "✅ Wheel uploaded to GCS"
+
+      - name: Restart GCE Encoding Worker
+        run: |
+          echo "🔄 Restarting encoding worker to pick up new wheel..."
+          gcloud compute ssh encoding-worker --zone=us-central1-c --project=nomadkaraoke \
+            --command="sudo systemctl restart encoding-worker" || true
+          echo "✅ Encoding worker restart triggered"
 
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker ${{ env.REGISTRY }} --quiet
@@ -1326,13 +1333,6 @@ jobs:
           # Skip preview to avoid needing broad read permissions on all GCP resources
           # Pulumi state is authoritative since infrastructure is only managed via Pulumi
           pulumi up --yes --skip-preview --stack nomadkaraoke/karaoke-gen-infrastructure/prod
-
-      - name: Restart GCE Encoding Worker
-        run: |
-          echo "🔄 Restarting encoding worker to pick up new code..."
-          gcloud compute ssh encoding-worker --zone=us-central1-a --project=nomadkaraoke \
-            --command="sudo systemctl restart encoding-worker" || true
-          echo "✅ Encoding worker restart triggered"
 
       - name: Summary
         if: success()


### PR DESCRIPTION
## Summary
- Fixed encoding worker not getting code updates on deploy
- The restart was in the wrong CI job with the wrong zone

## Root Cause
Two bugs in `ci.yml`:
1. **Wrong zone**: Used `us-central1-a` but encoding worker is in `us-central1-c`
2. **Race condition**: Restart was in `deploy-infrastructure` which runs in parallel with `deploy-backend` (wheel upload)

This meant the encoding worker restart would silently fail (wrong zone) or run before the new wheel was uploaded (race condition).

## Changes
- Move restart step from `deploy-infrastructure` to `deploy-backend`
- Place it immediately after wheel upload to GCS
- Fix zone to `us-central1-c`

## Testing
- Manually verified encoding worker was at v0.99.7 while backend was at v0.99.8
- Manually restarted with correct zone - now at v0.99.8
- CI-only change, no code tests affected

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)