### PR TITLE
fix(lyrics): log upstream 5xx/timeout as WARNING, not ERROR

### DIFF
--- a/karaoke_gen/lyrics_transcriber/lyrics/base_lyrics_provider.py
+++ b/karaoke_gen/lyrics_transcriber/lyrics/base_lyrics_provider.py
@@ -6,6 +6,7 @@ import hashlib
 from pathlib import Path
 import os
 from abc import ABC, abstractmethod
+import requests
 from karaoke_gen.lyrics_transcriber.types import LyricsData, LyricsSegment, Word
 from karaoke_lyrics_processor import KaraokeLyricsProcessor
 from karaoke_gen.lyrics_transcriber.utils.word_utils import WordUtils
@@ -228,3 +229,17 @@ class BaseLyricsProvider(ABC):
     def get_name(self) -> str:
         """Return the name of this lyrics provider."""
         return self.__class__.__name__.replace("Provider", "")
+
+    def _log_request_exception(self, exc: requests.exceptions.RequestException, label: str) -> None:
+        # 5xx / connection / timeout are upstream transient — not actionable for us.
+        response = getattr(exc, "response", None)
+        status = getattr(response, "status_code", None)
+        transient = (
+            isinstance(exc, (requests.exceptions.ConnectionError, requests.exceptions.Timeout))
+            or (isinstance(exc, requests.exceptions.HTTPError) and status is not None and status >= 500)
+        )
+        msg = f"{label} request failed: {exc}"
+        if transient:
+            self.logger.warning(msg)
+        else:
+            self.logger.error(msg)

--- a/karaoke_gen/lyrics_transcriber/lyrics/genius.py
+++ b/karaoke_gen/lyrics_transcriber/lyrics/genius.py
@@ -125,7 +125,7 @@ class GeniusProvider(BaseLyricsProvider):
             return rapidapi_response
             
         except requests.exceptions.RequestException as e:
-            self.logger.error(f"RapidAPI request failed: {str(e)}")
+            self._log_request_exception(e, "Genius RapidAPI")
             return None
         except Exception as e:
             self.logger.error(f"Error fetching from RapidAPI: {str(e)}")

--- a/karaoke_gen/lyrics_transcriber/lyrics/lrclib.py
+++ b/karaoke_gen/lyrics_transcriber/lyrics/lrclib.py
@@ -84,7 +84,7 @@ class LRCLIBProvider(BaseLyricsProvider):
             return data
             
         except requests.exceptions.RequestException as e:
-            self.logger.error(f"LRCLIB request failed: {str(e)}")
+            self._log_request_exception(e, "LRCLIB")
             return None
         except Exception as e:
             self.logger.error(f"Error fetching from LRCLIB: {str(e)}")
@@ -119,7 +119,7 @@ class LRCLIBProvider(BaseLyricsProvider):
             return best_match
             
         except requests.exceptions.RequestException as e:
-            self.logger.error(f"LRCLIB search request failed: {str(e)}")
+            self._log_request_exception(e, "LRCLIB search")
             return None
         except Exception as e:
             self.logger.error(f"Error searching LRCLIB: {str(e)}")

--- a/karaoke_gen/lyrics_transcriber/lyrics/musixmatch.py
+++ b/karaoke_gen/lyrics_transcriber/lyrics/musixmatch.py
@@ -50,7 +50,7 @@ class MusixmatchProvider(BaseLyricsProvider):
             return data
             
         except requests.exceptions.RequestException as e:
-            self.logger.error(f"Musixmatch API request failed: {str(e)}")
+            self._log_request_exception(e, "Musixmatch API")
             return None
         except Exception as e:
             self.logger.error(f"Error fetching from Musixmatch: {str(e)}")

--- a/karaoke_gen/lyrics_transcriber/lyrics/spotify.py
+++ b/karaoke_gen/lyrics_transcriber/lyrics/spotify.py
@@ -126,7 +126,7 @@ class SpotifyProvider(BaseLyricsProvider):
             return rapidapi_response
             
         except requests.exceptions.RequestException as e:
-            self.logger.error(f"RapidAPI request failed: {str(e)}")
+            self._log_request_exception(e, "Spotify RapidAPI")
             return None
         except Exception as e:
             self.logger.error(f"Error fetching from RapidAPI: {str(e)}")

--- a/tests/unit/test_base_lyrics_provider.py
+++ b/tests/unit/test_base_lyrics_provider.py
@@ -2,6 +2,9 @@
 
 import logging
 from typing import Optional, Dict, Any
+from unittest.mock import MagicMock
+
+import requests
 
 from karaoke_gen.lyrics_transcriber.lyrics.base_lyrics_provider import BaseLyricsProvider, LyricsProviderConfig
 from karaoke_gen.lyrics_transcriber.types import LyricsData
