### PR TITLE
feat: highlight user-edited words in lyrics review

### DIFF
--- a/frontend/components/lyrics-review/LyricsAnalyzer.tsx
+++ b/frontend/components/lyrics-review/LyricsAnalyzer.tsx
@@ -207,6 +207,33 @@ export default function LyricsAnalyzer({
     [history, historyIndex]
   )
 
+  // Compute which word IDs have been edited by the user (compared to initial state)
+  const editedWordIds = useMemo(() => {
+    const initial = history[0]
+    if (!initial || data === initial) return new Set<string>()
+    // Build map of word ID → text from initial state
+    const initialWordText = new Map<string, string>()
+    for (const segment of initial.corrected_segments) {
+      for (const word of segment.words) {
+        initialWordText.set(word.id, word.text)
+      }
+    }
+    const edited = new Set<string>()
+    for (const segment of data.corrected_segments) {
+      for (const word of segment.words) {
+        const originalText = initialWordText.get(word.id)
+        if (originalText === undefined) {
+          // Word was added by the user
+          edited.add(word.id)
+        } else if (originalText !== word.text) {
+          // Word text was changed
+          edited.add(word.id)
+        }
+      }
+    }
+    return edited
+  }, [data, history])
+
   // Reset history when initial data changes
   useEffect(() => {
     setHistory([initialData])
@@ -1254,6 +1281,7 @@ export default function LyricsAnalyzer({
           activeGapWordIds={activeGapWordIds}
           advancedMode={advancedMode}
           onAdvancedModeToggle={handleAdvancedModeToggle}
+          editedWordIds={editedWordIds}
         />
         <ReferenceView
           referenceSources={data.reference_lyrics}

--- a/frontend/components/lyrics-review/TranscriptionView.tsx
+++ b/frontend/components/lyrics-review/TranscriptionView.tsx
@@ -33,6 +33,7 @@ export default function TranscriptionView({
   activeGapWordIds,
   advancedMode = false,
   onAdvancedModeToggle,
+  editedWordIds,
 }: TranscriptionViewProps) {
   const t = useTranslations('lyricsReview.transcription')
   const [selectedSegmentIndex, setSelectedSegmentIndex] = useState<number | null>(null)
@@ -201,6 +202,7 @@ export default function TranscriptionView({
                       onEditCorrection={onEditCorrection}
                       onAcceptCorrection={onAcceptCorrection}
                       onShowCorrectionDetail={onShowCorrectionDetail}
+                      editedWordIds={editedWordIds}
                     />
                   </div>
                 </div>

--- a/frontend/components/lyrics-review/shared/HighlightedText.tsx
+++ b/frontend/components/lyrics-review/shared/HighlightedText.tsx
@@ -49,6 +49,8 @@ export interface HighlightedTextProps {
   onEditCorrection?: (wordId: string) => void
   onAcceptCorrection?: (wordId: string) => void
   onShowCorrectionDetail?: (wordId: string) => void
+  // User-edited word tracking
+  editedWordIds?: Set<string>
 }
 
 export function HighlightedText({
@@ -76,6 +78,7 @@ export function HighlightedText({
   onEditCorrection,
   onAcceptCorrection,
   onShowCorrectionDetail,
+  editedWordIds,
 }: HighlightedTextProps) {
   const { handleWordClick } = useWordClick({
     mode,
@@ -242,6 +245,7 @@ export function HighlightedText({
               isUncorrectedGap={wordPos.type === 'gap' && !wordPos.isCorrected}
               isCurrentlyPlaying={shouldHighlightWord(wordPos)}
               isActiveGap={activeGapWordIds?.has(wordPos.word.id)}
+              isUserEdited={editedWordIds?.has(wordPos.word.id)}
               id={`word-${wordPos.word.id}`}
               onClick={() =>
                 handleWordClick(
@@ -348,6 +352,7 @@ export function HighlightedText({
                       wordPos || { word: word.text, id: word.id }
                     )}
                     isActiveGap={activeGapWordIds?.has(word.id)}
+                    isUserEdited={editedWordIds?.has(word.id)}
                     id={`word-${word.id}`}
                     onClick={() => handleWordClick(word.text, word.id, anchor, sequence)}
                     correction={correctionInfo}

--- a/frontend/components/lyrics-review/shared/Word.tsx
+++ b/frontend/components/lyrics-review/shared/Word.tsx
@@ -14,6 +14,7 @@ export const WordComponent = React.memo(function Word({
   isUncorrectedGap,
   isCurrentlyPlaying,
   isActiveGap,
+  isUserEdited,
   padding = 'px-[3px] py-[1px]',
   onClick,
   id,
@@ -24,15 +25,18 @@ export const WordComponent = React.memo(function Word({
   }
 
   // Determine background color class
+  // User-edited takes priority over gap states (but not currently-playing or anchor)
   const bgColorClass = isCurrentlyPlaying
     ? 'bg-blue-500 text-white'
     : isAnchor
       ? HIGHLIGHT_CLASSES.anchor
-      : isCorrectedGap
-        ? HIGHLIGHT_CLASSES.corrected
-        : isUncorrectedGap
-          ? HIGHLIGHT_CLASSES.uncorrectedGap
-          : ''
+      : isUserEdited
+        ? HIGHLIGHT_CLASSES.userEdited
+        : isCorrectedGap
+          ? HIGHLIGHT_CLASSES.corrected
+          : isUncorrectedGap
+            ? HIGHLIGHT_CLASSES.uncorrectedGap
+            : ''
 
   const wordElement = (
     <span

--- a/frontend/lib/lyrics-review/constants.ts
+++ b/frontend/lib/lyrics-review/constants.ts
@@ -30,6 +30,7 @@ export const HIGHLIGHT_CLASSES = {
   uncorrectedGap: 'bg-orange-500/25',
   highlighted: 'bg-amber-400/40',
   playing: 'text-blue-500',
+  userEdited: 'bg-violet-500/25',
 } as const
 
 // CSS keyframes for flash animation (use with Tailwind animate utilities)

--- a/frontend/lib/lyrics-review/types.ts
+++ b/frontend/lib/lyrics-review/types.ts
@@ -337,6 +337,7 @@ export interface WordProps {
   isUncorrectedGap?: boolean
   isCurrentlyPlaying?: boolean
   isActiveGap?: boolean
+  isUserEdited?: boolean
   padding?: string
   onClick?: () => void
   id?: string
@@ -381,6 +382,7 @@ export interface TranscriptionViewProps {
   onShowCorrectionDetail?: (wordId: string) => void
   advancedMode?: boolean
   onAdvancedModeToggle?: (enabled: boolean) => void
+  editedWordIds?: Set<string>
 }
 
 export interface ReferenceViewProps extends BaseViewProps {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.167.0"
+version = "0.168.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Words edited by the user in lyrics review now show a **violet background** (`bg-violet-500/25`) so it's immediately obvious which words have been modified
- Compares current word text against initial state (`history[0]`), so undo/redo correctly updates highlights
- New words added by the user are also highlighted

## Changes
- `Word.tsx` — accepts `isUserEdited` prop, renders violet highlight
- `LyricsAnalyzer.tsx` — computes `editedWordIds` via `useMemo` comparing current vs initial data
- `TranscriptionView.tsx` / `HighlightedText.tsx` — thread `editedWordIds` set through to Word component
- `constants.ts` / `types.ts` — add `userEdited` highlight class and `isUserEdited` prop

## Color priority (highest → lowest)
1. Currently playing (blue solid)
2. Anchor (blue tint)
3. **User-edited (violet tint)** ← new
4. Corrected gap (green tint)
5. Uncorrected gap (orange tint)

## Test plan
- [x] All 743 existing tests pass
- [x] Frontend build succeeds
- [ ] Manually verify: edit a word in lyrics review → violet background appears
- [ ] Manually verify: undo the edit → violet background disappears
- [ ] Manually verify: add a new word → violet background appears on new word

<!-- @coderabbitai ignore -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)