### PR TITLE
fix(idle-shutdown): check multi-zone fallback VMs

### DIFF
--- a/infrastructure/functions/encoding_worker_idle/deploy.sh
+++ b/infrastructure/functions/encoding_worker_idle/deploy.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Deploy the encoding-worker-idle-shutdown Cloud Function.
+#
+# Pulumi manages the function resource (env vars, IAM, scheduler) but does not
+# package or upload the function source. This script does that.
+#
+# Run this:
+#   - any time you change main.py / requirements.txt
+#   - after pulumi up if Pulumi reports no diff but the function is on stale code
+#
+# Prerequisites:
+#   - gcloud CLI authenticated as a principal with cloudfunctions.functions.update
+#     and storage.objects.create on encoding-worker-idle-source-${PROJECT_ID}
+#   - Pulumi infrastructure deployed first (creates the bucket, SA, and the
+#     ENCODING_WORKER_FALLBACK_VMS secret env var binding)
+#
+# Usage:
+#   ./deploy.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ID="${GOOGLE_CLOUD_PROJECT:-nomadkaraoke}"
+REGION="us-central1"
+FUNCTION_NAME="encoding-worker-idle-shutdown"
+BUCKET_NAME="encoding-worker-idle-source-${PROJECT_ID}"
+
+echo "Deploying encoding-worker-idle-shutdown Cloud Function..."
+echo "  Project:  ${PROJECT_ID}"
+echo "  Region:   ${REGION}"
+echo "  Function: ${FUNCTION_NAME}"
+echo ""
+
+cd "${SCRIPT_DIR}"
+
+ZIP_PATH=/tmp/encoding-worker-idle-source.zip
+echo "Creating source ZIP..."
+rm -f "${ZIP_PATH}"
+zip -r "${ZIP_PATH}" main.py requirements.txt
+
+echo "Uploading to GCS..."
+gcloud storage cp "${ZIP_PATH}" "gs://${BUCKET_NAME}/encoding-worker-idle-source.zip"
+
+echo "Triggering function rebuild..."
+gcloud functions deploy "${FUNCTION_NAME}" \
+  --gen2 \
+  --region="${REGION}" \
+  --source="gs://${BUCKET_NAME}/encoding-worker-idle-source.zip" \
+  --project="${PROJECT_ID}"
+
+echo ""
+echo "Function deployed."
+echo ""
+echo "Verify ENCODING_WORKER_FALLBACK_VMS env var is wired:"
+echo "  gcloud functions describe ${FUNCTION_NAME} --gen2 --region=${REGION} --project=${PROJECT_ID} \\"
+echo "    --format='value(serviceConfig.secretEnvironmentVariables)'"
+echo ""
+echo "Trigger a one-off run (skips the 5-min schedule):"
+echo "  curl -X POST -H \"Authorization: Bearer \$(gcloud auth print-identity-token)\" \\"
+echo "    https://${REGION}-${PROJECT_ID}.cloudfunctions.net/${FUNCTION_NAME}"

--- a/infrastructure/functions/encoding_worker_idle/main.py
+++ b/infrastructure/functions/encoding_worker_idle/main.py
@@ -1,19 +1,29 @@
 """
 Encoding Worker Idle Shutdown Cloud Function.
 
-Triggered by Cloud Scheduler every 5 minutes. Checks both encoding worker
-VMs (a/b) and stops any that are idle.
+Triggered by Cloud Scheduler every 5 minutes. Checks all encoding worker
+VMs (primary, secondary, AND multi-zone fallbacks) and stops any that
+are idle. Without checking the fallbacks, a fallback VM started during a
+capacity event could be left running indefinitely after the event clears
+— observed 2026-05-07 with `encoding-worker-fallback-a` running 13+ hours
+idle (~$15 cost) because the previous version of this function only
+iterated primary/secondary in the default zone.
 
 Idle criteria (all must be true to stop a VM):
 - No active encoding jobs (from /health endpoint active_jobs)
 - No recent user activity (from Firestore last_activity_at > 15 min)
-  - Only applies to primary VM; secondary always stops if no active jobs
+  - Only applies to the *currently routed* VM: `active_override_vm` if
+    set, else primary. Secondary and non-active fallbacks always stop on
+    idle so they don't leak after a capacity event.
 - No deploy in progress (from Firestore deploy_in_progress flag)
 
 Environment variables:
 - GCP_PROJECT: GCP project ID (default: nomadkaraoke)
-- GCP_ZONE: Zone where VMs are located (default: us-central1-c)
+- GCP_ZONE: Default zone for primary/secondary (default: us-central1-c)
 - IDLE_TIMEOUT_MINUTES: Minutes of inactivity before shutdown (default: 15)
+- ENCODING_WORKER_FALLBACK_VMS: JSON list of {vm, zone, ip} for fallback
+  VMs in alternate zones. Same secret the backend uses for multi-zone
+  failover. Empty/missing → no fallbacks checked.
 """
 
 import json
