### PR TITLE
fix(custom-lyrics): allow modal content to scroll

### DIFF
--- a/frontend/components/lyrics-review/modals/CustomLyricsMode.tsx
+++ b/frontend/components/lyrics-review/modals/CustomLyricsMode.tsx
@@ -254,7 +254,7 @@ export default function CustomLyricsMode({
           </DialogTitle>
         </DialogHeader>
 
-        <div className="flex-1 overflow-hidden flex flex-col gap-4">
+        <div className="flex-1 overflow-y-auto flex flex-col gap-4">
           {/* Input phase */}
           {phase === 'input' && (
             <>


### PR DESCRIPTION
## Summary

Hotfix: the CustomLyricsMode dialog was \`overflow-hidden\`, which clipped the new Generation Settings panel (added in #741) below the 80vh dialog height with no way to scroll. Switching to \`overflow-y-auto\` lets the content scroll.

Confirmed via DOM inspection in prod: the panel renders correctly but is positioned below the visible viewport.

## Test plan

- [x] Existing CustomLyricsMode tests pass (9/9)
- [ ] Visual: open Custom Lyrics modal in prod after deploy, verify Generation Settings panel is visible (or scrollable into view)

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)