### PR TITLE
docs(render): runbook + lessons for capacity-resilience work

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -143,6 +143,45 @@ When two sequential human review steps can be combined into one, do it. We origi
 
 ## Common Gotchas
 
+### Encoding Worker Capacity Resilience (May 2026)
+
+**The 7 traps we hit, in order of discovery:**
+
+1. **GCP `compute.instances.start` is fire-and-forget by default.** When the call returns, that doesn't mean the VM started — `ZONE_RESOURCE_POOL_EXHAUSTED` and `503 SERVICE_UNAVAILABLE` are returned in the operation result, not as exceptions. Always inspect `operation.error_code` after the call. Originally caused two real-user job failures with empty error messages because the readiness gate just timed out on a VM that had never started. Fix in `EncodingWorkerManager.start_vm` (PR #748).
+
+2. **`f"...{e}"` produces empty string for bare `TimeoutError()`** (and any exception with no args). Users saw `"Video render failed: "` for 7+ minutes of retries. Always use `str(e) or repr(e)` as the fallback when surfacing exception messages to humans.
+
+3. **`compute.instances.start` returns `503 SERVICE_UNAVAILABLE` for transient backend stress, not just capacity.** Initial fix only classified `ZONE_RESOURCE_POOL_EXHAUSTED` as transient/recoverable; `503` got the generic `EncodingWorkerStartError` and never triggered multi-zone fallback. Either treat the `EncodingWorkerStartError` parent class as fallback-worthy (what we did, PR #750) or expand the capacity error code list.
+
+4. **GCE `c4d-highcpu-32` capacity in `us-central1-f` is unreliable enough to be useless as a fallback.** Provisioning failed there at create time on multiple attempts (the very thing the fallback is meant to mitigate). `-a` and `-b` are stable. (PR #749)
+
+5. **`google-auth ≥ 2.40` uses mTLS-over-HTTPS for the GCE metadata server when `/run/google-mds-mtls/` certs exist on the VM.** Newer GCE images ship those certs; the mTLS handshake then fails with `SSL CERTIFICATE_VERIFY_FAILED` on freshly-provisioned VMs. The worker can't refresh its SA token, all GCS reads/writes break. Fix: set `GCE_METADATA_MTLS_MODE=none` in the systemd EnvironmentFile to force HTTP-on-port-80 metadata access. (PR #750)
+
+6. **Composite Firestore index needed for `where(status) + order_by(updated_at)`.** Don't compose those server-side without the composite index. For small result sets just stream and sort in Python — matches the existing `recover-stuck-jobs` pattern. (PR #751)
+
+7. **`_request_with_retry` captured the URL once before the retry loop.** When the warmup-fallback updated the active URL override (e.g., switching from a dead primary to a live fallback), the retry loop kept hitting the original (dead) URL for all 8 attempts. Fix: thread the relative `path` through and re-resolve `_get_worker_url() + path` on retries after warmup has fired. (PR #752)
+
+**Architecture summary (post-fixes):**
+- 4 GCE encoding workers: 2 primaries in `us-central1-c` (blue-green) + 2 capacity fallbacks in `us-central1-a` and `us-central1-b`. All idle by default; started on demand.
+- `EncodingWorkerCandidate` list iterated in `ensure_any_running` — primary first, fallbacks in declared order. Capacity errors fall through to next candidate; non-capacity start errors also fall through (broadened in PR #750).
+- New `RENDER_PENDING_CAPACITY` job state for transient infra failures — different from `FAILED` (which is for unrecoverable bugs).
+- Cloud Scheduler fires `/api/internal/retry-pending-render-jobs` every 5 min; 24h hard timeout per job.
+- `EncodingWorkerConfig.active_url` returns the override URL when set, else primary. `_get_worker_url()` consults this with a 30s TTL cache.
+- Both Cloud Run service AND Cloud Run Job (video-encoding-job) need `ENCODING_WORKER_FALLBACK_VMS` env — they each instantiate their own `EncodingService`.
+
+**Files to know:**
+- `backend/services/encoding_worker_manager.py` — multi-zone iteration, active-override mgmt
+- `backend/services/encoding_errors.py` — typed exception hierarchy + capacity-error code set
+- `backend/services/encoding_service.py::_request_with_retry` — URL re-resolve on retries
+- `backend/services/encoding_service.py::_warmup_encoding_worker_fallback` — first-failure → start VM → invalidate URL cache
+- `backend/workers/render_video_worker.py::_park_job_for_capacity_retry` — transition to `RENDER_PENDING_CAPACITY`
+- `backend/api/routes/internal.py::retry_pending_render_jobs` — Cloud Scheduler entry point
+- `infrastructure/encoding-worker/startup.sh` — `GCE_METADATA_MTLS_MODE=none` is set here
+- `infrastructure/compute/encoding_worker_vm.py` — fallback VM IaC
+- `docs/archive/2026-05-05-encoding-worker-capacity-resilience-plan.md` — original 3-phase plan
+
+**See also:** TROUBLESHOOTING.md sections "Job stuck in `render_pending_capacity`", "Job failed: Video render failed: TimeoutError()", "Job stuck in `rendering_video` for hours".
+
 ### Firestore Timezone-Aware vs Naive Datetime Comparison (Apr 2026)
 **What happened**: First instance — `_build_user_public()` compared `referral_discount_expires_at` (from Firestore, timezone-aware) with `datetime.utcnow()` (naive), causing `TypeError: can't compare offset-naive and offset-aware datetimes`. This crashed the `verify_magic_link` endpoint, **blocking ALL logins for referred users** in production.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -193,6 +193,100 @@ gcloud compute instances describe encoding-worker-a \
 
 ---
 
+## Job stuck in `render_pending_capacity`
+
+**Symptoms:** Job status is `render_pending_capacity` (introduced 2026-05-05). User-facing message says *"Encoding capacity is temporarily unavailable. Your job will retry automatically — no action needed."*
+
+**Background — what this state means:** GCE returned `ZONE_RESOURCE_POOL_EXHAUSTED` or transient `503 SERVICE_UNAVAILABLE` from `compute.instances.start` on every encoding-worker VM (primary in `us-central1-c`, plus capacity fallbacks in `-a` and `-b`). The render worker parks the job in `RENDER_PENDING_CAPACITY` instead of failing it; Cloud Scheduler retries it every 5 min via `/api/internal/retry-pending-render-jobs`. Hard timeout is 24 hours (then transitions to `failed` with a clear permanent-failure message).
+
+**Check how many retries have run:**
+```bash
+python3 -c "
+import os; os.environ['GOOGLE_CLOUD_PROJECT']='nomadkaraoke'
+from google.cloud import firestore
+d = firestore.Client(project='nomadkaraoke').collection('jobs').document('JOB_ID').get().to_dict()
+print((d.get('state_data') or {}).get('render_pending_capacity'))
+"
+```
+
+**Force an immediate retry** (Cloud Scheduler runs every 5 min, but you can poke it manually):
+```bash
+ADMIN_TOKEN=$(gcloud secrets versions access latest --secret=admin-tokens --project=nomadkaraoke | cut -d',' -f1)
+curl -X POST https://api.nomadkaraoke.com/api/internal/retry-pending-render-jobs \
+  -H "X-Admin-Token: $ADMIN_TOKEN"
+```
+
+**Verify GCE has any capacity right now:**
+```bash
+# If this returns ZONE_RESOURCE_POOL_EXHAUSTED across all 4 zones, just wait
+for ZONE in us-central1-a us-central1-b us-central1-c us-central1-f; do
+  gcloud compute instances describe "encoding-worker-fallback-${ZONE##*-}" \
+    --zone=$ZONE --project=nomadkaraoke --format='value(status)' 2>/dev/null \
+    && echo "  ↑ in $ZONE"
+done
+```
+
+**Configuration knobs:** `MAX_PER_TICK = 1` and `MAX_WAIT_SECONDS = 24*3600` constants in `backend/api/routes/internal.py::retry_pending_render_jobs`.
+
+---
+
+## Job failed: "Video render failed: TimeoutError()"
+
+**Background:** This was the original signature of the 2026-05-05 capacity bug — empty exception message because `f"...{e}"` produced empty string for bare `TimeoutError()`. **As of 0.174.x the empty-message version should not happen** (we use `repr(e)` as fallback). If you see this exact form on a job after 2026-05-06, the render worker hit a `TimeoutError` *not* preceded by a typed `EncodingWorkerStartError` — most likely the URL re-resolve isn't engaging or a Cloud Run instance was killed mid-flight.
+
+**Check what the render actually saw:**
+```bash
+gcloud logging read \
+  "jsonPayload.message=~\"JOB_ID\" AND timestamp>=\"YYYY-MM-DDTHH:MM:SSZ\"" \
+  --project=nomadkaraoke --limit=50 --format='value(timestamp,jsonPayload.message)'
+```
+
+Look for these markers:
+- `Submitting render-video job to GCE worker: http://X.X.X.X:8080/render-video` — initial URL
+- `Trying candidate N/3: VM ... in us-central1-X` — multi-zone iteration starting
+- `Set active_override to ...` — fallback engaged
+- `Re-resolved encoding URL after warmup: A -> B` — added in 0.174.3, confirms the URL is updating between retries
+- `WORKER_END worker=render-video status=pending_capacity` — happy parking path
+- `WORKER_END worker=render-video status=error` — failed instead of parked (bug)
+
+**Most likely cause if no `Re-resolved` log appeared:** The job was rendered on a pre-0.174.3 revision. Just retry — the new revision is now serving.
+
+**Recovery:** retry the job via the admin endpoint or `/retry-pending-render-jobs`. The system is self-healing as long as at least one zone has capacity.
+
+---
+
+## Job stuck in `rendering_video` for hours (no failure log)
+
+**Symptoms:** Status frozen at `rendering_video` (progress 75%) for >30 minutes. No `WORKER_END worker=render-video` log entry exists. Last log is mid-retry like *"GCE worker connection failed (attempt 7/8)"*.
+
+**Cause:** The Cloud Run instance handling the render task was killed (autoscaler scaled down, OOM, or revision rollover) before the retry loop completed and could write a failure state. Cloud Tasks may have re-dispatched but landed somewhere unexpected.
+
+**Recovery:** manually transition to `review_complete` and re-trigger the render. The instrumental selection in `state_data` is preserved so no user re-work is needed:
+
+```bash
+ADMIN_TOKEN=$(gcloud secrets versions access latest --secret=admin-tokens --project=nomadkaraoke | cut -d',' -f1)
+JID=YOUR_JOB_ID
+python3 << EOF
+import os; os.environ['GOOGLE_CLOUD_PROJECT']='nomadkaraoke'
+from google.cloud import firestore
+from datetime import datetime, UTC
+db = firestore.Client(project='nomadkaraoke')
+now = datetime.now(UTC)
+db.collection('jobs').document('$JID').update({
+    'status': 'review_complete', 'progress': 70, 'updated_at': now,
+    'error_message': None, 'error_details': None,
+    'state_data.render_progress': {'stage': 'pending'},
+})
+EOF
+curl -X POST https://api.nomadkaraoke.com/api/internal/workers/render-video \
+  -H "X-Admin-Token: $ADMIN_TOKEN" -H "Content-Type: application/json" \
+  -d "{\"job_id\":\"$JID\"}"
+```
+
+This is a known hardening opportunity — the render worker should write a failure state on SIGTERM so Cloud Tasks can retry cleanly. See `docs/archive/2026-05-05-encoding-worker-capacity-resilience-plan.md`.
+
+---
+
 ## Deploy stuck in progress (`deploy_in_progress: true`)
 
 **Symptoms:** CI deploys fail immediately with "deploy already in progress". The flag in Firestore was never cleared after a previous failed deploy.

--- a/docs/archive/2026-05-06-capacity-resilience-session.md
+++ b/docs/archive/2026-05-06-capacity-resilience-session.md
@@ -1,0 +1,106 @@
+# Encoding Worker Capacity Resilience — Session Summary (May 5–6 2026)
+
+This session shipped the 3-phase capacity-resilience plan from
+[2026-05-05-encoding-worker-capacity-resilience-plan.md](2026-05-05-encoding-worker-capacity-resilience-plan.md)
+plus four follow-up fixes that surfaced once the system was exercised under
+real production load.
+
+This document records the **full arc** — the bugs we *thought* we were fixing,
+the bugs we *actually* hit, and the final state — so future sessions can
+understand why each piece exists.
+
+## The trigger
+
+Two real-user jobs failed with empty error messages: `Video render failed: ` (literally nothing after the colon).
+
+- `fbc651be` — The Corrs / Breathless — `arnoldespinojr@gmail.com`
+- `bee150fd` — Singing Melody / Want You Back — `nivekson@gmail.com`
+
+Investigation found **`ZONE_RESOURCE_POOL_EXHAUSTED`** in `us-central1-c` (out of `c4d-highcpu-32` capacity). The application's fire-and-forget `compute.instances.start()` call swallowed the GCE error completely; the readiness gate then timed out 120 s later; the HTTP retry loop ran for 7 more minutes and re-raised a bare `TimeoutError()` whose `str()` is empty.
+
+## What shipped
+
+### PR #748 — Capacity resilience (Phases 1-3)
+
+- New typed exception hierarchy: `EncodingWorkerStartError` (base), `EncodingWorkerCapacityError` (subclass for `ZONE_RESOURCE_POOL_EXHAUSTED` / `STOCKOUT` / `QUOTA_EXCEEDED`)
+- `EncodingWorkerManager.start_vm` waits for the operation result and raises typed errors instead of fire-and-forget
+- New `RENDER_PENDING_CAPACITY` job state — transient capacity issues park here instead of going to `FAILED`
+- `repr(e)` fallback in render worker's exception handler so empty-message errors no longer produce blank user messages
+- New `/api/internal/retry-pending-render-jobs` endpoint + Cloud Scheduler firing every 5 min, 24 h hard timeout
+- Multi-zone failover: `EncodingWorkerCandidate` list iterated in `ensure_any_running`, capacity errors fall through to next candidate, success on a non-primary sets `active_override_*` on the Firestore config doc
+- IaC: 2 fallback VMs added (originally `-a` and `-f`) — provisioned stopped, ~$10/mo each idle
+
+### PR #749 — Switch fallback `-f` → `-b`
+
+`pulumi up` failed creating the `-f` VM with — fittingly — `ZONE_RESOURCE_POOL_EXHAUSTED`. Capacity in `us-central1-f` for `c4d-highcpu-32` is too tight to be useful as a fallback. `-b` is reliable.
+
+### PR #750 — Three follow-up fixes
+
+1. **503 SERVICE_UNAVAILABLE didn't trigger fallback.** Multi-zone fallback only iterated on `EncodingWorkerCapacityError`. When GCE returned a transient `503` from `instances.start`, the typed exception was the parent `EncodingWorkerStartError` and the loop bailed instead of trying the next zone. Broadened to catch the parent class.
+2. **Fallback VMs failed with `SSL CERTIFICATE_VERIFY_FAILED`** on metadata-server access. `google-auth ≥ 2.40` uses mTLS-over-HTTPS to the metadata server when `/run/google-mds-mtls/` certs exist on the VM, which is the case on newer GCE images. Set `GCE_METADATA_MTLS_MODE=none` in the systemd EnvironmentFile to force HTTP.
+3. **`/retry` endpoint screens-existence check used wrong key.** Looked for `file_urls.screens.title` but the actual structure has `title_jpg`/`title_png`. Routed completed-review jobs back to `awaiting_review` forcing user re-work.
+
+Plus: progress callback was calling `transition_to_state(RENDERING_VIDEO)` while already in that state, polluting the timeline + error-monitor with `Invalid state transition` log spam.
+
+### PR #751 — Three more
+
+1. **`wait_for_worker_ready` looked in the wrong zone.** Multi-zone fallback successfully started a VM in `us-central1-a` but the readiness wait polled `us-central1-c` (the manager's default zone), got 404, gave up. Threaded the candidate's zone through.
+2. **`/retry-pending-render-jobs` returned 500 — composite index needed.** Query was `where(status) + order_by(updated_at)`. Fix: stream by status alone, sort in Python (small result set).
+3. **Cloud Run JOB (video-encoding-job) was missing the `ENCODING_WORKER_FALLBACK_VMS` env var.** Cloud Run service had it; the JOB instantiates its own `EncodingService` so it needed the secret too. Without it the final encoding step couldn't fall back when `-c` was exhausted.
+
+### PR #752 — URL re-resolve
+
+`_request_with_retry` captured the URL once before the retry loop. When the warmup-fallback updated the active URL override (switching from a dead primary to a live fallback), the retry loop kept hitting the original (dead) URL for all 8 attempts and raised a generic `TimeoutError` not caught by the typed-error path → job hard-failed instead of being parked. Threaded the relative `path` through and re-resolve `_get_worker_url() + path` on retries after warmup has fired.
+
+This was the bug that surfaced on `fae3eadc` after PR #751 deployed — multi-zone fallback engaged correctly, set the override, but the URL never updated mid-loop.
+
+## The recovery flow today
+
+```
+Render fails → typed error classification
+  ├─ EncodingWorkerCapacityError or EncodingWorkerStartError
+  │      ↓
+  │   ensure_any_running iterates candidates: [primary -c, fallback -a, fallback -b]
+  │      ↓
+  │      ├─ Any candidate succeeds → set active_override, invalidate URL cache,
+  │      │                            URL re-resolves on retry → request hits live VM ✓
+  │      └─ All candidates rejected → typed error propagates to render worker
+  │              ↓
+  │           render worker parks job in RENDER_PENDING_CAPACITY (NOT failed)
+  │              ↓
+  │           Cloud Scheduler retries every 5 min via /retry-pending-render-jobs
+  │              ↓
+  │           24 h hard timeout → transitions to FAILED with permanent message
+  │
+  └─ Other Exception → repr(e) fallback so message is informative → fail_job
+```
+
+## Hardening opportunities (not yet shipped)
+
+These came up during the session but weren't blocking; documenting for the next round.
+
+1. **Render worker doesn't handle SIGTERM gracefully.** When Cloud Run autoscales an instance down mid-render, the task is killed without writing a failure state. The job sits at `rendering_video` indefinitely until an operator manually retries. Workaround in `docs/TROUBLESHOOTING.md`. Fix would add a SIGTERM handler that sets `failed`/`render_pending_capacity` before exit, and ideally signals Cloud Tasks for retry.
+2. **Encoding worker loses in-memory job state on systemctl restart.** Observed once on `693c2254` — submit job to fallback-a, worker restarts (deploy or crash), poll for status returns `not found`. Workaround: retry the job (usually succeeds). Fix: persist job state to GCS or Firestore.
+3. **Concurrent renders against a single fallback VM cause `Connection reset by peer`.** Observed when 7 retries triggered in parallel against fallback-a. The encoding worker is single-tenant per render and can't queue HTTP-level. Workaround: trigger sequentially. Fix: add a submission queue/throttle in `EncodingService`.
+
+## Operational reference
+
+**VM topology (all idle by default):**
+```
+encoding-worker-a            us-central1-c   primary blue
+encoding-worker-b            us-central1-c   primary green
+encoding-worker-fallback-a   us-central1-a   capacity fallback
+encoding-worker-fallback-b   us-central1-b   capacity fallback
+```
+
+**Static IPs:** see Pulumi outputs `encoding_worker_*_ip`.
+
+**Configuration:**
+- `ENCODING_WORKER_FALLBACK_VMS` env (Cloud Run service + video-encoding-job): JSON list `[{"vm","zone","ip"}, ...]`. Stored in Secret Manager (`encoding-worker-fallback-vms`).
+- `GCE_METADATA_MTLS_MODE=none` in encoding worker `/opt/encoding-worker/env` (written by `infrastructure/encoding-worker/startup.sh` on every VM boot)
+- Cloud Scheduler `retry-pending-render-jobs` runs `*/5 * * * *`
+- Cloud Scheduler `recover-stuck-downloads` runs `*/5 * * * *` (existing; covers a different stage)
+
+**Jobs that hit and recovered from these bugs (May 5-6 2026):**
+
+The 2 originals (`fbc651be`, `bee150fd`) recovered organically. 9 others were explicitly retried during the session: `6b0bf198`, `052b94ab`, `0aefabf9`, `693c2254`, `ea83ccc6`, `549cdf90`, `3722ed7e`, `faafd5ad`, `9561402a`, `c84fbd76`, `fae3eadc`. All ended at `complete`.


### PR DESCRIPTION
## Summary

Documentation pass after shipping PRs #748-#752. Without these, the next operator or agent hitting a similar render failure has to re-derive everything from code + git history.

### What's added

1. **`docs/TROUBLESHOOTING.md`** — three new sections matching the failure modes the system can now surface:
   - *"Job stuck in `render_pending_capacity`"* — the new parked-for-retry state, how to check attempt count, how to poke the scheduler manually
   - *"Video render failed: TimeoutError()"* — regression guard; explains the empty-error history and the markers to look for in logs
   - *"Job stuck in `rendering_video` for hours"* — the Cloud Run-killed-mid-render case (separate hardening opportunity), with manual recovery procedure

2. **`docs/LESSONS-LEARNED.md`** — *"Encoding Worker Capacity Resilience (May 2026)"* — the seven traps we hit in order of discovery, the architectural summary post-fix, and the key file map. Future work starts here.

3. **`docs/archive/2026-05-06-capacity-resilience-session.md`** — full session arc capturing the trigger, each PR's motivation, the recovery flow today, and known unfixed hardening items so they don't get lost.

### What's not in this PR

- The original 3-phase plan (`docs/archive/2026-05-05-encoding-worker-capacity-resilience-plan.md`) stays as a historical record of what was planned before #750-#752 surfaced
- Workspace-level memory (`~/.claude/projects/-Users-andrew-Projects-nomadkaraoke/memory/`) updated separately — outside this repo

## Test plan

- [x] No code changes — pure docs
- [x] Markdown renders correctly (links to existing files use proper paths)
- [ ] Future-self test: a fresh agent with no session context should be able to diagnose a `render_pending_capacity` job using only TROUBLESHOOTING.md

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)