@@ -51,20 +61,20 @@ def get_firestore_client():
     return _firestore_client
 
 
-def get_vm_status(vm_name):
+def get_vm_status(vm_name, zone=ZONE):
     client = get_compute_client()
     try:
-        instance = client.get(project=PROJECT_ID, zone=ZONE, instance=vm_name)
+        instance = client.get(project=PROJECT_ID, zone=zone, instance=vm_name)
         return instance.status
     except Exception as e:
-        logger.error(f"Failed to get status for {vm_name}: {e}")
+        logger.error(f"Failed to get status for {vm_name} in {zone}: {e}")
         return "UNKNOWN"
 
 
-def get_vm_ip(vm_name):
+def get_vm_ip(vm_name, zone=ZONE):
     client = get_compute_client()
     try:
-        instance = client.get(project=PROJECT_ID, zone=ZONE, instance=vm_name)
+        instance = client.get(project=PROJECT_ID, zone=zone, instance=vm_name)
         for iface in instance.network_interfaces:
             for access in iface.access_configs:
                 if access.nat_i_p:
@@ -84,10 +94,36 @@ def check_active_jobs(vm_ip):
     return 0
 
 
-def stop_vm(vm_name):
+def stop_vm(vm_name, zone=ZONE):
     client = get_compute_client()
-    logger.info(f"Stopping idle VM: {vm_name}")
-    client.stop(project=PROJECT_ID, zone=ZONE, instance=vm_name)
+    logger.info(f"Stopping idle VM: {vm_name} in {zone}")
+    client.stop(project=PROJECT_ID, zone=zone, instance=vm_name)
+
+
+def _parse_fallback_vms():
+    """Return list of (vm_name, zone) tuples from ENCODING_WORKER_FALLBACK_VMS env.
+
+    Schema mirrors the backend: JSON list of {"vm","zone","ip"}. Returns
+    empty list when missing or malformed (worst case: we don't check
+    fallbacks, primary/secondary still get checked).
+    """
+    raw = os.environ.get("ENCODING_WORKER_FALLBACK_VMS", "")
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError) as exc:
+        logger.warning(f"Invalid ENCODING_WORKER_FALLBACK_VMS JSON: {exc}")
+        return []
+
+    fallbacks = []
+    for item in parsed:
+        try:
+            fallbacks.append((item["vm"], item["zone"]))
+        except (KeyError, TypeError) as exc:
+            logger.warning(f"Skipping malformed fallback entry {item}: {exc}")
+            continue
+    return fallbacks
 
 
 @functions_framework.http
@@ -130,19 +166,33 @@ def idle_shutdown(request):
         activity_time = datetime.fromisoformat(last_activity)
         has_recent_activity = activity_time > idle_cutoff
 
-    # Check each VM individually
+    # The currently-routed VM gets keep-alive-on-recent-activity treatment:
+    # capacity-fallback override wins, else primary. Secondary and non-active
+    # fallbacks always stop when idle so we don't leak them after a capacity
+    # event clears.
     primary_vm = config.get("primary_vm")
+    active_override_vm = config.get("active_override_vm")
+    active_vm = active_override_vm or primary_vm
+
+    # Build the full candidate list: primary + secondary in default zone,
+    # plus each multi-zone fallback in its own zone.
+    candidates = [
+        (primary_vm, ZONE),
+        (config.get("secondary_vm"), ZONE),
+    ]
+    candidates.extend(_parse_fallback_vms())
+
     results = {}
