### PR TITLE
fix(e2e): abort testmail.app fetch so waitForEmail honors its timeout

### DIFF
--- a/frontend/e2e/helpers/email-testing.ts
+++ b/frontend/e2e/helpers/email-testing.ts
@@ -160,8 +160,17 @@ export async function createEmailHelper(): Promise<EmailHelper> {
         url.searchParams.set('livequery', 'true');
         url.searchParams.set('wait', waitSeconds.toString());
 
+        // Node fetch has no default timeout — if testmail.app hangs (e.g. during a
+        // quota-exceeded redirect loop) the call would block until Playwright's
+        // per-test timeout (10+ min) instead of the intended waitForEmail timeout.
+        const controller = new AbortController();
+        const abortTimer = setTimeout(() => controller.abort(), (waitSeconds + 5) * 1000);
+
         try {
-          const response = await fetch(url.toString());
+          const response = await fetch(url.toString(), {
+            signal: controller.signal,
+            redirect: 'error',
+          });
 
           if (!response.ok) {
             throw new Error(`testmail.app API error: ${response.status} ${response.statusText}`);
@@ -189,10 +198,12 @@ export async function createEmailHelper(): Promise<EmailHelper> {
         } catch (error) {
           // If it's a timeout or network error, continue polling
           if (Date.now() - startTime < timeout) {
-            console.log(`Polling for email... (${Math.round((Date.now() - startTime) / 1000)}s elapsed)`);
+            console.log(`Polling for email... (${Math.round((Date.now() - startTime) / 1000)}s elapsed): ${error instanceof Error ? error.message : String(error)}`);
             continue;
           }
           throw error;
+        } finally {
+          clearTimeout(abortTimer);
         }
       }
 
@@ -307,8 +318,14 @@ export async function createEmailHelper(): Promise<EmailHelper> {
         url.searchParams.set('livequery', 'true');
         url.searchParams.set('wait', waitSeconds.toString());
 
+        const controller = new AbortController();
+        const abortTimer = setTimeout(() => controller.abort(), (waitSeconds + 5) * 1000);
+
         try {
-          const response = await fetch(url.toString());
+          const response = await fetch(url.toString(), {
+            signal: controller.signal,
+            redirect: 'error',
+          });
 
           if (!response.ok) {
             throw new Error(`testmail.app API error: ${response.status} ${response.statusText}`);
@@ -361,10 +378,12 @@ export async function createEmailHelper(): Promise<EmailHelper> {
           }
         } catch (error) {
           if (Date.now() - startTime < timeout) {
-            console.log(`Polling for completion email... (${Math.round((Date.now() - startTime) / 1000)}s elapsed)`);
+            console.log(`Polling for completion email... (${Math.round((Date.now() - startTime) / 1000)}s elapsed): ${error instanceof Error ? error.message : String(error)}`);
             continue;
           }
           throw error;
+        } finally {
+          clearTimeout(abortTimer);
         }
       }
 


### PR DESCRIPTION
## Summary

- Wraps each `fetch` in `waitForEmail` / `waitForCompletionEmail` with an `AbortController` (livequery `wait` + 5s buffer) so the helper fails fast when testmail.app's API hangs
- Disables redirect following (`redirect: 'error'`) so unexpected 3xx responses surface as errors instead of letting undici retry them up to its default limit
- Logs the underlying error each poll iteration so future regressions are diagnosable

## Why

The e2e-daily workflow was cancelling daily (Apr 18 & 19) because Stage 1 hit its 15m job timeout. Root cause traced via logs:

1. Backend sends the magic link email successfully: `Email sent to k1l43.test-*@inbox.testmail.app via SendGrid` (06:29:36 on 2026-04-19)
2. testmail.app's livequery API was returning redirect loops (Apr 17 failure: `TypeError: fetch failed ... [cause]: Error: redirect count exceeded` at `email-testing.ts:164`)
3. By Apr 18, the same call was hanging indefinitely. Node `fetch` has no default timeout, so the 60s caller timeout in `waitForEmail` was ignored — the call blocked until Playwright's 10m per-test timeout, retried, and got killed when the job's 15m limit expired. Result: silent 15m cancellation instead of a clean 60s failure with Discord alert.

The underlying testmail.app issue was the free-tier quota (100 parsed emails/month, 106 API calls this month) — account has been upgraded. This patch is the defence-in-depth so a provider hang can never again eat the whole job window.

## Test plan

- [ ] After merge, trigger `E2E Daily Test` via `workflow_dispatch` to confirm Stage 1 passes against the upgraded testmail account
- [ ] Confirm tomorrow's scheduled run (06:00 UTC) succeeds
- [ ] If testmail.app ever hangs again, Stage 1 should now fail cleanly in ≤65s with the new `Polling for email... : ...` log line and a Discord alert — no more silent 15m cancels

@coderabbitai ignore