### PR TITLE
ci: harden deploy curls with --max-time to prevent wedged runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
       - name: Refresh E2E session token
         id: refresh_token
         run: |
-          RESPONSE=$(curl -sf -X POST \
+          RESPONSE=$(curl -sf --connect-timeout 5 --max-time 30 -X POST \
             "https://api.nomadkaraoke.com/api/admin/users/e2e-test-runner@nomadkaraoke.com/impersonate" \
             -H "X-Admin-Token: ${{ secrets.E2E_ADMIN_TOKEN }}" \
             -H "Content-Type: application/json")
@@ -1228,7 +1228,7 @@ jobs:
 
           echo "Waiting for service at $HEALTH_URL..."
           for i in $(seq 1 18); do
-            RESPONSE=$(curl -sf "$HEALTH_URL" 2>/dev/null || echo "")
+            RESPONSE=$(curl -sf --connect-timeout 3 --max-time 5 "$HEALTH_URL" 2>/dev/null || echo "")
             if [ -n "$RESPONSE" ]; then
               WHEEL_VERSION=$(echo "$RESPONSE" | jq -r '.wheel_version // empty')
               echo "Health: version=$WHEEL_VERSION"
@@ -1264,7 +1264,8 @@ jobs:
             "${DEPLOY_TEST_PATH}/test-audio.flac"
 
           echo "Submitting test encode to $SECONDARY_IP..."
-          HTTP_CODE=$(curl -s -o /tmp/encode-response.json -w '%{http_code}' \
+          HTTP_CODE=$(curl -s --connect-timeout 5 --max-time 30 \
+            -o /tmp/encode-response.json -w '%{http_code}' \
             -X POST "http://${SECONDARY_IP}:8080/encode-preview" \
             -H "X-API-Key: $API_KEY" \
             -H "Content-Type: application/json" \
@@ -1293,7 +1294,7 @@ jobs:
 
           for i in $(seq 1 12); do
             sleep 5
-            JOB_STATUS=$(curl -s \
+            JOB_STATUS=$(curl -s --connect-timeout 3 --max-time 10 \
               "http://${SECONDARY_IP}:8080/status/deploy-health-check" \
               -H "X-API-Key: $API_KEY" 2>/dev/null | jq -r '.status // "unknown"' 2>/dev/null) || JOB_STATUS="unknown"
             echo "Encode status: $JOB_STATUS (attempt $i/12)"
@@ -1382,7 +1383,7 @@ jobs:
           API_KEY=$(gcloud secrets versions access latest \
             --secret=encoding-worker-api-key --project=nomadkaraoke)
 
-          ACTIVE_JOBS=$(curl -sf "http://${OLD_PRIMARY_IP}:8080/health" \
+          ACTIVE_JOBS=$(curl -sf --connect-timeout 3 --max-time 5 "http://${OLD_PRIMARY_IP}:8080/health" \
             | jq -r '.active_jobs // 0' 2>/dev/null || echo "0")
 
           if [ "$ACTIVE_JOBS" -gt 0 ]; then
@@ -1392,7 +1393,7 @@ jobs:
             while [ $ELAPSED -lt $DRAIN_TIMEOUT ]; do
               sleep 15
               ELAPSED=$((ELAPSED + 15))
-              ACTIVE_JOBS=$(curl -sf "http://${OLD_PRIMARY_IP}:8080/health" \
+              ACTIVE_JOBS=$(curl -sf --connect-timeout 3 --max-time 5 "http://${OLD_PRIMARY_IP}:8080/health" \
                 | jq -r '.active_jobs // 0' 2>/dev/null || echo "0")
               echo "Active jobs: $ACTIVE_JOBS (${ELAPSED}s elapsed)"
               if [ "$ACTIVE_JOBS" -eq 0 ]; then
@@ -1686,7 +1687,7 @@ jobs:
           sleep 15
 
           # Basic health check
-          curl -f "$SERVICE_URL/api/health" || exit 1
+          curl -f --connect-timeout 5 --max-time 30 "$SERVICE_URL/api/health" || exit 1
           echo "✅ Service is healthy"
 
           # Version verification with retries (Cloud Run may take time to route to new revision)
@@ -1694,7 +1695,7 @@ jobs:
           RETRY_DELAY=10
           for i in $(seq 1 $MAX_RETRIES); do
             echo "Checking deployed version (attempt $i/$MAX_RETRIES)..."
-            DEPLOYED_VERSION=$(curl -sf "$SERVICE_URL/api/health/detailed" | jq -r '.version // empty')
+            DEPLOYED_VERSION=$(curl -sf --connect-timeout 5 --max-time 30 "$SERVICE_URL/api/health/detailed" | jq -r '.version // empty')
 
             if [ "$DEPLOYED_VERSION" = "$EXPECTED_VERSION" ]; then
               echo "✅ Version verified: $DEPLOYED_VERSION"


### PR DESCRIPTION
## Summary

- Adds `--connect-timeout` and `--max-time` to all outbound `curl` calls in the CI deploy path and the E2E token-refresh step
- Addresses a follow-up note from a prior session: **"harden CI Wait for service health step with --max-time on curl (caused two near-wedged deploys this session)"**
- Prevents a wedged upstream from turning a 3-minute health-check budget into the 6-hour GH Actions job ceiling

## Context

Without `--max-time`, `curl` waits indefinitely for bytes once a TCP connection is established. When the encoding-worker's gunicorn worker wedges (accepts connections but doesn't respond), the poll loop's `for i in $(seq 1 18); do curl ...; sleep 10; done` blocks on iteration 1 forever instead of failing after 3 minutes.

Root cause applies to 7 `curl` calls across `ci.yml`; this PR hardens all of them for consistency, not just the one literally named in the note.

### Scale-up/down interaction

Confirmed the fix is compatible with the blue/green + idle-shutdown architecture:
- Cold-start of a stopped VM produces **ECONNREFUSED** (fast), not a hang — `--max-time` is never engaged during boot
- Existing `sleep` windows between poll attempts already cover VM cold-start time
- `config.deploy_in_progress` flag already blocks the idle-shutdown Cloud Function during deploys, so no new races introduced
- `--max-time` only engages when the remote wedges post-accept — the exact failure mode we want to bound

## Changes

| Line | Context | Connect / Max time |
|------|---------|--------------------|
| 271 | E2E impersonation token (Cloud Run) | 5s / 30s |
| 1231 | Wait for service health (**reported bug**) | 3s / 5s |
| 1267 | Deploy health check: submit encode | 5s / 30s |
| 1297 | Deploy health check: status poll | 3s / 10s |
| 1386 / 1396 | Drain old primary | 3s / 5s |
| 1690 | Backend basic health (Cloud Run) | 5s / 30s |
| 1698 | Backend version verify (Cloud Run) | 5s / 30s |

## Test plan

- [ ] YAML validity: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — passed locally
- [ ] CI runs against this PR succeed
- [ ] Post-merge: the deploy job itself is the real validation — the hardened curls run against real infrastructure. Merge should produce a normal-duration (~5-10 min) deploy with no hangs
- [ ] No behavioral change on the happy path — all previously-successful deploys behave identically

No backend/frontend code touched; no version bump needed.

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)