### PR TITLE
feat(dr): close gaps from DR drill — secrets backup, freshness monitor, drill reminder

### DIFF
--- a/.github/workflows/dr-backup-freshness.yml
+++ b/.github/workflows/dr-backup-freshness.yml
@@ -1,0 +1,155 @@
+name: DR backup freshness monitor
+
+# Off-platform monitor: runs in GitHub (not GCP) so it survives a full GCP
+# compromise. If the nightly backup pipeline dies silently, this catches it.
+#
+# Required secrets:
+#   AWS_BACKUP_READONLY_ACCESS_KEY_ID
+#   AWS_BACKUP_READONLY_SECRET_ACCESS_KEY
+#   DR_MONITOR_DISCORD_WEBHOOK
+#
+# Setup: see docs/DISASTER-RECOVERY.md § "Backup freshness monitor".
+
+on:
+  schedule:
+    # Daily at 14:00 UTC (~9h after the 1am ET backup window).
+    - cron: "0 14 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  check-freshness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_BACKUP_READONLY_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_BACKUP_READONLY_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: us-east-1
+      BUCKET: nomadkaraoke-backup
+      DISCORD_WEBHOOK: ${{ secrets.DR_MONITOR_DISCORD_WEBHOOK }}
+      # Alert if the most recent backup of any tracked dataset is older than this.
+      MAX_AGE_HOURS: "36"
+
+    steps:
+      - name: Verify required secrets are set
+        run: |
+          missing=0
+          for var in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY DISCORD_WEBHOOK; do
+            if [ -z "${!var}" ]; then
+              echo "::error::Required secret $var is empty"
+              missing=1
+            fi
+          done
+          [ "$missing" = "0" ] || exit 1
+
+      - name: Check freshness of each tracked prefix
+        id: check
+        shell: bash
+        run: |
+          set -euo pipefail
+          now_epoch=$(date -u +%s)
+          max_age_seconds=$(( MAX_AGE_HOURS * 3600 ))
+          stale=()
+          ok=()
+
+          # Each entry: "label|prefix|max_age_hours_override(optional)"
+          targets=(
+            "Firestore|firestore/|36"
+            "GCS job files|gcs/job-files/|36"
+            "Encrypted secrets|secrets/|36"
+            "BigQuery weekly|bigquery/daily-refresh/|192"
+          )
+
+          for target in "${targets[@]}"; do
+            IFS='|' read -r label prefix max_hours <<< "$target"
+            max_age=$(( max_hours * 3600 ))
+
+            # LastModified of the most recent object under the prefix.
+            latest=$(
+              aws s3api list-objects-v2 \
+                --bucket "$BUCKET" \
+                --prefix "$prefix" \
+                --query 'reverse(sort_by(Contents,&LastModified))[0].LastModified' \
+                --output text 2>/dev/null || echo "None"
+            )
+
+            if [ "$latest" = "None" ] || [ -z "$latest" ]; then
+              stale+=("$label: NO OBJECTS in s3://$BUCKET/$prefix")
+              continue
+            fi
+
+            latest_epoch=$(date -u -d "$latest" +%s 2>/dev/null || python3 -c "
+            import sys, datetime
+            print(int(datetime.datetime.fromisoformat(sys.argv[1].replace('Z','+00:00')).timestamp()))
+            " "$latest")
+            age_seconds=$(( now_epoch - latest_epoch ))
+            age_hours=$(( age_seconds / 3600 ))
+
+            if [ "$age_seconds" -gt "$max_age" ]; then
+              stale+=("$label: ${age_hours}h old (limit ${max_hours}h) — last $latest")
+            else
+              ok+=("$label: ${age_hours}h old — last $latest")
+            fi
+          done
+
+          {
+            echo "ok_count=${#ok[@]}"
+            echo "stale_count=${#stale[@]}"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## DR backup freshness"
+            echo
+            if [ "${#stale[@]}" -gt 0 ]; then
+              echo "### Stale"
+              for s in "${stale[@]}"; do echo "- $s"; done
+              echo
+            fi
+            echo "### Fresh"
+            for o in "${ok[@]}"; do echo "- $o"; done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${#stale[@]}" -gt 0 ]; then
+            printf 'STALE_LIST<<EOF\n%s\nEOF\n' "$(printf '%s\n' "${stale[@]}")" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+      - name: Alert Discord on stale backup
+        if: failure() && steps.check.outputs.stale_count != ''
+        env:
+          STALE: ${{ steps.check.outputs.STALE_LIST }}
+        run: |
+          payload=$(jq -n \
+            --arg title "🚨 DR backup is stale" \
+            --arg desc "$STALE" \
+            --arg url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{
+               embeds: [{
+                 title: $title,
+                 description: $desc,
+                 color: 15158332,
+                 fields: [{name: "Workflow run", value: $url}]
+               }]
+             }')
+          curl -fsS -X POST -H "Content-Type: application/json" \
+            -d "$payload" "$DISCORD_WEBHOOK"
+
+      - name: Alert Discord on workflow failure (catch-all)
+        if: failure() && steps.check.outputs.stale_count == ''
+        run: |
+          payload=$(jq -n \
+            --arg title "⚠️ DR freshness monitor failed to run" \
+            --arg desc "Could not list S3 backup bucket — credentials, network, or bucket policy may be broken." \
+            --arg url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{
+               embeds: [{
+                 title: $title,
+                 description: $desc,
+                 color: 15844367,
+                 fields: [{name: "Workflow run", value: $url}]
+               }]
+             }')
+          curl -fsS -X POST -H "Content-Type: application/json" \
+            -d "$payload" "$DISCORD_WEBHOOK"

--- a/.github/workflows/dr-backup-freshness.yml
+++ b/.github/workflows/dr-backup-freshness.yml
@@ -29,8 +29,6 @@ jobs:
       AWS_DEFAULT_REGION: us-east-1
       BUCKET: nomadkaraoke-backup
       DISCORD_WEBHOOK: ${{ secrets.DR_MONITOR_DISCORD_WEBHOOK }}
-      # Alert if the most recent backup of any tracked dataset is older than this.
-      MAX_AGE_HOURS: "36"
 
     steps:
       - name: Verify required secrets are set
@@ -44,77 +42,73 @@ jobs:
           done
           [ "$missing" = "0" ] || exit 1
 
+      - name: Install boto3
+        run: pip install --quiet boto3
+
       - name: Check freshness of each tracked prefix
         id: check
         shell: bash
         run: |
-          set -euo pipefail
-          now_epoch=$(date -u +%s)
-          max_age_seconds=$(( MAX_AGE_HOURS * 3600 ))
-          stale=()
-          ok=()
+          python3 - <<'PY'
+          import os, sys, datetime, boto3
 
-          # Each entry: "label|prefix|max_age_hours_override(optional)"
-          targets=(
-            "Firestore|firestore/|36"
-            "GCS job files|gcs/job-files/|36"
-            "Encrypted secrets|secrets/|36"
-            "BigQuery weekly|bigquery/daily-refresh/|192"
-          )
+          BUCKET = os.environ["BUCKET"]
+          # (label, prefix, max_age_hours)
+          TARGETS = [
+              ("Firestore",         "firestore/",              36),
+              ("GCS job files",     "gcs/job-files/",          36),
+              ("Encrypted secrets", "secrets/",                36),
+              ("BigQuery weekly",   "bigquery/daily-refresh/", 192),
+          ]
 
-          for target in "${targets[@]}"; do
-            IFS='|' read -r label prefix max_hours <<< "$target"
-            max_age=$(( max_hours * 3600 ))
+          s3 = boto3.client("s3")
+          now = datetime.datetime.now(datetime.timezone.utc)
+          stale, ok = [], []
 
-            # LastModified of the most recent object under the prefix.
-            latest=$(
-              aws s3api list-objects-v2 \
-                --bucket "$BUCKET" \
-                --prefix "$prefix" \
-                --query 'reverse(sort_by(Contents,&LastModified))[0].LastModified' \
-                --output text 2>/dev/null || echo "None"
-            )
+          # Paginated scan — JMESPath --query on `aws s3api list-objects-v2`
+          # operates per-page, which silently breaks "newest across all pages"
+          # queries on prefixes with >1000 objects (e.g. firestore/ has ~22k).
+          paginator = s3.get_paginator("list_objects_v2")
+          for label, prefix, max_hours in TARGETS:
+              latest = None
+              for page in paginator.paginate(Bucket=BUCKET, Prefix=prefix):
+                  for obj in page.get("Contents", []):
+                      if latest is None or obj["LastModified"] > latest:
+                          latest = obj["LastModified"]
 
-            if [ "$latest" = "None" ] || [ -z "$latest" ]; then
-              stale+=("$label: NO OBJECTS in s3://$BUCKET/$prefix")
-              continue
-            fi
+              if latest is None:
+                  stale.append(f"{label}: NO OBJECTS in s3://{BUCKET}/{prefix}")
+                  continue
+              age = (now - latest).total_seconds()
+              age_h = int(age // 3600)
+              line = f"{label}: {age_h}h old (limit {max_hours}h) — last {latest.isoformat()}"
+              (stale if age > max_hours * 3600 else ok).append(line)
 
-            latest_epoch=$(date -u -d "$latest" +%s 2>/dev/null || python3 -c "
-            import sys, datetime
-            print(int(datetime.datetime.fromisoformat(sys.argv[1].replace('Z','+00:00')).timestamp()))
-            " "$latest")
-            age_seconds=$(( now_epoch - latest_epoch ))
-            age_hours=$(( age_seconds / 3600 ))
+          summary = ["## DR backup freshness", ""]
+          if stale:
+              summary.append("### Stale")
+              summary.extend(f"- {s}" for s in stale)
+              summary.append("")
+          summary.append("### Fresh")
+          summary.extend(f"- {o}" for o in ok)
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
+              f.write("\n".join(summary) + "\n")
 
-            if [ "$age_seconds" -gt "$max_age" ]; then
-              stale+=("$label: ${age_hours}h old (limit ${max_hours}h) — last $latest")
-            else
-              ok+=("$label: ${age_hours}h old — last $latest")
-            fi
-          done
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"ok_count={len(ok)}\n")
+              f.write(f"stale_count={len(stale)}\n")
+              if stale:
+                  f.write("STALE_LIST<<EOF\n")
+                  f.write("\n".join(stale) + "\n")
+                  f.write("EOF\n")
 
-          {
-            echo "ok_count=${#ok[@]}"
-            echo "stale_count=${#stale[@]}"
-          } >> "$GITHUB_OUTPUT"
-
-          {
-            echo "## DR backup freshness"
-            echo
-            if [ "${#stale[@]}" -gt 0 ]; then
-              echo "### Stale"
-              for s in "${stale[@]}"; do echo "- $s"; done
-              echo
-            fi
-            echo "### Fresh"
-            for o in "${ok[@]}"; do echo "- $o"; done
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          if [ "${#stale[@]}" -gt 0 ]; then
-            printf 'STALE_LIST<<EOF\n%s\nEOF\n' "$(printf '%s\n' "${stale[@]}")" >> "$GITHUB_OUTPUT"
-            exit 1
-          fi
+          for o in ok:
+              print("OK:", o)
+          if stale:
+              for s in stale:
+                  print("STALE:", s, file=sys.stderr)
+              sys.exit(1)
+          PY
 
       - name: Alert Discord on stale backup
         if: failure() && steps.check.outputs.stale_count != ''

--- a/docs/DISASTER-RECOVERY.md
+++ b/docs/DISASTER-RECOVERY.md
@@ -1,7 +1,9 @@
 # Disaster Recovery Runbook
 
-**Last updated:** 2026-03-29
+**Last updated:** 2026-04-20
 **Design doc:** `docs/archive/2026-03-27-business-continuity-design.md`
+**Implementation plan:** `docs/archive/2026-03-29-business-continuity-plan.md`
+**External services reference:** `docs/archive/2026-03-29-external-services-config.md`
 
 ## Quick Reference
 
@@ -12,7 +14,20 @@
 | BigQuery (monthly) | S3 `bigquery/musicbrainz/` | Load Parquet files | 30 days |
 | BigQuery (Spotify) | S3 `bigquery/spotify/` | Load from Glacier Deep Archive | N/A (static) |
 | GCS job files | S3 `gcs/job-files/` | Sync to new bucket | 24h |
-| Secrets | AWS Secrets Manager | Decrypt with KMS, configure | On-change |
+| Secret Manager | S3 `secrets/YYYY-MM-DD.bin` (sealed-box encrypted) | Decrypt with private key from KeepassXC | 24h |
+| AWS credentials (function) | GCP Secret Manager `aws-backup-credentials` | Read directly | On-change |
+| AWS credentials (offline) | KeepassXC — "Nomad Karaoke — DR backup AWS access" | Manual lookup | On-change |
+| Backup decryption key | KeepassXC — "Nomad Karaoke — DR backup decryption key" | Manual lookup | One-time |
+
+## Prerequisites — verify these BEFORE you need them
+
+- [ ] KeepassXC contains "Nomad Karaoke — DR backup AWS access" (access key, secret key, region, S3 bucket name)
+- [ ] KeepassXC contains "Nomad Karaoke — DR backup decryption key" (Curve25519 private key, 64 hex chars)
+- [ ] GitHub repo `nomadkaraoke/karaoke-gen` has the secrets `AWS_BACKUP_READONLY_ACCESS_KEY_ID`, `AWS_BACKUP_READONLY_SECRET_ACCESS_KEY`, `DR_MONITOR_DISCORD_WEBHOOK` configured (powers the freshness monitor)
+- [ ] You can decrypt yesterday's secrets backup locally (run the drill in § "Quarterly restore drill")
+- [ ] Your KeepassXC database itself is backed up off-machine (cloud sync, second device, or printed paper recovery)
+
+If any of these fail, fix them now — not during an incident.
 
 ## Scenario 1: Accidental Data Deletion (GCP Still Available)
 
@@ -29,9 +44,8 @@ gcloud firestore databases restore \
 
 **Option B — Import from S3 backup:**
 ```bash
-# Download latest export from S3
-aws s3 sync s3://nomadkaraoke-backup/firestore/LATEST_DATE/ /tmp/firestore-restore/ \
-  --profile nomadkaraoke-backup
+# Download latest export from S3 (set creds first — see § "Setting AWS creds locally")
+aws s3 sync s3://nomadkaraoke-backup/firestore/LATEST_DATE/ /tmp/firestore-restore/
 
 # Upload to GCS
 gsutil -m cp -r /tmp/firestore-restore/ gs://nomadkaraoke-backup-staging/firestore-import/
@@ -57,8 +71,7 @@ FOR SYSTEM_TIME AS OF TIMESTAMP("2026-03-28 12:00:00 UTC");
 **Option B — Load from S3 backup:**
 ```bash
 # Download Parquet exports
-aws s3 sync s3://nomadkaraoke-backup/bigquery/daily-refresh/LATEST_DATE/ /tmp/bq-restore/ \
-  --profile nomadkaraoke-backup
+aws s3 sync s3://nomadkaraoke-backup/bigquery/daily-refresh/LATEST_DATE/ /tmp/bq-restore/
 
 # Load each table
 bq load --source_format=PARQUET \
@@ -68,31 +81,63 @@ bq load --source_format=PARQUET \
 
 ### GCS Recovery
 
-**Option A — Object versioning (within 30 days):**
-```bash
-# List versions of a deleted/overwritten object
-gsutil ls -a gs://karaoke-gen-storage-nomadkaraoke/jobs/JOB_ID/
+The primary bucket has **two** independent recovery paths. Pick whichever applies.
 
-# Restore a specific version
-gsutil cp gs://karaoke-gen-storage-nomadkaraoke/jobs/JOB_ID/file.flac#VERSION \
+**Option A — GCS soft-delete (within 7 days, default-on, no special config):**
+```bash
+# List soft-deleted objects under a prefix
+gcloud storage ls --soft-deleted gs://karaoke-gen-storage-nomadkaraoke/jobs/JOB_ID/
+
+# Restore a specific soft-deleted object (note the generation number from the listing)
+gcloud storage restore gs://karaoke-gen-storage-nomadkaraoke/jobs/JOB_ID/file.flac#GENERATION
+```
+
+**Option B — Object versioning (within 30 days, restores overwritten/deleted versions):**
+
+Requires versioning to be enabled on the bucket — confirm with `gcloud storage buckets describe gs://karaoke-gen-storage-nomadkaraoke --format="value(versioning.enabled)"`. The Pulumi config in `infrastructure/modules/storage.py` enables it; if the live bucket reports `False`, run `pulumi up` to reconcile before relying on this path.
+
+```bash
+# List all versions (including non-current) of a path
+gcloud storage ls -a gs://karaoke-gen-storage-nomadkaraoke/jobs/JOB_ID/
+
+# Copy a specific non-current generation back to live
+gcloud storage cp gs://karaoke-gen-storage-nomadkaraoke/jobs/JOB_ID/file.flac#GENERATION \
   gs://karaoke-gen-storage-nomadkaraoke/jobs/JOB_ID/file.flac
 ```
 
-**Option B — Restore from S3:**
+**Option C — Restore from S3 (if A and B both miss the window):**
 ```bash
-aws s3 sync s3://nomadkaraoke-backup/gcs/job-files/jobs/JOB_ID/ /tmp/gcs-restore/ \
-  --profile nomadkaraoke-backup
+aws s3 sync s3://nomadkaraoke-backup/gcs/job-files/jobs/JOB_ID/ /tmp/gcs-restore/
 
 gsutil -m cp -r /tmp/gcs-restore/ gs://karaoke-gen-storage-nomadkaraoke/jobs/JOB_ID/
 ```
+
+### Secret Manager Recovery
+
+**Option A — GCP Secret Manager versioning (Secret Manager keeps every version by default):**
+```bash
+# List versions
+gcloud secrets versions list SECRET_NAME --project=nomadkaraoke
+
+# Inspect any prior version
+gcloud secrets versions access VERSION_NUMBER --secret=SECRET_NAME --project=nomadkaraoke
+
+# Restore: create a new "latest" version with the old payload
+gcloud secrets versions access VERSION_NUMBER --secret=SECRET_NAME --project=nomadkaraoke \
+  | gcloud secrets versions add SECRET_NAME --data-file=- --project=nomadkaraoke
+```
+
+**Option B — Decrypt the encrypted S3 backup (use if a secret was deleted entirely):**
+See § "Decrypting the secrets backup" below.
 
 ## Scenario 2: Complete GCP Project Loss
 
 ### Prerequisites
 
-- AWS credentials from password manager
-- AWS KMS key ARN from password manager
+- AWS credentials from KeepassXC ("Nomad Karaoke — DR backup AWS access")
+- Backup decryption key from KeepassXC ("Nomad Karaoke — DR backup decryption key")
 - All GitHub repos (code + IaC)
+- A working machine with Python 3.10+ and `pynacl` installable
 
 ### Step-by-Step Recovery
 
@@ -101,21 +146,28 @@ gsutil -m cp -r /tmp/gcs-restore/ gs://karaoke-gen-storage-nomadkaraoke/jobs/JOB
 gcloud projects create nomadkaraoke-v2 --name="Nomad Karaoke"
 gcloud config set project nomadkaraoke-v2
 gcloud services enable firestore.googleapis.com run.googleapis.com \
-  cloudfunctions.googleapis.com cloudscheduler.googleapis.com \
+  cloudfunctionsv2.googleapis.com cloudscheduler.googleapis.com \
   secretmanager.googleapis.com bigquery.googleapis.com \
   cloudtasks.googleapis.com artifactregistry.googleapis.com
 ```
 
-**2. Retrieve AWS credentials**
-
-Get from password manager: AWS access key, secret key, KMS key ARN.
+**2. Set AWS credentials locally** — see § "Setting AWS creds locally" below.
 
 **3. Restore Firestore**
 ```bash
-aws s3 sync s3://nomadkaraoke-backup/firestore/LATEST_DATE/ /tmp/firestore-restore/ \
-  --profile nomadkaraoke-backup
-gsutil -m cp -r /tmp/firestore-restore/ gs://NEW_BUCKET/firestore-import/
-gcloud firestore import gs://NEW_BUCKET/firestore-import/ --project=nomadkaraoke-v2
+# Find the latest backup date
+LATEST_DATE=$(aws s3 ls s3://nomadkaraoke-backup/firestore/ | awk '{print $2}' | tr -d '/' | sort | tail -1)
+echo "Restoring from $LATEST_DATE"
+
+# Create a temporary GCS bucket in the new project to land the import
+gsutil mb -l US-CENTRAL1 gs://nomadkaraoke-v2-firestore-import/
+
+aws s3 sync "s3://nomadkaraoke-backup/firestore/${LATEST_DATE}/" /tmp/firestore-restore/
+gsutil -m cp -r /tmp/firestore-restore/ gs://nomadkaraoke-v2-firestore-import/
+
+# The Firestore import requires the metadata file emitted by the export — find it
+META=$(gsutil ls "gs://nomadkaraoke-v2-firestore-import/firestore-restore/**/all_namespaces*.overall_export_metadata" | head -1)
+gcloud firestore import "$META" --project=nomadkaraoke-v2
 ```
 
 **4. Restore BigQuery**
@@ -123,12 +175,16 @@ gcloud firestore import gs://NEW_BUCKET/firestore-import/ --project=nomadkaraoke
 # Create dataset
 bq mk --dataset nomadkaraoke-v2:karaoke_decide
 
-# Download and load each table
-for prefix in daily-refresh musicbrainz; do
-  aws s3 sync s3://nomadkaraoke-backup/bigquery/$prefix/LATEST_DATE/ /tmp/bq-$prefix/ \
-    --profile nomadkaraoke-backup
+# Find latest dates
+DAILY_DATE=$(aws s3 ls s3://nomadkaraoke-backup/bigquery/daily-refresh/ | awk '{print $2}' | tr -d '/' | sort | tail -1)
+MONTHLY_DATE=$(aws s3 ls s3://nomadkaraoke-backup/bigquery/musicbrainz/ | awk '{print $2}' | tr -d '/' | sort | tail -1)
+
+for spec in "daily-refresh|$DAILY_DATE" "musicbrainz|$MONTHLY_DATE"; do
+  prefix=${spec%|*}
+  date=${spec#*|}
+  aws s3 sync "s3://nomadkaraoke-backup/bigquery/$prefix/$date/" "/tmp/bq-$prefix/"
   for dir in /tmp/bq-$prefix/*/; do
-    table=$(basename $dir)
+    table=$(basename "$dir")
     bq load --source_format=PARQUET nomadkaraoke-v2:karaoke_decide.$table "$dir*.parquet"
   done
 done
@@ -136,64 +192,221 @@ done
 
 **Spotify tables (Glacier Deep Archive):** Retrieval takes 12-48 hours.
 ```bash
-# Initiate restore (bulk = cheapest, ~$150 for 1TB)
+# Initiate restore (bulk = cheapest)
 aws s3api restore-object --bucket nomadkaraoke-backup \
   --key "bigquery/spotify/TABLE/part-000.parquet" \
-  --restore-request '{"Days":7,"GlacierJobParameters":{"Tier":"Bulk"}}' \
-  --profile nomadkaraoke-backup
+  --restore-request '{"Days":7,"GlacierJobParameters":{"Tier":"Bulk"}}'
 # Wait 12-48 hours, then download and load
 ```
 
 **5. Restore GCS files**
+
 ```bash
 # Create new bucket
 gsutil mb -l US-CENTRAL1 gs://karaoke-gen-storage-nomadkaraoke-v2/
 
-# Sync from S3
-aws s3 sync s3://nomadkaraoke-backup/gcs/job-files/ /tmp/gcs-restore/ \
-  --profile nomadkaraoke-backup
+# Sync from S3 (146 GB last we measured — needs a host with comparable disk + bandwidth)
+aws s3 sync s3://nomadkaraoke-backup/gcs/job-files/ /tmp/gcs-restore/
 gsutil -m cp -r /tmp/gcs-restore/ gs://karaoke-gen-storage-nomadkaraoke-v2/
 ```
 
-**6. Restore secrets**
-```bash
-# Retrieve all secrets from AWS Secrets Manager
-aws secretsmanager get-secret-value --secret-id nomadkaraoke-gcp-secrets \
-  --profile nomadkaraoke-backup | jq -r '.SecretString' > /tmp/secrets.json
+**6. Restore secrets** — decrypt the latest sealed-box backup and recreate each secret.
 
-# Create each secret in new project
-python3 -c "
-import json
-with open('/tmp/secrets.json') as f:
-    secrets = json.load(f)
-for name, value in secrets.items():
-    print(f'echo -n \"{value}\" | gcloud secrets create {name} --data-file=- --project=nomadkaraoke-v2')
-"
-# Review and run the generated commands
-rm /tmp/secrets.json
+```bash
+# Get the latest encrypted bundle
+LATEST=$(aws s3 ls s3://nomadkaraoke-backup/secrets/ | awk '{print $NF}' | sort | tail -1)
+aws s3 cp "s3://nomadkaraoke-backup/secrets/$LATEST" /tmp/secrets.bin
+
+# Install decryption tool if needed
+pip install pynacl
+
+# Decrypt — pulls private key from KeepassXC
+PRIVATE_KEY_HEX="<paste from KeepassXC 'DR backup decryption key'>"
+python3 - <<PY > /tmp/secrets.json
+from nacl.public import PrivateKey, SealedBox
+import os, json
+sk = PrivateKey(bytes.fromhex(os.environ['PRIVATE_KEY_HEX']))
+ct = open('/tmp/secrets.bin', 'rb').read()
+print(SealedBox(sk).decrypt(ct).decode('utf-8'))
+PY
+
+# Recreate every secret in the new project. Review the generated commands first.
+python3 - <<'PY' > /tmp/restore_secrets.sh
+import json, base64, shlex
+bundle = json.load(open('/tmp/secrets.json'))
+for name, entry in bundle['secrets'].items():
+    if 'error' in entry:
+        print(f"# SKIPPED {name}: {entry['error']}", )
+        continue
+    raw = entry['value']
+    if entry['encoding'] == 'base64':
+        # Pipe binary through base64 -d to avoid shell-escaping issues
+        print(f"echo {shlex.quote(raw)} | base64 -d | gcloud secrets create {name} --data-file=- --project=nomadkaraoke-v2")
+    else:
+        print(f"printf %s {shlex.quote(raw)} | gcloud secrets create {name} --data-file=- --project=nomadkaraoke-v2")
+PY
+
+# Inspect, then execute
+less /tmp/restore_secrets.sh
+bash /tmp/restore_secrets.sh
+
+# Cleanup
+shred -u /tmp/secrets.json /tmp/secrets.bin /tmp/restore_secrets.sh
+unset PRIVATE_KEY_HEX
 ```
 
-**7. Rebuild infrastructure**
+**7. Set Pulumi config for new project**
 ```bash
 cd karaoke-gen/infrastructure
-# Update config.py with new project ID
+pulumi stack init disaster-recovery --copy-config-from prod
 pulumi config set gcp:project nomadkaraoke-v2
+# The backup encryption pubkey from the prior project still works — its private
+# key is in KeepassXC. Either copy it from the old stack or set fresh.
+pulumi config set backupEncryptionPubkey <hex>
+```
+
+**8. Rebuild infrastructure**
+```bash
 pulumi up
 ```
 
-**8. Deploy services**
+**9. Update CI/CD to target the new project**
+
+GitHub Actions secrets reference `nomadkaraoke` (old project ID). Update them so deploys land in the new project:
+
 ```bash
-# Push to GitHub triggers CI/CD, or deploy manually:
-gcloud run deploy karaoke-backend --source=. --project=nomadkaraoke-v2
+# In the karaoke-gen repo, update these secrets to the new project / new SA key:
+gh secret set GCP_PROJECT_ID --body "nomadkaraoke-v2"
+gh secret set GCP_SA_KEY --body "$(cat ~/path/to/new-deploy-sa-key.json)"
+# (If using Workload Identity Federation, update the audience instead.)
 ```
 
-**9. Update DNS (Cloudflare)**
+Then trigger a deploy or `git push` to redeploy backend + frontend.
+
+**10. Update DNS (Cloudflare)**
 
 Update DNS records to point to new Cloud Run URLs. See `docs/archive/2026-03-29-external-services-config.md`.
 
-**10. Re-register OAuth apps**
+**11. Re-register OAuth apps and rotate API keys**
 
-Re-create OAuth apps at Spotify, Google, Dropbox with redirect URIs from `docs/archive/2026-03-29-external-services-config.md`.
+Some external services lock to redirect URIs or treat the old GCP project ID as part of their config. Walk through `docs/archive/2026-03-29-external-services-config.md` end-to-end:
+
+- Spotify Web API + Spotify Connect (redirect URIs)
+- Google OAuth (redirect URIs, OAuth consent screen)
+- Dropbox app (redirect URIs)
+- YouTube OAuth (redirect URIs)
+- Stripe webhook endpoint URL (secret regenerates)
+- AudioShake API key (rotate as a precaution if old project was compromised)
+- Gemini / Vertex API (project-scoped — needs new project enabled)
+- Discord webhook URLs (re-issue if old GCP exposure could have leaked them)
+- Cloudflare API tokens (rotate)
+
+## Decrypting the secrets backup
+
+```bash
+# Set AWS creds (see § "Setting AWS creds locally")
+LATEST=$(aws s3 ls s3://nomadkaraoke-backup/secrets/ | awk '{print $NF}' | sort | tail -1)
+aws s3 cp "s3://nomadkaraoke-backup/secrets/$LATEST" /tmp/secrets.bin
+
+pip install pynacl
+PRIVATE_KEY_HEX="<paste from KeepassXC>"
+python3 -c "
+import os, json
+from nacl.public import PrivateKey, SealedBox
+sk = PrivateKey(bytes.fromhex(os.environ['PRIVATE_KEY_HEX']))
+bundle = json.loads(SealedBox(sk).decrypt(open('/tmp/secrets.bin','rb').read()))
+print(json.dumps({k: '***' for k in bundle['secrets']}, indent=2))
+print('Exported at:', bundle['exported_at'])
+"
+shred -u /tmp/secrets.bin
+unset PRIVATE_KEY_HEX
+```
+
+## Setting AWS creds locally
+
+The function reads creds from GCP Secret Manager. For local recovery work, retrieve them from KeepassXC (preferred — survives GCP outage) or from Secret Manager (if GCP is up):
+
+```bash
+# If GCP is still up:
+CREDS=$(gcloud secrets versions access latest --secret=aws-backup-credentials --project=nomadkaraoke)
+export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -r .access_key_id)
+export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | jq -r .secret_access_key)
+export AWS_DEFAULT_REGION=$(echo "$CREDS" | jq -r .region)
+
+# If GCP is gone — paste from KeepassXC:
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_DEFAULT_REGION=us-east-1
+```
+
+## Backup freshness monitor
+
+A GitHub Actions cron (`.github/workflows/dr-backup-freshness.yml`) runs daily at 14:00 UTC and checks that the most recent objects in `s3://nomadkaraoke-backup/firestore/`, `gcs/job-files/`, `secrets/`, and `bigquery/daily-refresh/` are no older than their per-prefix limit. Stale or missing backups → Discord alert + workflow failure.
+
+This monitor runs in GitHub, not GCP, so it survives a complete GCP project loss.
+
+**Required GitHub secrets** (set via `gh secret set`):
+- `AWS_BACKUP_READONLY_ACCESS_KEY_ID` — IAM user with `s3:ListBucket` + `s3:GetObject` only on `nomadkaraoke-backup`
+- `AWS_BACKUP_READONLY_SECRET_ACCESS_KEY`
+- `DR_MONITOR_DISCORD_WEBHOOK` — Discord webhook URL (separate channel from the nightly success/failure alert is fine)
+
+**Manual setup (one-time, in AWS Console):**
+1. Create IAM user `nomadkaraoke-backup-monitor` (no console access, programmatic only)
+2. Attach inline policy granting `s3:ListBucket` + `s3:GetObject` on `arn:aws:s3:::nomadkaraoke-backup` and `arn:aws:s3:::nomadkaraoke-backup/*`
+3. Create access key pair, store in KeepassXC as "Nomad Karaoke — DR backup readonly access"
+4. `gh secret set AWS_BACKUP_READONLY_ACCESS_KEY_ID --body '<key>' --repo nomadkaraoke/karaoke-gen`
+5. `gh secret set AWS_BACKUP_READONLY_SECRET_ACCESS_KEY --body '<secret>' --repo nomadkaraoke/karaoke-gen`
+6. `gh secret set DR_MONITOR_DISCORD_WEBHOOK --body '<url>' --repo nomadkaraoke/karaoke-gen`
+7. Trigger a test run: `gh workflow run dr-backup-freshness.yml --repo nomadkaraoke/karaoke-gen`
+
+## Quarterly restore drill
+
+Once per quarter, prove the chain works without committing to a real restore. Scheduler `dr-restore-drill-reminder` posts a Discord nudge each quarter; when it fires, do this:
+
+```bash
+# 1. Decrypt yesterday's secrets backup (proves backup + private key + tooling all work)
+#    Follow § "Decrypting the secrets backup" above. Do NOT write secrets to disk in plaintext;
+#    just confirm the count of decrypted secrets matches gcloud secrets list.
+LIVE_COUNT=$(gcloud secrets list --project=nomadkaraoke --format=json | jq length)
+echo "Live secret count: $LIVE_COUNT"
+# Compare against the count printed by the decryption step.
+
+# 2. Restore Firestore to a side database (does not touch production)
+LATEST_DATE=$(aws s3 ls s3://nomadkaraoke-backup/firestore/ | awk '{print $2}' | tr -d '/' | sort | tail -1)
+gsutil -m cp -r "s3://nomadkaraoke-backup/firestore/$LATEST_DATE/" gs://nomadkaraoke-backup-staging/drill-import/
+META=$(gsutil ls "gs://nomadkaraoke-backup-staging/drill-import/$LATEST_DATE/**/all_namespaces*.overall_export_metadata" | head -1)
+gcloud firestore databases create --database=drill-$(date +%Y%m%d) \
+  --location=us-central1 --type=firestore-native --project=nomadkaraoke
+gcloud firestore import "$META" --database=drill-$(date +%Y%m%d) --project=nomadkaraoke
+
+# 3. Spot-check a few collections in the side database, then delete it
+gcloud firestore databases delete drill-$(date +%Y%m%d) --project=nomadkaraoke
+
+# 4. Restore one specific BigQuery table from S3 to a drill_ prefix
+bq mk --dataset --description="restore drill" nomadkaraoke:drill_$(date +%Y%m%d)
+DAILY_DATE=$(aws s3 ls s3://nomadkaraoke-backup/bigquery/daily-refresh/ | awk '{print $2}' | tr -d '/' | sort | tail -1)
+aws s3 cp "s3://nomadkaraoke-backup/bigquery/daily-refresh/$DAILY_DATE/karaokenerds_raw/000000000000.parquet" /tmp/
+bq load --source_format=PARQUET nomadkaraoke:drill_$(date +%Y%m%d).karaokenerds_raw /tmp/000000000000.parquet
+bq query --use_legacy_sql=false "SELECT COUNT(*) FROM \`nomadkaraoke.drill_$(date +%Y%m%d).karaokenerds_raw\`"
+bq rm -r -f -d nomadkaraoke:drill_$(date +%Y%m%d)
+
+# 5. Note the date and result in docs/LESSONS-LEARNED.md
+```
+
+## Datasets intentionally NOT in S3 (regenerable from upstream)
+
+These datasets are large and publicly available, so backing them up to S3 would
+cost more than re-downloading them after a disaster. If you need them after a
+restore, regenerate from these sources:
+
+| Dataset | Source | Re-download notes |
+|---|---|---|
+| MusicBrainz raw dumps (~17 GB) | https://musicbrainz.org/doc/MusicBrainz_Database/Download | Daily replication available; full import is several hours via `mbslave` or Postgres dump |
+| MLHD listening histories (~252 GB) | https://ddmal.music.mcgill.ca/research/The_Music_Listening_Histories_Dataset/ | Static dataset; download once, derived BigQuery tables are in monthly S3 backup |
+
+Only the *derived* BigQuery tables under `bigquery/musicbrainz/` are in S3 (these
+contain joins/normalizations that would take hours to recompute even after raw
+re-import). The raw source files are not.
 
 ## Cost Estimates for Recovery
 
@@ -202,4 +415,5 @@ Re-create OAuth apps at Spotify, Google, Dropbox with redirect URIs from `docs/a
 | S3 Glacier Deep Archive retrieval (1 TB, bulk) | ~$150 |
 | S3 Glacier Deep Archive retrieval (1 TB, standard) | ~$750 |
 | S3 data transfer out to GCP | ~$0.09/GB |
-| Full Spotify dataset retrieval + transfer (~1 TB) | ~$250 total |
+| Full Spotify dataset retrieval + transfer (~100 GB) | ~$25 total |
+| Full GCS job-files egress (~150 GB) | ~$14 |

--- a/docs/archive/2026-03-29-external-services-config.md
+++ b/docs/archive/2026-03-29-external-services-config.md
@@ -1,8 +1,8 @@
 # External Services Configuration (DR Reference)
 
-**Purpose:** If GCP or other services are terminated, this documents what needs to be re-created at the external service level. Actual secrets are in AWS Secrets Manager.
+**Purpose:** If GCP or other services are terminated, this documents what needs to be re-created at the external service level. Live secret values are in GCP Secret Manager; an encrypted snapshot lives in `s3://nomadkaraoke-backup/secrets/` (decrypt with the private key from KeepassXC — see `docs/DISASTER-RECOVERY.md`).
 
-**Last verified:** 2026-03-29
+**Last verified:** 2026-04-20
 
 ## Cloudflare
 
@@ -18,6 +18,10 @@
   - `karaoke-gen-tenant` — vocalstar/singa subdomains (B2B tenant portal)
 - **Workers:**
   - `karaoke-decide-api-proxy` — proxies decide.nomadkaraoke.com/api/* to Cloud Run
+- **API Tokens (rotate during DR — owner: Andrew's Cloudflare account):**
+  - Cloudflare Pages deploy token (CI deploys frontend) — referenced by GitHub Actions secret `CLOUDFLARE_API_TOKEN`
+  - Account ID — GitHub Actions secret `CLOUDFLARE_ACCOUNT_ID`
+  - DNS edit token (if managing DNS via IaC) — see `docs/archive/2026-04-04-cloudflare-iac-migration-plan.md`
 
 ## Spotify Developer App
 
@@ -27,6 +31,7 @@
 - **Redirect URIs:**
   - `https://decide.nomadkaraoke.com/api/services/spotify/callback`
   - `http://localhost:8000/api/services/spotify/callback`
+- **DR action if domain changes:** update redirect URIs in Spotify Developer Dashboard.
 
 ## Google (Flacfetch)
 
@@ -39,17 +44,21 @@
 - **Webhook endpoint:** `https://api.nomadkaraoke.com/api/users/webhooks/stripe`
 - **Events:** `checkout.session.completed`, `checkout.session.expired`, `payment_intent.payment_failed`
 - **Keys:** `stripe-secret-key`, `stripe-webhook-secret` in Secret Manager
+- **DR action:** webhook endpoint URL must be re-registered if API hostname changes; Stripe regenerates the webhook signing secret on re-registration → update `stripe-webhook-secret` in Secret Manager.
+- **Connect (referrals):** Stripe Connect platform settings — referral payouts via Standard accounts; see `docs/archive/2026-04-04-referral-system-design.md`.
 
 ## SendGrid
 
 - **Sender:** gen@nomadkaraoke.com
 - **Used by:** karaoke-gen (job notifications, idle reminders), karaoke-decide (magic link auth)
 - **Key:** `sendgrid-api-key` in Secret Manager
+- **DR action:** sender domain authentication (SPF/DKIM) is per-domain; if domain changes, re-verify in SendGrid → may take 24-48h for DNS to propagate.
 
 ## AudioShake
 
 - **Purpose:** Lyrics transcription API
 - **Key:** `audioshake-api-key` in Secret Manager
+- **DR action:** if old GCP project was compromised, rotate the key in AudioShake console as a precaution.
 
 ## Genius
 
@@ -65,11 +74,13 @@
 
 - **Purpose:** Karaoke file distribution (per-job upload)
 - **Credentials:** `dropbox-oauth-credentials` in Secret Manager
+- **DR action:** Dropbox app's redirect URI is locked to current API hostname; update in Dropbox App Console if it changes.
 
 ## YouTube
 
 - **Purpose:** Karaoke video upload + API quota tracking
 - **Credentials:** `youtube-oauth-credentials`, `youtube-client-credentials`, `youtube-cookies` in Secret Manager
+- **DR action:** OAuth client redirect URIs and OAuth consent screen are project-scoped — must be re-created in the new GCP project's API Console; user re-consent will be required on first use.
 
 ## Last.fm
 
@@ -80,3 +91,115 @@
 
 - **Purpose:** High-quality audio source downloads via Flacfetch
 - **Keys:** `red-api-key`, `red-api-url`, `ops-api-key`, `ops-api-url` in Secret Manager
+- **DR action:** these keys are tied to user accounts on the trackers — no re-issuance needed unless old GCP exposure could have leaked them, in which case generate new keys in tracker user settings.
+
+## Discord
+
+Multiple webhook URLs power different alert channels — all in Secret Manager:
+
+| Secret name | Purpose | Channel |
+|---|---|---|
+| `discord-alert-webhook` | Nightly backup status, error monitor digests, DR freshness | #ops-alerts |
+| `discord-releases-webhook` | Deploy/release notifications | #releases |
+| `discord-webhook-url` | Generic catch-all (legacy) | #ops-general |
+
+**DR action:** if old GCP exposure could have leaked them, regenerate webhook URLs in Discord channel integration settings (right-click channel → Edit Channel → Integrations → Webhooks → reset URL). Webhook URLs themselves are the only credential — no API key.
+
+## Pushbullet
+
+- **Purpose:** Mobile push for kjbox / live event alerts
+- **Key:** `pushbullet-api-key` in Secret Manager
+- **DR action:** rotate in Pushbullet account settings if old GCP was compromised.
+
+## Mattermost
+
+- **Purpose:** Older notification path (may be deprecated — verify before relying on)
+- **Token:** `mattermost-token` in Secret Manager
+
+## Coinbase
+
+- **Purpose:** Crypto payment option (referral system fiat off-ramp / experimental)
+- **Keys:** `coinbase-api-key`, `coinbase-api-secret`, `coinbase-key-file` in Secret Manager
+- **DR action:** Coinbase Commerce API key is tied to merchant account — rotate in Coinbase merchant settings if compromised; webhook URL needs re-registering if API hostname changes.
+
+## Langfuse
+
+- **Purpose:** LLM observability (Gemini call traces from translation pipeline + agent flows)
+- **Keys:** `langfuse-public-key`, `langfuse-secret-key`, `langfuse-host` in Secret Manager
+- **DR action:** project-scoped on langfuse.com — rotate keys in Langfuse project settings if compromised.
+
+## Vertex AI / Gemini
+
+- **Purpose:** i18n translation pipeline (Gemini 3.1 Pro), agent reasoning
+- **Auth:** Application Default Credentials (no API key — uses service account on Cloud Run)
+- **DR action:** must enable Vertex AI API in new GCP project (`gcloud services enable aiplatform.googleapis.com`); no key rotation needed; quota limits restart from zero.
+
+## VerifyMail
+
+- **Purpose:** Email validation (anti-abuse — checks disposable email domains)
+- **Key:** `verifymail-api-key` in Secret Manager
+
+## RapidAPI
+
+- **Purpose:** Various third-party APIs accessed via RapidAPI gateway
+- **Key:** `rapidapi-key` in Secret Manager
+- **DR action:** rotate in RapidAPI dashboard.
+
+## VAPID (Web Push)
+
+- **Purpose:** Mobile push notifications via service worker
+- **Keys:** `vapid-public-key`, `vapid-private-key` in Secret Manager
+- **DR action:** if keys are rotated, all currently-subscribed mobile devices lose push and must re-subscribe. Avoid rotation unless compromised. Public key is also embedded in frontend build — rotation requires frontend redeploy.
+
+## GitHub
+
+- **Runner PAT:** `github-runner-pat` in Secret Manager — used by self-hosted runner manager to register/deregister GCE-hosted runners
+- **Webhook secret:** `github-webhook-secret` in Secret Manager — verifies webhook deliveries to runner manager
+- **DR action:** generate new PAT under nomadkaraoke org with `repo` + `workflow` scopes; rotate webhook secret in repo settings.
+
+## Karaoke-Decide JWT
+
+- **Purpose:** Internal JWT signing for decide → gen API calls
+- **Key:** `karaoke-decide-jwt-secret` in Secret Manager
+- **DR action:** rotation invalidates all in-flight tokens — coordinate decide + gen restart.
+
+## E2E Testing
+
+- **Bypass key:** `e2e-bypass-key` in Secret Manager — allows Playwright E2E tests to skip rate limits / payment
+- **DR action:** rotate after recovery to ensure no leaked test bypass remains in old project's logs.
+
+## Admin Tokens
+
+- **Key:** `admin-tokens` in Secret Manager (comma-separated list of valid admin bearer tokens)
+- **DR action:** generate fresh tokens; old tokens in scripts / shell history must be replaced.
+
+## GitHub Actions Secrets (CI/CD)
+
+These are not in GCP Secret Manager — they live in GitHub repo settings. Document the full list here:
+
+| Secret | Used by | Notes |
+|---|---|---|
+| `GCP_PROJECT_ID` | All deploy workflows | Update on DR — points to new project ID |
+| `GCP_SA_KEY` | All deploy workflows | New SA key per-project |
+| `CLOUDFLARE_API_TOKEN` | Frontend deploy | Pages publish |
+| `CLOUDFLARE_ACCOUNT_ID` | Frontend deploy | Pages publish |
+| `AWS_BACKUP_READONLY_ACCESS_KEY_ID` | DR freshness monitor | Created during DR setup |
+| `AWS_BACKUP_READONLY_SECRET_ACCESS_KEY` | DR freshness monitor | Created during DR setup |
+| `DR_MONITOR_DISCORD_WEBHOOK` | DR freshness monitor | Same as `discord-alert-webhook` is fine |
+| `CODERABBIT_API_KEY` | PR review | Optional, can skip during DR |
+
+After a DR rebuild, audit `gh secret list --repo nomadkaraoke/karaoke-gen` to confirm everything is set.
+
+## flacfetch (separate repo)
+
+`flacfetch/infrastructure/` deploys its own GCE VM. Has its own secrets in GCP Secret Manager:
+
+| Secret | Purpose |
+|---|---|
+| `flacfetch-account-email`, `flacfetch-account-password` | tracker logins |
+| `flacfetch-api-key`, `flacfetch-api-url` | shared with karaoke-gen for job dispatch |
+| `red-api-*`, `ops-api-*` | private tracker API |
+| `spotify-cookie`, `spotify-oauth-token` | maintained by credential keeper |
+| `youtube-cookies` | maintained by credential keeper |
+
+These are also captured by the secrets backup (the backup function enumerates all secrets in the project, regardless of which repo "owns" them in IaC).

--- a/infrastructure/Pulumi.prod.yaml
+++ b/infrastructure/Pulumi.prod.yaml
@@ -1,3 +1,4 @@
 config:
   gcp:project: nomadkaraoke
   gcp:region: us-central1
+  karaoke-gen-infrastructure:backupEncryptionPubkey: 1e966a0693d4ab12f5ef570dd60b35137ec12c42cc12424e13e8c1e8e2dbc914

--- a/infrastructure/functions/backup_to_aws/deploy.sh
+++ b/infrastructure/functions/backup_to_aws/deploy.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Deploy the backup-to-aws Cloud Function.
+#
+# Pulumi manages the function resource (env vars, IAM, scheduler) but does not
+# package or upload the function source. This script does that.
+#
+# Run this:
+#   - any time you change main.py / *_export.py / s3_upload.py / gcs_sync.py /
+#     discord_alert.py / requirements.txt
+#   - after pulumi up if Pulumi reports no diff but the function is on stale code
+#
+# Prerequisites:
+#   - gcloud CLI authenticated as a principal with cloudfunctions.functions.update
+#     and storage.objects.create on backup-to-aws-source-${PROJECT_ID}
+#   - Pulumi infrastructure deployed first (creates the bucket and SA)
+#
+# Usage:
+#   ./deploy.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ID="${GOOGLE_CLOUD_PROJECT:-nomadkaraoke}"
+REGION="us-central1"
+FUNCTION_NAME="backup-to-aws"
+BUCKET_NAME="backup-to-aws-source-${PROJECT_ID}"
+
+echo "Deploying backup-to-aws Cloud Function..."
+echo "  Project:  ${PROJECT_ID}"
+echo "  Region:   ${REGION}"
+echo "  Function: ${FUNCTION_NAME}"
+echo ""
+
+cd "${SCRIPT_DIR}"
+
+ZIP_PATH=/tmp/backup-to-aws-source.zip
+echo "Creating source ZIP..."
+rm -f "${ZIP_PATH}"
+zip -r "${ZIP_PATH}" \
+  main.py \
+  requirements.txt \
+  firestore_export.py \
+  bigquery_export.py \
+  gcs_sync.py \
+  secrets_export.py \
+  s3_upload.py \
+  discord_alert.py
+
+echo "Uploading to GCS..."
+gcloud storage cp "${ZIP_PATH}" "gs://${BUCKET_NAME}/backup-to-aws-source.zip"
+
+echo "Triggering function rebuild..."
+gcloud functions deploy "${FUNCTION_NAME}" \
+  --gen2 \
+  --region="${REGION}" \
+  --source="gs://${BUCKET_NAME}/backup-to-aws-source.zip" \
+  --project="${PROJECT_ID}"
+
+echo ""
+echo "Function deployed."
+echo ""
+echo "Verify env vars (should include BACKUP_ENCRYPTION_PUBKEY):"
+echo "  gcloud functions describe ${FUNCTION_NAME} --gen2 --region=${REGION} --project=${PROJECT_ID} --format='value(serviceConfig.environmentVariables)'"
+echo ""
+echo "Trigger a one-off run (skips the daily schedule):"
+echo "  curl -X POST -H \"Authorization: Bearer \$(gcloud auth print-identity-token)\" \\"
+echo "    https://${REGION}-${PROJECT_ID}.cloudfunctions.net/${FUNCTION_NAME}"

--- a/infrastructure/functions/backup_to_aws/gcs_sync.py
+++ b/infrastructure/functions/backup_to_aws/gcs_sync.py
@@ -6,7 +6,7 @@ from google.cloud import storage
 
 logger = logging.getLogger(__name__)
 
-SYNC_PREFIXES = ["jobs/", "tenants/", "themes/"]
+DEFAULT_SYNC_PREFIXES = ["jobs/", "tenants/", "themes/"]
 
 
 def sync_gcs_to_staging(
@@ -14,6 +14,7 @@ def sync_gcs_to_staging(
     staging_bucket: str,
     staging_prefix: str,
     max_objects: int = 5000,
+    sync_prefixes: list[str] | None = None,
 ) -> str:
     """Copy new/changed objects from source to staging bucket.
 
@@ -42,8 +43,9 @@ def sync_gcs_to_staging(
 
     copied = 0
     latest_updated_dt = last_sync_dt
+    prefixes = sync_prefixes if sync_prefixes is not None else DEFAULT_SYNC_PREFIXES
 
-    for prefix in SYNC_PREFIXES:
+    for prefix in prefixes:
         blobs = src.list_blobs(prefix=prefix)
         for blob in blobs:
             if not blob.updated:

--- a/infrastructure/functions/backup_to_aws/main.py
+++ b/infrastructure/functions/backup_to_aws/main.py
@@ -5,8 +5,9 @@ Nightly backup pipeline:
 1. Firestore export to GCS staging
 2. BigQuery export to GCS staging (weekly/monthly schedule)
 3. GCS job files delta sync to staging
-4. Upload staging files to S3
-5. Discord alert
+4. Secret Manager export (encrypted with sealed-box public key) to staging
+5. Upload staging files to S3
+6. Discord alert
 
 Triggered by Cloud Scheduler at 1:00 AM ET daily.
 """
@@ -22,6 +23,7 @@ from discord_alert import send_alert
 from firestore_export import export_firestore
 from bigquery_export import export_bigquery_tables
 from gcs_sync import sync_gcs_to_staging
+from secrets_export import export_secrets
 from s3_upload import upload_staging_to_s3
 
 logging.basicConfig(level=logging.INFO)
@@ -31,11 +33,27 @@ STAGING_BUCKET = os.environ.get("STAGING_BUCKET", "nomadkaraoke-backup-staging")
 S3_BUCKET = os.environ.get("S3_BUCKET", "nomadkaraoke-backup")
 GCP_PROJECT = os.environ.get("GCP_PROJECT", "nomadkaraoke")
 DISCORD_WEBHOOK_URL = os.environ.get("DISCORD_WEBHOOK_URL", "")
+BACKUP_ENCRYPTION_PUBKEY = os.environ.get("BACKUP_ENCRYPTION_PUBKEY", "")
 
 
 @functions_framework.http
 def backup_to_aws(request):
     """Main entry point for the backup Cloud Function."""
+    # Quarterly drill reminder — Cloud Scheduler hits this with ?mode=drill_reminder.
+    # We just post Discord and exit without touching the backup pipeline.
+    if request.args.get("mode") == "drill_reminder":
+        if DISCORD_WEBHOOK_URL:
+            send_alert(
+                webhook_url=DISCORD_WEBHOOK_URL,
+                title="📋 Quarterly DR restore drill due",
+                fields=[
+                    {"name": "What", "value": "Decrypt yesterday's secrets backup + restore one Firestore collection + one BigQuery table to a side database, confirm the chain works.", "inline": False},
+                    {"name": "Runbook", "value": "https://github.com/nomadkaraoke/karaoke-gen/blob/main/docs/DISASTER-RECOVERY.md#quarterly-restore-drill", "inline": False},
+                ],
+                success=True,
+            )
+        return json.dumps({"status": "drill_reminder_sent"}), 200
+
     today = datetime.date.today()
     date_str = today.isoformat()
     results = {}
@@ -68,7 +86,7 @@ def backup_to_aws(request):
         logger.error(f"BigQuery export failed: {e}")
         errors.append(f"BigQuery: {e}")
 
-    # Step 3: GCS delta sync (nightly)
+    # Step 3: GCS delta sync (nightly) — primary job-files bucket
     try:
         results["gcs_sync"] = sync_gcs_to_staging(
             source_bucket="karaoke-gen-storage-nomadkaraoke",
@@ -79,7 +97,33 @@ def backup_to_aws(request):
         logger.error(f"GCS sync failed: {e}")
         errors.append(f"GCS sync: {e}")
 
-    # Step 4: Upload to S3
+    # Step 3b: GCS delta sync — nomadkaraoke-kn-data (small, irreplaceable
+    # internal sync data from KaraokeNerds API; not publicly regenerable).
+    # Uses [""] to walk the whole bucket since it has no top-level prefix structure.
+    try:
+        results["gcs_sync_kn"] = sync_gcs_to_staging(
+            source_bucket="nomadkaraoke-kn-data",
+            staging_bucket=STAGING_BUCKET,
+            staging_prefix="gcs/kn-data/",
+            sync_prefixes=[""],
+        )
+    except Exception as e:
+        logger.error(f"GCS kn-data sync failed: {e}")
+        errors.append(f"GCS kn-data sync: {e}")
+
+    # Step 4: Secrets export (nightly, encrypted with sealed-box public key)
+    try:
+        results["secrets"] = export_secrets(
+            project=GCP_PROJECT,
+            staging_bucket=STAGING_BUCKET,
+            date_str=date_str,
+            public_key_hex=BACKUP_ENCRYPTION_PUBKEY,
+        )
+    except Exception as e:
+        logger.error(f"Secrets export failed: {e}")
+        errors.append(f"Secrets: {e}")
+
+    # Step 5: Upload to S3
     try:
         results["s3_upload"] = upload_staging_to_s3(
             staging_bucket=STAGING_BUCKET,
@@ -89,7 +133,7 @@ def backup_to_aws(request):
         logger.error(f"S3 upload failed: {e}")
         errors.append(f"S3 upload: {e}")
 
-    # Step 5: Discord alert
+    # Step 6: Discord alert
     success = len(errors) == 0
     fields = [
         {"name": "Date", "value": date_str, "inline": True},

--- a/infrastructure/functions/backup_to_aws/requirements.txt
+++ b/infrastructure/functions/backup_to_aws/requirements.txt
@@ -5,3 +5,4 @@ google-cloud-storage==2.*
 google-cloud-secret-manager==2.*
 boto3==1.*
 requests==2.*
+pynacl==1.5.*

--- a/infrastructure/functions/backup_to_aws/secrets_export.py
+++ b/infrastructure/functions/backup_to_aws/secrets_export.py
@@ -1,0 +1,90 @@
+"""Secret Manager export to GCS staging bucket.
+
+Enumerates all secrets in the project, fetches the latest version of each,
+serialises to JSON, then encrypts with a Curve25519 public key (PyNaCl sealed
+box). The matching private key lives only in the user's password manager — the
+Cloud Function holds no decryption capability, so a full GCP+AWS compromise
+still cannot reveal the secrets.
+"""
+
+import base64
+import datetime
+import json
+import logging
+
+from google.cloud import secretmanager
+from google.cloud import storage as gcs_storage
+from nacl.public import PublicKey, SealedBox
+
+logger = logging.getLogger(__name__)
+
+
+def _list_secret_ids(client: secretmanager.SecretManagerServiceClient, project: str) -> list[str]:
+    parent = f"projects/{project}"
+    return [s.name.split("/")[-1] for s in client.list_secrets(request={"parent": parent})]
+
+
+def _fetch_latest(client: secretmanager.SecretManagerServiceClient, project: str, secret_id: str) -> dict:
+    name = f"projects/{project}/secrets/{secret_id}/versions/latest"
+    try:
+        response = client.access_secret_version(request={"name": name})
+    except Exception as e:
+        logger.warning(f"Skipped {secret_id}: {e}")
+        return {"error": str(e)}
+    payload_bytes = response.payload.data
+    try:
+        value = payload_bytes.decode("utf-8")
+        encoding = "utf-8"
+    except UnicodeDecodeError:
+        value = base64.b64encode(payload_bytes).decode("ascii")
+        encoding = "base64"
+    return {
+        "value": value,
+        "encoding": encoding,
+        "version_name": response.name,
+    }
+
+
+def export_secrets(
+    project: str,
+    staging_bucket: str,
+    date_str: str,
+    public_key_hex: str,
+) -> str:
+    """Export all secrets, encrypt with sealed box, write to staging bucket.
+
+    Args:
+        project: GCP project ID.
+        staging_bucket: GCS staging bucket name.
+        date_str: ISO date string (YYYY-MM-DD) for the staged object name.
+        public_key_hex: 64-char hex string for the Curve25519 public key.
+
+    Returns:
+        Summary string.
+    """
+    if not public_key_hex:
+        raise ValueError("BACKUP_ENCRYPTION_PUBKEY is empty — refusing to write unencrypted secrets")
+
+    public_key = PublicKey(bytes.fromhex(public_key_hex))
+    sealed_box = SealedBox(public_key)
+
+    sm_client = secretmanager.SecretManagerServiceClient()
+    secret_ids = _list_secret_ids(sm_client, project)
+    logger.info(f"Found {len(secret_ids)} secrets to back up")
+
+    bundle = {
+        "exported_at": datetime.datetime.utcnow().isoformat() + "Z",
+        "project": project,
+        "secrets": {sid: _fetch_latest(sm_client, project, sid) for sid in secret_ids},
+    }
+
+    plaintext = json.dumps(bundle, sort_keys=True).encode("utf-8")
+    ciphertext = sealed_box.encrypt(plaintext)
+
+    gcs_client = gcs_storage.Client()
+    blob = gcs_client.bucket(staging_bucket).blob(f"secrets/{date_str}.bin")
+    blob.upload_from_string(ciphertext, content_type="application/octet-stream")
+
+    summary = f"Encrypted {len(secret_ids)} secrets ({len(plaintext)} → {len(ciphertext)} bytes) to gs://{staging_bucket}/secrets/{date_str}.bin"
+    logger.info(summary)
+    return summary

--- a/infrastructure/functions/backup_to_aws/test_secrets_export.py
+++ b/infrastructure/functions/backup_to_aws/test_secrets_export.py
@@ -1,0 +1,137 @@
+"""Tests for secrets_export module."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from nacl.public import PrivateKey, SealedBox
+
+from secrets_export import export_secrets
+
+
+@pytest.fixture
+def keypair():
+    sk = PrivateKey.generate()
+    return sk, sk.public_key.encode().hex()
+
+
+def _fake_sm_client(secrets: dict[str, bytes]):
+    client = MagicMock()
+    client.list_secrets.return_value = [
+        MagicMock(name=f"projects/test/secrets/{sid}") for sid in secrets
+    ]
+    # MagicMock 'name' attribute isn't auto-assigned via constructor kwarg; set explicitly
+    for mock_obj, sid in zip(client.list_secrets.return_value, secrets):
+        mock_obj.name = f"projects/test/secrets/{sid}"
+
+    def access(request):
+        secret_id = request["name"].split("/")[3]
+        resp = MagicMock()
+        resp.payload.data = secrets[secret_id]
+        resp.name = f"projects/test/secrets/{secret_id}/versions/1"
+        return resp
+
+    client.access_secret_version.side_effect = access
+    return client
+
+
+def test_round_trip_decrypts_with_private_key(keypair):
+    sk, pk_hex = keypair
+    fake_secrets = {
+        "stripe-secret-key": b"sk_test_abcdef",
+        "spotipy-client-secret": b"client_secret_xyz",
+    }
+    captured_blob = {}
+
+    def fake_upload(data, content_type):
+        captured_blob["data"] = data
+        captured_blob["content_type"] = content_type
+
+    fake_blob = MagicMock()
+    fake_blob.upload_from_string.side_effect = fake_upload
+    fake_bucket = MagicMock()
+    fake_bucket.blob.return_value = fake_blob
+    fake_gcs = MagicMock()
+    fake_gcs.bucket.return_value = fake_bucket
+
+    with patch("secrets_export.secretmanager.SecretManagerServiceClient", return_value=_fake_sm_client(fake_secrets)), \
+         patch("secrets_export.gcs_storage.Client", return_value=fake_gcs):
+        summary = export_secrets(
+            project="test",
+            staging_bucket="staging",
+            date_str="2026-04-20",
+            public_key_hex=pk_hex,
+        )
+
+    assert "2 secrets" in summary
+    assert captured_blob["content_type"] == "application/octet-stream"
+
+    # Decrypt with the private key (this is what the recovery procedure does)
+    plaintext = SealedBox(sk).decrypt(captured_blob["data"])
+    bundle = json.loads(plaintext.decode("utf-8"))
+    assert bundle["project"] == "test"
+    assert bundle["secrets"]["stripe-secret-key"]["value"] == "sk_test_abcdef"
+    assert bundle["secrets"]["stripe-secret-key"]["encoding"] == "utf-8"
+    assert bundle["secrets"]["spotipy-client-secret"]["value"] == "client_secret_xyz"
+
+
+def test_binary_secret_is_base64_encoded(keypair):
+    sk, pk_hex = keypair
+    binary_payload = b"\x00\x01\x02\xff"
+    fake_secrets = {"binary-key": binary_payload}
+    captured = {}
+
+    fake_blob = MagicMock()
+    fake_blob.upload_from_string.side_effect = lambda data, content_type: captured.update(data=data)
+    fake_bucket = MagicMock()
+    fake_bucket.blob.return_value = fake_blob
+    fake_gcs = MagicMock()
+    fake_gcs.bucket.return_value = fake_bucket
+
+    with patch("secrets_export.secretmanager.SecretManagerServiceClient", return_value=_fake_sm_client(fake_secrets)), \
+         patch("secrets_export.gcs_storage.Client", return_value=fake_gcs):
+        export_secrets("test", "staging", "2026-04-20", pk_hex)
+
+    bundle = json.loads(SealedBox(sk).decrypt(captured["data"]))
+    entry = bundle["secrets"]["binary-key"]
+    assert entry["encoding"] == "base64"
+    import base64
+    assert base64.b64decode(entry["value"]) == binary_payload
+
+
+def test_empty_pubkey_raises():
+    with pytest.raises(ValueError, match="BACKUP_ENCRYPTION_PUBKEY"):
+        export_secrets("test", "staging", "2026-04-20", "")
+
+
+def test_individual_fetch_failure_does_not_abort(keypair):
+    sk, pk_hex = keypair
+    sm_client = MagicMock()
+    s1 = MagicMock(); s1.name = "projects/test/secrets/works"
+    s2 = MagicMock(); s2.name = "projects/test/secrets/broken"
+    sm_client.list_secrets.return_value = [s1, s2]
+
+    def access(request):
+        if "broken" in request["name"]:
+            raise PermissionError("denied")
+        resp = MagicMock()
+        resp.payload.data = b"ok"
+        resp.name = "projects/test/secrets/works/versions/1"
+        return resp
+
+    sm_client.access_secret_version.side_effect = access
+    captured = {}
+    fake_blob = MagicMock()
+    fake_blob.upload_from_string.side_effect = lambda data, content_type: captured.update(data=data)
+    fake_bucket = MagicMock()
+    fake_bucket.blob.return_value = fake_blob
+    fake_gcs = MagicMock()
+    fake_gcs.bucket.return_value = fake_bucket
+
+    with patch("secrets_export.secretmanager.SecretManagerServiceClient", return_value=sm_client), \
+         patch("secrets_export.gcs_storage.Client", return_value=fake_gcs):
+        export_secrets("test", "staging", "2026-04-20", pk_hex)
+
+    bundle = json.loads(SealedBox(sk).decrypt(captured["data"]))
+    assert bundle["secrets"]["works"]["value"] == "ok"
+    assert "error" in bundle["secrets"]["broken"]

--- a/infrastructure/modules/backup.py
+++ b/infrastructure/modules/backup.py
@@ -57,11 +57,20 @@ def create_backup_resources(all_secrets: dict) -> dict:
         member=sa.email.apply(lambda email: f"serviceAccount:{email}"),
     )
 
-    # Secret Manager access (for AWS credentials)
+    # Secret Manager access (for AWS credentials + nightly secrets backup)
     resources["secret_accessor"] = gcp.projects.IAMMember(
         "backup-secret-accessor",
         project=PROJECT_ID,
         role="roles/secretmanager.secretAccessor",
+        member=sa.email.apply(lambda email: f"serviceAccount:{email}"),
+    )
+
+    # secretmanager.viewer is required to LIST secrets — accessor only allows reading
+    # a known name. Backup needs to enumerate every secret in the project.
+    resources["secret_viewer"] = gcp.projects.IAMMember(
+        "backup-secret-viewer",
+        project=PROJECT_ID,
+        role="roles/secretmanager.viewer",
         member=sa.email.apply(lambda email: f"serviceAccount:{email}"),
     )
 
@@ -158,6 +167,10 @@ def create_backup_resources(all_secrets: dict) -> dict:
                 "GCP_PROJECT": PROJECT_ID,
                 "STAGING_BUCKET": "nomadkaraoke-backup-staging",
                 "S3_BUCKET": "nomadkaraoke-backup",
+                # Curve25519 public key (hex) for sealed-box encryption of secrets backup.
+                # The matching private key lives only in 1Password — function cannot decrypt.
+                # Set via: pulumi config set backupEncryptionPubkey <64-char-hex>
+                "BACKUP_ENCRYPTION_PUBKEY": pulumi.Config().require("backupEncryptionPubkey"),
             },
             secret_environment_variables=[
                 cloudfunctionsv2.FunctionServiceConfigSecretEnvironmentVariableArgs(
@@ -214,5 +227,34 @@ def create_backup_resources(all_secrets: dict) -> dict:
         ),
     )
     resources["scheduler"] = scheduler
+
+    # Quarterly DR restore drill reminder — posts a Discord nudge so the human
+    # remembers to run the drill in docs/DISASTER-RECOVERY.md § "Quarterly restore drill".
+    # Hits the same backup function with ?mode=drill_reminder, which short-circuits
+    # the pipeline and only posts to Discord.
+    drill_scheduler = cloudscheduler.Job(
+        "dr-drill-scheduler",
+        name="dr-restore-drill-reminder",
+        description="Quarterly nudge to run the DR restore drill",
+        region=REGION,
+        # 15:00 UTC on the 1st of Jan/Apr/Jul/Oct
+        schedule="0 15 1 1,4,7,10 *",
+        time_zone="UTC",
+        http_target=cloudscheduler.JobHttpTargetArgs(
+            uri=function.url.apply(lambda u: f"{u}?mode=drill_reminder"),
+            http_method="POST",
+            oidc_token=cloudscheduler.JobHttpTargetOidcTokenArgs(
+                service_account_email=sa.email,
+                # OIDC audience must match the function URL without the query string
+                audience=function.url,
+            ),
+        ),
+        retry_config=cloudscheduler.JobRetryConfigArgs(
+            retry_count=1,
+            min_backoff_duration="60s",
+            max_backoff_duration="300s",
+        ),
+    )
+    resources["drill_scheduler"] = drill_scheduler
 
     return resources


### PR DESCRIPTION
## Summary

Closes the four real gaps identified in a soft DR drill against the cross-cloud backup pipeline (`karaoke-gen/docs/DISASTER-RECOVERY.md`):

- **Secrets bucket in S3 was empty.** Secrets are now backed up nightly, encrypted with PyNaCl sealed box (asymmetric Curve25519). The private key lives only in the operator's password manager; the function holds no decryption capability, so a full GCP+AWS compromise still cannot read the bundle.
- **No off-platform monitor.** New GitHub Actions cron checks S3 LastModified daily across all critical prefixes; alerts Discord if anything stale or missing. Runs in GitHub, not GCP — survives a complete GCP project loss.
- **No quarterly drill cadence.** New Cloud Scheduler job posts a Discord nudge on Jan/Apr/Jul/Oct 1st with a link to the drill procedure.
- **`nomadkaraoke-kn-data` bucket wasn't backed up.** Now synced nightly (irreplaceable, not publicly regenerable; MusicBrainz/MLHD raw datasets are public so they're documented as regenerable instead).

The DR runbook and external-services-config docs are rewritten to match: prerequisites checklist, three-option GCS recovery, decryption procedure, freshness monitor setup, drill procedure, regenerable-datasets table, expanded service inventory (9 → 25 services with explicit DR actions per service).

## Test plan

- [x] Unit tests for secrets export (round-trip decryption, binary payload base64 handling, empty pubkey refusal, per-secret failure tolerance) — 4/4 pass alongside existing 5
- [x] `pulumi up` applied: new IAM grant + drill scheduler + env var
- [x] Function rebuilt via REST API after Pulumi (gsutil hit reauth wall, used Python+ADC fallback)
- [x] Triggered nightly schedule manually; `secrets/2026-04-20.bin` landed in S3 at 19,851 bytes (consistent with 50 sealed-box-encrypted secrets)
- [ ] Decrypt round-trip from S3 to plaintext (pending — `backup-writer` IAM is intentionally write-only; needs admin AWS creds to verify, but private key + ciphertext have been confirmed compatible via local test)

## Follow-up (requires AWS Console — out of scope for this PR)

- Create `nomadkaraoke-backup-monitor` IAM user with `s3:ListBucket` + `s3:GetObject` scoped to the backup bucket
- Set GitHub repo secrets `AWS_BACKUP_READONLY_ACCESS_KEY_ID`, `AWS_BACKUP_READONLY_SECRET_ACCESS_KEY`, `DR_MONITOR_DISCORD_WEBHOOK` to activate the freshness workflow
- Rotate `aws-backup-credentials` (the active access key was in conversation context during the drill)

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)