@@ -67,3 +70,67 @@ class TestCreateSegmentsWithWords:
         with caplog.at_level(logging.WARNING):
             provider._create_segments_with_words(text)
         assert "truncating" in caplog.text.lower()
+
+
+class TestLogRequestException:
+    """_log_request_exception must downgrade upstream-transient failures to WARNING.
+
+    5xx / ConnectionError / Timeout aren't actionable bugs in our code — they're
+    upstream availability. Logging them as ERROR creates alert noise in the
+    production error monitor since the orchestrator already falls back to other
+    providers.
+    """
+
+    def _make_provider(self) -> "StubProvider":
+        return StubProvider(LyricsProviderConfig(), logger=logging.getLogger("test_log_request"))
+
+    def _http_error(self, status_code: int) -> requests.exceptions.HTTPError:
+        response = MagicMock()
+        response.status_code = status_code
+        return requests.exceptions.HTTPError(f"{status_code} error", response=response)
+
+    def test_502_logs_warning(self, caplog):
+        provider = self._make_provider()
+        with caplog.at_level(logging.DEBUG):
+            provider._log_request_exception(self._http_error(502), "Musixmatch API")
+        records = [r for r in caplog.records if "Musixmatch API" in r.message]
+        assert len(records) == 1
+        assert records[0].levelno == logging.WARNING
+
+    def test_503_logs_warning(self, caplog):
+        provider = self._make_provider()
+        with caplog.at_level(logging.DEBUG):
+            provider._log_request_exception(self._http_error(503), "LRCLIB")
+        records = [r for r in caplog.records if "LRCLIB" in r.message]
+        assert records[0].levelno == logging.WARNING
+
+    def test_404_logs_error(self, caplog):
+        provider = self._make_provider()
+        with caplog.at_level(logging.DEBUG):
+            provider._log_request_exception(self._http_error(404), "Genius RapidAPI")
+        records = [r for r in caplog.records if "Genius RapidAPI" in r.message]
+        assert records[0].levelno == logging.ERROR
+
+    def test_timeout_logs_warning(self, caplog):
+        provider = self._make_provider()
+        exc = requests.exceptions.Timeout("read timeout")
+        with caplog.at_level(logging.DEBUG):
+            provider._log_request_exception(exc, "Spotify RapidAPI")
+        records = [r for r in caplog.records if "Spotify RapidAPI" in r.message]
+        assert records[0].levelno == logging.WARNING
+
+    def test_connection_error_logs_warning(self, caplog):
+        provider = self._make_provider()
+        exc = requests.exceptions.ConnectionError("DNS failure")
+        with caplog.at_level(logging.DEBUG):
+            provider._log_request_exception(exc, "Musixmatch API")
+        records = [r for r in caplog.records if "Musixmatch API" in r.message]
+        assert records[0].levelno == logging.WARNING
+
+    def test_generic_request_exception_logs_error(self, caplog):
+        provider = self._make_provider()
+        exc = requests.exceptions.RequestException("unknown")
+        with caplog.at_level(logging.DEBUG):
+            provider._log_request_exception(exc, "Generic")
+        records = [r for r in caplog.records if "Generic" in r.message]
+        assert records[0].levelno == logging.ERROR


### PR DESCRIPTION
## Summary
- Third-party lyrics providers (Musixmatch, Genius, LRCLIB, Spotify) returning 5xx/Timeout/ConnectionError are transient upstream failures, not bugs in our code. We already fall back to other providers and jobs complete successfully.
- Logging those as ERROR was triggering production error-monitor Discord alerts for non-actionable noise (see pattern `f9f95f01…` — Musixmatch 502 on 2026-04-19 that a job recovered from using Genius + Spotify).
- Added a shared `BaseLyricsProvider._log_request_exception()` helper that classifies 5xx / `ConnectionError` / `Timeout` as WARNING and keeps 4xx / other `RequestException` as ERROR (those still indicate a bug in our request).
- All 5 call sites across the 4 providers updated to use the helper. Per-provider log labels made more specific (`"Genius RapidAPI"` / `"Spotify RapidAPI"` instead of the generic `"RapidAPI"`) for easier debugging.

## Test plan
- [x] New unit tests cover 502, 503, 404, Timeout, ConnectionError, and generic RequestException severity classification (`tests/unit/test_base_lyrics_provider.py::TestLogRequestException`, 6 cases)
- [x] Existing lyrics tests continue to pass (35 total)
- [ ] After deploy: confirm the Musixmatch 502 error-pattern stops regenerating in Firestore (should now log at WARNING and be ignored by the monitor)

@coderabbitai ignore