### PR TITLE
fix(docker): Add missing backend directory to Dockerfile.base

### DIFF
--- a/backend/Dockerfile.base
+++ b/backend/Dockerfile.base
@@ -54,6 +54,7 @@ WORKDIR /app
 COPY pyproject.toml README.md LICENSE /app/
 COPY karaoke_gen /app/karaoke_gen
 COPY lyrics_transcriber_temp /app/lyrics_transcriber_temp
+COPY backend /app/backend
 
 # Install all Python dependencies (the slow part - cached in base image)
 RUN pip install --no-cache-dir --upgrade pip && \


### PR DESCRIPTION
## Summary
- Fixes Docker base image build failure by adding missing `backend` directory to COPY command

## Context
The `backend` package was previously added to `pyproject.toml` packages list but `Dockerfile.base` wasn't updated to copy the directory. This caused the editable install to fail with:

```
ValueError: /app/backend does not contain any element
```

This was discovered when the push notifications PR (#274) triggered a base image rebuild.

## Test plan
- [ ] CI passes (specifically Deploy - Backend job should succeed now)

@coderabbitai ignore