-    for vm_name in [primary_vm, config.get("secondary_vm")]:
+    for vm_name, vm_zone in candidates:
         if not vm_name:
             continue
 
-        status = get_vm_status(vm_name)
+        status = get_vm_status(vm_name, vm_zone)
         if status != "RUNNING":
             results[vm_name] = f"already_{status.lower()}"
             continue
 
-        vm_ip = get_vm_ip(vm_name)
+        vm_ip = get_vm_ip(vm_name, vm_zone)
         if vm_ip:
             active_jobs = check_active_jobs(vm_ip)
             if active_jobs > 0:
@@ -150,13 +200,14 @@ def idle_shutdown(request):
                 logger.info(f"{vm_name} has {active_jobs} active jobs, keeping alive")
                 continue
 
-        # Recent activity keeps PRIMARY alive only (not secondary)
-        if vm_name == primary_vm and has_recent_activity:
+        # Only the currently-routed VM (primary, or active_override fallback)
+        # gets the keep-alive treatment. Other VMs stop on idle.
+        if vm_name == active_vm and has_recent_activity:
             results[vm_name] = "active_session"
-            logger.info(f"{vm_name} (primary) kept alive due to recent activity")
+            logger.info(f"{vm_name} (active) kept alive due to recent activity")
             continue
 
-        stop_vm(vm_name)
+        stop_vm(vm_name, vm_zone)
         results[vm_name] = "stopped"
 
     return json.dumps({"status": "checked", "results": results}), 200

--- a/infrastructure/functions/encoding_worker_idle/test_idle_shutdown.py
+++ b/infrastructure/functions/encoding_worker_idle/test_idle_shutdown.py
@@ -237,3 +237,206 @@ class TestIdleShutdown:
         # Both should be stopped since no activity recorded
         assert result["results"]["encoding-worker-a"] == "stopped"
         assert result["results"]["encoding-worker-b"] == "stopped"
