### PR TITLE
security: add gitleaks pre-commit hook and CI scan

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,9 +1,30 @@
-#!/bin/bash
-# Auto-translate when English translation files change.
-# Uses GCS cache so this is near-instant for small changes.
-# Skip with: git commit --no-verify
+#!/usr/bin/env bash
+# Nomad Karaoke pre-commit hook (karaoke-gen variant)
+#   1. Gitleaks secret scan (fail fast)
+#   2. i18n auto-translation when en.json changes
+# Enable: git config core.hooksPath .githooks
+set -eu
 
-set -e
+# ---------------------------------------------------------------------------
+# 1. Gitleaks secret scan
+# ---------------------------------------------------------------------------
+
+if command -v gitleaks >/dev/null 2>&1; then
+  if ! gitleaks protect --staged --redact --no-banner; then
+    printf '\n\033[31m✗ gitleaks detected a potential secret in staged changes.\033[0m\n' >&2
+    printf '  • If real: remove it, rotate the credential, then re-commit.\n' >&2
+    printf '  • If false positive: add an allowlist entry to .gitleaks.toml.\n' >&2
+    printf '  • Emergency override (not recommended): git commit --no-verify\n' >&2
+    exit 1
+  fi
+else
+  printf '\033[33mwarn:\033[0m gitleaks not installed — skipping secret scan\n' >&2
+  printf '      install: brew install gitleaks\n' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# 2. i18n auto-translation
+# ---------------------------------------------------------------------------
 
 STAGED_EN=$(git diff --cached --name-only --diff-filter=ACM | grep -E '(messages|translations)/en\.json$' || true)
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,10 @@
+name: Security
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  gitleaks:
+    uses: nomadkaraoke/.github/.github/workflows/gitleaks.yml@main

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,60 @@
+# Nomad Karaoke shared gitleaks config.
+# Extends the default ruleset with one custom rule for Discord webhooks
+# and an allowlist covering known false-positive paths.
+
+title = "Nomad Karaoke"
+
+[extend]
+useDefault = true
+
+# ---------------------------------------------------------------------------
+# Custom rules
+# ---------------------------------------------------------------------------
+
+[[rules]]
+id = "discord-webhook-url"
+description = "Discord webhook URL (token embedded in URL)"
+regex = '''https://(?:discord|discordapp)\.com/api/webhooks/\d{17,20}/[A-Za-z0-9_-]{60,}'''
+tags = ["discord", "webhook", "secret"]
+
+# ---------------------------------------------------------------------------
+# Global allowlist
+# ---------------------------------------------------------------------------
+
+[allowlist]
+description = "Paths and patterns that are known false positives"
+
+paths = [
+  '''(?i)\.(jpg|jpeg|png|gif|bmp|svg|webp|pdf|ico|mp3|mp4|wav|flac|m4a)$''',
+  '''(^|/)(package-lock\.json|yarn\.lock|pnpm-lock\.yaml|poetry\.lock|Podfile\.lock|Cargo\.lock|go\.sum|composer\.lock|Gemfile\.lock|uv\.lock)$''',
+  '''(^|/)node_modules/''',
+  '''(^|/)vendor/''',
+  '''(^|/)wp-content/''',
+  '''(^|/)\.dart_tool/''',
+  '''(^|/)\.venv/''',
+  '''(^|/)\.next/''',
+  '''(^|/)build/''',
+  '''(^|/)dist/''',
+  '''(^|/)\.flutter-plugins''',
+  '''(^|/)test[-_]?fixtures?/''',
+  '''(^|/)tests?/.*conftest\.py$''',
+  '''(^|/)tests?/.*test_[^/]+\.py$''',
+  '''(^|/)tests?/.*_test\.py$''',
+  '''(^|/).*\.(test|spec)\.(js|mjs|cjs|ts|tsx|jsx)$''',
+  '''(^|/).*\.test\.local\.(js|mjs|cjs|ts|tsx|jsx|py)$''',
+  '''(^|/).*\.local\.(js|mjs|cjs|ts|tsx|jsx|py)$''',
+]
+
+regexes = [
+  # Explicit placeholder patterns
+  '''YOUR_[A-Z_]{2,}''',
+  '''EXAMPLE_[A-Z_]{2,}''',
+  '''PLACEHOLDER_[A-Z_]{2,}''',
+  '''CHANGE[_-]?ME''',
+  '''<[A-Z_]{2,}>''',
+  '''\$\{[A-Z_]{2,}\}''',
+
+  # Firebase / GCP client API keys — public by design (identify the project,
+  # access is gated by Firebase Security Rules).
+  '''AIzaSy[A-Za-z0-9_-]{33}''',
+]


### PR DESCRIPTION
## Summary

Adds org-wide gitleaks secret-scanning in two layers:

1. **Local pre-commit hook** (`.githooks/pre-commit`) — blocks commits containing potential secrets before they're even created. Enable with `git config core.hooksPath .githooks`.
2. **CI backstop** (`.github/workflows/security.yml`) — calls the reusable gitleaks workflow in `nomadkaraoke/.github`, scans every PR and push to `main`.

Config: `.gitleaks.toml` extends the default gitleaks rules with a dedicated Discord-webhook rule and an allowlist for known false-positive paths (lockfiles, vendor/, node_modules/, Flutter `.dart_tool/`, WordPress `wp-content/`, Python test fixtures, Firebase/GCP client API keys).

## Why

Following the 2026-04-17 Discord webhook URL leak — a real webhook URL sat in `nomadkaraoke/karaoke-gen`'s archived setup docs for ~9 months, was scraped, and was used to push malware into the `#releases` channel.

Existing defenses: GitHub push protection (enabled on all public repos). This PR adds the two missing layers (local pre-commit, CI).

## Test plan

- [ ] After merge, create a test commit with a fake Discord webhook URL — the CI job should fail.
- [ ] Run `brew install gitleaks && git config core.hooksPath .githooks` locally, then attempt the same commit — the pre-commit hook should block it.

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)