### PR TITLE
fix(lyrics-review): re-enable Unsync from Cursor after backwards scrub

### DIFF
--- a/frontend/components/lyrics-review/__tests__/LyricsSynchronizer.unsync.test.tsx
+++ b/frontend/components/lyrics-review/__tests__/LyricsSynchronizer.unsync.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react'
+import LyricsSynchronizer from '../synchronizer/LyricsSynchronizer'
+import type { LyricsSegment } from '@/lib/lyrics-review/types'
+
+// Stub heavy children so the test focuses on the SyncControls disabled state.
+jest.mock('../synchronizer/TimelineCanvas', () => () => null)
+jest.mock('../synchronizer/UpcomingWordsBar', () => () => null)
+
+function makeSegment(words: Array<{ text: string; start: number | null; end: number | null }>): LyricsSegment {
+  return {
+    id: 'seg-1',
+    text: words.map((w) => w.text).join(' '),
+    start_time: words[0]?.start ?? null,
+    end_time: words[words.length - 1]?.end ?? null,
+    words: words.map((w, i) => ({
+      id: `w-${i}`,
+      text: w.text,
+      start_time: w.start,
+      end_time: w.end,
+    })),
+  }
+}
+
+describe('LyricsSynchronizer — Unsync from Cursor button', () => {
+  const baseProps = {
+    onPlaySegment: jest.fn(),
+    onSave: jest.fn(),
+    onCancel: jest.fn(),
+    setModalSpacebarHandler: jest.fn(),
+  }
+
+  // Synced words at 5s and 18s
+  const segments = [
+    makeSegment([
+      { text: 'first', start: 5, end: 5.5 },
+      { text: 'second', start: 18, end: 18.5 },
+    ]),
+  ]
+
+  it('enables button when currentTime is before some synced words', () => {
+    render(<LyricsSynchronizer {...baseProps} segments={segments} currentTime={10} />)
+    expect(screen.getByRole('button', { name: /unsync from cursor/i })).toBeEnabled()
+  })
+
+  it('disables button when currentTime is past all synced words', () => {
+    render(<LyricsSynchronizer {...baseProps} segments={segments} currentTime={20} />)
+    expect(screen.getByRole('button', { name: /unsync from cursor/i })).toBeDisabled()
+  })
+
+  // Regression: previously canUnsyncFromCursor read currentTimeRef.current inside
+  // useMemo, which is one frame stale. When currentTime jumped backwards (user
+  // scrubbed) the cached value was wrong and the button stayed disabled even
+  // though synced words existed after the cursor.
+  it('re-enables the button after currentTime jumps backwards past synced words', () => {
+    const { rerender } = render(
+      <LyricsSynchronizer {...baseProps} segments={segments} currentTime={20} />
+    )
+    expect(screen.getByRole('button', { name: /unsync from cursor/i })).toBeDisabled()
+
+    rerender(<LyricsSynchronizer {...baseProps} segments={segments} currentTime={10} />)
+    expect(screen.getByRole('button', { name: /unsync from cursor/i })).toBeEnabled()
+  })
+})

--- a/frontend/components/lyrics-review/synchronizer/LyricsSynchronizer.tsx
+++ b/frontend/components/lyrics-review/synchronizer/LyricsSynchronizer.tsx
@@ -310,10 +310,14 @@ const LyricsSynchronizer = memo(function LyricsSynchronizer({
     })
   }, [])
 
-  // Check if there are words after cursor that can be unsynced
+  // Check if there are words after cursor that can be unsynced.
+  // Use the currentTime prop directly (not currentTimeRef) — reading the ref
+  // here is one frame stale because the effect that updates ref.current runs
+  // AFTER this useMemo. When currentTime jumps backward (user scrubs), the
+  // useMemo computes against the previous (higher) ref value and caches the
+  // wrong answer until currentTime changes again.
   const canUnsyncFromCursor = useMemo(() => {
-    const cursorTime = currentTimeRef.current
-    return allWords.some((w) => w.start_time !== null && w.start_time > cursorTime)
+    return allWords.some((w) => w.start_time !== null && w.start_time > currentTime)
   }, [allWords, currentTime])
 
   // Open edit lyrics modal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.173.0"
+version = "0.173.1"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- The 'Unsync from Cursor' button in the lyrics re-sync modal stayed disabled after a user paused playback and scrubbed the audio backwards, even when synced words clearly existed past the cursor.
- Root cause: \`canUnsyncFromCursor\` was a \`useMemo\` that read \`currentTimeRef.current\` while depending on \`[allWords, currentTime]\`. The effect that mirrors \`currentTime\` into the ref runs *after* the render, so the useMemo computed against the previous (higher) ref value when \`currentTime\` jumped backwards, cached \`false\`, and never re-ran (because \`currentTime\` then stayed put while paused).
- Fix: read \`currentTime\` directly inside the useMemo. Other \`currentTimeRef.current\` uses are inside event handlers (which run after effects) and are unaffected.

## Test plan

- [x] New unit test (\`LyricsSynchronizer.unsync.test.tsx\`) covering the happy path, the genuinely-disabled path, and the regression: render with \`currentTime=20\`, then re-render with \`currentTime=10\`, assert button enabled. Verified the regression test fails on the broken code and passes on the fix.
- [x] Full Jest suite passes (888 tests).
- [x] Reproduced and verified the fix manually in a local Next dev pointed at prod backend, with the actual stuck job (\`2cb49a45\`).

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)