### PR TITLE
fix(mfy): Fix order success redirect URL to use frontend app

### DIFF
--- a/backend/services/stripe_service.py
+++ b/backend/services/stripe_service.py
@@ -202,9 +202,9 @@ class StripeService:
             return False, None, "Payment processing is not configured"
 
         try:
-            # Default URLs - redirect to homepage success page
+            # Default URLs - redirect to gen app success page
             if not success_url:
-                success_url = "https://nomadkaraoke.com/order/success/?session_id={CHECKOUT_SESSION_ID}"
+                success_url = f"{self.frontend_url}/order/success?session_id={{CHECKOUT_SESSION_ID}}"
             if not cancel_url:
                 cancel_url = "https://nomadkaraoke.com/#do-it-for-me"
 

--- a/backend/tests/test_stripe_service.py
+++ b/backend/tests/test_stripe_service.py
@@ -1,0 +1,205 @@
+"""
+Tests for StripeService.
+
+Tests cover:
+- Made-for-you checkout session URL generation
+- Credit purchase checkout session URL generation
+- Package validation
+"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+import os
+
+
+class TestStripeServiceUrls:
+    """Tests for checkout session URL generation."""
+
+    @pytest.fixture
+    def stripe_service(self):
+        """Create a StripeService instance with mocked Stripe."""
+        # Set required env vars
+        with patch.dict(os.environ, {
+            'STRIPE_SECRET_KEY': 'sk_test_fake',
+            'FRONTEND_URL': 'https://gen.nomadkaraoke.com',
+        }):
+            # Import here to pick up env vars
+            from backend.services.stripe_service import StripeService
+            service = StripeService()
+            return service
+
+    def test_made_for_you_success_url_uses_frontend_url(self, stripe_service):
+        """Test that made-for-you checkout uses frontend_url, not hardcoded domain."""
+        # Mock stripe.checkout.Session.create to capture the params
+        with patch('stripe.checkout.Session.create') as mock_create:
+            mock_session = MagicMock()
+            mock_session.id = 'cs_test_123'
+            mock_session.url = 'https://checkout.stripe.com/test'
+            mock_create.return_value = mock_session
+
+            success, url, message = stripe_service.create_made_for_you_checkout_session(
+                customer_email='customer@example.com',
+                artist='Test Artist',
+                title='Test Song',
+            )
+
+            # Verify the call was made
+            assert mock_create.called
+            call_kwargs = mock_create.call_args[1]
+
+            # Verify success_url uses frontend_url and correct path
+            success_url = call_kwargs['success_url']
+            assert success_url.startswith('https://gen.nomadkaraoke.com')
+            assert '/order/success' in success_url
+            assert 'session_id=' in success_url
+
+    def test_made_for_you_success_url_not_hardcoded_to_marketing_site(self, stripe_service):
+        """Test that success_url is NOT the old hardcoded marketing site URL."""
+        with patch('stripe.checkout.Session.create') as mock_create:
+            mock_session = MagicMock()
+            mock_session.id = 'cs_test_123'
+            mock_session.url = 'https://checkout.stripe.com/test'
+            mock_create.return_value = mock_session
+
+            stripe_service.create_made_for_you_checkout_session(
+                customer_email='customer@example.com',
+                artist='Test Artist',
+                title='Test Song',
+            )
+
+            call_kwargs = mock_create.call_args[1]
+            success_url = call_kwargs['success_url']
+
+            # The bug was: success_url = "https://nomadkaraoke.com/order/success/"
+            # (note: nomadkaraoke.com WITHOUT the 'gen.' prefix - that's the marketing site)
+            # This should NOT be the case anymore - should use gen.nomadkaraoke.com
+            assert not success_url.startswith('https://nomadkaraoke.com/')
+            # Should use the frontend URL (gen.nomadkaraoke.com)
+            assert success_url.startswith('https://gen.nomadkaraoke.com')
+
+    def test_made_for_you_respects_custom_frontend_url(self):
+        """Test that made-for-you checkout uses custom FRONTEND_URL if set."""
+        with patch.dict(os.environ, {
+            'STRIPE_SECRET_KEY': 'sk_test_fake',
+            'FRONTEND_URL': 'https://custom.example.com',
+        }):
+            from backend.services.stripe_service import StripeService
+            service = StripeService()
+
+            with patch('stripe.checkout.Session.create') as mock_create:
+                mock_session = MagicMock()
+                mock_session.id = 'cs_test_123'
+                mock_session.url = 'https://checkout.stripe.com/test'
+                mock_create.return_value = mock_session
+
+                service.create_made_for_you_checkout_session(
+                    customer_email='customer@example.com',
+                    artist='Test Artist',
+                    title='Test Song',
+                )
+
+                call_kwargs = mock_create.call_args[1]
+                success_url = call_kwargs['success_url']
+                assert success_url.startswith('https://custom.example.com')
+
+    def test_credit_purchase_success_url_uses_payment_success(self, stripe_service):
+        """Test that credit purchase checkout uses /payment/success path."""
+        with patch('stripe.checkout.Session.create') as mock_create:
+            mock_session = MagicMock()
+            mock_session.id = 'cs_test_123'
+            mock_session.url = 'https://checkout.stripe.com/test'
+            mock_create.return_value = mock_session
+
+            success, url, message = stripe_service.create_checkout_session(
+                package_id='1_credit',
+                user_email='user@example.com',
+            )
+
+            call_kwargs = mock_create.call_args[1]
+            success_url = call_kwargs['success_url']
+
+            # Credit purchases go to /payment/success
+            assert '/payment/success' in success_url
+            assert success_url.startswith('https://gen.nomadkaraoke.com')
+
+    def test_made_for_you_uses_order_success_path(self, stripe_service):
+        """Test that made-for-you uses /order/success path (not /payment/success)."""
+        with patch('stripe.checkout.Session.create') as mock_create:
+            mock_session = MagicMock()
+            mock_session.id = 'cs_test_123'
+            mock_session.url = 'https://checkout.stripe.com/test'
+            mock_create.return_value = mock_session
+
+            stripe_service.create_made_for_you_checkout_session(
+                customer_email='customer@example.com',
+                artist='Test Artist',
+                title='Test Song',
+            )
+
+            call_kwargs = mock_create.call_args[1]
+            success_url = call_kwargs['success_url']
+
+            # Made-for-you orders go to /order/success (different messaging)
+            assert '/order/success' in success_url
+            # Should NOT go to /payment/success
+            assert '/payment/success' not in success_url
+
+
+class TestStripeServiceMetadata:
+    """Tests for checkout session metadata."""
+
+    @pytest.fixture
+    def stripe_service(self):
+        """Create a StripeService instance with mocked Stripe."""
+        with patch.dict(os.environ, {
+            'STRIPE_SECRET_KEY': 'sk_test_fake',
+            'FRONTEND_URL': 'https://gen.nomadkaraoke.com',
+        }):
+            from backend.services.stripe_service import StripeService
+            return StripeService()
+
+    def test_made_for_you_includes_order_type_metadata(self, stripe_service):
+        """Test that made-for-you checkout includes order_type in metadata."""
+        with patch('stripe.checkout.Session.create') as mock_create:
+            mock_session = MagicMock()
+            mock_session.id = 'cs_test_123'
+            mock_session.url = 'https://checkout.stripe.com/test'
+            mock_create.return_value = mock_session
+
+            stripe_service.create_made_for_you_checkout_session(
+                customer_email='customer@example.com',
+                artist='Test Artist',
+                title='Test Song',
+                notes='Special request',
+            )
+
+            call_kwargs = mock_create.call_args[1]
+            metadata = call_kwargs['metadata']
+
+            assert metadata['order_type'] == 'made_for_you'
+            assert metadata['customer_email'] == 'customer@example.com'
+            assert metadata['artist'] == 'Test Artist'
+            assert metadata['title'] == 'Test Song'
+            assert metadata['notes'] == 'Special request'
+
+    def test_made_for_you_truncates_long_notes(self, stripe_service):
+        """Test that notes longer than 500 chars are truncated."""
+        with patch('stripe.checkout.Session.create') as mock_create:
+            mock_session = MagicMock()
+            mock_session.id = 'cs_test_123'
+            mock_session.url = 'https://checkout.stripe.com/test'
+            mock_create.return_value = mock_session
+
+            long_notes = 'x' * 600
+
+            stripe_service.create_made_for_you_checkout_session(
+                customer_email='customer@example.com',
+                artist='Test Artist',
+                title='Test Song',
+                notes=long_notes,
+            )
+
+            call_kwargs = mock_create.call_args[1]
+            metadata = call_kwargs['metadata']
+
+            assert len(metadata['notes']) == 500

--- a/frontend/app/order/success/page.tsx
+++ b/frontend/app/order/success/page.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { Suspense } from "react"
+import { useSearchParams } from "next/navigation"
+import { CheckCircle, Loader2, Mail, Clock } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+function OrderSuccessContent() {
+  const searchParams = useSearchParams()
+  const sessionId = searchParams.get("session_id")
+
+  return (
+    <div className="max-w-md w-full bg-card border border-border rounded-xl p-8 text-center">
+      <CheckCircle className="w-16 h-16 text-success mx-auto mb-4" />
+
+      <h1 className="text-2xl font-bold text-foreground mb-2">
+        Order Confirmed!
+      </h1>
+
+      <p className="text-muted-foreground mb-6">
+        Thank you for your order. We&apos;re creating your custom karaoke video now.
+      </p>
+
+      <div className="space-y-4 mb-6">
+        <div className="flex items-center gap-3 text-left p-3 bg-secondary rounded-lg">
+          <Clock className="w-5 h-5 text-primary flex-shrink-0" />
+          <div>
+            <p className="font-medium text-foreground">Delivery within 24 hours</p>
+            <p className="text-sm text-muted-foreground">
+              Most orders are completed in just a few hours
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3 text-left p-3 bg-secondary rounded-lg">
+          <Mail className="w-5 h-5 text-primary flex-shrink-0" />
+          <div>
+            <p className="font-medium text-foreground">Check your email</p>
+            <p className="text-sm text-muted-foreground">
+              We&apos;ll send your video when it&apos;s ready
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <Button
+          asChild
+          className="w-full bg-primary hover:bg-primary/90"
+        >
+          <a href="https://nomadkaraoke.com">
+            Back to Nomad Karaoke
+          </a>
+        </Button>
+
+        <p className="text-xs text-muted-foreground">
+          Questions? Email us at help@nomadkaraoke.com
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export default function OrderSuccessPage() {
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <Suspense
+        fallback={
+          <div className="max-w-md w-full bg-card border border-border rounded-xl p-8 text-center">
+            <Loader2 className="w-16 h-16 text-primary mx-auto mb-4 animate-spin" />
+            <p className="text-muted-foreground">Loading...</p>
+          </div>
+        }
+      >
+        <OrderSuccessContent />
+      </Suspense>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Fixed made-for-you order checkout redirecting to non-existent page after payment
- Customers were seeing black/404 screen at `nomadkaraoke.com/order/success/` (doesn't exist)
- Now correctly redirects to `gen.nomadkaraoke.com/order/success` with proper thank-you page

## Changes
- `backend/services/stripe_service.py`: Use `self.frontend_url` instead of hardcoded wrong domain for made-for-you checkout success URL
- `frontend/app/order/success/page.tsx`: New success page for made-for-you orders with appropriate messaging (delivery timeframe, email notification info)
- `backend/tests/test_stripe_service.py`: Added 7 tests for Stripe service URL generation

## Root Cause
The credit purchase checkout correctly used `self.frontend_url` to build the success URL, but made-for-you checkout had a hardcoded URL pointing to the marketing site (`nomadkaraoke.com`) instead of the app (`gen.nomadkaraoke.com`).

## Testing
- [x] Backend tests pass (7 new tests)
- [x] Frontend builds successfully
- [x] New `/order/success` route appears in build output

## Review
- [x] Local CodeRabbit review completed
- [x] No issues found

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)