### PR TITLE
fix: resolve 3 production errors — OOM, index order_by, missing exports

### DIFF
--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -532,6 +532,7 @@ class UserService:
                 self.db.collection(USERS_COLLECTION)
                 .where(filter=FieldFilter("signup_ip", "==", ip_address))
                 .where(filter=FieldFilter("created_at", ">=", cutoff))
+                .order_by("created_at", direction=firestore.Query.DESCENDING)
             )
 
             count = 0
@@ -563,6 +564,7 @@ class UserService:
                 self.db.collection(USERS_COLLECTION)
                 .where(filter=FieldFilter("device_fingerprint", "==", device_fingerprint))
                 .where(filter=FieldFilter("created_at", ">=", cutoff))
+                .order_by("created_at", direction=firestore.Query.DESCENDING)
             )
 
             count = 0

--- a/backend/tests/test_anti_abuse.py
+++ b/backend/tests/test_anti_abuse.py
@@ -279,7 +279,7 @@ class TestIPRateLimiting:
 
         # Simulate 2 matching users
         mock_docs = [MagicMock(), MagicMock()]
-        mock_db.collection.return_value.where.return_value.where.return_value.stream.return_value = mock_docs
+        mock_db.collection.return_value.where.return_value.where.return_value.order_by.return_value.stream.return_value = mock_docs
 
         from backend.services.user_service import UserService
         service = UserService()
@@ -297,7 +297,7 @@ class TestIPRateLimiting:
 
         # 2 signups = rate limited
         mock_docs = [MagicMock(), MagicMock()]
-        mock_db.collection.return_value.where.return_value.where.return_value.stream.return_value = mock_docs
+        mock_db.collection.return_value.where.return_value.where.return_value.order_by.return_value.stream.return_value = mock_docs
 
         from backend.services.user_service import UserService
         service = UserService()
@@ -312,7 +312,7 @@ class TestIPRateLimiting:
         mock_fs.Client.return_value = mock_db
 
         mock_docs = [MagicMock()]
-        mock_db.collection.return_value.where.return_value.where.return_value.stream.return_value = mock_docs
+        mock_db.collection.return_value.where.return_value.where.return_value.order_by.return_value.stream.return_value = mock_docs
 
         from backend.services.user_service import UserService
         service = UserService()
@@ -348,7 +348,7 @@ class TestFingerprintRateLimiting:
         mock_fs.Client.return_value = mock_db
 
         mock_docs = [MagicMock(), MagicMock(), MagicMock()]
-        mock_db.collection.return_value.where.return_value.where.return_value.stream.return_value = mock_docs
+        mock_db.collection.return_value.where.return_value.where.return_value.order_by.return_value.stream.return_value = mock_docs
 
         from backend.services.user_service import UserService
         service = UserService()
@@ -377,7 +377,7 @@ class TestFingerprintRateLimiting:
                 return iter([])  # IP query: 0 results
             return iter([MagicMock(), MagicMock()])  # Fingerprint query: 2 results
 
-        mock_db.collection.return_value.where.return_value.where.return_value.stream = stream_side_effect
+        mock_db.collection.return_value.where.return_value.where.return_value.order_by.return_value.stream = stream_side_effect
 
         from backend.services.user_service import UserService
         service = UserService()
@@ -396,7 +396,7 @@ class TestFingerprintRateLimiting:
         mock_fs.Client.return_value = mock_db
 
         # IP query returns 0
-        mock_db.collection.return_value.where.return_value.where.return_value.stream.return_value = []
+        mock_db.collection.return_value.where.return_value.where.return_value.order_by.return_value.stream.return_value = []
 
         from backend.services.user_service import UserService
         service = UserService()

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -566,6 +566,8 @@ pulumi.export("firestore_index_gen_users_active_credits", db_resources["firestor
 pulumi.export("firestore_index_gen_users_active_email", db_resources["firestore_index_gen_users_active_email"].name)
 pulumi.export("firestore_field_logs_ttl", db_resources["firestore_field_logs_ttl"].name)
 pulumi.export("firestore_index_logs_worker_timestamp", db_resources["firestore_index_logs_worker_timestamp"].name)
+pulumi.export("firestore_index_gen_users_signup_ip", db_resources["firestore_index_gen_users_signup_ip"].name)
+pulumi.export("firestore_index_gen_users_device_fingerprint", db_resources["firestore_index_gen_users_device_fingerprint"].name)
 
 # Service accounts
 pulumi.export("service_account_email", backend_service_account.email)

--- a/infrastructure/config.py
+++ b/infrastructure/config.py
@@ -131,7 +131,7 @@ class EncodingWorkerConfig:
     IDLE_CHECK_SCHEDULE = "*/5 * * * *"  # Every 5 minutes
     IDLE_TIMEOUT_MINUTES = 15
     FUNCTION_NAME = "encoding-worker-idle-shutdown"
-    FUNCTION_MEMORY = "256M"
+    FUNCTION_MEMORY = "512M"  # Increased from 256M — OOM with gRPC/Firestore/Compute client libs
     FUNCTION_TIMEOUT = 120  # 2 minutes
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.169.0"
+version = "0.169.1"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Fix encoding-worker-idle-shutdown OOM by bumping memory from 256M to 512M
- Fix signup rate-limit queries failing with FAILED_PRECONDITION by adding explicit `order_by(created_at, DESCENDING)` to match existing composite indexes
- Add missing `pulumi.export` for gen_users signup_ip and device_fingerprint indexes

## Changes
- `infrastructure/config.py`: `FUNCTION_MEMORY` 256M → 512M (matches github-runner-manager precedent)
- `backend/services/user_service.py`: Added `.order_by("created_at", direction=firestore.Query.DESCENDING)` to `count_recent_signups_from_ip()` and `count_recent_signups_from_fingerprint()` — without this, Firestore defaults to ASC which doesn't match the DESC indexes, causing every query to fail and silently disabling anti-abuse rate limiting
- `infrastructure/__main__.py`: Added 2 missing `pulumi.export` lines for index visibility
- `backend/tests/test_anti_abuse.py`: Updated mock chains to include `.order_by()` in the call chain

## Testing
- [x] All 37 anti-abuse tests pass
- [x] Full test suite: 1476 passed (5 pre-existing error-monitor config failures unrelated to this PR)
- [x] Verified Firestore indexes exist and are READY via `gcloud firestore indexes composite list`
- [x] Confirmed root cause via Cloud Logging — `FailedPrecondition: The query requires an index`

## Review
- [x] Local CodeRabbit review completed (no issues in changed files)

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)