### PR TITLE
fix(error-monitor): Gen2 Cloud Functions log as cloud_run_revision

### DIFF
--- a/backend/services/error_monitor/config.py
+++ b/backend/services/error_monitor/config.py
@@ -31,6 +31,14 @@ MONITORED_CLOUD_RUN_SERVICES: list[str] = [
     "karaoke-backend",
     "karaoke-decide",
     "audio-separator",
+    # Gen2 Cloud Functions appear as Cloud Run services in logs
+    "gdrive-validator",
+    "github-runner-manager",
+    "backup-to-aws",
+    "divebar-mirror",
+    "kn-data-sync",
+    "divebar-lookup",
+    "encoding-worker-idle-shutdown",
 ]
 
 MONITORED_CLOUD_RUN_JOBS: list[str] = [
@@ -40,15 +48,9 @@ MONITORED_CLOUD_RUN_JOBS: list[str] = [
     "audio-download-job",
 ]
 
-MONITORED_CLOUD_FUNCTIONS: list[str] = [
-    "gdrive-validator",
-    "runner_manager",
-    "backup_to_aws",
-    "divebar_mirror",
-    "kn_data_sync",
-    "divebar_lookup",
-    "encoding_worker_idle",
-]
+# Gen2 Cloud Functions log as cloud_run_revision, not cloud_function.
+# Their names are in MONITORED_CLOUD_RUN_SERVICES above.
+MONITORED_CLOUD_FUNCTIONS: list[str] = []
 
 MONITORED_GCE_INSTANCES: list[str] = [
     "encoding-worker-a",


### PR DESCRIPTION
## Summary

- Gen2 Cloud Functions appear as `cloud_run_revision` in Cloud Logging, not `cloud_function`
- First error monitor run found 0 errors because Cloud Functions were queried under wrong resource type
- Moves function service names into `MONITORED_CLOUD_RUN_SERVICES` with correct hyphenated names matching actual Cloud Run service names

## Errors being missed

- `karaoke-backend`: Dropbox expired token, invalid state transitions (rendering_video duplicate)
- `encoding-worker-idle-shutdown`: Memory limit exceeded (244 MiB) every 5 minutes

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)