+
+
+# Helper for the fallback-aware fixtures below — fallbacks live in alternate
+# zones, so the mock compute client needs to dispatch get() by zone.
+def _zone_dispatching_get(instances_by_vm):
+    """Return a side_effect that returns the right mock per-VM lookup."""
+
+    def fake_get(project, zone, instance):
+        try:
+            return instances_by_vm[instance]
+        except KeyError as e:  # noqa: BLE001
+            raise Exception(f"unexpected instance lookup: {instance}") from e
+
+    return fake_get
+
+
+class TestFallbackVms:
+    """Tests for multi-zone fallback VM handling.
+
+    Without these checks, fallback VMs left running after a capacity event
+    leak indefinitely (observed 2026-05-07: fallback-a ran 13+ hours idle).
+    """
+
+    @pytest.fixture
+    def fallback_env(self, monkeypatch):
+        """Set ENCODING_WORKER_FALLBACK_VMS env var with two fallbacks."""
+        monkeypatch.setenv(
+            "ENCODING_WORKER_FALLBACK_VMS",
+            json.dumps([
+                {"vm": "encoding-worker-fallback-a", "zone": "us-central1-a", "ip": "1.1.1.1"},
+                {"vm": "encoding-worker-fallback-b", "zone": "us-central1-b", "ip": "2.2.2.2"},
+            ]),
+        )
+
+    def test_idle_fallback_gets_stopped(self, mock_compute, mock_firestore, fallback_env):
+        """A fallback VM that's RUNNING but idle (no jobs, not active) must be stopped.
+        This is the bug the fix addresses — previously fallbacks were never checked."""
+        recent = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+        config = _make_config(last_activity_at=recent)
+        _setup_firestore(mock_firestore, config)
+
+        # Primary RUNNING with recent activity → kept alive
+        # Secondary TERMINATED → already_terminated
+        # Fallback-a RUNNING but idle (active_override is None) → MUST stop
+        # Fallback-b TERMINATED → already_terminated
+        instances = {
+            "encoding-worker-a": _make_instance(status="RUNNING", ip="1.2.3.4"),
+            "encoding-worker-b": _make_instance(status="TERMINATED"),
+            "encoding-worker-fallback-a": _make_instance(status="RUNNING", ip="1.1.1.1"),
+            "encoding-worker-fallback-b": _make_instance(status="TERMINATED"),
+        }
+        mock_compute.get.side_effect = _zone_dispatching_get(instances)
+
+        with patch("main.check_active_jobs", return_value=0):
+            response, status_code = main.idle_shutdown(MagicMock())
+
+        result = json.loads(response)
+        assert result["results"]["encoding-worker-a"] == "active_session"
+        assert result["results"]["encoding-worker-b"] == "already_terminated"
+        assert result["results"]["encoding-worker-fallback-a"] == "stopped"
+        assert result["results"]["encoding-worker-fallback-b"] == "already_terminated"
+
+        # The fallback stop must target its own zone, not the default
+        stop_calls = mock_compute.stop.call_args_list
+        assert len(stop_calls) == 1
+        assert stop_calls[0].kwargs["instance"] == "encoding-worker-fallback-a"
+        assert stop_calls[0].kwargs["zone"] == "us-central1-a"
+
+    def test_active_override_fallback_kept_alive_on_recent_activity(
+        self, mock_compute, mock_firestore, fallback_env,
+    ):
+        """When a capacity-fallback override is set, that fallback is the
+        currently-routed VM and gets the keep-alive treatment (matching
+        what primary normally gets). Primary should still stop on idle."""
+        recent = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+        config = {
+            **_make_config(last_activity_at=recent),
+            "active_override_vm": "encoding-worker-fallback-a",
+        }
+        _setup_firestore(mock_firestore, config)
+
+        instances = {
+            "encoding-worker-a": _make_instance(status="RUNNING", ip="1.2.3.4"),
+            "encoding-worker-b": _make_instance(status="TERMINATED"),
+            "encoding-worker-fallback-a": _make_instance(status="RUNNING", ip="1.1.1.1"),
+            "encoding-worker-fallback-b": _make_instance(status="TERMINATED"),
+        }
+        mock_compute.get.side_effect = _zone_dispatching_get(instances)
+
+        with patch("main.check_active_jobs", return_value=0):
+            response, status_code = main.idle_shutdown(MagicMock())
+
+        result = json.loads(response)
+        # Primary now gets stopped because fallback is the active VM
+        assert result["results"]["encoding-worker-a"] == "stopped"
+        # Fallback-a is the currently-routed VM, kept alive on recent activity
+        assert result["results"]["encoding-worker-fallback-a"] == "active_session"
+
+    def test_fallback_with_active_jobs_kept_alive(
+        self, mock_compute, mock_firestore, fallback_env,
+    ):
+        """Fallback VM mid-encoding (active_jobs>0) must NOT be stopped —
+        the encoding job would die mid-run."""
+        old = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat()
+        config = _make_config(last_activity_at=old)
+        _setup_firestore(mock_firestore, config)
+
+        instances = {
+            "encoding-worker-a": _make_instance(status="TERMINATED"),
+            "encoding-worker-b": _make_instance(status="TERMINATED"),
+            "encoding-worker-fallback-a": _make_instance(status="RUNNING", ip="1.1.1.1"),
+            "encoding-worker-fallback-b": _make_instance(status="TERMINATED"),
+        }
+        mock_compute.get.side_effect = _zone_dispatching_get(instances)
+
+        with patch("main.check_active_jobs", return_value=3):
+            response, status_code = main.idle_shutdown(MagicMock())
+
+        result = json.loads(response)
+        assert result["results"]["encoding-worker-fallback-a"] == "active_jobs=3"
+        mock_compute.stop.assert_not_called()
+
+    def test_no_fallback_env_var_falls_back_to_primary_secondary_only(
+        self, mock_compute, mock_firestore, monkeypatch,
+    ):
+        """If ENCODING_WORKER_FALLBACK_VMS is missing, function still works
+        for primary/secondary — no crash, no fallback iteration."""
+        monkeypatch.delenv("ENCODING_WORKER_FALLBACK_VMS", raising=False)
+        old = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat()
+        config = _make_config(last_activity_at=old)
+        _setup_firestore(mock_firestore, config)
+
+        instance = _make_instance(status="RUNNING", ip="1.2.3.4")
+        mock_compute.get.return_value = instance
+
+        with patch("main.check_active_jobs", return_value=0):
+            response, status_code = main.idle_shutdown(MagicMock())
+
+        result = json.loads(response)
+        assert "encoding-worker-a" in result["results"]
+        assert "encoding-worker-b" in result["results"]
+        assert "encoding-worker-fallback-a" not in result["results"]
+
+    def test_malformed_fallback_env_doesnt_crash(
+        self, mock_compute, mock_firestore, monkeypatch,
+    ):
+        """Bad JSON in fallback env must NOT prevent primary/secondary
+        idle-shutdown from running. The cost of malformed env is just no
+        fallback checking, not a broken function."""
+        monkeypatch.setenv("ENCODING_WORKER_FALLBACK_VMS", "not json {{{")
+        old = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat()
+        config = _make_config(last_activity_at=old)
+        _setup_firestore(mock_firestore, config)
+
+        instance = _make_instance(status="RUNNING", ip="1.2.3.4")
+        mock_compute.get.return_value = instance
+
+        with patch("main.check_active_jobs", return_value=0):
+            response, status_code = main.idle_shutdown(MagicMock())
+
+        result = json.loads(response)
+        assert result["status"] == "checked"
+        assert "encoding-worker-a" in result["results"]
+
+
+class TestParseFallbackVms:
+    """Direct unit tests for the _parse_fallback_vms helper."""
+
+    def test_returns_empty_when_env_missing(self, monkeypatch):
+        monkeypatch.delenv("ENCODING_WORKER_FALLBACK_VMS", raising=False)
+        assert main._parse_fallback_vms() == []
+
+    def test_returns_empty_on_malformed_json(self, monkeypatch):
+        monkeypatch.setenv("ENCODING_WORKER_FALLBACK_VMS", "not json")
+        assert main._parse_fallback_vms() == []
+
+    def test_returns_tuples_of_vm_zone(self, monkeypatch):
+        monkeypatch.setenv(
+            "ENCODING_WORKER_FALLBACK_VMS",
+            json.dumps([
+                {"vm": "fb-a", "zone": "us-central1-a", "ip": "1.1.1.1"},
+                {"vm": "fb-b", "zone": "us-central1-b", "ip": "2.2.2.2"},
+            ]),
+        )
+        assert main._parse_fallback_vms() == [
+            ("fb-a", "us-central1-a"),
+            ("fb-b", "us-central1-b"),
+        ]
+
+    def test_skips_malformed_entries(self, monkeypatch):
+        """Entries missing required keys are skipped, valid entries kept."""
+        monkeypatch.setenv(
+            "ENCODING_WORKER_FALLBACK_VMS",
+            json.dumps([
+                {"vm": "fb-a", "zone": "us-central1-a"},  # ok, missing ip is fine
+                {"vm": "fb-no-zone"},  # malformed: no zone
+                {"vm": "fb-c", "zone": "us-central1-c"},  # ok
+            ]),
+        )
+        assert main._parse_fallback_vms() == [
+            ("fb-a", "us-central1-a"),
+            ("fb-c", "us-central1-c"),
+        ]

