### PR TITLE
fix(lyrics-review): trim previous word end_time so tap-mode resync doesn't overlap

### DIFF
--- a/frontend/components/lyrics-review/__tests__/LyricsSynchronizer.tapOverlap.test.tsx
+++ b/frontend/components/lyrics-review/__tests__/LyricsSynchronizer.tapOverlap.test.tsx
@@ -1,0 +1,134 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import LyricsSynchronizer from '../synchronizer/LyricsSynchronizer'
+import type { LyricsSegment } from '@/lib/lyrics-review/types'
+
+// Stub heavy children — we only care about timing logic, not rendering.
+jest.mock('../synchronizer/TimelineCanvas', () => () => null)
+jest.mock('../synchronizer/UpcomingWordsBar', () => () => null)
+
+function makeSegment(words: Array<{ text: string; start: number | null; end: number | null }>): LyricsSegment {
+  return {
+    id: 'seg-1',
+    text: words.map((w) => w.text).join(' '),
+    start_time: words[0]?.start ?? null,
+    end_time: words[words.length - 1]?.end ?? null,
+    words: words.map((w, i) => ({
+      id: `w-${i}`,
+      text: w.text,
+      start_time: w.start,
+      end_time: w.end,
+    })),
+  }
+}
+
+function flushTimers() {
+  jest.advanceTimersByTime(100)
+}
+
+describe('LyricsSynchronizer — tap-mode prevents overlapping word timings', () => {
+  let capturedHandler: ((e: KeyboardEvent) => void) | undefined
+
+  beforeEach(() => {
+    capturedHandler = undefined
+    // The component reads window.getAudioDuration / isAudioPlaying
+    ;(window as unknown as { getAudioDuration: () => number }).getAudioDuration = () => 60
+    ;(window as unknown as { isAudioPlaying: boolean }).isAudioPlaying = false
+    ;(window as unknown as { toggleAudioPlayback: () => void }).toggleAudioPlayback = jest.fn()
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  function setModalSpacebarHandler(handler: ((e: KeyboardEvent) => void) | undefined) {
+    capturedHandler = handler
+  }
+
+  // Regression: previously, a tap on word A set A.end_time = A.start + 0.5s. Then
+  // when word B was tapped within 500ms, handleKeyDown's "fix prev word" branch
+  // was gated on prevWord.end_time === null and didn't fire, leaving A.end > B.start.
+  // For songs with words sung in rapid succession this caused the karaoke video
+  // to highlight 2-3 words simultaneously throughout. The fix must trim A.end
+  // whenever B.start would precede it, regardless of whether end_time was
+  // already set by the tap optimistic-end heuristic.
+  it('trims previous word end_time when next tap arrives within 500ms', async () => {
+    const onSave = jest.fn()
+    const segments = [
+      makeSegment([
+        { text: 'We', start: null, end: null },
+        { text: 'walk', start: null, end: null },
+        { text: 'in', start: null, end: null },
+      ]),
+    ]
+
+    const { rerender } = render(
+      <LyricsSynchronizer
+        segments={segments}
+        currentTime={0}
+        onPlaySegment={jest.fn()}
+        onSave={onSave}
+        onCancel={jest.fn()}
+        setModalSpacebarHandler={setModalSpacebarHandler}
+      />
+    )
+
+    // Enter manual-sync mode.
+    fireEvent.click(screen.getByRole('button', { name: /start sync/i }))
+
+    expect(capturedHandler).toBeDefined()
+    const dispatch = (type: 'keydown' | 'keyup', t: number) => {
+      // currentTime drives wordStartTimeRef. Re-render so the component's
+      // currentTimeRef is updated before the event fires.
+      rerender(
+        <LyricsSynchronizer
+          segments={segments}
+          currentTime={t}
+          onPlaySegment={jest.fn()}
+          onSave={onSave}
+          onCancel={jest.fn()}
+          setModalSpacebarHandler={setModalSpacebarHandler}
+        />
+      )
+      act(() => {
+        const ev = new KeyboardEvent(type, { code: 'Space', bubbles: true })
+        capturedHandler!(ev)
+      })
+    }
+
+    // Word 0 ("We") — tap at t=2.0, release 50ms later (isTap=true → end = 2.5)
+    dispatch('keydown', 2.0)
+    // press duration tracked via Date.now(); fast-forward 50ms
+    act(() => { jest.advanceTimersByTime(50) })
+    dispatch('keyup', 2.05)
+
+    // Word 1 ("walk") — tap at t=2.2 (200ms after word 0's start). Without the
+    // fix, word 0 still claims to end at 2.5, overlapping word 1 by 300ms.
+    dispatch('keydown', 2.2)
+    act(() => { jest.advanceTimersByTime(50) })
+    dispatch('keyup', 2.25)
+
+    // Word 2 ("in") — tap at t=2.4
+    dispatch('keydown', 2.4)
+    act(() => { jest.advanceTimersByTime(50) })
+    dispatch('keyup', 2.45)
+
+    flushTimers()
+
+    // Apply
+    fireEvent.click(screen.getByRole('button', { name: /^apply$/i }))
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+    const saved: LyricsSegment[] = onSave.mock.calls[0][0]
+    const words = saved.flatMap((s) => s.words)
+
+    expect(words).toHaveLength(3)
+    expect(words[0].start_time).toBeCloseTo(2.0, 3)
+    expect(words[1].start_time).toBeCloseTo(2.2, 3)
+    expect(words[2].start_time).toBeCloseTo(2.4, 3)
+
+    // Core assertion: word 0's end must NOT extend past word 1's start.
+    expect(words[0].end_time!).toBeLessThanOrEqual(words[1].start_time!)
+    expect(words[1].end_time!).toBeLessThanOrEqual(words[2].start_time!)
+  })
+})

--- a/frontend/components/lyrics-review/synchronizer/LyricsSynchronizer.tsx
+++ b/frontend/components/lyrics-review/synchronizer/LyricsSynchronizer.tsx
@@ -576,12 +576,21 @@ const LyricsSynchronizer = memo(function LyricsSynchronizer({
 
       if (syncWordIndex > 0) {
         const prevWord = newWords[syncWordIndex - 1]
-        if (prevWord.start_time !== null && prevWord.end_time === null) {
-          const gap = currentTimeRef.current - prevWord.start_time
-          if (gap > 1.0) {
-            prevWord.end_time = prevWord.start_time + 0.5
-          } else {
-            prevWord.end_time = currentTimeRef.current - 0.005
+        if (prevWord.start_time !== null) {
+          // Cap previous word's end at the new word's start so they never
+          // overlap. Tap-mode keyUp optimistically sets end_time = start + 500ms;
+          // when the next word starts within 500ms, that placeholder must
+          // shrink, otherwise the karaoke video lights up multiple words at
+          // once. Hold-mode words may also still have null end_time if a
+          // keyUp was missed — they get the same cap.
+          const cap = currentTimeRef.current - 0.005
+          if (prevWord.end_time === null || prevWord.end_time > cap) {
+            const gap = currentTimeRef.current - prevWord.start_time
+            if (prevWord.end_time === null && gap > 1.0) {
+              prevWord.end_time = prevWord.start_time + 0.5
+            } else {
+              prevWord.end_time = Math.max(prevWord.start_time + 0.05, cap)
+            }
           }
         }
       }
@@ -680,12 +689,16 @@ const LyricsSynchronizer = memo(function LyricsSynchronizer({
 
     if (syncWordIndex > 0) {
       const prevWord = newWords[syncWordIndex - 1]
-      if (prevWord.start_time !== null && prevWord.end_time === null) {
-        const gap = currentTimeRef.current - prevWord.start_time
-        if (gap > 1.0) {
-          prevWord.end_time = prevWord.start_time + 0.5
-        } else {
-          prevWord.end_time = currentTimeRef.current - 0.005
+      if (prevWord.start_time !== null) {
+        // See handleKeyDown for rationale — same overlap-prevention logic.
+        const cap = currentTimeRef.current - 0.005
+        if (prevWord.end_time === null || prevWord.end_time > cap) {
+          const gap = currentTimeRef.current - prevWord.start_time
+          if (prevWord.end_time === null && gap > 1.0) {
+            prevWord.end_time = prevWord.start_time + 0.5
+          } else {
+            prevWord.end_time = Math.max(prevWord.start_time + 0.05, cap)
+          }
         }
       }
     }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karaoke-gen-frontend",
-  "version": "0.85.9",
+  "version": "0.86.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "karaoke-gen-frontend",
-      "version": "0.85.9",
+      "version": "0.86.0",
       "dependencies": {
         "@fingerprintjs/fingerprintjs": "^5.1.0",
         "@hookform/resolvers": "^3.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.173.1"
+version = "0.173.2"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- In the Re-sync Existing Lyrics modal, tap mode (spacebar press <200ms) optimistically sets `currentWord.end_time = start + 500ms`. When the next word is tapped within 500ms, `handleKeyDown`'s "fix prev word" branch was gated on `prevWord.end_time === null` and never fired, leaving the previous word claiming to last 500ms past where the next word started.
- Effect: for any song with words sung in rapid succession (median sustained-singing tempo), the karaoke video lights up 2–3 words simultaneously throughout. Surfaced in production on a real client job where 80% of consecutive word pairs overlapped (median 283ms).
- Fix: in `handleKeyDown` and `handleTapStart`, always trim `prevWord.end_time` when it overshoots `currentTime - 5ms`, regardless of whether it was set by the optimistic placeholder. Hold-mode behavior preserved (null end_time still gets the 500ms-or-snap-to-now treatment for huge gaps).

## Test plan
- [x] New regression test `LyricsSynchronizer.tapOverlap.test.tsx` — drives the synchronizer through three rapid taps (200ms apart) and asserts no consecutive word overlaps. Fails on `main`, passes with the fix.
- [x] `npm run test:unit` — 889/889 pass
- [ ] Manual verification on prod after deploy: re-sync a few words quickly in the modal, click Apply, generate preview, confirm word durations are no longer all 500ms and that highlight transitions cleanly word-to-word.

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)