### PR TITLE
fix(error-monitor): alert on out-of-band patterns (e.g. frontend crashes)

### DIFF
--- a/backend/services/error_monitor/firestore_adapter.py
+++ b/backend/services/error_monitor/firestore_adapter.py
@@ -137,6 +137,19 @@ class ErrorPatternsAdapter:
         )
         return [snap.to_dict() for snap in query.stream()]
 
+    def get_unalerted_new_patterns(self) -> list[dict]:
+        """Return patterns with status="new" and alerted_at=None.
+
+        These are typically patterns written by a path other than the current
+        monitor cycle — most notably frontend crashes ingested via
+        ``POST /api/client-errors``. The monitor uses this to ensure out-of-band
+        patterns still get a Discord alert on the next scheduled run.
+        """
+        query = self._db.collection(_COL_PATTERNS).where(
+            "status", "==", "new"
+        ).where("alerted_at", "==", None)
+        return [snap.to_dict() for snap in query.stream()]
+
     # ------------------------------------------------------------------
     # Patterns — upsert
     # ------------------------------------------------------------------

--- a/backend/services/error_monitor/monitor.py
+++ b/backend/services/error_monitor/monitor.py
@@ -356,11 +356,6 @@ class ErrorMonitor:
         groups = _group_by_pattern(raw_entries)
         logger.info("Grouped into %d distinct patterns", len(groups))
 
-        if not groups:
-            logger.info("No new error entries found this cycle; checking auto-resolve.")
-            self._check_auto_resolve()
-            return
-
         # ── Step 3: Upsert to Firestore ────────────────────────────────────
         new_pattern_ids: list[str] = []
         spike_patterns: list[dict] = []
@@ -394,6 +389,43 @@ class ErrorMonitor:
                         }
                     )
                     logger.info("Spike detected for pattern %s", pattern_id)
+
+        # ── Step 3b: Pick up out-of-band patterns (e.g. frontend crashes) ──
+        # Patterns written via POST /api/client-errors land directly in
+        # Firestore without going through the log-scraping pipeline, so they
+        # won't be in new_pattern_ids / groups from Steps 1-3. Ensure any
+        # pattern with status="new" and alerted_at=None still gets a Discord
+        # alert on this cycle.
+        try:
+            unalerted = self.firestore_adapter.get_unalerted_new_patterns()
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to query unalerted patterns: %s", exc)
+            unalerted = []
+
+        for pattern in unalerted:
+            pid = pattern.get("pattern_id")
+            if not pid or pid in groups:
+                continue
+            groups[pid] = {
+                "service": pattern.get("service", "unknown"),
+                "resource_type": pattern.get("resource_type", "unknown"),
+                "normalized": pattern.get("normalized_message", ""),
+                "sample_message": pattern.get("sample_message", ""),
+                "count": pattern.get("total_count", 1),
+            }
+            if pid not in new_pattern_ids:
+                new_pattern_ids.append(pid)
+                logger.info(
+                    "Picked up out-of-band pattern %s (%s)",
+                    pid,
+                    pattern.get("service", "unknown"),
+                )
+
+        # If nothing to alert on this cycle, go straight to auto-resolve.
+        if not new_pattern_ids and not spike_patterns:
+            logger.info("No new or unalerted patterns this cycle; checking auto-resolve.")
+            self._check_auto_resolve()
+            return
 
         # ── Step 4: LLM dedup ─────────────────────────────────────────────
         if new_pattern_ids and get_llm_enabled():

