### PR TITLE
Show bot-block message instead of misleading age-restriction

### DIFF
--- a/backend/api/routes/file_upload.py
+++ b/backend/api/routes/file_upload.py
@@ -1635,6 +1635,13 @@ async def create_job_from_url(
                     detail = "This YouTube video is private and cannot be downloaded."
                 elif availability.get("is_removed"):
                     detail = "This YouTube video has been removed and cannot be downloaded."
+                elif availability.get("is_bot_blocked"):
+                    detail = (
+                        "We're temporarily unable to access YouTube to download this video — "
+                        "YouTube is asking our server to verify it's not a bot. "
+                        "Please try again in a few minutes, or use Audio Search to find this song "
+                        "from another source."
+                    )
                 elif availability.get("is_age_restricted"):
                     detail = "This YouTube video is age-restricted and cannot be downloaded."
                 else:

--- a/backend/services/flacfetch_client.py
+++ b/backend/services/flacfetch_client.py
@@ -680,7 +680,8 @@ class FlacfetchClient:
 
         Returns:
             Dict with keys: available, video_id, title, error,
-            is_geo_restricted, is_age_restricted, is_private, is_removed
+            is_geo_restricted, is_age_restricted, is_private, is_removed,
+            is_bot_blocked
 
         Raises:
             FlacfetchServiceError: On request failure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.174.8"
+version = "0.174.9"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Companion to flacfetch [PR #25](https://github.com/nomadkaraoke/flacfetch/pull/25) (merged, deployed). When flacfetch returns the new `is_bot_blocked: true` flag, surface a clear user message explaining YouTube's bot challenge is temporary — instead of falling through to the misleading "This YouTube video is age-restricted" response.

## Test plan

- [x] Backend tests for affected paths: 211 pass
- [x] flacfetch 0.20.0 (with the new field) is already running on the prod VM — verified end-to-end that `is_bot_blocked: true` is returned for bot-challenged videos.
- [ ] CI green

## Notes

- Forward-compatible: if `is_bot_blocked` is absent (older flacfetch), `availability.get()` returns falsy and the existing fallthrough kicks in.
- The four pre-existing elif branches (geo / private / removed / age) are also hardcoded English. Migrating them all to the backend `t()` helper would be scope creep; this PR matches the existing pattern.

@coderabbitai ignore