### PR TITLE
fix(render): re-resolve encoding worker URL between retry attempts

### DIFF
--- a/backend/services/encoding_service.py
+++ b/backend/services/encoding_service.py
@@ -288,6 +288,7 @@ class EncodingService:
         json_payload: Optional[Dict[str, Any]] = None,
         timeout: float = 30.0,
         job_id: str = "unknown",
+        path: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Make an HTTP request with retry logic for transient failures.
@@ -297,11 +298,18 @@ class EncodingService:
 
         Args:
             method: HTTP method (GET, POST)
-            url: Request URL
+            url: Initial request URL (used for the first attempt)
             headers: Request headers
             json_payload: JSON body for POST requests
             timeout: Request timeout in seconds
             job_id: Job ID for logging
+            path: Endpoint path (e.g. "/render-video"). When set, retry attempts
+                AFTER the warmup runs re-resolve the URL via _get_worker_url() +
+                path. This is what lets multi-zone fallback take effect mid-loop:
+                the warmup may set a new active_override (e.g. switching to a
+                fallback VM in another zone) and invalidate the URL cache; the
+                next retry then targets the freshly-routed URL instead of the
+                original primary which is dead.
 
         Returns:
             Dict with keys:
@@ -316,8 +324,22 @@ class EncodingService:
         """
         last_exception = None
         backoff = INITIAL_BACKOFF_SECONDS
+        warmup_ran = False
 
         for attempt in range(MAX_RETRIES + 1):
+            # Re-resolve URL on retries after the warmup has fired, so that any
+            # active_override change made by the warmup actually takes effect.
+            # Without this, all 8 retry attempts hammer the original (dead)
+            # URL even though the warmup successfully routed to a fallback VM.
+            if path and warmup_ran and self._worker_manager is not None:
+                resolved = f"{self._get_worker_url()}{path}"
+                if resolved != url:
+                    logger.info(
+                        f"[job:{job_id}] Re-resolved encoding URL after warmup: "
+                        f"{url} -> {resolved}"
+                    )
+                    url = resolved
+
             try:
                 async with aiohttp.ClientSession() as session:
                     if method.upper() == "POST":
@@ -344,6 +366,7 @@ class EncodingService:
                 if attempt == 0:
                     try:
                         await self._warmup_encoding_worker_fallback(job_id)
+                        warmup_ran = True
                     except EncodingWorkerStartError as start_err:
                         # No VM could be started — capacity exhaustion or
                         # transient backend errors (e.g. 503). Hammering the
@@ -398,7 +421,8 @@ class EncodingService:
         if not self.is_configured:
             raise RuntimeError("Encoding service not configured")
 
-        url = f"{self._get_worker_url()}/encode"
+        path = "/encode"
+        url = f"{self._get_worker_url()}{path}"
         headers = {"X-API-Key": self._api_key, "Content-Type": "application/json"}
         payload = {
             "job_id": job_id,
@@ -416,6 +440,7 @@ class EncodingService:
             json_payload=payload,
             timeout=30.0,
             job_id=job_id,
+            path=path,
         )
 
         if resp["status"] == 401:
@@ -459,7 +484,8 @@ class EncodingService:
         if not self.is_configured:
             raise RuntimeError("Encoding service not configured")
 
-        url = f"{self._get_worker_url()}/status/{job_id}"
+        path = f"/status/{job_id}"
+        url = f"{self._get_worker_url()}{path}"
         headers = {"X-API-Key": self._api_key}
 
         resp = await self._request_with_retry(
@@ -468,6 +494,7 @@ class EncodingService:
             headers=headers,
             timeout=30.0,
             job_id=job_id,
+            path=path,
         )
 
         if resp["status"] == 401:
@@ -647,7 +674,8 @@ class EncodingService:
         if not self.is_configured:
             raise RuntimeError("Encoding service not configured")
 
-        url = f"{self._get_worker_url()}/encode-preview"
+        path = "/encode-preview"
+        url = f"{self._get_worker_url()}{path}"
         headers = {"X-API-Key": self._api_key, "Content-Type": "application/json"}
         payload = {
             "job_id": job_id,
@@ -670,6 +698,7 @@ class EncodingService:
             json_payload=payload,
             timeout=30.0,
             job_id=job_id,
+            path=path,
         )
 
         if resp["status"] == 401:
@@ -765,7 +794,8 @@ class EncodingService:
         if not self.is_configured:
             raise RuntimeError("Encoding service not configured")
 
-        url = f"{self._get_worker_url()}/render-video"
+        path = "/render-video"
+        url = f"{self._get_worker_url()}{path}"
         headers = {"X-API-Key": self._api_key, "Content-Type": "application/json"}
         payload = {"job_id": job_id, **render_config}
 
@@ -778,6 +808,7 @@ class EncodingService:
             json_payload=payload,
             timeout=30.0,
             job_id=job_id,
+            path=path,
         )
 
         if resp["status"] == 401:

--- a/backend/tests/test_encoding_service.py
+++ b/backend/tests/test_encoding_service.py
@@ -210,7 +210,7 @@ class TestRequestWithRetry:
 
         original_request = encoding_service._request_with_retry
 
-        async def mock_request_with_retry(method, url, headers, json_payload=None, timeout=30.0, job_id="unknown"):
+        async def mock_request_with_retry(method, url, headers, json_payload=None, timeout=30.0, job_id="unknown", path=None):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -286,6 +286,87 @@ class TestRequestWithRetry:
         # Warmup is invoked exactly once (after the first failure) and its
         # capacity error short-circuits the retry loop.
         assert warmup_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_url_reresolves_after_warmup_so_fallback_takes_effect(self, encoding_service):
+        """After warmup updates active_override, retry attempts must hit the new URL.
+
+        Regression guard for the bug seen on job fae3eadc 2026-05-06: warmup
+        successfully routed to fallback-a in us-central1-a (set the active_
+        override, invalidated the URL cache), but the retry loop kept hitting
+        the original primary URL it captured before the loop started, all 8
+        attempts timed out, and the render worker failed the job hard with
+        TimeoutError() instead of letting the (working) fallback handle it.
+        """
+        attempts_seen_urls = []
+
+        # Sequence of URLs returned by _get_worker_url():
+        #   first call (used to build initial url): primary (dead)
+        #   subsequent calls (after warmup invalidated cache): fallback (live)
+        url_sequence = iter([
+            "http://primary.dead:8080",
+            "http://fallback.live:8080",
+            "http://fallback.live:8080",
+            "http://fallback.live:8080",
+        ])
+
+        # Track which URLs the loop actually hits
+        class FailingThenOkSession:
+            def __init__(self, url):
+                self.url = url
+            async def __aenter__(self):
+                attempts_seen_urls.append(self.url)
+                if "primary.dead" in self.url:
+                    raise asyncio.TimeoutError()
+                # On fallback URL, return a fake successful response
+                resp = AsyncMock()
+                resp.status = 200
+                resp.json = AsyncMock(return_value={"ok": True})
+                resp.text = AsyncMock(return_value="ok")
+                return resp
+            async def __aexit__(self, *a):
+                return False
+
+        class FakeSession:
+            async def __aenter__(self):
+                return self
+            async def __aexit__(self, *a):
+                return False
+            def post(self, url, **kwargs):
+                return FailingThenOkSession(url)
+
+        async def warmup_noop(job_id):
+            return None  # represents successful warmup that updated override
+
+        # Re-resolve only fires when worker_manager is wired (production mode).
+        encoding_service._worker_manager = MagicMock()
+
+        with patch.object(encoding_service, "_get_worker_url", side_effect=lambda: next(url_sequence)), \
+             patch("aiohttp.ClientSession", return_value=FakeSession()), \
+             patch.object(
+                 encoding_service,
+                 "_warmup_encoding_worker_fallback",
+                 side_effect=warmup_noop,
+             ), \
+             patch("asyncio.sleep", new_callable=AsyncMock):
+
+            initial_url = encoding_service._get_worker_url() + "/render-video"
+            result = await encoding_service._request_with_retry(
+                method="POST",
+                url=initial_url,
+                headers={},
+                json_payload={"job_id": "test"},
+                timeout=1.0,
+                job_id="test",
+                path="/render-video",
+            )
+
+        # First attempt hits primary (fails). Second attempt re-resolves URL
+        # post-warmup and hits fallback (succeeds).
+        assert result["status"] == 200
+        assert len(attempts_seen_urls) == 2
+        assert "primary.dead" in attempts_seen_urls[0]
+        assert "fallback.live" in attempts_seen_urls[1]
 
 
 class TestWarmupFallback:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.174.2"
+version = "0.174.3"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Bug observed on job `fae3eadc` 2026-05-06: multi-zone fallback successfully routed to fallback-a in us-central1-a — set `active_override` in Firestore, invalidated the URL cache — but `_request_with_retry` had already captured the original (primary, dead) URL **before** the retry loop started, and used it for all 8 retry attempts. Every attempt timed out, the retry loop re-raised `TimeoutError()` (not a typed start error), and the render worker's `except EncodingWorkerStartError` didn't catch it → job hard-failed instead of being parked for auto-retry.

Without this fix, the scheduler's auto-retry can't actually recover a job once the URL gets stuck on a dead VM, even though all the multi-zone plumbing engages correctly.

## Fix

`_request_with_retry` now accepts an optional `path` parameter (e.g. `/render-video`) and re-resolves the full URL via `_get_worker_url() + path` on retry attempts **after** the warmup has fired. Updated all four call sites: `submit_encoding_job`, `get_job_status`, `submit_preview_encoding_job`, `submit_render_video_job`.

The `_health` callsite uses `aiohttp.ClientSession` directly without `_request_with_retry`, so no change needed there.

## Trace from the affected job

```
21:15:39 Trying candidate 1/3: VM encoding-worker-b in us-central1-c (status TERMINATED)
21:15:41 Candidate encoding-worker-b in us-central1-c start failed (503), trying next candidate
21:15:41 Set active_override to encoding-worker-fallback-a in us-central1-a (capacity fallback)
21:15:41 [job:fae3eadc] Encoding worker unreachable — VM encoding-worker-fallback-a already running/starting
21:15:41 [job:fae3eadc] GCE worker connection failed (attempt 1/8): TimeoutError. Retrying in 5.0s...
21:16:17 [job:fae3eadc] GCE worker connection failed (attempt 2/8): TimeoutError. Retrying in 10.0s...
... (all 8 attempts to dead primary URL — should have hit fallback-a from attempt 2 onwards)
21:20:48 [job:fae3eadc] WORKER_END worker=render-video status=error duration=341.6s error=TimeoutError()
21:20:49 Job fae3eadc failed: Video render failed: TimeoutError()
```

After this fix, attempt 2 onwards will resolve to `http://34.55.231.54:8080/render-video` (fallback-a) instead of the dead primary, and the request will succeed.

## Test plan

- [x] New regression test `test_url_reresolves_after_warmup_so_fallback_takes_effect` — first attempt to dead URL fails, warmup updates override, second attempt re-resolves to live URL and succeeds. Asserts both URLs were actually requested (in order)
- [x] All 84 capacity-related tests pass locally
- [ ] After merge: monitor for any new \"TimeoutError after warmup\" patterns — should disappear

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)