### PR TITLE
fix: Stripe webhook crash — payments not crediting users

### DIFF
--- a/backend/services/stripe_service.py
+++ b/backend/services/stripe_service.py
@@ -6,6 +6,7 @@ Handles:
 - Processing webhook events
 - Managing customer records
 """
+import json
 import logging
 import os
 from typing import Optional, Dict, Any, Tuple
@@ -290,7 +291,10 @@ class StripeService:
             event = stripe.Webhook.construct_event(
                 payload, signature, self.webhook_secret
             )
-            return True, event, "Webhook verified"
+            # Convert Stripe Event object to plain dict — Stripe SDK v14+
+            # returns StripeObject instances that don't support .get()
+            event_dict = json.loads(str(event))
+            return True, event_dict, "Webhook verified"
         except stripe.error.SignatureVerificationError as e:
             logger.error(f"Invalid webhook signature: {e}")
             return False, None, "Invalid signature"

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -13,6 +13,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Optional, List, Tuple
 
+from google.api_core import exceptions as google_exceptions
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 from google.cloud.firestore_v1 import Increment
@@ -999,7 +1000,7 @@ class UserService:
                         'amount': amount,
                         'processed_at': datetime.utcnow()
                     })
-                except Exception:
+                except google_exceptions.AlreadyExists:
                     # Document already exists - this session was already processed
                     logger.info(f"Stripe session {stripe_session_id} already processed (idempotent skip)")
                     return False, 0, "Session already processed"

--- a/poetry.lock
+++ b/poetry.lock
@@ -10702,4 +10702,4 @@ local-whisper = ["whisper-timestamped"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "fd26762a0d3f754ddc150bb24dc6d1ee1a15cb8154584950b213029751315ed2"
+content-hash = "6ed6be0dbeef6f31529246a14d2ad4286edc5ab2fe455433a886429a78f8054b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.168.1"
+version = "0.168.2"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"
@@ -97,7 +97,7 @@ google-cloud-run = "0.15.0"  # Cloud Run Jobs for long-running video encoding (P
 python-dotenv = ">=1.0.0"
 pydub = ">=0.25.1"
 # Payment and email services
-stripe = ">=7.0.0"
+stripe = "^14.1.0"
 sendgrid = ">=6.10.0"
 email-validator = ">=2.0.0"  # For Pydantic EmailStr validation
 # Web Push notifications


### PR DESCRIPTION
@coderabbitai ignore

## Summary

- **Critical production fix**: All Stripe payment webhooks have been returning 500 since ~April 9, meaning users pay but don't receive credits or confirmation emails
- **Root cause**: Stripe SDK v14+ `Event` objects don't support `.get()` (unlike older versions that inherited from `dict`). The webhook handler calls `event.get("type")` at line 1020, which raises `AttributeError: get`
- **Fix**: Convert Stripe Event to plain dict via `json.loads(str(event))` in `verify_webhook_signature()`, before the event reaches the handler
- **Secondary fix**: Narrow `except Exception` to `except AlreadyExists` in `add_credits` idempotency check — was masking permission/network errors as "already processed"
- **Pin stripe to `^14.1.0`** (was `>=7.0.0`) to prevent unexpected major upgrades in Docker builds

## Impact

- **3 payments ($59.50 total) for 2 users** affected since April 9
- Stripe retries failed webhooks for 3 days — all affected payments are within the retry window and will be processed automatically after deploy
- No manual intervention needed for credits or emails

## Test plan

- [x] All 59 existing payment/credit tests pass
- [x] Verified fix with Stripe v14 Event objects (unicode, empty metadata, refund events)
- [ ] After deploy: monitor logs for successful webhook processing
- [ ] Verify affected users receive credits via Stripe webhook retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)