--- a/infrastructure/modules/encoding_worker_manager.py
+++ b/infrastructure/modules/encoding_worker_manager.py
@@ -54,6 +54,18 @@ def grant_idle_shutdown_permissions(service_account):
         member=service_account.email.apply(lambda e: f"serviceAccount:{e}"),
     )
 
+    # The function reads the multi-zone fallback list from Secret Manager
+    # (same secret the backend uses) so it knows which fallback VMs to
+    # check during idle-sweep. Without this, fallbacks left running after
+    # a capacity event leak indefinitely.
+    bindings["fallback_secret"] = gcp.secretmanager.SecretIamMember(
+        "idle-shutdown-fallback-secret",
+        project=PROJECT_ID,
+        secret_id="encoding-worker-fallback-vms",
+        role="roles/secretmanager.secretAccessor",
+        member=service_account.email.apply(lambda e: f"serviceAccount:{e}"),
+    )
+
     return bindings
 
 
@@ -101,6 +113,17 @@ def create_idle_shutdown_resources():
                 "GCP_ZONE": ENCODING_WORKER_ZONE,
                 "IDLE_TIMEOUT_MINUTES": str(EncodingWorkerConfig.IDLE_TIMEOUT_MINUTES),
             },
+            # Multi-zone fallback list — same secret as the backend uses for
+            # capacity failover. Function reads this to know which fallback
+            # VMs to check during idle-sweep.
+            secret_environment_variables=[
+                gcp.cloudfunctionsv2.FunctionServiceConfigSecretEnvironmentVariableArgs(
+                    key="ENCODING_WORKER_FALLBACK_VMS",
+                    project_id=PROJECT_ID,
+                    secret="encoding-worker-fallback-vms",
+                    version="latest",
+                ),
+            ],
         ),
         opts=pulumi.ResourceOptions(
             depends_on=list(perms.values()),


### PR DESCRIPTION
## Summary

The encoding-worker idle-shutdown Cloud Function only iterated \`[primary_vm, secondary_vm]\` in the default zone — capacity-fallback VMs in alternate zones (\`-a\`/\`-b\`) were never checked, so a fallback started during a capacity event stayed RUNNING indefinitely after the event resolved.

Observed 2026-05-07: \`encoding-worker-fallback-a\` in \`us-central1-a\` ran for 13+ hours idle (~\$15 cost) before manual intervention.

## Changes

- **\`infrastructure/functions/encoding_worker_idle/main.py\`**:
  - Read \`ENCODING_WORKER_FALLBACK_VMS\` env (same secret the backend uses for capacity failover) and iterate fallbacks alongside primary/secondary.
  - Threaded \`zone\` through \`get_vm_status\` / \`get_vm_ip\` / \`stop_vm\` so cross-zone shutdowns work.
  - Keep-alive-on-recent-activity now follows \`active_override_vm\` (the currently-routed VM during a capacity event), not always the primary. Otherwise an active capacity-fallback would get killed while serving real traffic.
- **\`infrastructure/modules/encoding_worker_manager.py\`** (Pulumi):
  - Wire the \`encoding-worker-fallback-vms\` secret into the function via \`secret_environment_variables\`.
  - New \`gcp.secretmanager.SecretIamMember\` binding so the function's SA can read that secret.
- **\`infrastructure/functions/encoding_worker_idle/deploy.sh\`** (new): uploads source zip and triggers function rebuild. Was missing for this function (other functions all have one); matches the pattern from \`backup_to_aws/deploy.sh\` etc.
- **\`infrastructure/functions/encoding_worker_idle/test_idle_shutdown.py\`**: 9 new tests:
  - Idle fallback gets stopped (in its own zone)
  - Active-override fallback kept alive on recent activity (primary stops instead)
  - Fallback with active jobs not stopped
  - Graceful behavior when env var missing or malformed JSON
  - 4 unit tests on the \`_parse_fallback_vms\` helper
  - All 18 tests pass.

## Already applied to prod

I ran \`pulumi up\` and \`deploy.sh\` from this branch to apply the fix. CI's pulumi-up will be a no-op on merge.

**End-to-end verification:**
1. Started \`encoding-worker-fallback-a\` manually (RUNNING)
2. Triggered \`encoding-worker-idle-check\` scheduler
3. fallback-a went to STOPPING within ~20s ✅

Before fix: fallback-a would have stayed RUNNING (old code never checked fallbacks).
After fix: fallback gets stopped on the next 5-min idle sweep.

## Test plan

- [x] 18 unit tests pass locally (9 existing + 9 new)
- [x] \`pulumi preview\`: 1 created (secret IAM), 1 updated (function with secret env var), 263 unchanged
- [x] \`pulumi up\` applied successfully
- [x] \`deploy.sh\` deployed new function code
- [x] Manually verified: fallback-a started → triggered idle-check → stopped

@coderabbitai ignore