### PR TITLE
fix: brighter lime-green highlight for user-edited words

### DIFF
--- a/frontend/lib/lyrics-review/constants.ts
+++ b/frontend/lib/lyrics-review/constants.ts
@@ -30,7 +30,7 @@ export const HIGHLIGHT_CLASSES = {
   uncorrectedGap: 'bg-orange-500/25',
   highlighted: 'bg-amber-400/40',
   playing: 'text-blue-500',
-  userEdited: 'bg-violet-500/25',
+  userEdited: 'bg-lime-400/40',
 } as const
 
 // CSS keyframes for flash animation (use with Tailwind animate utilities)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.168.0"
+version = "0.168.1"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Changes user-edited word highlight from subtle violet (`bg-violet-500/25`) to bright lime green (`bg-lime-400/40`)
- Much more visible and obvious which words have been edited
- Distinct from AI-corrected words which use `bg-green-500/25`

## Test plan
- [x] All 743 tests pass
- [ ] Edit a word in lyrics review → bright green background appears

<!-- @coderabbitai ignore -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)