### PR TITLE
fix(lyrics): compact Edit-All grid + preserve word timing on same-count edits

### DIFF
--- a/frontend/components/lyrics-review/__tests__/ReplaceSegmentsMode.test.tsx
+++ b/frontend/components/lyrics-review/__tests__/ReplaceSegmentsMode.test.tsx
@@ -187,6 +187,51 @@ describe('Replace Segments Mode', () => {
     expect(savedSegments[2].words[0].text).toBe('Third')
   })
 
+  it('preserves per-word timing when word count is unchanged (e.g. case-only edit)', async () => {
+    const user = userEvent.setup()
+    await openReplaceSegmentsMode()
+
+    // Lowercase the second segment only — same word count (2 words)
+    const textarea = screen.getByRole('textbox')
+    await user.clear(textarea)
+    await user.type(textarea, 'Hello world\ngoodbye moon\nThird line here')
+
+    const applyButton = screen.getByRole('button', { name: 'Apply' })
+    await user.click(applyButton)
+
+    const savedSegments = defaultProps.onSave.mock.calls[0][0]
+
+    // Changed segment — text updated, but original word-level timing + IDs preserved
+    expect(savedSegments[1].text).toBe('goodbye moon')
+    expect(savedSegments[1].words).toHaveLength(2)
+    expect(savedSegments[1].words[0].text).toBe('goodbye')
+    expect(savedSegments[1].words[0].id).toBe('w3')
+    expect(savedSegments[1].words[0].start_time).toBe(3)
+    expect(savedSegments[1].words[0].end_time).toBe(4)
+    expect(savedSegments[1].words[1].text).toBe('moon')
+    expect(savedSegments[1].words[1].id).toBe('w4')
+    expect(savedSegments[1].words[1].start_time).toBe(4)
+    expect(savedSegments[1].words[1].end_time).toBe(5)
+  })
+
+  it('preserves word confidence when word count is unchanged', async () => {
+    const user = userEvent.setup()
+    await openReplaceSegmentsMode()
+
+    const textarea = screen.getByRole('textbox')
+    await user.clear(textarea)
+    // Change one word in third segment, same count (3 words)
+    await user.type(textarea, 'Hello world\nGoodbye moon\nThird lane here')
+
+    const applyButton = screen.getByRole('button', { name: 'Apply' })
+    await user.click(applyButton)
+
+    const savedSegments = defaultProps.onSave.mock.calls[0][0]
+    expect(savedSegments[2].words[1].text).toBe('lane')
+    expect(savedSegments[2].words[1].confidence).toBe(0.9)
+    expect(savedSegments[2].words[1].id).toBe('w6')
+  })
+
   it('preserves segment id and timing for changed lines', async () => {
     const user = userEvent.setup()
     await openReplaceSegmentsMode()

--- a/frontend/components/lyrics-review/modals/ModeSelectionModal.tsx
+++ b/frontend/components/lyrics-review/modals/ModeSelectionModal.tsx
@@ -3,7 +3,7 @@
 import { useTranslations } from 'next-intl'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import { RefreshCw, ClipboardPaste, TextCursorInput, CaseSensitive, X } from 'lucide-react'
+import { RefreshCw, ClipboardPaste, TextCursorInput, CaseSensitive, X, type LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 interface ModeSelectionModalProps {
@@ -16,6 +16,17 @@ interface ModeSelectionModalProps {
   hasExistingLyrics: boolean
 }
 
+type ModeOption = {
+  key: string
+  icon: LucideIcon
+  title: string
+  desc: string
+  tag?: string
+  tagTone?: 'positive' | 'caution'
+  primary?: boolean
+  onSelect: () => void
+}
+
 export default function ModeSelectionModal({
   open,
   onClose,
@@ -26,9 +37,51 @@ export default function ModeSelectionModal({
   hasExistingLyrics,
 }: ModeSelectionModalProps) {
   const t = useTranslations('lyricsReview.modals.modeSelection')
+  const tCommon = useTranslations('common')
+
+  const options: ModeOption[] = [
+    hasExistingLyrics && {
+      key: 'resync',
+      icon: RefreshCw,
+      title: t('resyncTitle'),
+      desc: t('resyncDesc'),
+      tag: t('resyncRecommended'),
+      tagTone: 'positive' as const,
+      primary: true,
+      onSelect: onSelectResync,
+    },
+    hasExistingLyrics && {
+      key: 'replaceSegments',
+      icon: TextCursorInput,
+      title: t('replaceSegmentTitle'),
+      desc: t('replaceSegmentDesc'),
+      tag: t('replaceSegmentRecommended'),
+      tagTone: 'positive' as const,
+      onSelect: onSelectReplaceSegments,
+    },
+    hasExistingLyrics && {
+      key: 'changeCase',
+      icon: CaseSensitive,
+      title: t('changeCaseTitle'),
+      desc: t('changeCaseDesc'),
+      tag: t('changeCaseRecommended'),
+      tagTone: 'positive' as const,
+      onSelect: onSelectChangeCase,
+    },
+    {
+      key: 'replaceAll',
+      icon: ClipboardPaste,
+      title: t('replaceAllTitle'),
+      desc: t('replaceAllDesc'),
+      tag: t('replaceAllWarning'),
+      tagTone: 'caution' as const,
+      onSelect: onSelectReplace,
+    },
+  ].filter((opt): opt is ModeOption => Boolean(opt))
+
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-2xl">
         <DialogHeader>
           <DialogTitle className="flex items-center justify-between">
             <span>{t('title')}</span>
@@ -38,103 +91,61 @@ export default function ModeSelectionModal({
           </DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-4">
+        <div className="space-y-3">
           <p className="text-sm text-muted-foreground">{t('chooseMethod')}</p>
 
-          <div className="flex flex-col gap-3">
-            {/* Re-sync Existing option - only show if there are existing lyrics */}
-            {hasExistingLyrics && (
-              <div
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {options.map(({ key, icon: Icon, title, desc, tag, tagTone, primary, onSelect }) => (
+              <button
+                key={key}
+                type="button"
+                onClick={onSelect}
                 className={cn(
-                  'p-4 border-2 border-primary rounded-lg cursor-pointer',
-                  'hover:bg-primary/10 transition-colors'
+                  'p-3 rounded-lg border text-left transition-colors',
+                  'flex gap-3 items-start',
+                  'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+                  primary
+                    ? 'border-2 border-primary hover:bg-primary/10'
+                    : 'hover:bg-muted/30 hover:border-muted-foreground'
                 )}
-                onClick={onSelectResync}
               >
-                <div className="flex items-start gap-3">
-                  <RefreshCw className="h-10 w-10 text-primary mt-0.5" />
-                  <div className="flex-1">
-                    <h3 className="text-lg font-semibold text-primary">{t('resyncTitle')}</h3>
-                    <p className="text-sm text-muted-foreground mt-1">
-                      {t('resyncDesc')}
-                    </p>
-                    <p className="text-xs text-green-500 mt-2">{t('resyncRecommended')}</p>
+                <Icon
+                  className={cn(
+                    'h-7 w-7 shrink-0 mt-0.5',
+                    primary ? 'text-primary' : 'text-muted-foreground'
+                  )}
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                    <h3
+                      className={cn(
+                        'text-sm font-semibold leading-tight',
+                        primary && 'text-primary'
+                      )}
+                    >
+                      {title}
+                    </h3>
+                    {tag && (
+                      <span
+                        className={cn(
+                          'text-[11px] font-medium leading-tight',
+                          tagTone === 'caution' ? 'text-yellow-500' : 'text-green-500'
+                        )}
+                      >
+                        {tag}
+                      </span>
+                    )}
                   </div>
+                  <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{desc}</p>
                 </div>
-              </div>
-            )}
-
-            {/* Replace Segment Lyrics option - only show if there are existing lyrics */}
-            {hasExistingLyrics && (
-              <div
-                className={cn(
-                  'p-4 border rounded-lg cursor-pointer',
-                  'hover:bg-muted/30 hover:border-muted-foreground transition-colors'
-                )}
-                onClick={onSelectReplaceSegments}
-              >
-                <div className="flex items-start gap-3">
-                  <TextCursorInput className="h-10 w-10 text-muted-foreground mt-0.5" />
-                  <div className="flex-1">
-                    <h3 className="text-lg font-semibold">{t('replaceSegmentTitle')}</h3>
-                    <p className="text-sm text-muted-foreground mt-1">
-                      {t('replaceSegmentDesc')}
-                    </p>
-                    <p className="text-xs text-green-500 mt-2">{t('replaceSegmentRecommended')}</p>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* Change Case option - only show if there are existing lyrics */}
-            {hasExistingLyrics && (
-              <div
-                className={cn(
-                  'p-4 border rounded-lg cursor-pointer',
-                  'hover:bg-muted/30 hover:border-muted-foreground transition-colors'
-                )}
-                onClick={onSelectChangeCase}
-              >
-                <div className="flex items-start gap-3">
-                  <CaseSensitive className="h-10 w-10 text-muted-foreground mt-0.5" />
-                  <div className="flex-1">
-                    <h3 className="text-lg font-semibold">{t('changeCaseTitle')}</h3>
-                    <p className="text-sm text-muted-foreground mt-1">
-                      {t('changeCaseDesc')}
-                    </p>
-                    <p className="text-xs text-green-500 mt-2">{t('changeCaseRecommended')}</p>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* Replace All option */}
-            <div
-              className={cn(
-                'p-4 border rounded-lg cursor-pointer',
-                'hover:bg-muted/30 hover:border-muted-foreground transition-colors'
-              )}
-              onClick={onSelectReplace}
-            >
-              <div className="flex items-start gap-3">
-                <ClipboardPaste className="h-10 w-10 text-muted-foreground mt-0.5" />
-                <div className="flex-1">
-                  <h3 className="text-lg font-semibold">{t('replaceAllTitle')}</h3>
-                  <p className="text-sm text-muted-foreground mt-1">
-                    {t('replaceAllDesc')}
-                  </p>
-                  <p className="text-xs text-yellow-500 mt-2">
-                    {t('replaceAllWarning')}
-                  </p>
-                </div>
-              </div>
-            </div>
+              </button>
+            ))}
           </div>
         </div>
 
         <DialogFooter>
           <Button variant="outline" onClick={onClose}>
-            Cancel
+            {tCommon('cancel')}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/components/lyrics-review/modals/ReplaceAllLyricsModal.tsx
+++ b/frontend/components/lyrics-review/modals/ReplaceAllLyricsModal.tsx
@@ -145,7 +145,9 @@ export default function ReplaceAllLyricsModal({
     onClose()
   }, [onClose])
 
-  // Apply replace segments: build updated segments with new words for changed lines
+  // Apply replace segments: build updated segments with new words for changed lines.
+  // When a line changed but the word count is the same, preserve per-word timing/IDs
+  // and only update the word text — so case-only or single-word edits don't drop timing.
   const handleApplyReplaceSegments = useCallback(() => {
     const newLines = inputText.split('\n')
     const updatedSegments: LyricsSegment[] = existingSegments.map((segment, i) => {
@@ -157,7 +159,22 @@ export default function ReplaceAllLyricsModal({
         return JSON.parse(JSON.stringify(segment))
       }
 
-      // Changed — create new words with distributed timing
+      const newWordTexts = newLineText.split(/\s+/).filter((w) => w.length > 0)
+
+      // Same word count — preserve timing, only swap text per word
+      if (newWordTexts.length === segment.words.length && newWordTexts.length > 0) {
+        const updatedWords = segment.words.map((word, idx) => ({
+          ...word,
+          text: newWordTexts[idx],
+        }))
+        return {
+          ...segment,
+          text: newLineText,
+          words: updatedWords,
+        }
+      }
+
+      // Word count changed — distribute timing across new words
       const newWords = createWordsWithDistributedTiming(
         newLineText,
         segment.start_time,

--- a/frontend/lib/lyrics-review/utils/__tests__/caseConversion.test.ts
+++ b/frontend/lib/lyrics-review/utils/__tests__/caseConversion.test.ts
@@ -64,6 +64,24 @@ describe('convertCase', () => {
     it('handles string with no letters', () => {
       expect(convertCase('123 !@#', 'sentence')).toBe('123 !@#')
     })
+
+    it('capitalizes the first accented letter correctly', () => {
+      expect(convertCase('über alles', 'sentence')).toBe('Über alles')
+    })
+  })
+
+  describe('unicode handling', () => {
+    it('title-cases accented Latin characters', () => {
+      expect(convertCase('über alles éclair', 'title')).toBe('Über Alles Éclair')
+    })
+
+    it('lowercases Cyrillic correctly', () => {
+      expect(convertCase('ПРИВЕТ мир', 'lower')).toBe('привет мир')
+    })
+
+    it('title-cases Cyrillic correctly', () => {
+      expect(convertCase('привет мир', 'title')).toBe('Привет Мир')
+    })
   })
 })
 

--- a/frontend/lib/lyrics-review/utils/caseConversion.ts
+++ b/frontend/lib/lyrics-review/utils/caseConversion.ts
@@ -15,18 +15,22 @@ export function convertCase(text: string, caseType: CaseType): string {
   }
 }
 
+function capitalizeFirstLetter(text: string): string {
+  const firstLetter = text.search(/\p{L}/u)
+  if (firstLetter === -1) return text
+  return (
+    text.slice(0, firstLetter) +
+    text.charAt(firstLetter).toUpperCase() +
+    text.slice(firstLetter + 1)
+  )
+}
+
 function toTitleCase(text: string): string {
-  return text.replace(/\S+/g, (word) => {
-    const lower = word.toLowerCase()
-    return lower.charAt(0).toUpperCase() + lower.slice(1)
-  })
+  return text.replace(/\S+/gu, (word) => capitalizeFirstLetter(word.toLowerCase()))
 }
 
 function toSentenceCase(text: string): string {
-  const lower = text.toLowerCase()
-  const firstLetter = lower.search(/[a-z]/i)
-  if (firstLetter === -1) return lower
-  return lower.slice(0, firstLetter) + lower.charAt(firstLetter).toUpperCase() + lower.slice(firstLetter + 1)
+  return capitalizeFirstLetter(text.toLowerCase())
 }
 
 export function applyCaseToSegments(
@@ -36,10 +40,10 @@ export function applyCaseToSegments(
   const perLine = caseType === 'sentence'
   return segments.map((segment) => {
     const transform = (s: string) => convertCase(s, caseType)
-    // For sentence case, find the first word containing a cased letter — so a
+    // For sentence case, find the first word containing a Unicode letter — so a
     // leading punctuation-only token doesn't steal the capitalization.
     const firstCasedIndex = perLine
-      ? segment.words.findIndex((w) => /[A-Za-z]/.test(w.text))
+      ? segment.words.findIndex((w) => /\p{L}/u.test(w.text))
       : -1
     const newWords = segment.words.map((word, index) => ({
       ...word,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.170.0"
+version = "0.170.1"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Two fixes to the **Edit All Lyrics** feature shipped in #718:

1. **Mode selection was cramped.** 4 vertically-stacked cards didn't scale as
   options were added. Now a **2×2 grid** in a wider dialog — faster to scan
   and ready for future options.

2. **Replace Segment Lyrics dropped word timing on same-count edits.** A
   lowercase-only pass over one word in a segment reset every word's timing
   in every segment. Fixed: if the new word count matches the original,
   per-word `id`/`start_time`/`end_time`/`confidence` are preserved and only
   `.text` is updated. Distributed timing is only used when word count
   actually changes.

## Bonus: Unicode-aware case conversion

`toTitleCase` / `toSentenceCase` now use `\p{L}` (Unicode letter property)
instead of ASCII-only regexes, so accented Latin (`über` → `Über`) and
Cyrillic (`привет` → `Привет`) are cased correctly.

## Changes

- `components/lyrics-review/modals/ModeSelectionModal.tsx` — rewritten as a
  data-driven 2×2 grid of semantic `<button>` cards.
- `components/lyrics-review/modals/ReplaceAllLyricsModal.tsx` — per-word
  timing preserved on matching-count edits.
- `lib/lyrics-review/utils/caseConversion.ts` — Unicode-aware helpers,
  extracted shared `capitalizeFirstLetter`.
- Tests: +2 ReplaceSegments tests, +4 Unicode tests. All 780 pass.

## Test plan

- [ ] Edit All Lyrics → verify 2×2 card grid, tab key focuses each card
- [ ] Replace Segment Lyrics → edit just one word's case in one line → confirm
      every other segment's word timings are unchanged
- [ ] Change Case with an accented-text song → verify Title/Sentence case
      capitalize the accented first letter
- [ ] Mobile viewport → grid collapses to single column

@coderabbitai ignore