### PR TITLE
test(error-monitor): fix pre-existing broken tests

### DIFF
--- a/tests/unit/services/error_monitor/test_config.py
+++ b/tests/unit/services/error_monitor/test_config.py
@@ -12,7 +12,9 @@ class TestMonitoredServiceLists:
     def test_cloud_run_services_count(self):
         from backend.services.error_monitor import config
 
-        assert len(config.MONITORED_CLOUD_RUN_SERVICES) == 3
+        # Gen2 Cloud Functions log as cloud_run_revision, so they live in
+        # MONITORED_CLOUD_RUN_SERVICES alongside real Cloud Run services.
+        assert len(config.MONITORED_CLOUD_RUN_SERVICES) >= 3
 
     def test_cloud_run_services_contains_expected(self):
         from backend.services.error_monitor import config
@@ -34,25 +36,33 @@ class TestMonitoredServiceLists:
         assert "audio-separation-job" in config.MONITORED_CLOUD_RUN_JOBS
         assert "audio-download-job" in config.MONITORED_CLOUD_RUN_JOBS
 
-    def test_cloud_functions_count_at_least_7(self):
-        from backend.services.error_monitor import config
-
-        assert len(config.MONITORED_CLOUD_FUNCTIONS) >= 7
-
-    def test_cloud_functions_contains_expected(self):
+    def test_gen2_cloud_functions_monitored_as_cloud_run_services(self):
+        # Gen2 Cloud Functions log under resource.type=cloud_run_revision,
+        # so they must appear in MONITORED_CLOUD_RUN_SERVICES, not
+        # MONITORED_CLOUD_FUNCTIONS. See config.py comment.
         from backend.services.error_monitor import config
 
         expected = [
             "gdrive-validator",
-            "runner_manager",
-            "backup_to_aws",
-            "divebar_mirror",
-            "kn_data_sync",
-            "divebar_lookup",
-            "encoding_worker_idle",
+            "github-runner-manager",
+            "backup-to-aws",
+            "divebar-mirror",
+            "kn-data-sync",
+            "divebar-lookup",
+            "encoding-worker-idle-shutdown",
         ]
         for fn in expected:
-            assert fn in config.MONITORED_CLOUD_FUNCTIONS, f"Expected '{fn}' in MONITORED_CLOUD_FUNCTIONS"
+            assert (
+                fn in config.MONITORED_CLOUD_RUN_SERVICES
+            ), f"Expected Gen2 function '{fn}' in MONITORED_CLOUD_RUN_SERVICES"
+
+    def test_cloud_functions_list_empty_for_gen1_only(self):
+        # MONITORED_CLOUD_FUNCTIONS is reserved for Gen1 Cloud Functions
+        # (which log as resource.type=cloud_function). All current functions
+        # are Gen2 and are handled via MONITORED_CLOUD_RUN_SERVICES.
+        from backend.services.error_monitor import config
+
+        assert config.MONITORED_CLOUD_FUNCTIONS == []
 
     def test_gce_instances_count_at_least_4(self):
         from backend.services.error_monitor import config

--- a/tests/unit/services/error_monitor/test_firestore_adapter.py
+++ b/tests/unit/services/error_monitor/test_firestore_adapter.py
@@ -341,7 +341,10 @@ class TestUpsertPatternExisting:
             count=5,
             timestamp=now,
         )
-        adapter.upsert_pattern(data)
+        # Freeze _utcnow so prune_rolling_counts keeps the existing entry
+        # (2h-old relative to fixture now, not relative to real clock time).
+        with patch("backend.services.error_monitor.firestore_adapter._utcnow", return_value=now):
+            adapter.upsert_pattern(data)
 
         updated = doc_ref.update.call_args[0][0]
         assert "rolling_counts" in updated
@@ -1048,7 +1051,8 @@ class TestPruneRollingCounts:
             {"ts": now.isoformat(), "count": 2},                          # recent
         ]
 
-        result = adapter._prune_rolling_counts(rolling)
+        with patch("backend.services.error_monitor.firestore_adapter._utcnow", return_value=now):
+            result = adapter._prune_rolling_counts(rolling)
 
         assert len(result) == 2
         assert result[0]["count"] == 7
@@ -1065,7 +1069,8 @@ class TestPruneRollingCounts:
             {"ts": now.isoformat(), "count": 3},
         ]
 
-        result = adapter._prune_rolling_counts(rolling)
+        with patch("backend.services.error_monitor.firestore_adapter._utcnow", return_value=now):
+            result = adapter._prune_rolling_counts(rolling)
         assert len(result) == 3
 
     def test_empty_list_returns_empty(self):


### PR DESCRIPTION
## Summary
Two pre-existing test breakages surfaced when the `Package Unit Tests` CI gate re-ran on a newer PR (it had been skipped on recent frontend-only changes):

1. **`test_config.py`** — assumed the old `MONITORED_CLOUD_FUNCTIONS` list, but PR #716 moved Gen2 Cloud Functions into `MONITORED_CLOUD_RUN_SERVICES` (since they log as `cloud_run_revision`). Tests updated to assert the new structure with the current kebab-case names.

2. **`test_firestore_adapter.py`** — three tests used hardcoded datetimes (`2026-04-10`) that are now more than 7 days stale relative to the real clock, so `_prune_rolling_counts` discarded all fixture entries. The three affected tests now freeze `_utcnow` via `patch`, keeping them stable over time.

No production code changes.

## Test plan
- [x] `python -m pytest tests/unit/services/error_monitor/` — all 310 pass locally
- [x] Verified the 6 previously-failing tests now pass
- [x] No changes outside `tests/unit/services/error_monitor/`

@coderabbitai ignore