--- a/tests/unit/services/error_monitor/test_firestore_adapter.py
+++ b/tests/unit/services/error_monitor/test_firestore_adapter.py
@@ -1115,3 +1115,73 @@ class TestGetPatternsForAutoResolve:
 
         assert isinstance(results, list)
         assert results[0]["pattern_id"] == "p1"
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_unalerted_new_patterns
+# ---------------------------------------------------------------------------
+
+
+class TestGetUnalertedNewPatterns:
+    """get_unalerted_new_patterns should filter for status=new AND alerted_at=None."""
+
+    def test_queries_correct_collection_and_filters(self):
+        db = _make_db()
+        # Two chained .where() calls, final stream() returns []
+        second_where = MagicMock()
+        second_where.stream.return_value = []
+        first_where = MagicMock()
+        first_where.where.return_value = second_where
+        db.collection.return_value.where.return_value = first_where
+
+        Adapter = _import_adapter()
+        adapter = Adapter(db=db)
+        adapter.get_unalerted_new_patterns()
+
+        db.collection.assert_called_with("error_patterns")
+        # first .where should filter status=="new"
+        first_where_call = db.collection.return_value.where.call_args
+        assert first_where_call is not None
+        # second .where should filter alerted_at==None
+        second_where_call = first_where.where.call_args
+        assert second_where_call is not None
+
+    def test_returns_list_of_dicts(self):
+        db = _make_db()
+        snap = _make_doc_snapshot(
+            exists=True,
+            data={
+                "pattern_id": "fe_p1",
+                "service": "frontend",
+                "status": "new",
+                "alerted_at": None,
+            },
+        )
+        second_where = MagicMock()
+        second_where.stream.return_value = [snap]
+        first_where = MagicMock()
+        first_where.where.return_value = second_where
+        db.collection.return_value.where.return_value = first_where
+
+        Adapter = _import_adapter()
+        adapter = Adapter(db=db)
+        results = adapter.get_unalerted_new_patterns()
+
+        assert isinstance(results, list)
+        assert len(results) == 1
+        assert results[0]["pattern_id"] == "fe_p1"
+        assert results[0]["service"] == "frontend"
+
+    def test_returns_empty_when_no_matches(self):
+        db = _make_db()
+        second_where = MagicMock()
+        second_where.stream.return_value = []
+        first_where = MagicMock()
+        first_where.where.return_value = second_where
+        db.collection.return_value.where.return_value = first_where
+
+        Adapter = _import_adapter()
+        adapter = Adapter(db=db)
+        results = adapter.get_unalerted_new_patterns()
+
+        assert results == []


### PR DESCRIPTION
@coderabbitai ignore

Follow-up to #725 — found during post-deploy verification. The error-monitor Cloud Run Job only alerted on patterns its own Cloud Logging scan produced. Frontend crash patterns inserted via the new \`POST /api/client-errors\` endpoint landed in Firestore with \`status=new\`/\`alerted_at=None\` but never fired a Discord alert.

## Fix

- New adapter method \`get_unalerted_new_patterns()\` — queries Firestore for \`status=new\` AND \`alerted_at=None\`.
- New Step 3b in the monitor cycle merges those out-of-band patterns into \`new_pattern_ids\` + \`groups\` before the LLM/dedup/alert steps.
- Early-exit moved from "no log entries" to "no patterns AND no unalerted" so an empty-log cycle still flushes pending frontend alerts.
- 3 new unit tests for the adapter method.

## Verified reproduction (pre-fix)

Three frontend patterns from #725's live-verification are currently sitting in \`error_patterns\` with \`alerted_at=None\`:
- \`fad2f5811881700e...\` (curl probe)
- \`f84b386bc152102e...\` (async throw via Firefox)
- \`13a3b42284f7e66f...\` (unhandled rejection via Firefox)

The 01:31 UTC monitor execution ran and processed 1 backend log entry — our 3 frontend patterns were ignored because they weren't in \`new_pattern_ids\`.

## Test plan

- [ ] Merge + deploy.
- [ ] Manually trigger the Cloud Run Job (\`gcloud run jobs execute nomad-error-monitor --region=us-central1\`).
- [ ] Confirm Discord receives 3 alerts for the pending frontend patterns.
- [ ] Confirm those patterns now have \`alerted_at\` set in Firestore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)