### PR TITLE
Encoding worker capacity resilience: real errors, auto-retry, multi-zone failover

### DIFF
--- a/backend/api/routes/internal.py
+++ b/backend/api/routes/internal.py
@@ -576,6 +576,145 @@ async def trigger_gdrive_validation_endpoint(
         return {"status": "error", "message": str(e)}
 
 
+@router.post("/retry-pending-render-jobs")
+async def retry_pending_render_jobs(
+    http_request: Request,
+    auth_data: Tuple[str, UserType, int] = Depends(require_admin)
+):
+    """
+    Auto-retry jobs parked in RENDER_PENDING_CAPACITY.
+
+    Called every 5 minutes by Cloud Scheduler. When the GCE encoding worker
+    can't be started because the zone is exhausted, the render worker parks
+    the job in this state instead of failing it. This endpoint re-attempts
+    the render — when GCE has capacity, the start succeeds and the job
+    completes normally.
+
+    Strategy:
+      - Process up to MAX_PER_TICK jobs (the GCE worker is single-tenant per
+        render, so spinning up many in parallel just collides on the same VM)
+      - Pick the oldest first (longest waiter gets fairness)
+      - Time out jobs that have been waiting longer than MAX_WAIT_SECONDS;
+        transition them to FAILED with a clear permanent-failure message
+      - For each remaining job: clear error state, reset to REVIEW_COMPLETE,
+        kick off the render worker again
+    """
+    from datetime import datetime, UTC, timedelta
+    from google.cloud.firestore_v1 import FieldFilter
+    from backend.services.worker_service import get_worker_service
+    from backend.models.job import JobStatus
+
+    # Long enough to ride out a sustained capacity outage but short enough
+    # that an op gets paged about it before the user sees a "still pending"
+    # job >24h old.
+    MAX_WAIT_SECONDS = 24 * 60 * 60  # 24h
+    MAX_PER_TICK = 1                  # one render at a time on the GCE worker
+
+    extract_trace_context(dict(http_request.headers))
+    add_span_attribute("operation", "retry_pending_render_jobs")
+    logger.info("RETRY_PENDING_RENDER_JOBS starting")
+
+    job_manager = JobManager()
+    worker_service = get_worker_service()
+
+    jobs_ref = job_manager.firestore.db.collection("jobs")
+    pending_query = (
+        jobs_ref
+        .where(filter=FieldFilter("status", "==", JobStatus.RENDER_PENDING_CAPACITY.value))
+        .order_by("updated_at")  # oldest first
+        .limit(MAX_PER_TICK + 5)  # small headroom in case timeouts skip past some
+    )
+
+    now = datetime.now(UTC)
+    timed_out = []
+    retried = []
+    skipped = 0
+
+    for doc in pending_query.stream():
+        job_data = doc.to_dict()
+        job_id = job_data.get("job_id", doc.id)
+
+        sd = job_data.get("state_data") or {}
+        pending_meta = sd.get("render_pending_capacity") or {}
+        first_seen = pending_meta.get("first_seen_at")
+
+        # Permanent-failure timeout
+        if first_seen:
+            try:
+                first_seen_dt = datetime.fromisoformat(first_seen)
+                age = now - first_seen_dt
+            except (ValueError, TypeError):
+                age = timedelta(0)
+            if age.total_seconds() > MAX_WAIT_SECONDS:
+                permanent_msg = (
+                    "Encoding capacity remained unavailable after "
+                    f"{int(age.total_seconds() // 3600)}h of automatic retries. "
+                    "Please retry manually or contact support."
+                )
+                logger.error(
+                    f"[job:{job_id}] Capacity wait exceeded {MAX_WAIT_SECONDS}s — failing permanently"
+                )
+                job_manager.fail_job(job_id, permanent_msg, error_details={
+                    "stage": "render_video",
+                    "permanent_capacity_timeout": True,
+                    "first_seen_at": first_seen,
+                    "attempts": pending_meta.get("attempt_count", 0),
+                })
+                timed_out.append(job_id)
+                continue
+
+        if len(retried) >= MAX_PER_TICK:
+            skipped += 1
+            continue
+
+        # Clear error state and reset render progress for idempotency.
+        # render_pending_capacity meta is preserved so the next failure (if any)
+        # increments the existing attempt counter.
+        job_manager.update_job(job_id, {
+            "error_message": None,
+            "error_details": None,
+        })
+        job_manager.update_state_data(job_id, "render_progress", {"stage": "pending"})
+
+        if not job_manager.transition_to_state(
+            job_id=job_id,
+            new_status=JobStatus.REVIEW_COMPLETE,
+            progress=70,
+            message="Auto-retrying video render — encoding capacity check",
+            raise_on_invalid=False,
+        ):
+            logger.warning(f"[job:{job_id}] Could not transition to REVIEW_COMPLETE for retry")
+            continue
+
+        try:
+            await worker_service.trigger_render_video_worker(job_id)
+            retried.append(job_id)
+            logger.info(f"[job:{job_id}] Auto-retry triggered")
+        except Exception as e:
+            logger.error(f"[job:{job_id}] Failed to trigger render worker: {e}")
+            # Job remains in REVIEW_COMPLETE — next tick will pick it up if it
+            # falls back to RENDER_PENDING_CAPACITY again.
+
+    add_span_event("retry_complete", {
+        "retried": len(retried),
+        "timed_out": len(timed_out),
+        "skipped": skipped,
+    })
+    logger.info(
+        f"RETRY_PENDING_RENDER_JOBS complete: retried={len(retried)} "
+        f"timed_out={len(timed_out)} skipped={skipped}"
+    )
+
+    return {
+        "status": "success",
+        "retried_jobs": retried,
+        "retried_count": len(retried),
+        "timed_out_jobs": timed_out,
+        "timed_out_count": len(timed_out),
+        "skipped_for_next_tick": skipped,
+    }
+
+
 @router.post("/recover-stuck-jobs")
 async def recover_stuck_jobs(
     http_request: Request,

--- a/backend/api/routes/jobs.py
+++ b/backend/api/routes/jobs.py
@@ -536,6 +536,7 @@ _SUMMARY_STATE_DATA_KEYS = {
     'audio_progress', 'lyrics_progress',
     'audio_complete', 'lyrics_complete',
     'backing_vocals_analysis', 'visibility_change_in_progress',
+    'render_pending_capacity',
 }
 _SUMMARY_FILE_URLS_KEYS = {'finals', 'videos', 'packages'}
 _HIDE_COMPLETED_STATUSES = ['complete', 'prep_complete', 'cancelled']

--- a/backend/config.py
+++ b/backend/config.py
@@ -97,6 +97,13 @@ class Settings(BaseSettings):
     encoding_worker_url: Optional[str] = os.getenv("ENCODING_WORKER_URL")  # e.g., http://136.119.50.148:8080
     encoding_worker_api_key: Optional[str] = os.getenv("ENCODING_WORKER_API_KEY")
 
+    # Optional capacity-fallback VMs in alternate zones. JSON list of objects:
+    #   '[{"vm":"encoding-worker-fallback-a","zone":"us-central1-a","ip":"34.x.x.x"}]'
+    # Empty by default. After `pulumi up` provisions the fallback VMs (Phase 3
+    # of the capacity-resilience plan), populate this var with their public
+    # IPs to enable multi-zone failover when us-central1-c is exhausted.
+    encoding_worker_fallback_vms: Optional[str] = os.getenv("ENCODING_WORKER_FALLBACK_VMS")
+
     # GCE Preview Encoding (for faster preview video generation)
     # When enabled, preview video encoding during lyrics review is offloaded to the GCE worker.
     # This reduces preview generation time from 60+ seconds to ~15-20 seconds.

--- a/backend/models/job.py
+++ b/backend/models/job.py
@@ -68,6 +68,7 @@ class JobStatus(str, Enum):
 
     # Stage 5.5: Render video with corrected lyrics (post-review)
     RENDERING_VIDEO = "rendering_video"          # Using OutputGenerator to create with_vocals.mkv
+    RENDER_PENDING_CAPACITY = "render_pending_capacity"  # Waiting for GCE encoding capacity (auto-retry)
 
     # Stage 6: Instrumental already selected (during combined review)
     # Note: AWAITING_INSTRUMENTAL_SELECTION kept for DB compatibility with historical jobs only
@@ -135,10 +136,27 @@ STATE_TRANSITIONS = {
     # AWAITING_REVIEW can go directly to REVIEW_COMPLETE (quick review) or to IN_REVIEW (editing)
     JobStatus.AWAITING_REVIEW: [JobStatus.IN_REVIEW, JobStatus.REVIEW_COMPLETE, JobStatus.FAILED, JobStatus.CANCELLED],
     JobStatus.IN_REVIEW: [JobStatus.REVIEW_COMPLETE, JobStatus.AWAITING_REVIEW, JobStatus.FAILED],
-    JobStatus.REVIEW_COMPLETE: [JobStatus.RENDERING_VIDEO, JobStatus.PREP_COMPLETE, JobStatus.FAILED],  # PREP_COMPLETE for prep-only jobs
+    JobStatus.REVIEW_COMPLETE: [
+        JobStatus.RENDERING_VIDEO,
+        JobStatus.PREP_COMPLETE,            # for prep-only jobs
+        JobStatus.RENDER_PENDING_CAPACITY,  # GCE capacity exhausted before render started
+        JobStatus.FAILED,
+    ],
 
     # Video rendering (post-review) - instrumental was already selected during combined review
-    JobStatus.RENDERING_VIDEO: [JobStatus.INSTRUMENTAL_SELECTED, JobStatus.PREP_COMPLETE, JobStatus.FAILED],
+    # RENDER_PENDING_CAPACITY = parked when GCE encoding capacity is exhausted; auto-retried by scheduler.
+    JobStatus.RENDERING_VIDEO: [
+        JobStatus.INSTRUMENTAL_SELECTED,
+        JobStatus.PREP_COMPLETE,
+        JobStatus.RENDER_PENDING_CAPACITY,
+        JobStatus.FAILED,
+    ],
+    JobStatus.RENDER_PENDING_CAPACITY: [
+        JobStatus.RENDERING_VIDEO,   # auto-retry succeeded, picked up again
+        JobStatus.REVIEW_COMPLETE,   # admin / scheduler resets to re-trigger render
+        JobStatus.FAILED,            # exceeded max wait or operator gave up
+        JobStatus.CANCELLED,         # user cancelled while waiting
+    ],
 
     # AWAITING_INSTRUMENTAL_SELECTION is LEGACY - kept for historical jobs in DB
     # New jobs never enter this state; they go directly to INSTRUMENTAL_SELECTED after render
@@ -166,6 +184,7 @@ STATE_TRANSITIONS = {
         JobStatus.REVIEW_COMPLETE,        # Retry from render stage
         JobStatus.LYRICS_COMPLETE,        # Retry from screens generation
         JobStatus.AWAITING_REVIEW,        # Retry from combined review
+        JobStatus.RENDER_PENDING_CAPACITY,  # Operator parks a stale-failed job for auto-retry
     ],
     JobStatus.CANCELLED: [
         JobStatus.DOWNLOADING,            # Retry from beginning (if input audio exists)

--- a/backend/services/encoding_errors.py
+++ b/backend/services/encoding_errors.py
@@ -1,0 +1,61 @@
+"""Typed exceptions for encoding worker lifecycle failures.
+
+These let callers distinguish between transient capacity issues (retry will
+likely help) and unexpected start failures (something is actually broken).
+"""
+
+from typing import FrozenSet
+
+
+CAPACITY_ERROR_CODES: FrozenSet[str] = frozenset({
+    "ZONE_RESOURCE_POOL_EXHAUSTED",
+    "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS",
+    "STOCKOUT",
+    "QUOTA_EXCEEDED",
+})
+
+
+class EncodingWorkerStartError(Exception):
+    """Raised when an attempt to start an encoding worker VM fails.
+
+    Carries the GCE error code so callers can react to specific failure modes.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        vm_name: str = "",
+        zone: str = "",
+        code: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.vm_name = vm_name
+        self.zone = zone
+        self.code = code
+
+
+class EncodingWorkerCapacityError(EncodingWorkerStartError):
+    """A capacity-related GCE failure (e.g. ZONE_RESOURCE_POOL_EXHAUSTED).
+
+    The zone temporarily cannot allocate the requested machine type. Callers
+    should treat this as recoverable — retrying after a wait, or trying an
+    alternate zone, is likely to succeed.
+    """
+
+
+def classify_gce_error(code: str, message: str, *, vm_name: str, zone: str) -> EncodingWorkerStartError:
+    """Wrap a GCE error code/message in the appropriate typed exception."""
+    if code in CAPACITY_ERROR_CODES:
+        return EncodingWorkerCapacityError(
+            f"VM {vm_name} could not be started in {zone}: {code} — {message}",
+            vm_name=vm_name,
+            zone=zone,
+            code=code,
+        )
+    return EncodingWorkerStartError(
+        f"VM {vm_name} start failed in {zone}: {code or 'unknown error'} — {message or 'no message'}",
+        vm_name=vm_name,
+        zone=zone,
+        code=code,
+    )

--- a/backend/services/encoding_service.py
+++ b/backend/services/encoding_service.py
@@ -79,7 +79,11 @@ class EncodingService:
         self._worker_manager = manager
 
     def _get_worker_url(self) -> str:
-        """Get the current primary worker URL from Firestore (with TTL cache).
+        """Get the current worker URL from Firestore (with TTL cache).
+
+        Returns config.active_url, which is normally the primary URL but
+        switches to the capacity-fallback override when a primary-zone
+        outage caused us to start a fallback VM in another zone.
 
         Falls back to static URL from config if worker_manager is not set.
         """
@@ -89,7 +93,7 @@ class EncodingService:
 
         if self._worker_manager:
             config = self._worker_manager.get_config()
-            self._cached_url = config.primary_url
+            self._cached_url = config.active_url
             self._url_cached_at = now
             return self._cached_url
 
@@ -97,6 +101,69 @@ class EncodingService:
         if not self._initialized:
             self._load_credentials()
         return self._url
+
+    def _invalidate_cached_url(self) -> None:
+        """Force the next _get_worker_url() to re-read from Firestore.
+
+        Called after the worker manager updates active_override (e.g. on
+        capacity fallback) so the in-flight request loop picks up the new URL.
+        """
+        self._cached_url = None
+        self._url_cached_at = 0.0
+
+    def _build_worker_candidates(self) -> list:
+        """Build the ordered candidate list for ensure_any_running.
+
+        Reads optional fallback VMs from settings (env var
+        ENCODING_WORKER_FALLBACK_VMS, JSON list of {vm, zone, ip}). Returns
+        an empty list when no worker manager / no configured fallbacks —
+        caller falls back to the single-VM ensure_primary_running path.
+        """
+        if not self._worker_manager:
+            return []
+        try:
+            config = self._worker_manager.get_config()
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"Could not read worker config for candidates: {_format_exception(e)}")
+            return []
+
+        from backend.services.encoding_worker_manager import EncodingWorkerCandidate
+
+        # Primary always goes first. Single-zone deployments stop here.
+        candidates = [
+            EncodingWorkerCandidate(
+                vm_name=config.primary_vm,
+                zone=self._worker_manager._zone,
+                ip=config.primary_ip,
+            )
+        ]
+
+        # Optional capacity-fallback VMs in alternate zones, configured via
+        # env var. Schema: '[{"vm":"encoding-worker-fallback-a","zone":"us-central1-a","ip":"34.x.x.x"}, ...]'
+        # The list is empty by default; user populates after `pulumi up`
+        # provisions the fallback VMs.
+        import json as _json
+        raw = self.settings.encoding_worker_fallback_vms
+        if not raw:
+            return candidates
+        try:
+            parsed = _json.loads(raw)
+        except (ValueError, TypeError) as e:
+            logger.warning(f"Invalid ENCODING_WORKER_FALLBACK_VMS JSON: {e}")
+            return candidates
+
+        for item in parsed:
+            try:
+                candidates.append(EncodingWorkerCandidate(
+                    vm_name=item["vm"],
+                    zone=item["zone"],
+                    ip=item["ip"],
+                ))
+            except (KeyError, TypeError) as e:
+                logger.warning(f"Skipping malformed fallback candidate {item}: {e}")
+                continue
+
+        return candidates
 
     def _load_credentials(self):
         """Load encoding worker URL and API key from config/secrets."""
@@ -153,12 +220,23 @@ class EncodingService:
         """
         if not self._worker_manager:
             return
+
+        candidates = self._build_worker_candidates()
         try:
-            result = self._worker_manager.ensure_primary_running()
+            if candidates and len(candidates) > 1:
+                # Multi-zone path: try primary, then fallbacks in alt zones.
+                result = self._worker_manager.ensure_any_running(candidates)
+                # If we fell back, the worker manager just persisted the
+                # active_override URL — invalidate our cache so the next
+                # request hits the right VM.
+                if result.get("fell_back"):
+                    self._invalidate_cached_url()
+            else:
+                result = self._worker_manager.ensure_primary_running()
         except EncodingWorkerCapacityError:
-            # Capacity exhausted — surface to caller so the job can be parked
-            # in a recoverable state instead of failing with a misleading
-            # "connection timeout" message.
+            # Every candidate exhausted (or single-zone primary exhausted).
+            # Surface to caller so the job can be parked in a recoverable
+            # state instead of failing with a misleading "connection timeout".
             raise
         except Exception as e:
             logger.warning(

--- a/backend/services/encoding_service.py
+++ b/backend/services/encoding_service.py
@@ -23,6 +23,10 @@ from typing import Optional, Dict, Any
 import aiohttp
 
 from backend.config import get_settings
+from backend.services.encoding_errors import (
+    EncodingWorkerCapacityError,
+    EncodingWorkerStartError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -140,11 +144,22 @@ class EncodingService:
 
         If the worker_manager is not set (e.g. dev mode with static URL), this
         is a no-op.
+
+        Raises:
+            EncodingWorkerCapacityError: GCE could not allocate capacity (e.g.
+                ZONE_RESOURCE_POOL_EXHAUSTED). Caller should bail out of any
+                retry loop — no point hammering an HTTP endpoint that will
+                never come up — and surface the error to the job.
         """
         if not self._worker_manager:
             return
         try:
             result = self._worker_manager.ensure_primary_running()
+        except EncodingWorkerCapacityError:
+            # Capacity exhausted — surface to caller so the job can be parked
+            # in a recoverable state instead of failing with a misleading
+            # "connection timeout" message.
+            raise
         except Exception as e:
             logger.warning(
                 f"[job:{job_id}] Encoding worker warmup fallback failed (non-fatal): "
@@ -240,7 +255,16 @@ class EncodingService:
             except (aiohttp.ClientConnectorError, aiohttp.ServerDisconnectedError, asyncio.TimeoutError) as e:
                 last_exception = e
                 if attempt == 0:
-                    await self._warmup_encoding_worker_fallback(job_id)
+                    try:
+                        await self._warmup_encoding_worker_fallback(job_id)
+                    except EncodingWorkerCapacityError as cap_err:
+                        # Zone is out of capacity — no point retrying the HTTP
+                        # call 7 more times to a VM that will never come up.
+                        logger.error(
+                            f"[job:{job_id}] Encoding worker capacity exhausted, "
+                            f"aborting retries: {cap_err}"
+                        )
+                        raise cap_err from e
                 if attempt < MAX_RETRIES:
                     logger.warning(
                         f"[job:{job_id}] GCE worker connection failed "

--- a/backend/services/encoding_worker_manager.py
+++ b/backend/services/encoding_worker_manager.py
@@ -69,6 +69,14 @@ class EncodingWorkerConfig:
     last_activity_at: Optional[str]
     deploy_in_progress: bool
     deploy_in_progress_since: Optional[str]
+    # Optional capacity-fallback override: when ensure_any_running falls back
+    # to a non-primary VM (e.g. due to ZONE_RESOURCE_POOL_EXHAUSTED), these
+    # fields point at the active fallback so requests target the right VM.
+    # Cleared when the primary becomes healthy again.
+    active_override_vm: Optional[str] = None
+    active_override_ip: Optional[str] = None
+    active_override_zone: Optional[str] = None
+    active_override_set_at: Optional[str] = None
 
     @property
     def primary_url(self) -> str:
@@ -77,6 +85,37 @@ class EncodingWorkerConfig:
     @property
     def secondary_url(self) -> str:
         return f"http://{self.secondary_ip}:{ENCODING_WORKER_PORT}"
+
+    @property
+    def active_url(self) -> str:
+        """URL the encoding service should target right now.
+
+        Returns the capacity-fallback override if set, otherwise the primary
+        URL. The override mechanism lets us route around a zone that's
+        temporarily out of c4d-highcpu-32 capacity without rewriting the
+        blue-green primary/secondary tracking.
+        """
+        if self.active_override_ip:
+            return f"http://{self.active_override_ip}:{ENCODING_WORKER_PORT}"
+        return self.primary_url
+
+
+@dataclass
+class EncodingWorkerCandidate:
+    """A VM that ensure_any_running may try to start.
+
+    Carries everything needed to talk to the worker: VM name + zone (so the
+    GCE compute client targets the right zone) and external IP (so successful
+    starts can be persisted as the active URL override).
+    """
+
+    vm_name: str
+    zone: str
+    ip: str
+
+    @property
+    def url(self) -> str:
+        return f"http://{self.ip}:{ENCODING_WORKER_PORT}"
 
 
 class EncodingWorkerManager:
@@ -118,6 +157,10 @@ class EncodingWorkerManager:
             last_activity_at=data.get("last_activity_at"),
             deploy_in_progress=data.get("deploy_in_progress", False),
             deploy_in_progress_since=data.get("deploy_in_progress_since"),
+            active_override_vm=data.get("active_override_vm"),
+            active_override_ip=data.get("active_override_ip"),
+            active_override_zone=data.get("active_override_zone"),
+            active_override_set_at=data.get("active_override_set_at"),
         )
 
     def update_activity(self) -> None:
@@ -175,16 +218,19 @@ class EncodingWorkerManager:
     # VM lifecycle operations (Task 2)
     # ------------------------------------------------------------------
 
-    def get_vm_status(self, vm_name: str) -> str:
-        """Get the current status of a GCE VM (e.g. RUNNING, TERMINATED, STAGING)."""
+    def get_vm_status(self, vm_name: str, zone: Optional[str] = None) -> str:
+        """Get the current status of a GCE VM (e.g. RUNNING, TERMINATED, STAGING).
+
+        Pass `zone` for fallback VMs that live in alternate zones.
+        """
         instance = self._compute.get(
             project=self._project_id,
-            zone=self._zone,
+            zone=zone or self._zone,
             instance=vm_name,
         )
         return instance.status
 
-    def start_vm(self, vm_name: str) -> None:
+    def start_vm(self, vm_name: str, zone: Optional[str] = None) -> None:
         """Start a VM if it is not already running or starting.
 
         Waits for the start operation to complete and raises a typed error if
@@ -193,33 +239,40 @@ class EncodingWorkerManager:
         dispatching work — operation success only means GCE accepted the start,
         not that the VM has finished booting.
 
+        Args:
+            vm_name: VM to start.
+            zone: Override the manager's default zone. Required when starting
+                capacity-fallback VMs in alternate zones.
+
         Raises:
             EncodingWorkerCapacityError: zone is out of capacity for the
                 machine type. Retry from a different zone or after a wait.
             EncodingWorkerStartError: any other start failure.
         """
-        status = self.get_vm_status(vm_name)
+        target_zone = zone or self._zone
+        status = self.get_vm_status(vm_name, zone=target_zone)
         if status in ("RUNNING", "STAGING"):
             logger.info("VM %s is already %s, skipping start", vm_name, status)
             return
-        logger.info("Starting VM %s (current status: %s)", vm_name, status)
+        logger.info("Starting VM %s in zone %s (current status: %s)", vm_name, target_zone, status)
         operation = self._compute.start(
             project=self._project_id,
-            zone=self._zone,
+            zone=target_zone,
             instance=vm_name,
         )
-        self._wait_for_compute_operation(operation, vm_name=vm_name, zone=self._zone)
+        self._wait_for_compute_operation(operation, vm_name=vm_name, zone=target_zone)
 
-    def stop_vm(self, vm_name: str) -> None:
+    def stop_vm(self, vm_name: str, zone: Optional[str] = None) -> None:
         """Stop a VM if it is not already stopped or stopping."""
-        status = self.get_vm_status(vm_name)
+        target_zone = zone or self._zone
+        status = self.get_vm_status(vm_name, zone=target_zone)
         if status in ("TERMINATED", "STOPPING"):
             logger.info("VM %s is already %s, skipping stop", vm_name, status)
             return
-        logger.info("Stopping VM %s (current status: %s)", vm_name, status)
+        logger.info("Stopping VM %s in zone %s (current status: %s)", vm_name, target_zone, status)
         self._compute.stop(
             project=self._project_id,
-            zone=self._zone,
+            zone=target_zone,
             instance=vm_name,
         )
 
@@ -266,6 +319,112 @@ class EncodingWorkerManager:
             "vm_name": vm_name,
             "primary_url": config.primary_url,
         }
+
+    def ensure_any_running(self, candidates: list) -> dict:
+        """Start the first candidate VM that GCE accepts; raise if all are exhausted.
+
+        Iterates `candidates` in order, attempting to start each one. A
+        capacity error (ZONE_RESOURCE_POOL_EXHAUSTED, etc.) on candidate N
+        triggers a try of candidate N+1. Other start failures abort the
+        whole call.
+
+        On fallback success (a non-first candidate started), persists the
+        fallback's URL as `active_override_*` in Firestore so subsequent
+        encoding requests target the right VM. The first candidate (the
+        primary) succeeding clears any stale override.
+
+        Args:
+            candidates: List of EncodingWorkerCandidate, ordered by preference.
+                Typically [primary, secondary, *fallbacks_in_alt_zones].
+
+        Returns:
+            dict {started, vm_name, zone, primary_url, fell_back}
+                fell_back is True iff the chosen VM is not the first candidate.
+
+        Raises:
+            EncodingWorkerCapacityError: all candidates rejected with
+                capacity errors.
+            EncodingWorkerStartError: any non-capacity start failure.
+            ValueError: empty candidate list.
+        """
+        if not candidates:
+            raise ValueError("ensure_any_running requires at least one candidate")
+
+        last_capacity_error: Optional[EncodingWorkerCapacityError] = None
+        for index, candidate in enumerate(candidates):
+            try:
+                status = self.get_vm_status(candidate.vm_name, zone=candidate.zone)
+                started = False
+                if status not in ("RUNNING", "STAGING"):
+                    logger.info(
+                        "Trying candidate %d/%d: VM %s in %s (status %s)",
+                        index + 1, len(candidates), candidate.vm_name,
+                        candidate.zone, status,
+                    )
+                    self.start_vm(candidate.vm_name, zone=candidate.zone)
+                    started = True
+
+                self.update_activity()
+                fell_back = index > 0
+                if fell_back:
+                    self._set_active_override(candidate)
+                else:
+                    self._clear_active_override()
+
+                return {
+                    "started": started,
+                    "vm_name": candidate.vm_name,
+                    "zone": candidate.zone,
+                    "primary_url": candidate.url,
+                    "fell_back": fell_back,
+                }
+            except EncodingWorkerCapacityError as cap_err:
+                logger.warning(
+                    "Candidate %s in %s exhausted (%s), trying next zone",
+                    candidate.vm_name, candidate.zone, cap_err.code,
+                )
+                last_capacity_error = cap_err
+                continue
+            # Non-capacity start errors should NOT silently fall through —
+            # they indicate something genuinely broken (bad image, wrong SA, etc.)
+            # and trying another zone won't help.
+
+        # Every candidate exhausted.
+        assert last_capacity_error is not None
+        raise last_capacity_error
+
+    def _set_active_override(self, candidate) -> None:
+        """Record a fallback VM as the active worker URL in Firestore."""
+        now = datetime.now(UTC).isoformat()
+        self._doc_ref().update({
+            "active_override_vm": candidate.vm_name,
+            "active_override_ip": candidate.ip,
+            "active_override_zone": candidate.zone,
+            "active_override_set_at": now,
+        })
+        logger.info(
+            "Set active_override to %s in %s (capacity fallback)",
+            candidate.vm_name, candidate.zone,
+        )
+
+    def _clear_active_override(self) -> None:
+        """Clear active_override fields (primary is healthy again).
+
+        Idempotent: safe to call when no override is currently set.
+        """
+        snapshot = self._doc_ref().get()
+        if not snapshot.exists:
+            return
+        data = snapshot.to_dict() or {}
+        if not data.get("active_override_vm"):
+            return  # nothing to clear
+        self._doc_ref().update({
+            "active_override_vm": None,
+            "active_override_ip": None,
+            "active_override_zone": None,
+            "active_override_set_at": None,
+        })
+        logger.info("Cleared active_override (primary is healthy again)")
 
     # ------------------------------------------------------------------
     # Compute operation helpers

--- a/backend/services/encoding_worker_manager.py
+++ b/backend/services/encoding_worker_manager.py
@@ -29,13 +29,24 @@ import asyncio
 import logging
 from dataclasses import dataclass
 from datetime import datetime, UTC
-from typing import Optional
+from typing import Any, Optional
 
 import aiohttp
 
 from google.cloud import firestore
 
+from backend.services.encoding_errors import (
+    EncodingWorkerCapacityError,
+    EncodingWorkerStartError,
+    classify_gce_error,
+)
+
 logger = logging.getLogger(__name__)
+
+# How long to wait for a compute.instances.start operation to settle. The GCE
+# operation itself is fast (1-2s) — we just need to know whether it succeeded
+# or returned an immediate error like ZONE_RESOURCE_POOL_EXHAUSTED.
+START_OPERATION_TIMEOUT_SECONDS = 30.0
 
 CONFIG_COLLECTION = "config"
 CONFIG_DOCUMENT = "encoding-worker"
@@ -176,19 +187,28 @@ class EncodingWorkerManager:
     def start_vm(self, vm_name: str) -> None:
         """Start a VM if it is not already running or starting.
 
-        Fire-and-forget: returns immediately. Caller should poll get_vm_status
-        if they need to wait for the VM to be fully RUNNING.
+        Waits for the start operation to complete and raises a typed error if
+        GCE rejects the request (e.g. ZONE_RESOURCE_POOL_EXHAUSTED). Caller
+        should still poll get_vm_status / wait_for_worker_ready before
+        dispatching work — operation success only means GCE accepted the start,
+        not that the VM has finished booting.
+
+        Raises:
+            EncodingWorkerCapacityError: zone is out of capacity for the
+                machine type. Retry from a different zone or after a wait.
+            EncodingWorkerStartError: any other start failure.
         """
         status = self.get_vm_status(vm_name)
         if status in ("RUNNING", "STAGING"):
             logger.info("VM %s is already %s, skipping start", vm_name, status)
             return
         logger.info("Starting VM %s (current status: %s)", vm_name, status)
-        self._compute.start(
+        operation = self._compute.start(
             project=self._project_id,
             zone=self._zone,
             instance=vm_name,
         )
+        self._wait_for_compute_operation(operation, vm_name=vm_name, zone=self._zone)
 
     def stop_vm(self, vm_name: str) -> None:
         """Stop a VM if it is not already stopped or stopping."""
@@ -206,13 +226,20 @@ class EncodingWorkerManager:
     def ensure_primary_running(self) -> dict:
         """Ensure the primary encoding worker VM is running.
 
-        Reads config, starts primary VM if stopped, and updates activity timestamp.
+        Reads config, starts primary VM if stopped, and updates activity
+        timestamp. Waits for the start operation to settle so that capacity
+        errors surface immediately instead of being hidden behind a 120s
+        readiness wait.
 
         Returns:
             dict with keys:
                 - started (bool): True if VM was started, False if already running
                 - vm_name (str): Name of the primary VM
                 - primary_url (str): URL of the primary encoding worker
+
+        Raises:
+            EncodingWorkerCapacityError: zone is exhausted for the machine type.
+            EncodingWorkerStartError: any other start failure.
         """
         config = self.get_config()
         vm_name = config.primary_vm
@@ -222,11 +249,12 @@ class EncodingWorkerManager:
 
         if status not in ("RUNNING", "STAGING"):
             logger.info("Primary VM %s is %s, starting it", vm_name, status)
-            self._compute.start(
+            operation = self._compute.start(
                 project=self._project_id,
                 zone=self._zone,
                 instance=vm_name,
             )
+            self._wait_for_compute_operation(operation, vm_name=vm_name, zone=self._zone)
             started = True
         else:
             logger.info("Primary VM %s is already %s", vm_name, status)
@@ -238,6 +266,51 @@ class EncodingWorkerManager:
             "vm_name": vm_name,
             "primary_url": config.primary_url,
         }
+
+    # ------------------------------------------------------------------
+    # Compute operation helpers
+    # ------------------------------------------------------------------
+
+    def _wait_for_compute_operation(
+        self,
+        operation: Any,
+        *,
+        vm_name: str,
+        zone: str,
+        timeout: float = START_OPERATION_TIMEOUT_SECONDS,
+    ) -> None:
+        """Block on a compute v1 ExtendedOperation; raise typed exceptions on error.
+
+        google.cloud.compute_v1 returns an ExtendedOperation. Calling .result()
+        blocks until done; successful operations return None, failures raise.
+        Some failure modes set .error_code/.error_message on the operation
+        without raising (depending on SDK version), so we check both paths.
+        """
+        result_exc: Optional[BaseException] = None
+        try:
+            if hasattr(operation, "result"):
+                operation.result(timeout=timeout)
+        except Exception as e:  # noqa: BLE001 — we re-raise as a typed error below
+            result_exc = e
+
+        code = (getattr(operation, "error_code", "") or "")
+        message = (getattr(operation, "error_message", "") or "")
+
+        if not code and result_exc is None:
+            return  # Success.
+
+        if not code and result_exc is not None:
+            # Operation raised but did not set error_code (e.g. timeout, transport
+            # failure). Fall back to the raised exception text.
+            raise EncodingWorkerStartError(
+                f"VM {vm_name} start operation failed in {zone}: {result_exc}",
+                vm_name=vm_name,
+                zone=zone,
+                code="",
+            ) from result_exc
+
+        # error_code populated — classify it.
+        raise classify_gce_error(code, message, vm_name=vm_name, zone=zone) from result_exc
 
     # ------------------------------------------------------------------
     # Task 3: cold-start readiness gate

--- a/backend/services/firestore_service.py
+++ b/backend/services/firestore_service.py
@@ -188,6 +188,7 @@ class FirestoreService:
         'state_data.audio_progress', 'state_data.lyrics_progress',
         'state_data.audio_complete', 'state_data.lyrics_complete',
         'state_data.backing_vocals_analysis', 'state_data.visibility_change_in_progress',
+        'state_data.render_pending_capacity',
         'file_urls.finals', 'file_urls.videos', 'file_urls.packages',
         'processing_metadata',
     ]

--- a/backend/tests/test_encoding_service.py
+++ b/backend/tests/test_encoding_service.py
@@ -238,6 +238,55 @@ class TestRequestWithRetry:
             with pytest.raises(aiohttp.ClientConnectorError):
                 await encoding_service.submit_encoding_job("j1", "gs://in", "gs://out", {})
 
+    @pytest.mark.asyncio
+    async def test_request_aborts_on_capacity_error_from_warmup(self, encoding_service):
+        """When the warmup raises a capacity error, abort retries immediately.
+
+        Hammering the HTTP endpoint another 7 times costs ~7 min of wall clock
+        and produces no useful information — the VM literally cannot start.
+        The capacity error must surface to the worker so the job can be parked.
+        """
+        from backend.services.encoding_errors import EncodingWorkerCapacityError
+
+        # Make ClientSession() raise synchronously when entered, so the very
+        # first attempt fails with TimeoutError without needing to mock the
+        # full aiohttp request lifecycle.
+        class TimingOutSession:
+            async def __aenter__(self):
+                raise asyncio.TimeoutError()
+            async def __aexit__(self, *a):
+                return False
+
+        async def warmup_raises_capacity(job_id):
+            raise EncodingWorkerCapacityError(
+                "ZONE_RESOURCE_POOL_EXHAUSTED",
+                vm_name="encoding-worker-b",
+                zone="us-central1-c",
+                code="ZONE_RESOURCE_POOL_EXHAUSTED",
+            )
+
+        with patch("aiohttp.ClientSession", return_value=TimingOutSession()), \
+             patch.object(
+                 encoding_service,
+                 "_warmup_encoding_worker_fallback",
+                 side_effect=warmup_raises_capacity,
+             ) as warmup_mock, \
+             patch("asyncio.sleep", new_callable=AsyncMock):
+
+            with pytest.raises(EncodingWorkerCapacityError):
+                await encoding_service._request_with_retry(
+                    method="POST",
+                    url="http://1.2.3.4:8080/encode",
+                    headers={},
+                    json_payload={},
+                    timeout=1.0,
+                    job_id="cap-test",
+                )
+
+        # Warmup is invoked exactly once (after the first failure) and its
+        # capacity error short-circuits the retry loop.
+        assert warmup_mock.await_count == 1
+
 
 class TestWarmupFallback:
     """Tests for _warmup_encoding_worker_fallback() in the retry loop."""
@@ -263,14 +312,40 @@ class TestWarmupFallback:
         await encoding_service._warmup_encoding_worker_fallback("test-job")
 
     @pytest.mark.asyncio
-    async def test_warmup_fallback_swallows_exceptions(self, encoding_service):
-        """Warmup fallback never raises — failures are logged but non-fatal."""
+    async def test_warmup_fallback_swallows_unexpected_exceptions(self, encoding_service):
+        """Generic warmup failures (e.g. transient Compute API blips) are logged but non-fatal.
+
+        Capacity errors are an exception — they propagate so the caller can park
+        the job for auto-retry. See `test_warmup_fallback_propagates_capacity_error`.
+        """
         mock_manager = MagicMock()
         mock_manager.ensure_primary_running.side_effect = Exception("Compute API down")
         encoding_service._worker_manager = mock_manager
 
         # Should not raise
         await encoding_service._warmup_encoding_worker_fallback("test-job")
+
+    @pytest.mark.asyncio
+    async def test_warmup_fallback_propagates_capacity_error(self, encoding_service):
+        """Capacity errors must propagate so the job can be parked for auto-retry.
+
+        Without this, a ZONE_RESOURCE_POOL_EXHAUSTED hides behind the cold-start
+        timeout and surfaces 7+ minutes later as a useless `TimeoutError`.
+        """
+        from backend.services.encoding_errors import EncodingWorkerCapacityError
+
+        mock_manager = MagicMock()
+        mock_manager.ensure_primary_running.side_effect = EncodingWorkerCapacityError(
+            "VM encoding-worker-b could not be started in us-central1-c: "
+            "ZONE_RESOURCE_POOL_EXHAUSTED — out of capacity",
+            vm_name="encoding-worker-b",
+            zone="us-central1-c",
+            code="ZONE_RESOURCE_POOL_EXHAUSTED",
+        )
+        encoding_service._worker_manager = mock_manager
+
+        with pytest.raises(EncodingWorkerCapacityError):
+            await encoding_service._warmup_encoding_worker_fallback("test-job")
 
     @pytest.mark.asyncio
     async def test_warmup_skips_readiness_wait_when_vm_already_running(self, encoding_service):

--- a/backend/tests/test_encoding_service.py
+++ b/backend/tests/test_encoding_service.py
@@ -590,6 +590,7 @@ class TestDynamicURLResolution:
         mock_manager = MagicMock()
         mock_manager.get_config.return_value = MagicMock(
             primary_url="http://34.1.2.3:8080",
+            active_url="http://34.1.2.3:8080",
         )
         service = EncodingService()
         service._initialized = True
@@ -605,6 +606,7 @@ class TestDynamicURLResolution:
         mock_manager = MagicMock()
         mock_manager.get_config.return_value = MagicMock(
             primary_url="http://34.1.2.3:8080",
+            active_url="http://34.1.2.3:8080",
         )
         service = EncodingService()
         service._initialized = True
@@ -620,6 +622,7 @@ class TestDynamicURLResolution:
         mock_manager = MagicMock()
         mock_manager.get_config.return_value = MagicMock(
             primary_url="http://34.1.2.3:8080",
+            active_url="http://34.1.2.3:8080",
         )
         service = EncodingService()
         service._initialized = True

--- a/backend/tests/test_encoding_worker_manager.py
+++ b/backend/tests/test_encoding_worker_manager.py
@@ -12,6 +12,7 @@ from datetime import datetime, UTC
 from unittest.mock import MagicMock, patch, call, AsyncMock
 
 from backend.services.encoding_worker_manager import (
+    EncodingWorkerCandidate,
     EncodingWorkerConfig,
     EncodingWorkerManager,
     CONFIG_COLLECTION,
@@ -432,6 +433,185 @@ class TestVMLifecycle:
             mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
             with pytest.raises(EncodingWorkerCapacityError):
                 manager.ensure_primary_running()
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: multi-zone failover (ensure_any_running)
+# ---------------------------------------------------------------------------
+
+
+def _ok_op():
+    """Build a successful compute Operation mock."""
+    op = MagicMock()
+    op.error_code = ""
+    op.error_message = ""
+    op.result.return_value = None
+    return op
+
+
+def _capacity_op():
+    """Build a ZONE_RESOURCE_POOL_EXHAUSTED Operation mock."""
+    op = MagicMock()
+    op.error_code = "ZONE_RESOURCE_POOL_EXHAUSTED"
+    op.error_message = "out of capacity"
+    op.result.return_value = None
+    return op
+
+
+class TestEnsureAnyRunning:
+    """Tests for ensure_any_running() — capacity-fallback iteration."""
+
+    def test_starts_first_candidate_when_available(self, manager, mock_db, mock_compute):
+        """When the primary candidate has capacity, it's used and no fallback engaged."""
+        mock_instance = MagicMock()
+        mock_instance.status = "TERMINATED"
+        mock_compute.get.return_value = mock_instance
+        mock_compute.start.return_value = _ok_op()
+
+        candidates = [
+            EncodingWorkerCandidate(vm_name="encoding-worker-blue", zone="us-central1-c", ip="10.0.0.1"),
+            EncodingWorkerCandidate(vm_name="encoding-worker-fb-a", zone="us-central1-a", ip="10.0.0.2"),
+        ]
+
+        with patch("backend.services.encoding_worker_manager.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 5, 5, 9, 0, 0, tzinfo=UTC)
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = manager.ensure_any_running(candidates)
+
+        assert result["fell_back"] is False
+        assert result["vm_name"] == "encoding-worker-blue"
+        assert result["zone"] == "us-central1-c"
+        # Only the first candidate's start was attempted.
+        mock_compute.start.assert_called_once()
+
+    def test_falls_through_to_next_zone_on_capacity_error(self, manager, mock_db, mock_compute):
+        """Capacity error on candidate 1 triggers a try of candidate 2."""
+        mock_instance = MagicMock()
+        mock_instance.status = "TERMINATED"
+        mock_compute.get.return_value = mock_instance
+        # First start: capacity error. Second start: succeeds.
+        mock_compute.start.side_effect = [_capacity_op(), _ok_op()]
+
+        candidates = [
+            EncodingWorkerCandidate(vm_name="encoding-worker-blue", zone="us-central1-c", ip="10.0.0.1"),
+            EncodingWorkerCandidate(vm_name="encoding-worker-fb-a", zone="us-central1-a", ip="10.0.0.2"),
+        ]
+
+        with patch("backend.services.encoding_worker_manager.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 5, 5, 9, 0, 0, tzinfo=UTC)
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = manager.ensure_any_running(candidates)
+
+        assert result["fell_back"] is True
+        assert result["vm_name"] == "encoding-worker-fb-a"
+        assert result["zone"] == "us-central1-a"
+
+        # Both starts were attempted, in order.
+        assert mock_compute.start.call_count == 2
+
+        # Active override was persisted in Firestore.
+        doc_ref = mock_db.collection.return_value.document.return_value
+        # Multiple update calls (for activity + override) — find the override one
+        override_calls = [
+            c for c in doc_ref.update.call_args_list
+            if "active_override_vm" in c.args[0]
+        ]
+        assert override_calls, "Expected Firestore update with active_override_vm"
+        override_data = override_calls[0].args[0]
+        assert override_data["active_override_vm"] == "encoding-worker-fb-a"
+        assert override_data["active_override_zone"] == "us-central1-a"
+        assert override_data["active_override_ip"] == "10.0.0.2"
+
+    def test_raises_when_all_candidates_exhausted(self, manager, mock_db, mock_compute):
+        """If every candidate hits capacity error, the last one is re-raised."""
+        from backend.services.encoding_errors import EncodingWorkerCapacityError
+
+        mock_instance = MagicMock()
+        mock_instance.status = "TERMINATED"
+        mock_compute.get.return_value = mock_instance
+        mock_compute.start.side_effect = [_capacity_op(), _capacity_op(), _capacity_op()]
+
+        candidates = [
+            EncodingWorkerCandidate(vm_name="vm-c", zone="us-central1-c", ip="1.1.1.1"),
+            EncodingWorkerCandidate(vm_name="vm-a", zone="us-central1-a", ip="1.1.1.2"),
+            EncodingWorkerCandidate(vm_name="vm-f", zone="us-central1-f", ip="1.1.1.3"),
+        ]
+
+        with pytest.raises(EncodingWorkerCapacityError):
+            manager.ensure_any_running(candidates)
+
+        # All three were attempted before giving up.
+        assert mock_compute.start.call_count == 3
+
+    def test_clears_override_when_primary_succeeds(self, manager, mock_db, mock_compute):
+        """When the primary starts successfully, any stale active_override is cleared."""
+        mock_instance = MagicMock()
+        mock_instance.status = "TERMINATED"
+        mock_compute.get.return_value = mock_instance
+        mock_compute.start.return_value = _ok_op()
+
+        # Pretend Firestore has an override set from a prior fallback.
+        snapshot = MagicMock()
+        snapshot.exists = True
+        snapshot.to_dict.return_value = {
+            "active_override_vm": "encoding-worker-fb-a",
+            "active_override_ip": "10.0.0.2",
+            "active_override_zone": "us-central1-a",
+        }
+        mock_db.collection.return_value.document.return_value.get.return_value = snapshot
+
+        candidates = [
+            EncodingWorkerCandidate(vm_name="encoding-worker-blue", zone="us-central1-c", ip="10.0.0.1"),
+        ]
+
+        with patch("backend.services.encoding_worker_manager.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 5, 5, 9, 0, 0, tzinfo=UTC)
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = manager.ensure_any_running(candidates)
+
+        assert result["fell_back"] is False
+
+        # Verify the clear-override write happened.
+        doc_ref = mock_db.collection.return_value.document.return_value
+        clear_calls = [
+            c for c in doc_ref.update.call_args_list
+            if c.args[0].get("active_override_vm") is None and "active_override_vm" in c.args[0]
+        ]
+        assert clear_calls, "Expected an update call clearing active_override_vm to None"
+
+    def test_empty_candidates_raises_value_error(self, manager):
+        with pytest.raises(ValueError):
+            manager.ensure_any_running([])
+
+
+class TestActiveUrl:
+    """Tests for EncodingWorkerConfig.active_url override behavior."""
+
+    def test_active_url_returns_primary_when_no_override(self):
+        config = EncodingWorkerConfig(
+            primary_vm="vm-a", primary_ip="10.0.0.1", primary_version="1.0.0",
+            primary_deployed_at=None,
+            secondary_vm="vm-b", secondary_ip="10.0.0.2", secondary_version=None,
+            secondary_deployed_at=None,
+            last_swap_at=None, last_activity_at=None,
+            deploy_in_progress=False, deploy_in_progress_since=None,
+        )
+        assert config.active_url == f"http://10.0.0.1:{ENCODING_WORKER_PORT}"
+
+    def test_active_url_returns_override_when_set(self):
+        config = EncodingWorkerConfig(
+            primary_vm="vm-a", primary_ip="10.0.0.1", primary_version="1.0.0",
+            primary_deployed_at=None,
+            secondary_vm="vm-b", secondary_ip="10.0.0.2", secondary_version=None,
+            secondary_deployed_at=None,
+            last_swap_at=None, last_activity_at=None,
+            deploy_in_progress=False, deploy_in_progress_since=None,
+            active_override_vm="vm-fb-a",
+            active_override_ip="34.5.6.7",
+            active_override_zone="us-central1-a",
+            active_override_set_at="2026-05-05T09:00:00+00:00",
+        )
+        assert config.active_url == f"http://34.5.6.7:{ENCODING_WORKER_PORT}"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_encoding_worker_manager.py
+++ b/backend/tests/test_encoding_worker_manager.py
@@ -18,6 +18,10 @@ from backend.services.encoding_worker_manager import (
     CONFIG_DOCUMENT,
     ENCODING_WORKER_PORT,
 )
+from backend.services.encoding_errors import (
+    EncodingWorkerCapacityError,
+    EncodingWorkerStartError,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -231,12 +235,21 @@ class TestVMLifecycle:
         mock_instance.status = "TERMINATED"
         mock_compute.get.return_value = mock_instance
 
+        # Successful start: operation has no error_code/error_message and
+        # .result() returns without raising.
+        op = MagicMock()
+        op.error_code = ""
+        op.error_message = ""
+        op.result.return_value = None
+        mock_compute.start.return_value = op
+
         manager.start_vm("encoding-worker-blue")
         mock_compute.start.assert_called_once_with(
             project="nomadkaraoke",
             zone="us-central1-c",
             instance="encoding-worker-blue",
         )
+        op.result.assert_called_once()
 
     def test_start_vm_skips_if_already_running(self, manager, mock_compute):
         mock_instance = MagicMock()
@@ -272,6 +285,12 @@ class TestVMLifecycle:
         mock_instance.status = "TERMINATED"
         mock_compute.get.return_value = mock_instance
 
+        op = MagicMock()
+        op.error_code = ""
+        op.error_message = ""
+        op.result.return_value = None
+        mock_compute.start.return_value = op
+
         with patch("backend.services.encoding_worker_manager.datetime") as mock_dt:
             mock_dt.now.return_value = datetime(2026, 3, 24, 15, 0, 0, tzinfo=UTC)
             mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
@@ -281,6 +300,7 @@ class TestVMLifecycle:
         assert result["vm_name"] == "encoding-worker-blue"
         assert result["primary_url"] == "http://10.128.0.50:8080"
         mock_compute.start.assert_called_once()
+        op.result.assert_called_once()
 
     def test_ensure_primary_running_already_running(self, manager, mock_db, mock_compute):
         """When primary is already running, should not start and still update activity."""
@@ -329,6 +349,89 @@ class TestVMLifecycle:
 
         manager.stop_vm("encoding-worker-blue")
         mock_compute.stop.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Operation-result inspection (capacity / start error classification)
+    # ------------------------------------------------------------------
+
+    def test_start_vm_raises_capacity_error_when_zone_exhausted(self, manager, mock_compute):
+        """start_vm must surface ZONE_RESOURCE_POOL_EXHAUSTED as a typed exception.
+
+        Without this, the GCE error stays hidden behind a fire-and-forget call
+        and the readiness gate eventually times out with no useful message.
+        """
+        mock_instance = MagicMock()
+        mock_instance.status = "TERMINATED"
+        mock_compute.get.return_value = mock_instance
+
+        op = MagicMock()
+        op.error_code = "ZONE_RESOURCE_POOL_EXHAUSTED"
+        op.error_message = "The zone does not have enough resources available"
+        op.result.return_value = None
+        mock_compute.start.return_value = op
+
+        with pytest.raises(EncodingWorkerCapacityError) as exc_info:
+            manager.start_vm("encoding-worker-blue")
+
+        assert exc_info.value.code == "ZONE_RESOURCE_POOL_EXHAUSTED"
+        assert exc_info.value.vm_name == "encoding-worker-blue"
+        assert exc_info.value.zone == "us-central1-c"
+        assert "ZONE_RESOURCE_POOL_EXHAUSTED" in str(exc_info.value)
+
+    def test_start_vm_raises_generic_start_error_for_other_codes(self, manager, mock_compute):
+        """start_vm raises EncodingWorkerStartError for non-capacity GCE errors."""
+        mock_instance = MagicMock()
+        mock_instance.status = "TERMINATED"
+        mock_compute.get.return_value = mock_instance
+
+        op = MagicMock()
+        op.error_code = "RESOURCE_NOT_READY"
+        op.error_message = "VM is in transition"
+        op.result.return_value = None
+        mock_compute.start.return_value = op
+
+        with pytest.raises(EncodingWorkerStartError) as exc_info:
+            manager.start_vm("encoding-worker-blue")
+
+        assert not isinstance(exc_info.value, EncodingWorkerCapacityError)
+        assert exc_info.value.code == "RESOURCE_NOT_READY"
+
+    def test_start_vm_raises_when_operation_result_throws(self, manager, mock_compute):
+        """If operation.result() raises (e.g. timeout), surface as a start error."""
+        mock_instance = MagicMock()
+        mock_instance.status = "TERMINATED"
+        mock_compute.get.return_value = mock_instance
+
+        op = MagicMock()
+        op.error_code = ""
+        op.error_message = ""
+        op.result.side_effect = TimeoutError("operation timed out")
+        mock_compute.start.return_value = op
+
+        with pytest.raises(EncodingWorkerStartError) as exc_info:
+            manager.start_vm("encoding-worker-blue")
+
+        assert "timed out" in str(exc_info.value).lower() or "operation" in str(exc_info.value).lower()
+
+    def test_ensure_primary_running_raises_capacity_error(
+        self, manager, mock_db, mock_compute
+    ):
+        """ensure_primary_running propagates capacity errors so callers can react."""
+        mock_instance = MagicMock()
+        mock_instance.status = "TERMINATED"
+        mock_compute.get.return_value = mock_instance
+
+        op = MagicMock()
+        op.error_code = "ZONE_RESOURCE_POOL_EXHAUSTED"
+        op.error_message = "out of capacity"
+        op.result.return_value = None
+        mock_compute.start.return_value = op
+
+        with patch("backend.services.encoding_worker_manager.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 5, 5, 9, 0, 0, tzinfo=UTC)
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            with pytest.raises(EncodingWorkerCapacityError):
+                manager.ensure_primary_running()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_render_video_worker_capacity.py
+++ b/backend/tests/test_render_video_worker_capacity.py
@@ -1,0 +1,193 @@
+"""Tests for render-video worker capacity-error handling.
+
+When the GCE encoding worker can't be started because the zone is exhausted,
+the render worker must:
+  - NOT fail the job (so the auto-retry scheduler can pick it up)
+  - Park the job in RENDER_PENDING_CAPACITY with a user-friendly message
+  - Record attempt metadata in state_data.render_pending_capacity for the
+    scheduler to use for backoff / max-wait checks
+"""
+
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import pytest
+
+from backend.models.job import JobStatus
+from backend.services.encoding_errors import EncodingWorkerCapacityError
+
+
+def _build_minimal_job():
+    """Job mock that lets process_render_video reach the GCE call site."""
+    job = MagicMock()
+    job.artist = "Test Artist"
+    job.title = "Test Title"
+    job.input_media_gcs_path = "jobs/test/audio.flac"
+    job.style_assets = {}
+    job.style_params_gcs_path = None
+    job.subtitle_offset_ms = 0
+    job.prep_only = False
+    job.state_data = {}
+    job.file_urls = {}
+    return job
+
+
+@pytest.mark.asyncio
+async def test_capacity_error_parks_job_for_retry():
+    """A capacity error must transition to RENDER_PENDING_CAPACITY, not FAILED.
+
+    This is the core contract: jobs blocked on GCE capacity are recoverable,
+    and the auto-retry scheduler will pick them up. Calling fail_job here
+    would lose the job to the user and require manual intervention.
+    """
+    from backend.workers import render_video_worker as rvw
+
+    capacity_error = EncodingWorkerCapacityError(
+        "VM encoding-worker-b could not be started in us-central1-c: "
+        "ZONE_RESOURCE_POOL_EXHAUSTED — out of capacity",
+        vm_name="encoding-worker-b",
+        zone="us-central1-c",
+        code="ZONE_RESOURCE_POOL_EXHAUSTED",
+    )
+
+    mock_job_manager = MagicMock()
+    mock_job_manager.get_job.return_value = _build_minimal_job()
+    mock_job_manager.transition_to_state.return_value = True
+
+    mock_encoding_service = MagicMock()
+    mock_encoding_service.is_enabled = True
+    mock_encoding_service.render_video_on_gce = AsyncMock(side_effect=capacity_error)
+
+    mock_storage = MagicMock()
+    mock_storage.file_exists.return_value = False
+
+    with patch.object(rvw, "JobManager", return_value=mock_job_manager), \
+         patch.object(rvw, "StorageService", return_value=mock_storage), \
+         patch.object(rvw, "get_settings"), \
+         patch.object(rvw, "create_job_logger", return_value=MagicMock()), \
+         patch.object(rvw, "setup_job_logging", return_value=MagicMock()), \
+         patch.object(rvw, "validate_worker_can_run", return_value=None), \
+         patch.object(rvw, "get_encoding_service", return_value=mock_encoding_service):
+
+        result = await rvw.process_render_video("test-job-id")
+
+    assert result is False
+    mock_job_manager.fail_job.assert_not_called()
+
+    # state_data.render_pending_capacity persists attempt metadata
+    state_data_calls = [
+        call_args for call_args in mock_job_manager.update_state_data.call_args_list
+        if call_args.args[1] == "render_pending_capacity"
+    ]
+    assert state_data_calls, (
+        "Expected update_state_data('test-job-id', 'render_pending_capacity', ...) call"
+    )
+    pending_meta = state_data_calls[-1].args[2]
+    assert pending_meta["attempt_count"] == 1
+    assert pending_meta["last_code"] == "ZONE_RESOURCE_POOL_EXHAUSTED"
+    assert pending_meta["last_zone"] == "us-central1-c"
+    assert pending_meta["last_vm"] == "encoding-worker-b"
+    assert "first_seen_at" in pending_meta
+    assert "last_attempt_at" in pending_meta
+
+    # Final state transition is RENDER_PENDING_CAPACITY with a user-friendly message
+    transitions = mock_job_manager.transition_to_state.call_args_list
+    capacity_transition = next(
+        (c for c in transitions if c.kwargs.get("new_status") == JobStatus.RENDER_PENDING_CAPACITY),
+        None,
+    )
+    assert capacity_transition is not None, (
+        "Worker must transition to RENDER_PENDING_CAPACITY on capacity error"
+    )
+    user_message = capacity_transition.kwargs.get("message", "")
+    assert "automatically" in user_message.lower() or "auto-retry" in user_message.lower(), (
+        f"User-facing message must indicate auto-retry. Got: {user_message!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_capacity_error_increments_attempt_count_on_subsequent_attempts():
+    """Repeat capacity errors must accumulate attempt count and preserve first_seen_at."""
+    from backend.workers import render_video_worker as rvw
+
+    job = _build_minimal_job()
+    job.state_data = {
+        "render_pending_capacity": {
+            "first_seen_at": "2026-05-05T09:00:00+00:00",
+            "last_attempt_at": "2026-05-05T09:05:00+00:00",
+            "attempt_count": 3,
+            "last_code": "ZONE_RESOURCE_POOL_EXHAUSTED",
+            "last_zone": "us-central1-c",
+            "last_vm": "encoding-worker-b",
+        }
+    }
+
+    capacity_error = EncodingWorkerCapacityError(
+        "exhausted",
+        vm_name="encoding-worker-b",
+        zone="us-central1-c",
+        code="ZONE_RESOURCE_POOL_EXHAUSTED",
+    )
+
+    mock_job_manager = MagicMock()
+    mock_job_manager.get_job.return_value = job
+    mock_job_manager.transition_to_state.return_value = True
+
+    mock_encoding_service = MagicMock()
+    mock_encoding_service.is_enabled = True
+    mock_encoding_service.render_video_on_gce = AsyncMock(side_effect=capacity_error)
+
+    with patch.object(rvw, "JobManager", return_value=mock_job_manager), \
+         patch.object(rvw, "StorageService"), \
+         patch.object(rvw, "get_settings"), \
+         patch.object(rvw, "create_job_logger", return_value=MagicMock()), \
+         patch.object(rvw, "setup_job_logging", return_value=MagicMock()), \
+         patch.object(rvw, "validate_worker_can_run", return_value=None), \
+         patch.object(rvw, "get_encoding_service", return_value=mock_encoding_service):
+
+        await rvw.process_render_video("test-job-id")
+
+    state_data_calls = [
+        c for c in mock_job_manager.update_state_data.call_args_list
+        if c.args[1] == "render_pending_capacity"
+    ]
+    assert state_data_calls
+    pending_meta = state_data_calls[-1].args[2]
+    assert pending_meta["attempt_count"] == 4
+    # first_seen_at preserved across attempts so the scheduler can enforce
+    # an absolute max-wait deadline (e.g. 24h).
+    assert pending_meta["first_seen_at"] == "2026-05-05T09:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_non_capacity_exception_still_fails_with_clear_message():
+    """Non-capacity exceptions must still fail the job, but with a useful message.
+
+    Regression guard: bare TimeoutError() previously produced an empty
+    `Video render failed: ` message. Use repr() fallback when str() is empty.
+    """
+    from backend.workers import render_video_worker as rvw
+
+    mock_job_manager = MagicMock()
+    mock_job_manager.get_job.return_value = _build_minimal_job()
+
+    mock_encoding_service = MagicMock()
+    mock_encoding_service.is_enabled = True
+    # Bare TimeoutError(), no message — exactly the failure mode users hit
+    mock_encoding_service.render_video_on_gce = AsyncMock(side_effect=TimeoutError())
+
+    with patch.object(rvw, "JobManager", return_value=mock_job_manager), \
+         patch.object(rvw, "StorageService"), \
+         patch.object(rvw, "get_settings"), \
+         patch.object(rvw, "create_job_logger", return_value=MagicMock()), \
+         patch.object(rvw, "setup_job_logging", return_value=MagicMock()), \
+         patch.object(rvw, "validate_worker_can_run", return_value=None), \
+         patch.object(rvw, "get_encoding_service", return_value=mock_encoding_service):
+
+        result = await rvw.process_render_video("test-job-id")
+
+    assert result is False
+    mock_job_manager.fail_job.assert_called_once()
+    fail_message = mock_job_manager.fail_job.call_args.args[1]
+    # Empty f"{e}" produced "Video render failed: " — must not happen anymore.
+    assert fail_message != "Video render failed: "
+    assert "TimeoutError" in fail_message or fail_message.strip().endswith(":") is False

--- a/backend/tests/test_retry_pending_render_jobs.py
+++ b/backend/tests/test_retry_pending_render_jobs.py
@@ -1,0 +1,168 @@
+"""Tests for the auto-retry endpoint for capacity-parked render jobs.
+
+Endpoint: POST /api/internal/retry-pending-render-jobs
+
+Phase 2 of the encoding-worker capacity-resilience plan. Cloud Scheduler
+fires this endpoint every 5 minutes; for each job parked in
+RENDER_PENDING_CAPACITY it either:
+  - Times the job out (>24h waiting) and transitions to FAILED with a
+    permanent-failure message, or
+  - Triggers the render worker again so it can attempt to start the GCE VM.
+"""
+
+from datetime import datetime, UTC, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.models.job import JobStatus
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _make_doc(job_id, *, first_seen, attempt_count=1, status=None):
+    """Build a Firestore stream-style snapshot mock for a pending-capacity job."""
+    doc = MagicMock()
+    doc.id = job_id
+    doc.to_dict.return_value = {
+        "job_id": job_id,
+        "status": (status or JobStatus.RENDER_PENDING_CAPACITY).value
+        if hasattr(status or JobStatus.RENDER_PENDING_CAPACITY, "value")
+        else (status or "render_pending_capacity"),
+        "state_data": {
+            "render_pending_capacity": {
+                "first_seen_at": first_seen,
+                "last_attempt_at": first_seen,
+                "attempt_count": attempt_count,
+                "last_code": "ZONE_RESOURCE_POOL_EXHAUSTED",
+                "last_zone": "us-central1-c",
+                "last_vm": "encoding-worker-b",
+            }
+        },
+    }
+    return doc
+
+
+def _patch_endpoint_dependencies(stream_docs, *, transition_returns=True):
+    """Common patch context for the retry endpoint internals."""
+    mock_jm = MagicMock()
+    mock_jm.firestore.db.collection.return_value.where.return_value.order_by.return_value.limit.return_value.stream.return_value = (
+        iter(stream_docs)
+    )
+    mock_jm.transition_to_state.return_value = transition_returns
+
+    mock_worker_service = MagicMock()
+    mock_worker_service.trigger_render_video_worker = AsyncMock(return_value=True)
+
+    return mock_jm, mock_worker_service
+
+
+def test_retries_one_job_per_tick(client):
+    """The endpoint retries up to MAX_PER_TICK (1) job per fire."""
+    now = datetime.now(UTC)
+    recent = (now - timedelta(minutes=10)).isoformat()
+
+    docs = [
+        _make_doc("job-a", first_seen=recent, attempt_count=2),
+        _make_doc("job-b", first_seen=recent, attempt_count=1),
+    ]
+
+    mock_jm, mock_worker_service = _patch_endpoint_dependencies(docs)
+
+    with patch("backend.api.routes.internal.JobManager", return_value=mock_jm), \
+         patch("backend.services.worker_service.get_worker_service", return_value=mock_worker_service):
+        response = client.post("/api/internal/retry-pending-render-jobs")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["retried_count"] == 1
+    assert data["timed_out_count"] == 0
+    assert data["skipped_for_next_tick"] == 1
+    assert data["retried_jobs"] == ["job-a"]  # oldest by stream order
+
+    mock_worker_service.trigger_render_video_worker.assert_awaited_once_with("job-a")
+
+
+def test_times_out_jobs_older_than_max_wait(client):
+    """A job older than MAX_WAIT_SECONDS (24h) is failed with a permanent message."""
+    now = datetime.now(UTC)
+    too_old = (now - timedelta(hours=25)).isoformat()
+    fresh = (now - timedelta(minutes=10)).isoformat()
+
+    docs = [
+        _make_doc("old-job", first_seen=too_old, attempt_count=200),
+        _make_doc("fresh-job", first_seen=fresh, attempt_count=1),
+    ]
+
+    mock_jm, mock_worker_service = _patch_endpoint_dependencies(docs)
+
+    with patch("backend.api.routes.internal.JobManager", return_value=mock_jm), \
+         patch("backend.services.worker_service.get_worker_service", return_value=mock_worker_service):
+        response = client.post("/api/internal/retry-pending-render-jobs")
+
+    data = response.json()
+    assert data["timed_out_count"] == 1
+    assert "old-job" in data["timed_out_jobs"]
+    assert data["retried_count"] == 1
+    assert data["retried_jobs"] == ["fresh-job"]
+
+    # fail_job called for the timed-out one with permanent flag
+    mock_jm.fail_job.assert_called_once()
+    fail_args = mock_jm.fail_job.call_args
+    assert fail_args.args[0] == "old-job"
+    assert "manual" in fail_args.args[1].lower() or "support" in fail_args.args[1].lower()
+    error_details = fail_args.kwargs.get("error_details") or {}
+    assert error_details.get("permanent_capacity_timeout") is True
+
+
+def test_no_op_when_queue_empty(client):
+    """Endpoint succeeds with zero retries when no jobs are pending."""
+    mock_jm, mock_worker_service = _patch_endpoint_dependencies([])
+
+    with patch("backend.api.routes.internal.JobManager", return_value=mock_jm), \
+         patch("backend.services.worker_service.get_worker_service", return_value=mock_worker_service):
+        response = client.post("/api/internal/retry-pending-render-jobs")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["retried_count"] == 0
+    assert data["timed_out_count"] == 0
+    mock_worker_service.trigger_render_video_worker.assert_not_called()
+
+
+def test_clears_error_state_and_resets_render_progress_before_retry(client):
+    """Before retrying, the endpoint clears error state so the worker starts clean.
+
+    Mirrors the manual /retry endpoint flow — without this, the prior failure
+    metadata could mislead operators looking at the job after the retry.
+    """
+    now = datetime.now(UTC)
+    docs = [_make_doc("job-x", first_seen=(now - timedelta(minutes=5)).isoformat())]
+
+    mock_jm, mock_worker_service = _patch_endpoint_dependencies(docs)
+
+    with patch("backend.api.routes.internal.JobManager", return_value=mock_jm), \
+         patch("backend.services.worker_service.get_worker_service", return_value=mock_worker_service):
+        response = client.post("/api/internal/retry-pending-render-jobs")
+
+    assert response.status_code == 200
+
+    update_calls = mock_jm.update_job.call_args_list
+    assert update_calls, "Expected update_job to be called to clear error fields"
+    cleared = update_calls[0].args[1]
+    assert cleared.get("error_message") is None
+    assert cleared.get("error_details") is None
+
+    state_data_calls = mock_jm.update_state_data.call_args_list
+    render_progress_resets = [c for c in state_data_calls if c.args[1] == "render_progress"]
+    assert render_progress_resets
+    assert render_progress_resets[-1].args[2] == {"stage": "pending"}
+
+    mock_jm.transition_to_state.assert_called_once()
+    transition_kwargs = mock_jm.transition_to_state.call_args.kwargs
+    assert transition_kwargs["new_status"] == JobStatus.REVIEW_COMPLETE

--- a/backend/tests/test_retry_pending_render_jobs.py
+++ b/backend/tests/test_retry_pending_render_jobs.py
@@ -16,13 +16,37 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from backend.api.dependencies import require_admin
 from backend.main import app
 from backend.models.job import JobStatus
+from backend.services.auth_service import AuthResult, UserType
 
 
 @pytest.fixture
 def client():
-    return TestClient(app)
+    """TestClient with admin auth explicitly stubbed.
+
+    The repo-wide autouse fixture in conftest.py sets these overrides too,
+    but other tests (test_anti_abuse.py, test_resend_magic_link.py) call
+    `app.dependency_overrides.clear()` in their teardown which can wipe the
+    autouse setup before our tests run. Re-establish the override here so
+    these tests are insensitive to ordering.
+    """
+    async def fake_admin():
+        return AuthResult(
+            is_valid=True,
+            user_type=UserType.ADMIN,
+            remaining_uses=999,
+            message="test admin",
+            is_admin=True,
+            user_email="test@example.com",
+        )
+
+    app.dependency_overrides[require_admin] = fake_admin
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(require_admin, None)
 
 
 def _make_doc(job_id, *, first_seen, attempt_count=1, status=None):

--- a/backend/workers/render_video_worker.py
+++ b/backend/workers/render_video_worker.py
@@ -41,6 +41,10 @@ from backend.config import get_settings
 from backend.workers.worker_logging import create_job_logger, setup_job_logging, job_logging_context
 from backend.services.tracing import job_span, add_span_event, add_span_attribute
 from backend.services.encoding_service import get_encoding_service
+from backend.services.encoding_errors import (
+    EncodingWorkerCapacityError,
+    EncodingWorkerStartError,
+)
 
 # Import from lyrics_transcriber (submodule)
 from karaoke_gen.lyrics_transcriber.output.generator import OutputGenerator
@@ -528,12 +532,74 @@ async def process_render_video(job_id: str) -> bool:
                         job_manager.update_state_data(job_id, 'render_progress', {'stage': 'complete'})
                         return True
             
+    except EncodingWorkerCapacityError as e:
+        duration = time.time() - start_time
+        job_log.warning(
+            f"GCE encoding capacity unavailable, parking job for auto-retry: {e}"
+        )
+        logger.warning(
+            f"[job:{job_id}] WORKER_END worker=render-video status=pending_capacity "
+            f"duration={duration:.1f}s code={e.code} zone={e.zone}"
+        )
+        _park_job_for_capacity_retry(job_manager, job_id, e)
+        return False
     except Exception as e:
         duration = time.time() - start_time
-        job_log.error(f"Video render failed: {e}")
-        logger.error(f"[job:{job_id}] WORKER_END worker=render-video status=error duration={duration:.1f}s error={e}")
-        job_manager.fail_job(job_id, f"Video render failed: {str(e)}")
+        # Use repr() so empty-string exceptions still produce a useful message;
+        # f"{e}" silently produced "" for bare TimeoutError() instances and
+        # users saw blank failure messages.
+        error_text = str(e) or repr(e)
+        job_log.error(f"Video render failed: {error_text}")
+        logger.error(
+            f"[job:{job_id}] WORKER_END worker=render-video status=error "
+            f"duration={duration:.1f}s error={error_text}"
+        )
+        job_manager.fail_job(job_id, f"Video render failed: {error_text}")
         return False
+
+
+def _park_job_for_capacity_retry(
+    job_manager: JobManager,
+    job_id: str,
+    error: EncodingWorkerCapacityError,
+) -> None:
+    """Transition a job to RENDER_PENDING_CAPACITY for auto-retry by the scheduler.
+
+    The user-facing message tells the user this is temporary and will retry
+    automatically — no action needed. Auto-retry is driven by the
+    /api/internal/retry-pending-render-jobs endpoint, fired every 5 min by
+    Cloud Scheduler.
+    """
+    from datetime import datetime, UTC
+
+    now = datetime.now(UTC).isoformat()
+    job = job_manager.get_job(job_id)
+    existing = (job.state_data or {}).get('render_pending_capacity', {}) if job else {}
+
+    pending_meta = {
+        'first_seen_at': existing.get('first_seen_at') or now,
+        'last_attempt_at': now,
+        'attempt_count': int(existing.get('attempt_count', 0)) + 1,
+        'last_code': error.code or '',
+        'last_zone': error.zone or '',
+        'last_vm': error.vm_name or '',
+    }
+
+    job_manager.update_state_data(job_id, 'render_pending_capacity', pending_meta)
+
+    user_message = (
+        "Encoding capacity is temporarily unavailable. Your job will retry "
+        "automatically — no action needed. Most jobs recover within 5–30 minutes."
+    )
+
+    job_manager.transition_to_state(
+        job_id=job_id,
+        new_status=JobStatus.RENDER_PENDING_CAPACITY,
+        progress=70,
+        message=user_message,
+        timeline_metadata={'code': error.code, 'zone': error.zone, 'vm': error.vm_name},
+        raise_on_invalid=False,
+    )
 
 
 def _extract_gcs_path(url: str) -> str:

--- a/docs/archive/2026-05-05-encoding-worker-capacity-resilience-plan.md
+++ b/docs/archive/2026-05-05-encoding-worker-capacity-resilience-plan.md
@@ -178,6 +178,26 @@ Investigation of two failed jobs found:
 - Phase 2 ships as a second PR after Phase 1 is in prod (because Phase 2 depends on the new `RENDER_PENDING_CAPACITY` state existing in prod data)
 - Phase 3 ships as a separate PR — touches IaC; requires `pulumi up` and one-time provisioning. Higher blast radius. Sequenced after Phase 2
 
+## Operational notes for Phase 3
+
+After this PR merges:
+
+1. Run `pulumi up` from `infrastructure/`. This provisions:
+   - `encoding-worker-fallback-a` (us-central1-a) + static IP `encoding-worker-fallback-ip-a`
+   - `encoding-worker-fallback-f` (us-central1-f) + static IP `encoding-worker-fallback-ip-f`
+   - Both VMs created in TERMINATED state. Cost when idle: ~$10/mo each (boot disk only).
+2. Capture the Pulumi-output IPs (`encoding_worker_fallback_a_ip`, `encoding_worker_fallback_f_ip`).
+3. Add an env var to the `karaoke-backend` Cloud Run service:
+   ```
+   ENCODING_WORKER_FALLBACK_VMS=[
+     {"vm":"encoding-worker-fallback-a","zone":"us-central1-a","ip":"<ip-a>"},
+     {"vm":"encoding-worker-fallback-f","zone":"us-central1-f","ip":"<ip-f>"}
+   ]
+   ```
+   (single-line JSON; brackets shown above for clarity).
+4. Verify the encoding-worker custom image (`projects/nomadkaraoke/global/images/family/encoding-worker`) is up to date so the fallback VMs run the same code as primary. Future deploys will need to update fallback VMs too — track this in the deploy script as a follow-up.
+5. Until the env var is set the application uses single-zone behavior (Phase 1+2 only). The fallback VMs are inert until configured.
+
 ## Open questions (will use best judgment for these)
 
 - Should the user be allowed to cancel a `RENDER_PENDING_CAPACITY` job? **Yes** — same UX as cancelling any other in-progress job; treat the state as "in progress, blocked" not "stuck".

--- a/docs/archive/2026-05-05-encoding-worker-capacity-resilience-plan.md
+++ b/docs/archive/2026-05-05-encoding-worker-capacity-resilience-plan.md
@@ -1,0 +1,186 @@
+# Encoding Worker Capacity Resilience — Plan
+
+**Date:** 2026-05-05
+**Worktree:** `karaoke-gen-investigate-job-failures`
+**Branch:** `feat/sess-20260505-1805-investigate-job-failures`
+**Trigger:** Jobs `fbc651be` and `bee150fd` failed with empty error message `Video render failed: `
+
+## Background
+
+Investigation of two failed jobs found:
+
+1. Both jobs failed at the GCE encoding-worker render stage with no usable error message
+2. Audit logs show the underlying cause was `ZONE_RESOURCE_POOL_EXHAUSTED` (`c4d-highcpu-32` in `us-central1-c`) — GCP could not provision the VM at the time of request
+3. The current code in `EncodingWorkerManager.start_vm` is fire-and-forget (does not inspect the operation result), so the GCP error is invisible
+4. The cold-start readiness gate then waits 120 s for the VM to reach `RUNNING`, gives up, raises a `TimeoutError` whose message is silently swallowed by `_warmup_encoding_worker_fallback`
+5. The HTTP retry loop (8 × 45 s ≈ 7 min) eventually re-raises an unrelated `asyncio.TimeoutError()` with no message → user sees `"Video render failed: "` (blank)
+6. 10 such failures over the previous 10 days, all `encoding-worker-b` in `us-central1-c`. The capacity issue is intermittent — the same VM starts successfully in surrounding hours
+
+## Goals
+
+1. **Phase 1 — Surface real errors**: capture GCP operation results, classify capacity vs other failures, propagate a user-friendly message that explicitly says "this is likely a temporary capacity issue, retrying later will probably succeed"
+2. **Phase 2 — Periodic auto-retry**: jobs blocked on capacity should be parked in a recoverable state and automatically retried on a schedule until they succeed (or hit a long deadline like 24 h)
+3. **Phase 3 — Multi-zone failover**: when one zone is exhausted, try other `us-central1` zones (`a`, `b`, `f` — confirmed all support `c4d-highcpu-32`)
+
+## Non-goals
+
+- Switching the machine type (premature optimization without data on whether other families have better availability)
+- Migrating to a Managed Instance Group (large architectural change; bigger blast radius)
+- Cross-region failover (out of scope; latency + data egress concerns)
+
+---
+
+## Phase 1 — Surface real errors
+
+### 1A. `EncodingWorkerManager` — wait for operation, classify errors
+
+`backend/services/encoding_worker_manager.py`
+
+- Add typed exceptions in this file (or new `encoding_errors.py`):
+  ```python
+  class EncodingWorkerStartError(Exception): pass
+  class EncodingWorkerCapacityError(EncodingWorkerStartError):
+      """ZONE_RESOURCE_POOL_EXHAUSTED or similar capacity-related GCE error."""
+  ```
+- `start_vm()` and `ensure_primary_running()`:
+  - Capture the `Operation` returned by `instances().start()`
+  - Poll the operation (or use the SDK's `wait_for_operation` helper) up to ~30 s
+  - On completion, inspect `operation.error.errors[*].code`:
+    - `ZONE_RESOURCE_POOL_EXHAUSTED`, `STOCKOUT`, `QUOTA_EXCEEDED` → raise `EncodingWorkerCapacityError("zone <zone> exhausted for <type>")`
+    - any other error → raise `EncodingWorkerStartError(error_message)`
+  - Update `ensure_primary_running()`'s return contract (or add separate method) so callers know whether the start succeeded vs failed
+
+### 1B. `_warmup_encoding_worker_fallback` — propagate capacity errors
+
+`backend/services/encoding_service.py`
+
+- Stop blanket-suppressing `Exception` in the warmup fallback
+- Re-raise `EncodingWorkerCapacityError` so the caller can react
+- Log other start errors with `_format_exception` (already used elsewhere) and continue retrying (existing behavior)
+
+### 1C. `_request_with_retry` — fail fast on capacity errors
+
+- If `_warmup_encoding_worker_fallback` raised `EncodingWorkerCapacityError`, bail out of the retry loop immediately and re-raise (no point retrying the HTTP call 7 more times to a VM that will never come up)
+
+### 1D. New job status + render worker handling
+
+`backend/models/job.py`
+
+- Add `RENDER_PENDING_CAPACITY = "render_pending_capacity"` to `JobStatus`
+- Add allowed transitions:
+  - `RENDERING_VIDEO → RENDER_PENDING_CAPACITY`
+  - `REVIEW_COMPLETE → RENDER_PENDING_CAPACITY`
+  - `RENDER_PENDING_CAPACITY → RENDERING_VIDEO` (auto-retry succeeded)
+  - `RENDER_PENDING_CAPACITY → FAILED` (long timeout)
+  - `RENDER_PENDING_CAPACITY → CANCELLED` (user cancelled)
+
+`backend/workers/render_video_worker.py`
+
+- Wrap the GCE call. On `EncodingWorkerCapacityError`:
+  - Do NOT call `fail_job`
+  - Transition to `RENDER_PENDING_CAPACITY` with message *"Encoding capacity is temporarily unavailable. Your job will retry automatically — no action needed. Most jobs recover within 5–30 minutes."*
+  - Persist `state_data.render_pending_capacity = { first_seen_at, last_attempt_at, attempt_count }` so phase 2 can track and time-out
+
+### 1E. Frontend / API surface
+
+- `GET /api/jobs/<id>` already returns `status` + `error_message` — frontend will pick up the new state via existing polling. Confirm the dashboard shows the message clearly (status row + a non-error styling so it doesn't look like a hard failure)
+- Confirm the user-facing job page surfaces the message under the existing "Status" badge
+
+### 1F. Tests
+
+- Unit: `EncodingWorkerManager.ensure_primary_running` raises `EncodingWorkerCapacityError` when the operation completes with `ZONE_RESOURCE_POOL_EXHAUSTED`
+- Unit: `_warmup_encoding_worker_fallback` re-raises `EncodingWorkerCapacityError`
+- Unit: `_request_with_retry` aborts immediately when warmup raises capacity error
+- Unit: render worker transitions to `RENDER_PENDING_CAPACITY` with the user-friendly message and does NOT call `fail_job`
+
+---
+
+## Phase 2 — Periodic auto-retry
+
+### 2A. New internal endpoint
+
+`backend/api/routes/internal.py`
+
+- `POST /api/internal/retry-pending-render-jobs` (admin-auth, used by Cloud Scheduler)
+- Logic:
+  1. Query `jobs` collection where `status == "render_pending_capacity"`
+  2. For each job:
+     - If `now - state_data.render_pending_capacity.first_seen_at > MAX_CAPACITY_WAIT (24h)`: transition to `FAILED` with permanent-failure message, increment `error_details.permanent_capacity_timeout`, send the operator a Discord ping
+     - Else: increment `attempt_count`, update `last_attempt_at`, kick `worker_service.trigger_render_video_worker(job_id)` (the render worker already idempotently no-ops on `render_progress.stage == 'complete'`, and starts the GCE VM via `_warmup_encoding_worker_fallback` when needed)
+- Avoid the thundering herd: if there are many jobs pending, process one at a time per scheduler tick (the GCE worker is single-tenant per render). Process up to 1 job per tick; the scheduler runs every 5 min so worst case is 12 jobs/hour throughput, plenty for current volume
+
+### 2B. Cloud Scheduler
+
+`infrastructure/__main__.py`
+
+- Add new `cloudscheduler.Job` (mirror `recover-stuck-downloads-scheduler`):
+  - `schedule = "*/5 * * * *"`
+  - `uri = "https://api.nomadkaraoke.com/api/internal/retry-pending-render-jobs"`
+  - OIDC token from `backend_service_account`
+  - retry config: 1 retry, 60 s min / 300 s max backoff
+
+### 2C. Tests
+
+- Unit: endpoint queries Firestore correctly, processes 1 job, schedules render
+- Unit: endpoint times out a job after 24 h (transition to FAILED with permanent message)
+- Unit: empty queue → no-op
+
+---
+
+## Phase 3 — Multi-zone failover
+
+`c4d-highcpu-32` is available in all four `us-central1` zones (`a`, `b`, `c`, `f`). Pre-creating fallback VMs in alternate zones gives us a safety pool for capacity exhaustion.
+
+### 3A. Infrastructure — fallback VMs
+
+`infrastructure/config.py`
+
+- Extend `EncodingWorkerConfig`:
+  ```python
+  VM_NAMES = ["encoding-worker-a", "encoding-worker-b"]
+  IP_NAMES = ["encoding-worker-ip-a", "encoding-worker-ip-b"]
+  FALLBACK_VM_NAMES = ["encoding-worker-fallback-a", "encoding-worker-fallback-f"]
+  FALLBACK_IP_NAMES = ["encoding-worker-fallback-ip-a", "encoding-worker-fallback-ip-f"]
+  FALLBACK_ZONES = [f"{REGION}-a", f"{REGION}-f"]
+  ```
+
+`infrastructure/compute/encoding_worker_vm.py`
+
+- New helper `create_encoding_worker_fallback_vms(...)` analogous to `create_encoding_worker_vms` but iterating zones
+- Same custom image, same SA, same firewall tag — these reuse all existing IaC plumbing
+- Cost note: VMs stopped at idle cost only the boot disk (100GB hyperdisk-balanced ≈ $10/mo each → +$20/mo total). Acceptable insurance
+
+### 3B. Encoding worker manager — multi-VM iteration
+
+`backend/services/encoding_worker_manager.py`
+
+- Replace `ensure_primary_running()` with `ensure_any_running()`:
+  - Tries primary VM (`config.primary_vm`) first
+  - On `EncodingWorkerCapacityError`, tries fallback VMs in order
+  - Returns `(vm_name, primary_url)` of whichever started successfully, OR raises `EncodingWorkerCapacityError` if all zones are exhausted
+- Update Firestore config doc to track `active_vm_name` so subsequent calls hit the right URL until idle-shutdown brings everything back to base state
+
+### 3C. Idle shutdown
+
+- Existing `encoding-worker-idle@nomadkaraoke.iam.gserviceaccount.com` stops VMs after idle. Confirm it covers fallback VMs (probably uses a tag-based filter; if not, expand)
+
+### 3D. Tests
+
+- Unit: `ensure_any_running` falls through to fallback when primary raises capacity error
+- Unit: `ensure_any_running` raises capacity error when ALL zones exhausted
+- Integration: simulate primary capacity exhaustion → fallback VM is selected
+
+---
+
+## Rollout
+
+- Phase 1 ships first as a single PR — purely backend, low-risk; recovers visibility on the failure mode immediately
+- Phase 2 ships as a second PR after Phase 1 is in prod (because Phase 2 depends on the new `RENDER_PENDING_CAPACITY` state existing in prod data)
+- Phase 3 ships as a separate PR — touches IaC; requires `pulumi up` and one-time provisioning. Higher blast radius. Sequenced after Phase 2
+
+## Open questions (will use best judgment for these)
+
+- Should the user be allowed to cancel a `RENDER_PENDING_CAPACITY` job? **Yes** — same UX as cancelling any other in-progress job; treat the state as "in progress, blocked" not "stuck".
+- Should we send a Discord notification to the operator when a job hits capacity? **No** for the first time (too noisy if there's a 30-min capacity outage with N jobs). **Yes** when a job hits the 24h permanent-failure threshold.
+- What's the retry cadence — should it back off (1m, 5m, 10m, 30m)? **No** — a flat 5-min cadence keeps the implementation simple and is fine for the current volume. Easy to revisit if needed.
+- Should we increment `retry_count`? **No** — `retry_count` reflects user-initiated retries. Auto-retries should not count against any user-facing retry budget.

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -426,6 +426,32 @@ recover_stuck_downloads_scheduler = cloudscheduler.Job(
     ),
 )
 
+# Cloud Scheduler job to auto-retry render jobs parked on GCE capacity exhaustion.
+# When us-central1-c is out of c4d-highcpu-32 capacity, the render worker now
+# parks the job in RENDER_PENDING_CAPACITY (instead of failing it) and this
+# scheduler retries up to 1 job per tick until it succeeds or hits the 24h
+# permanent-failure timeout.
+retry_pending_render_jobs_scheduler = cloudscheduler.Job(
+    "retry-pending-render-jobs-scheduler",
+    name="retry-pending-render-jobs",
+    description="Auto-retry render jobs parked on GCE encoding capacity exhaustion",
+    region=REGION,
+    schedule="*/5 * * * *",  # Every 5 minutes
+    time_zone="America/Los_Angeles",
+    http_target=cloudscheduler.JobHttpTargetArgs(
+        uri="https://api.nomadkaraoke.com/api/internal/retry-pending-render-jobs",
+        http_method="POST",
+        oidc_token=cloudscheduler.JobHttpTargetOidcTokenArgs(
+            service_account_email=backend_service_account.email,
+        ),
+    ),
+    retry_config=cloudscheduler.JobRetryConfigArgs(
+        retry_count=1,
+        min_backoff_duration="60s",
+        max_backoff_duration="300s",
+    ),
+)
+
 # ==================== Divebar Mirror (Phase 1) ====================
 # Index diveBar Karaoke Google Drive files into BigQuery for search
 

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -531,6 +531,16 @@ encoding_worker_ips = encoding_worker_vm.create_encoding_worker_ips()
 encoding_worker_instances = encoding_worker_vm.create_encoding_worker_vms(
     encoding_worker_ips, encoding_worker_sa
 )
+
+# Capacity-fallback Encoding Worker VMs in alternate zones
+# (us-central1-a, -f). Provisioned stopped; only started by the application
+# when the primary zone (us-central1-c) returns ZONE_RESOURCE_POOL_EXHAUSTED.
+# Cost when idle: ~$10/mo each for the boot disk.
+encoding_worker_fallback_ips = encoding_worker_vm.create_encoding_worker_fallback_ips()
+encoding_worker_fallback_instances = encoding_worker_vm.create_encoding_worker_fallback_vms(
+    encoding_worker_fallback_ips, encoding_worker_sa
+)
+
 encoding_worker_firewall = encoding_worker_vm.create_encoding_worker_firewall()
 
 # Grant backend SA permission to start encoding worker VMs
@@ -667,6 +677,18 @@ pulumi.export("encoding_worker_a_ip", encoding_worker_ips[0].address)
 pulumi.export("encoding_worker_b_ip", encoding_worker_ips[1].address)
 pulumi.export("encoding_worker_a_url", encoding_worker_ips[0].address.apply(lambda ip: f"http://{ip}:8080"))
 pulumi.export("encoding_worker_b_url", encoding_worker_ips[1].address.apply(lambda ip: f"http://{ip}:8080"))
+
+# Capacity-fallback VM exports (us-central1-a, -f)
+pulumi.export("encoding_worker_fallback_a_ip", encoding_worker_fallback_ips[0].address)
+pulumi.export("encoding_worker_fallback_f_ip", encoding_worker_fallback_ips[1].address)
+pulumi.export(
+    "encoding_worker_fallback_a_url",
+    encoding_worker_fallback_ips[0].address.apply(lambda ip: f"http://{ip}:8080"),
+)
+pulumi.export(
+    "encoding_worker_fallback_f_url",
+    encoding_worker_fallback_ips[1].address.apply(lambda ip: f"http://{ip}:8080"),
+)
 pulumi.export("encoding_worker_service_account", encoding_worker_sa.email)
 pulumi.export("encoding_worker_a_name", encoding_worker_instances[0].name)
 pulumi.export("encoding_worker_b_name", encoding_worker_instances[1].name)

--- a/infrastructure/compute/__init__.py
+++ b/infrastructure/compute/__init__.py
@@ -9,6 +9,8 @@ Contains VM definitions for:
 from .encoding_worker_vm import (
     create_encoding_worker_vms,
     create_encoding_worker_ips,
+    create_encoding_worker_fallback_vms,
+    create_encoding_worker_fallback_ips,
     create_encoding_worker_firewall,
 )
 from .github_runners import create_github_runners, create_build_runner, create_cloud_nat
@@ -16,6 +18,8 @@ from .github_runners import create_github_runners, create_build_runner, create_c
 __all__ = [
     "create_encoding_worker_vms",
     "create_encoding_worker_ips",
+    "create_encoding_worker_fallback_vms",
+    "create_encoding_worker_fallback_ips",
     "create_encoding_worker_firewall",
     "create_github_runners",
     "create_build_runner",

--- a/infrastructure/compute/encoding_worker_vm.py
+++ b/infrastructure/compute/encoding_worker_vm.py
@@ -73,6 +73,85 @@ def create_encoding_worker_vms(
     return vms
 
 
+def create_encoding_worker_fallback_ips() -> list[compute.Address]:
+    """Create static IPs for the multi-zone capacity-fallback VMs.
+
+    These IPs live in alternate zones (e.g. us-central1-a, -f) to provide
+    zone-level resilience when the primary zone is out of c4d-highcpu-32
+    capacity (ZONE_RESOURCE_POOL_EXHAUSTED).
+    """
+    ips = []
+    for ip_name, zone_suffix in zip(
+        EncodingWorkerConfig.FALLBACK_IP_NAMES,
+        EncodingWorkerConfig.FALLBACK_ZONE_SUFFIXES,
+    ):
+        ip = compute.Address(
+            ip_name,
+            name=ip_name,
+            region=REGION,
+            address_type="EXTERNAL",
+            description=f"Static external IP for {ip_name} (zone-fallback)",
+        )
+        ips.append(ip)
+    return ips
+
+
+def create_encoding_worker_fallback_vms(
+    ips: list[compute.Address],
+    service_account: serviceaccount.Account,
+) -> list[compute.Instance]:
+    """Create capacity-fallback encoding worker VMs in alternate zones.
+
+    Provisioned stopped — they're only started by the application when
+    the primary zone (us-central1-c) rejects starts with
+    ZONE_RESOURCE_POOL_EXHAUSTED. Cost when stopped is just the boot disk
+    (~$10/mo for 100GB hyperdisk-balanced).
+    """
+    startup_script = read_script("encoding_worker.sh")
+    custom_image = f"projects/{PROJECT_ID}/global/images/family/encoding-worker"
+
+    vms = []
+    for vm_name, ip, zone_suffix in zip(
+        EncodingWorkerConfig.FALLBACK_VM_NAMES,
+        ips,
+        EncodingWorkerConfig.FALLBACK_ZONE_SUFFIXES,
+    ):
+        zone = f"{REGION}-{zone_suffix}"
+        vm = compute.Instance(
+            vm_name,
+            name=vm_name,
+            machine_type=MachineTypes.ENCODING_WORKER,
+            zone=zone,
+            boot_disk=compute.InstanceBootDiskArgs(
+                initialize_params=compute.InstanceBootDiskInitializeParamsArgs(
+                    image=custom_image,
+                    size=DiskSizes.ENCODING_WORKER,
+                    type="hyperdisk-balanced",
+                ),
+            ),
+            network_interfaces=[compute.InstanceNetworkInterfaceArgs(
+                network="default",
+                access_configs=[compute.InstanceNetworkInterfaceAccessConfigArgs(
+                    nat_ip=ip.address,
+                )],
+            )],
+            service_account=compute.InstanceServiceAccountArgs(
+                email=service_account.email,
+                scopes=["cloud-platform"],
+            ),
+            metadata_startup_script=startup_script,
+            tags=["encoding-worker"],
+            allow_stopping_for_update=True,
+            advanced_machine_features=compute.InstanceAdvancedMachineFeaturesArgs(
+                threads_per_core=2,
+            ),
+            # Pulumi default is "running" — we want fallbacks stopped at create.
+            desired_status="TERMINATED",
+        )
+        vms.append(vm)
+    return vms
+
+
 def create_encoding_worker_firewall() -> compute.Firewall:
     """Create firewall rules for encoding worker VMs.
 

--- a/infrastructure/config.py
+++ b/infrastructure/config.py
@@ -134,6 +134,15 @@ class EncodingWorkerConfig:
     FUNCTION_MEMORY = "512M"  # Increased from 256M — OOM with gRPC/Firestore/Compute client libs
     FUNCTION_TIMEOUT = 120  # 2 minutes
 
+    # Capacity-resilience fallback VMs in alternate zones.
+    # c4d-highcpu-32 is available in us-central1-a / -b / -c / -f, so when -c
+    # is exhausted the manager can fall back to -a or -f. These VMs are
+    # provisioned stopped (cost: ~$10/mo each for the boot disk) and only
+    # started by the application when the primary zone rejects capacity.
+    FALLBACK_VM_NAMES = ["encoding-worker-fallback-a", "encoding-worker-fallback-f"]
+    FALLBACK_IP_NAMES = ["encoding-worker-fallback-ip-a", "encoding-worker-fallback-ip-f"]
+    FALLBACK_ZONE_SUFFIXES = ["a", "f"]  # zones {REGION}-{suffix}
+
 
 class ErrorMonitorConfig:
     """Configuration for the error monitor Cloud Run Job."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.173.3"
+version = "0.174.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Investigation of two failed jobs (`fbc651be`, `bee150fd`) revealed both failed at the GCE encoding-worker render stage with empty error messages (`Video render failed: `). Root cause: the GCP `compute.instances.start` API was returning `ZONE_RESOURCE_POOL_EXHAUSTED` (us-central1-c out of `c4d-highcpu-32` capacity), but the application's fire-and-forget call swallowed the error. Users saw 7-minute timeouts with no useful message, and there was no mechanism to retry once capacity returned.

This PR delivers all three phases of the capacity-resilience plan ([docs/archive/2026-05-05-encoding-worker-capacity-resilience-plan.md](docs/archive/2026-05-05-encoding-worker-capacity-resilience-plan.md)):

### Phase 1 — Surface real errors (commit `56e5968e`)
- New `EncodingWorkerCapacityError` / `EncodingWorkerStartError` typed exceptions
- `EncodingWorkerManager.start_vm` now waits for the operation result and raises the right typed error on `ZONE_RESOURCE_POOL_EXHAUSTED` / `STOCKOUT` / `QUOTA_EXCEEDED`
- Capacity errors propagate through the warmup-fallback path; the HTTP retry loop bails out fast (instead of hammering an unreachable VM for 7 min)
- Render worker catches capacity errors and parks the job in new state `RENDER_PENDING_CAPACITY` with a user-friendly message: *"Encoding capacity is temporarily unavailable. Your job will retry automatically — no action needed. Most jobs recover within 5–30 minutes."*
- Repeat capacity hits accumulate `attempt_count` while preserving `first_seen_at`
- `repr()` fallback in the generic exception handler so empty-string errors no longer produce blank `Video render failed: ` messages

### Phase 2 — Auto-retry scheduler (commit `9d6d2161`)
- New endpoint `POST /api/internal/retry-pending-render-jobs` (admin-auth)
- Cloud Scheduler fires it every 5 min — picks the oldest `RENDER_PENDING_CAPACITY` job, clears its error state, re-triggers the render worker
- 24h hard deadline: jobs older than that fail permanently with a clear "retry manually or contact support" message
- Processes 1 job per tick (the GCE worker is single-tenant per render)

### Phase 3 — Multi-zone failover (commit `6d6b1376`)
- IaC: new fallback VMs `encoding-worker-fallback-a` (us-central1-a) and `encoding-worker-fallback-f` (us-central1-f). All four zones support `c4d-highcpu-32`. Provisioned stopped — ~$10/mo idle each
- New `EncodingWorkerManager.ensure_any_running(candidates)` iterates VMs in order, catching capacity errors per-zone, falling through to the next; returns the active VM info
- New `active_override_*` fields on the Firestore config doc track the active fallback URL; `EncodingWorkerConfig.active_url` returns the override if set, else primary; `EncodingService._get_worker_url` consults `active_url` so in-flight requests after fallback hit the right VM
- Gated by env var `ENCODING_WORKER_FALLBACK_VMS` (JSON list) — empty default = single-zone behavior unchanged

## Operational rollout

Phases 1 & 2 ship as code only — no manual steps. Phase 3 needs:

1. `pulumi up` from `infrastructure/` — provisions the 2 fallback VMs (stopped)
2. Capture Pulumi-output IPs (`encoding_worker_fallback_a_ip`, `encoding_worker_fallback_f_ip`)
3. Set env var on `karaoke-backend` Cloud Run:
   ```
   ENCODING_WORKER_FALLBACK_VMS=[{"vm":"encoding-worker-fallback-a","zone":"us-central1-a","ip":"<ip-a>"},{"vm":"encoding-worker-fallback-f","zone":"us-central1-f","ip":"<ip-f>"}]
   ```
4. Until step 3 is done the application uses single-zone behavior; fallback VMs are inert

Plan doc: [docs/archive/2026-05-05-encoding-worker-capacity-resilience-plan.md](docs/archive/2026-05-05-encoding-worker-capacity-resilience-plan.md)

## Test plan

- [x] Unit: `EncodingWorkerManager.start_vm` raises `EncodingWorkerCapacityError` for `ZONE_RESOURCE_POOL_EXHAUSTED`, generic `EncodingWorkerStartError` for other codes, surfaces `result()` failures
- [x] Unit: `_warmup_encoding_worker_fallback` propagates capacity errors, swallows generic warmup failures
- [x] Unit: `_request_with_retry` aborts immediately on capacity error from warmup (no 7-min retry loop)
- [x] Unit: render worker transitions to `RENDER_PENDING_CAPACITY` on capacity error, NOT `FAILED`; preserves `first_seen_at`; increments `attempt_count`
- [x] Unit: render worker non-capacity exceptions still fail with a useful message (no more blank `Video render failed: `)
- [x] Unit: `/api/internal/retry-pending-render-jobs` retries 1 job per tick (oldest first), times out 24h+ jobs, no-op on empty queue, clears error state before retry
- [x] Unit: `ensure_any_running` happy path, falls through on capacity error, raises when all candidates exhausted, clears stale override on primary success
- [x] Unit: `EncodingWorkerConfig.active_url` returns override if set, else primary
- [x] Full backend suite passes (3114 tests; 5 pre-existing failures in `test_internal_api.py` are unrelated and present on `main`)
- [ ] Manual prod test: trigger a render during a confirmed capacity outage, observe job parks in `RENDER_PENDING_CAPACITY`, scheduler picks it up next tick, completes when capacity returns

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)