### PR TITLE
feat(runners): ephemeral GHA runner dispatcher behind RUNNER_MODE flag

### DIFF
--- a/.github/workflows/build-runner-images.yml
+++ b/.github/workflows/build-runner-images.yml
@@ -1,0 +1,238 @@
+name: Build GHA Runner Images
+
+# Produces three custom GCE images used by the ephemeral GitHub Actions runner
+# dispatcher: gha-runner-general, gha-runner-build, gha-runner-gpu.
+#
+# Flow per variant:
+#   1. Create a temporary build VM from debian-cloud/debian-12 with
+#      infrastructure/scripts/runner-image-provision.sh as metadata-startup-script.
+#   2. Poll for /opt/runner-image-ready via gcloud ssh (survives kernel-upgrade reboots).
+#   3. Stop the VM, snapshot its boot disk to a new image in the `gha-runner-<variant>`
+#      image family with name gha-runner-<variant>-<timestamp>.
+#   4. Delete the build VM (boot disk auto-deletes).
+#   5. Deprecate older images in the family, keeping the newest 3 ACTIVE.
+
+on:
+  workflow_dispatch:
+    inputs:
+      variants:
+        description: 'Comma-separated variants to build (general,build,gpu) or "all"'
+        required: false
+        default: 'all'
+      skip_prune:
+        description: 'Skip deprecation of old images (debugging)'
+        type: boolean
+        required: false
+        default: false
+  schedule:
+    # Monthly on the 1st at 02:00 UTC
+    - cron: '0 2 1 * *'
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  GCP_PROJECT: nomadkaraoke
+  BUILD_REGION: us-central1
+  BUILD_ZONE: us-central1-a
+  BASE_IMAGE: projects/debian-cloud/global/images/family/debian-12
+  KEEP_IMAGES_PER_FAMILY: 3
+
+jobs:
+  resolve-matrix:
+    name: Resolve variant matrix
+    runs-on: ubuntu-latest
+    outputs:
+      variants: ${{ steps.resolve.outputs.variants }}
+    steps:
+      - id: resolve
+        run: |
+          requested='${{ github.event.inputs.variants || 'all' }}'
+          if [[ "$requested" == "all" || -z "$requested" ]]; then
+            echo 'variants=["general","build","gpu"]' >> "$GITHUB_OUTPUT"
+          else
+            json="$(echo "$requested" | tr ',' '\n' | jq -R . | jq -sc .)"
+            echo "variants=$json" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Build ${{ matrix.variant }} image
+    needs: resolve-matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: ${{ fromJSON(needs.resolve-matrix.outputs.variants) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.GCP_PROJECT }}
+
+      - name: Resolve build parameters
+        id: params
+        run: |
+          variant='${{ matrix.variant }}'
+          ts="$(date -u +%Y%m%d-%H%M%S)"
+          name="gha-runner-${variant}-${ts}"
+          family="gha-runner-${variant}"
+          vm="gha-image-build-${variant}-${ts}"
+
+          case "$variant" in
+            general|build)
+              machine="n2-standard-8"
+              disk_size="50"
+              accel=""
+              ;;
+            gpu)
+              # Build with a T4 attached so DKMS module is built and validated
+              # against the kernel that ships in the image.
+              machine="n1-standard-4"
+              disk_size="200"
+              accel="--maintenance-policy=TERMINATE --accelerator=type=nvidia-tesla-t4,count=1"
+              ;;
+            *)
+              echo "Unknown variant: $variant" >&2
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "name=$name"
+            echo "family=$family"
+            echo "vm=$vm"
+            echo "machine=$machine"
+            echo "disk_size=$disk_size"
+            echo "accel=$accel"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create build VM
+        run: |
+          set -euo pipefail
+          gcloud compute instances create '${{ steps.params.outputs.vm }}' \
+            --project='${{ env.GCP_PROJECT }}' \
+            --zone='${{ env.BUILD_ZONE }}' \
+            --machine-type='${{ steps.params.outputs.machine }}' \
+            --image='${{ env.BASE_IMAGE }}' \
+            --boot-disk-size='${{ steps.params.outputs.disk_size }}GB' \
+            --boot-disk-type=pd-balanced \
+            --boot-disk-auto-delete \
+            --service-account="${{ secrets.GCP_SERVICE_ACCOUNT }}" \
+            --scopes=https://www.googleapis.com/auth/cloud-platform \
+            --metadata=enable-oslogin=TRUE,image-variant='${{ matrix.variant }}' \
+            --metadata-from-file=startup-script=infrastructure/scripts/runner-image-provision.sh \
+            --labels=purpose=gha-runner-image-builder,variant='${{ matrix.variant }}' \
+            ${{ steps.params.outputs.accel }}
+
+      - name: Wait for provisioning to complete
+        env:
+          VM: ${{ steps.params.outputs.vm }}
+          ZONE: ${{ env.BUILD_ZONE }}
+          PROJECT: ${{ env.GCP_PROJECT }}
+        run: |
+          set -euo pipefail
+          # Provisioning includes 14GB model download for GPU variant — be patient.
+          # The provision script writes /opt/runner-image-ready when complete.
+          # Tolerate transient SSH failures during the kernel-upgrade reboot.
+          deadline=$(( $(date +%s) + 75 * 60 ))
+          attempt=0
+          while (( $(date +%s) < deadline )); do
+            attempt=$((attempt+1))
+            if gcloud compute ssh "$VM" --zone="$ZONE" --project="$PROJECT" \
+                --tunnel-through-iap --quiet \
+                --command='test -f /opt/runner-image-ready' 2>/dev/null; then
+              echo "Image ready (attempt $attempt)"
+              gcloud compute ssh "$VM" --zone="$ZONE" --project="$PROJECT" \
+                --tunnel-through-iap --quiet \
+                --command='cat /opt/runner-image-ready /opt/runner-image-variant'
+              exit 0
+            fi
+            echo "Attempt $attempt: not ready yet, sleeping 30s..."
+            sleep 30
+          done
+          echo "Timed out waiting for /opt/runner-image-ready" >&2
+          gcloud compute ssh "$VM" --zone="$ZONE" --project="$PROJECT" \
+            --tunnel-through-iap --quiet \
+            --command='tail -200 /var/log/runner-image-provision.log' || true
+          exit 1
+
+      - name: Stop build VM
+        env:
+          VM: ${{ steps.params.outputs.vm }}
+          ZONE: ${{ env.BUILD_ZONE }}
+          PROJECT: ${{ env.GCP_PROJECT }}
+        run: |
+          set -euo pipefail
+          gcloud compute instances stop "$VM" --zone="$ZONE" --project="$PROJECT" --quiet
+          # Belt-and-suspenders wait for TERMINATED.
+          for _ in $(seq 1 60); do
+            status=$(gcloud compute instances describe "$VM" --zone="$ZONE" --project="$PROJECT" --format='value(status)')
+            [[ "$status" == "TERMINATED" ]] && break
+            sleep 5
+          done
+
+      - name: Create image
+        env:
+          VM: ${{ steps.params.outputs.vm }}
+          ZONE: ${{ env.BUILD_ZONE }}
+          PROJECT: ${{ env.GCP_PROJECT }}
+          IMAGE: ${{ steps.params.outputs.name }}
+          FAMILY: ${{ steps.params.outputs.family }}
+        run: |
+          set -euo pipefail
+          # Capture the boot disk before VM deletion releases it.
+          disk=$(gcloud compute instances describe "$VM" --zone="$ZONE" --project="$PROJECT" \
+            --format='value(disks[0].source.scope(disks).segment(1))')
+          gcloud compute images create "$IMAGE" \
+            --project="$PROJECT" \
+            --source-disk="$disk" \
+            --source-disk-zone="$ZONE" \
+            --family="$FAMILY" \
+            --description="GHA ephemeral runner image (${{ matrix.variant }}) built ${{ github.run_id }}" \
+            --labels=purpose=gha-ephemeral-runner,variant=${{ matrix.variant }},built-by=gha
+          echo "Created $IMAGE in family $FAMILY"
+
+      - name: Delete build VM
+        if: always()
+        env:
+          VM: ${{ steps.params.outputs.vm }}
+          ZONE: ${{ env.BUILD_ZONE }}
+          PROJECT: ${{ env.GCP_PROJECT }}
+        run: |
+          gcloud compute instances delete "$VM" --zone="$ZONE" --project="$PROJECT" --quiet || true
+
+      - name: Deprecate old images (keep newest ${{ env.KEEP_IMAGES_PER_FAMILY }})
+        if: ${{ github.event.inputs.skip_prune != 'true' }}
+        env:
+          PROJECT: ${{ env.GCP_PROJECT }}
+          FAMILY: ${{ steps.params.outputs.family }}
+          KEEP: ${{ env.KEEP_IMAGES_PER_FAMILY }}
+        run: |
+          set -euo pipefail
+          # List ACTIVE images in this family, newest first, skip the top $KEEP.
+          to_deprecate=$(gcloud compute images list \
+            --project="$PROJECT" \
+            --filter="family=$FAMILY AND status=READY AND -deprecated.state:*" \
+            --sort-by='~creationTimestamp' \
+            --format='value(name)' | tail -n +$((KEEP+1)))
+          if [[ -z "$to_deprecate" ]]; then
+            echo "Nothing to deprecate."
+            exit 0
+          fi
+          for img in $to_deprecate; do
+            echo "Deprecating $img"
+            gcloud compute images deprecate "$img" \
+              --project="$PROJECT" \
+              --state=DEPRECATED \
+              --replacement="projects/$PROJECT/global/images/family/$FAMILY"
+          done

--- a/docs/EPHEMERAL-GHA-RUNNERS.md
+++ b/docs/EPHEMERAL-GHA-RUNNERS.md
@@ -218,6 +218,20 @@ start them.
 
 Savings realised: ~$220/mo (7×200GB pd-ssd at $32/mo each).
 
+## Follow-ups (not in initial PR)
+
+* **Dedicated image-builder service account.** The build workflow currently
+  uses the `github-actions-deployer@` SA (broad CI/CD perms). Best practice
+  is a separate `gha-runner-image-builder@` SA with only `artifactregistry.reader`
+  + `logging.logWriter`. The build VM doesn't need write perms anywhere
+  — `gcloud compute images create` is invoked from the GHA runner, not the
+  VM. Adds 1 SA + 2 IAM bindings + a new repo secret.
+* **OIDC token verification for the scheduler entry point.** The function
+  currently checks `Authorization: Bearer <jwt>` is present and non-trivially
+  long, which keeps random callers out but doesn't cryptographically verify
+  the token. Adding full verification needs `google-auth` in the function's
+  requirements.txt and a one-time JWKS fetch; defer until we observe abuse.
+
 ## Known gotchas
 
 * **claude-readonly ADC blocks Pulumi storage writes.** The workspace's

--- a/docs/EPHEMERAL-GHA-RUNNERS.md
+++ b/docs/EPHEMERAL-GHA-RUNNERS.md
@@ -1,0 +1,263 @@
+# Ephemeral GitHub Actions Runners
+
+Operational runbook for the create-on-demand GHA runner dispatcher. Replaces
+the previous fixed pool of 7 long-lived VMs with single-use ephemeral VMs to
+eliminate ~$230/mo of always-billed pd-ssd boot disks.
+
+## High-level architecture
+
+```
+GitHub webhook (workflow_job.queued)
+        │
+        ▼
+runner-dispatcher Cloud Function (github-runner-manager)
+        │  ─ pick image family from labels (general | build | gpu)
+        │  ─ mint a JIT runner config from GitHub
+        │  ─ compute.instances.insert with --auto-delete boot disk
+        │  ─ return 200
+        ▼
+Fresh GCE VM boots from custom image
+        │  ─ startup-script reads JIT config from metadata
+        │  ─ runs ./run.sh --jitconfig (registers + runs one job + de-registers)
+        │  ─ on exit, trap fires `shutdown -h +1`
+        ▼
+Boot disk auto-deletes; VM is gone
+
+Every 15 min: orphan cleanup pass
+        │  ─ list VMs labelled purpose=gha-ephemeral-runner
+        │  ─ cross-reference with org runners list
+        │  ─ delete VMs older than 30 min with no registration
+        │  ─ delete VMs older than 2 h regardless (hung job protection)
+        │  ─ de-register zombie GHA runners with no live VM
+```
+
+## Modes
+
+Controlled by Pulumi config `karaoke-gen-infrastructure:runnerMode`:
+
+* **`legacy`** (default) — keeps the original start/stop pool behaviour. The
+  Cloud Function uses `start_runners` / `check_and_stop_idle_runners` against
+  the existing `github-runner-{1,2,3}`, `github-build-runner`, and
+  `github-gpu-runner-{1,2,3}` VMs. **No behavioural change** vs. pre-this-PR.
+
+* **`ephemeral`** — webhook creates a fresh VM per job via JIT registration;
+  scheduler runs orphan cleanup. The legacy VMs are not touched (and should be
+  left in their existing TERMINATED state until Phase 4).
+
+Switching modes is a two-step operation handled entirely by Pulumi:
+
+```bash
+pulumi config set karaoke-gen-infrastructure:runnerMode ephemeral
+pulumi up --target 'urn:...:Function::runner-manager-function'
+```
+
+(replace `ephemeral` ↔ `legacy` to roll back; takes ~2 min for the function to
+re-deploy).
+
+## Image families
+
+Three GCE image families are maintained by
+[`.github/workflows/build-runner-images.yml`](../.github/workflows/build-runner-images.yml):
+
+| Family | Base | Bakes | Built on |
+|---|---|---|---|
+| `gha-runner-general` | Debian 12 | Docker, gcloud, runner v2.332, Python 3.13 (pyenv), Node 20, Java 21, FFmpeg, Poetry | n2-standard-8, 50GB pd-balanced |
+| `gha-runner-build` | Debian 12 | Same as general + pre-pulled `karaoke-backend-base`/`:latest` + `fake-gcs-server` | n2-standard-8, 50GB pd-balanced |
+| `gha-runner-gpu` | Debian 12 | NVIDIA driver + CUDA 12.4, Python 3.13 (compiled), FFmpeg+libsamplerate, audio-separator models (~14GB at `/opt/audio-separator-models`) | n1-standard-4 + T4, 200GB pd-balanced |
+
+Each image is tagged `gha-runner-<variant>-<YYYYMMDD-HHMMSS>` and joined to the
+matching image family. The dispatcher always selects from the family, so the
+newest non-deprecated image wins automatically. The build workflow keeps the
+newest 3 images per family and deprecates the rest.
+
+Build cadence: monthly cron (`0 2 1 * *` UTC) + `workflow_dispatch`. Manual:
+
+```bash
+gh workflow run build-runner-images.yml -f variants=general,build
+gh workflow run build-runner-images.yml -f variants=gpu
+gh workflow run build-runner-images.yml          # all three
+```
+
+Pulumi does **not** manage images — they're produced by the GHA workflow. The
+runtime dispatcher resolves `projects/nomadkaraoke/global/images/family/gha-runner-<variant>`
+directly, which means image lifecycle and code lifecycle are decoupled.
+
+## Operator handoff: rollout sequence
+
+The plan document is at
+[`docs/archive/2026-05-16-ephemeral-gha-runners-plan.md`](archive/2026-05-16-ephemeral-gha-runners-plan.md)
+(this repo) and at `nomadkaraoke/docs/archive/2026-05-16-ephemeral-gha-runners-plan.md`
+(workspace root, original). Phases 1–2 (code) and 5 (monitoring) are landed in
+this PR. Phases 3 and 4 (cutover + decommission) are operator-driven.
+
+### Phase 1 — Build the images (one-time)
+
+After this PR merges:
+
+1. Trigger the workflow for the cheapest variant first to validate plumbing:
+   ```bash
+   gh workflow run build-runner-images.yml -f variants=general
+   ```
+   First build takes ~25 min on `general`/`build`, ~60 min on `gpu` (model
+   downloads dominate).
+
+2. Verify the image landed:
+   ```bash
+   gcloud compute images describe-from-family gha-runner-general \
+     --project=nomadkaraoke \
+     --format='value(name,creationTimestamp,labels)'
+   ```
+
+3. Repeat for `build` and `gpu`.
+
+4. Smoke test by launching a one-off VM manually:
+   ```bash
+   gcloud compute instances create gha-smoke-test \
+     --zone=us-central1-a \
+     --machine-type=e2-standard-4 \
+     --image-family=gha-runner-general \
+     --image-project=nomadkaraoke \
+     --metadata=enable-oslogin=TRUE
+   gcloud compute ssh gha-smoke-test --zone=us-central1-a \
+     --command='docker --version && python3 --version && /home/runner/actions-runner/bin/Runner.Listener --version'
+   gcloud compute instances delete gha-smoke-test --zone=us-central1-a --quiet
+   ```
+
+### Phase 2 — Apply the dispatcher changes (Pulumi)
+
+This PR adds:
+- `RUNNER_MODE`, `GCP_FALLBACK_ZONE`, `GITHUB_ORG`, `RUNNER_SERVICE_ACCOUNT`
+  env vars on `github-runner-manager`
+- Replaces the Cloud Function source archive with the new
+  `runner_manager/` + `ephemeral.py` code
+- Adds 2 log-based metrics + 2 alert policies for runner observability
+
+Apply locally (the workspace's ADC points at a read-only SA — Pulumi from
+this terminal will fail with 403 on `storage.objects.create`, so use an
+account with write access, e.g. `gcloud config configurations activate admin`):
+
+```bash
+cd karaoke-gen/infrastructure
+pulumi preview --diff
+# expected: ~2 changes (runner-manager-source replace, runner-manager-function update)
+#           + 5 creates (log metrics, alert policies)
+pulumi up --target 'urn:pulumi:prod::karaoke-gen-infrastructure::gcp:storage/bucketObject:BucketObject::runner-manager-source' \
+          --target 'urn:pulumi:prod::karaoke-gen-infrastructure::gcp:cloudfunctionsv2/function:Function::runner-manager-function' \
+          --target 'urn:pulumi:prod::karaoke-gen-infrastructure::gcp:logging/metric:Metric::runner-dispatcher-failures' \
+          --target 'urn:pulumi:prod::karaoke-gen-infrastructure::gcp:logging/metric:Metric::runner-dispatcher-orphan-kills' \
+          --target 'urn:pulumi:prod::karaoke-gen-infrastructure::gcp:monitoring/alertPolicy:AlertPolicy::runner-dispatcher-failures-alert' \
+          --target 'urn:pulumi:prod::karaoke-gen-infrastructure::gcp:monitoring/alertPolicy:AlertPolicy::runner-dispatcher-long-lived-vm-alert'
+```
+
+After apply, `RUNNER_MODE` is still `legacy` — no behavioural change yet.
+
+> **Why `--target`?** There's an unrelated pending `divebar-sync-vm` recreate
+> from the May 16 cost sprint. Until that PR's deploy runs, scoping to these
+> targets keeps this rollout isolated.
+
+### Phase 3 — Cutover to ephemeral
+
+**Only after Phase 1 produced all 3 images AND Phase 2 dispatcher deployed.**
+
+1. Manual one-off test: invoke the dispatcher directly with a synthetic
+   webhook payload (signature verification will reject this, but you can
+   alternatively flip the mode just for this test by setting the env var on
+   the function via `gcloud functions deploy`-style override, or use a real
+   PR — see step 3).
+
+2. Switch the dispatcher to ephemeral mode globally:
+   ```bash
+   pulumi config set karaoke-gen-infrastructure:runnerMode ephemeral
+   pulumi up --target 'urn:pulumi:prod::karaoke-gen-infrastructure::gcp:cloudfunctionsv2/function:Function::runner-manager-function'
+   ```
+   The 7 legacy VMs are currently in `TERMINATED` state (the idle-check
+   stopped them). With `RUNNER_MODE=ephemeral` the dispatcher no longer
+   starts them — they sit idle until Phase 4 deletion.
+
+3. Trigger a real test run by opening (or pushing to) any branch on
+   `karaoke-gen` or `python-audio-separator`. Verify in Cloud Console that:
+   - `runner-manager-function` invocations succeed (no 503s)
+   - `gcloud compute instances list --filter=labels.purpose=gha-ephemeral-runner` shows VMs appearing and disappearing
+   - The CI job completes within `1.5×` the prior wall clock
+   - The orphan-cleanup pass (every 15 min via `runner-manager-idle-check`
+     scheduler) prints `kept_vms: []` once jobs are done
+
+4. Monitor the new alert policies for a week before Phase 4:
+   - `GHA Runner Dispatcher - Create Failures` (any failure = page)
+   - `GHA Runner Dispatcher - VM Alive > 2h` (orphan cleanup didn't work)
+
+**Rollback:** `pulumi config set karaoke-gen-infrastructure:runnerMode legacy && pulumi up --target ...:runner-manager-function`.
+Legacy VMs are still in Pulumi state; the next workflow_job webhook will
+start them.
+
+### Phase 4 — Decommission the legacy VMs (destructive)
+
+**Only after Phase 3 has run cleanly for ≥1 week with real CI traffic.**
+
+1. In `karaoke-gen/infrastructure/config.py`, set `NUM_GITHUB_RUNNERS = 0`
+   and `NUM_GPU_RUNNERS = 0`.
+2. In `karaoke-gen/infrastructure/__main__.py`, remove the
+   `github_runners.create_github_runners(...)`, `create_build_runner(...)`,
+   and `create_gpu_runners(...)` calls along with their references.
+3. In `karaoke-gen/infrastructure/modules/runner_manager.py`, remove the
+   idle-check scheduler (no longer needed once ephemeral is the only mode).
+4. In `karaoke-gen/infrastructure/functions/runner_manager/main.py`, delete
+   the legacy `start_runners` / `check_and_stop_idle_runners` paths and the
+   `RUNNER_MODE` branching. Keep webhook signature verification.
+5. `pulumi up` (locally, since legacy VM delete needs `compute.instances.delete`
+   which `claude-readonly` blocks).
+6. Verify:
+   ```bash
+   gcloud compute instances list --filter="name~'github-(runner|gpu|build)'" --project=nomadkaraoke
+   # should return zero rows
+   gcloud compute disks list --filter="users:'github-'" --project=nomadkaraoke
+   # should return zero rows
+   ```
+7. Remove the unused `RUNNER_NAMES` and `GPU_RUNNER_NAMES` env vars from the
+   Pulumi runner_manager module (cosmetic).
+
+Savings realised: ~$220/mo (7×200GB pd-ssd at $32/mo each).
+
+## Known gotchas
+
+* **claude-readonly ADC blocks Pulumi storage writes.** The workspace's
+  `GOOGLE_APPLICATION_CREDENTIALS` points at a read-only SA. Pulumi 403s on
+  `storage.objects.create` when re-uploading the function source bundle.
+  Apply Pulumi changes from a shell that uses `admin@nomadkaraoke.com` (or
+  temporarily unset the env var). Do NOT switch to `gcloud` to bypass — see
+  `feedback_claude_readonly_adc.md` in memory.
+* **Pulumi state has a pending `divebar-sync-vm` recreate.** Unrelated to
+  this work; will be applied by the cost-sprint PR's CI deploy.
+* **us-east4 GPU fallback uses external IPs**, not Cloud NAT. There's no NAT
+  in us-east4; provisioning one for a rarely-used fallback zone wasn't worth
+  the complexity. Ephemeral external IPs are free while the VM is running.
+* **Pre-existing test failure** in
+  `infrastructure/functions/runner_manager/test_runner_manager.py::TestCheckGithubForPendingJobs::test_checks_both_queued_and_in_progress`.
+  Assumes 2 GitHub API calls; code now iterates 2 repos × 2 statuses = 4.
+  Unrelated to this PR.
+* **Existing legacy test `test_runner_manager.py` still passes** in 25/26
+  scenarios; the new `test_ephemeral.py` adds 20 tests, all passing.
+* **Image build VM uses `n2-standard-8`** to speed up apt + downloads, even
+  though runtime general/build VMs are `e2-standard-4`/`e2-standard-8`. This
+  is intentional — image build is ~25 min on n2; ~45 min on e2.
+* **The `--ephemeral` flag is implicit** when `./run.sh --jitconfig` is used.
+  Don't pass `--ephemeral` explicitly with `--jitconfig` — GitHub's runner
+  rejects the combination.
+* **The provision script's GPU kernel-upgrade reboot** is the slowest part of
+  the GPU build. The first build will reboot once mid-provisioning; the
+  workflow tolerates this via SSH retry-with-grace.
+
+## Files added by this work
+
+* `karaoke-gen/infrastructure/scripts/runner-image-provision.sh` — provision logic
+* `karaoke-gen/.github/workflows/build-runner-images.yml` — image build pipeline
+* `karaoke-gen/infrastructure/functions/runner_manager/ephemeral.py` — new dispatcher
+* `karaoke-gen/infrastructure/functions/runner_manager/test_ephemeral.py` — 20 tests
+* `karaoke-gen/docs/EPHEMERAL-GHA-RUNNERS.md` — this file
+
+## Files modified by this work
+
+* `karaoke-gen/infrastructure/functions/runner_manager/main.py` — route on RUNNER_MODE
+* `karaoke-gen/infrastructure/modules/runner_manager.py` — new env vars, runnerMode config
+* `karaoke-gen/infrastructure/modules/monitoring.py` — runner-dispatcher alerts
+* `karaoke-gen/infrastructure/__main__.py` — wire monitoring resources

--- a/docs/EPHEMERAL-GHA-RUNNERS.md
+++ b/docs/EPHEMERAL-GHA-RUNNERS.md
@@ -234,6 +234,17 @@ Savings realised: ~$220/mo (7×200GB pd-ssd at $32/mo each).
 
 ## Known gotchas
 
+* **Source-bundle replacement doesn't auto-redeploy the Cloud Function** (fixed
+  forward, but worth knowing). The original code uploaded a new source bundle
+  via `BucketObject` replace, but the `cloudfunctionsv2.Function` resource
+  pointed at the bucket+name without pinning a generation, so Pulumi saw no
+  diff on the Function and the live function kept serving the previously
+  staged copy. Fixed by adding `generation=source_archive.generation` to the
+  Function's `storage_source`. If you ever see a Pulumi apply complete cleanly
+  but the live function still serving old code, run
+  `gcloud functions deploy github-runner-manager --gen2 --region=us-central1
+  --project=nomadkaraoke --source=gs://nomadkaraoke-runner-manager-source/runner-manager-source.zip
+  --runtime=python312 --entry-point=handle_request --quiet`.
 * **claude-readonly ADC blocks Pulumi storage writes.** The workspace's
   `GOOGLE_APPLICATION_CREDENTIALS` points at a read-only SA. Pulumi 403s on
   `storage.objects.create` when re-uploading the function source bundle.

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -195,6 +195,9 @@ error_monitor_resources = error_monitor_module.create_error_monitor(
 # Alert policies
 alert_policies = monitoring.create_alert_policies()
 
+# Ephemeral GHA-runner dispatcher: log-based metrics + alerts
+runner_observability = monitoring.create_ephemeral_runner_observability()
+
 # ==================== Cloud Function: GDrive Validator ====================
 
 # Cloud Storage bucket for function source code

--- a/infrastructure/functions/runner_manager/ephemeral.py
+++ b/infrastructure/functions/runner_manager/ephemeral.py
@@ -408,24 +408,27 @@ def create_ephemeral_runner(labels: Iterable[str], pat: str) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _list_ephemeral_vms_in_zone(zone: str) -> list[compute_v1.Instance]:
+def _list_all_ephemeral_vms() -> list[tuple[str, compute_v1.Instance]]:
+    """Return (zone, instance) for every ephemeral runner VM in the project.
+
+    Uses ``aggregatedList`` so the cleanup pass picks up VMs in any zone —
+    not just the currently-configured primary/fallback. Without this,
+    reconfiguring ``GCP_ZONE`` or ``GCP_FALLBACK_ZONE`` would orphan any VMs
+    still running in the old zones.
+    """
     client = get_compute_client()
-    request = compute_v1.ListInstancesRequest(
+    request = compute_v1.AggregatedListInstancesRequest(
         project=PROJECT_ID,
-        zone=zone,
         filter=f'labels.purpose="{VM_PURPOSE_LABEL}"',
     )
-    return list(client.list(request=request))
-
-
-def _list_all_ephemeral_vms() -> list[tuple[str, compute_v1.Instance]]:
-    """Return (zone, instance) for every ephemeral runner VM across known zones."""
     pairs: list[tuple[str, compute_v1.Instance]] = []
-    zones = {PRIMARY_ZONE}
-    if FALLBACK_ZONE:
-        zones.add(FALLBACK_ZONE)
-    for zone in zones:
-        for instance in _list_ephemeral_vms_in_zone(zone):
+    for zone_path, scoped in client.aggregated_list(request=request):
+        # zone_path is like "zones/us-central1-a"; aggregated_list also yields
+        # "global" / "regions/..." entries that don't contain instances.
+        if not zone_path.startswith("zones/"):
+            continue
+        zone = zone_path.removeprefix("zones/")
+        for instance in getattr(scoped, "instances", []) or []:
             pairs.append((zone, instance))
     return pairs
 

--- a/infrastructure/functions/runner_manager/ephemeral.py
+++ b/infrastructure/functions/runner_manager/ephemeral.py
@@ -1,0 +1,522 @@
+"""
+Ephemeral GitHub Actions runner dispatcher.
+
+Creates a single-use GCE VM per `workflow_job.queued` webhook, registers it as
+a JIT-config ephemeral runner with the nomadkaraoke org, and lets the VM
+self-destruct after the job runs. An orphan-cleanup pass runs every 15 min to
+catch VMs whose job died before the runner could de-register itself.
+
+This module is invoked from main.py when RUNNER_MODE=ephemeral.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import urllib.error
+import urllib.request
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable
+
+from google.cloud import compute_v1
+
+PROJECT_ID = os.environ.get("GCP_PROJECT", "nomadkaraoke")
+PRIMARY_ZONE = os.environ.get("GCP_ZONE", "us-central1-a")
+FALLBACK_ZONE = os.environ.get("GCP_FALLBACK_ZONE", "us-east4-c")
+GITHUB_ORG = os.environ.get("GITHUB_ORG", "nomadkaraoke")
+RUNNER_GROUP_ID = int(os.environ.get("RUNNER_GROUP_ID", "1"))
+RUNNER_SERVICE_ACCOUNT = os.environ.get(
+    "RUNNER_SERVICE_ACCOUNT", "github-runner@nomadkaraoke.iam.gserviceaccount.com"
+)
+
+# Orphan cleanup thresholds
+ORPHAN_GRACE_MINUTES = int(os.environ.get("ORPHAN_GRACE_MINUTES", "30"))
+MAX_VM_LIFETIME_MINUTES = int(os.environ.get("MAX_VM_LIFETIME_MINUTES", "120"))
+
+VM_PURPOSE_LABEL = "gha-ephemeral-runner"
+
+GITHUB_API = "https://api.github.com"
+
+
+@dataclass(frozen=True)
+class FamilySpec:
+    """Per-image-family runtime configuration."""
+
+    name: str
+    machine_type: str
+    disk_size_gb: int
+    image_family: str  # GCE image family that the dispatcher selects
+    extra_runner_labels: tuple[str, ...]
+    has_gpu: bool
+    needs_external_ip_in_fallback_zone: bool
+
+
+FAMILIES: dict[str, FamilySpec] = {
+    "general": FamilySpec(
+        name="general",
+        machine_type="e2-standard-4",
+        disk_size_gb=100,
+        image_family="gha-runner-general",
+        extra_runner_labels=("x64", "gcp", "large-disk"),
+        has_gpu=False,
+        needs_external_ip_in_fallback_zone=False,
+    ),
+    "build": FamilySpec(
+        name="build",
+        machine_type="e2-standard-8",
+        disk_size_gb=100,
+        image_family="gha-runner-build",
+        extra_runner_labels=("x64", "gcp", "large-disk", "docker-build"),
+        has_gpu=False,
+        needs_external_ip_in_fallback_zone=False,
+    ),
+    "gpu": FamilySpec(
+        name="gpu",
+        machine_type="n1-standard-4",
+        disk_size_gb=150,
+        image_family="gha-runner-gpu",
+        extra_runner_labels=("x64", "gcp", "gpu"),
+        has_gpu=True,
+        # No Cloud NAT in us-east4 yet; rely on an ephemeral external IP for the
+        # rare fallback case rather than provisioning region-wide NAT.
+        needs_external_ip_in_fallback_zone=True,
+    ),
+}
+
+
+# Inline startup script kept tiny — the heavy lifting is baked into the image.
+# JIT config is fetched from instance metadata so it stays out of public logs.
+STARTUP_SCRIPT = r"""#!/bin/bash
+set -uo pipefail
+# Always shut down on exit so the auto-delete boot disk goes away with us.
+trap 'shutdown -h +1' EXIT
+
+JIT=$(curl -s -H "Metadata-Flavor: Google" \
+  "http://metadata.google.internal/computeMetadata/v1/instance/attributes/jit-config")
+if [[ -z "$JIT" ]]; then
+    echo "ERROR: jit-config metadata missing" >&2
+    exit 1
+fi
+
+cd /home/runner/actions-runner
+# --jitconfig implies --ephemeral: runs one job, deregisters, exits.
+sudo -u runner ./run.sh --jitconfig "$JIT"
+"""
+
+
+# ---------------------------------------------------------------------------
+# Lazy GCE / HTTP clients (so unit tests can mock them)
+# ---------------------------------------------------------------------------
+
+_compute_client: compute_v1.InstancesClient | None = None
+
+
+def get_compute_client() -> compute_v1.InstancesClient:
+    global _compute_client
+    if _compute_client is None:
+        _compute_client = compute_v1.InstancesClient()
+    return _compute_client
+
+
+# ---------------------------------------------------------------------------
+# Label / family resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_family(labels: Iterable[str]) -> FamilySpec:
+    """Pick the right image family for a queued job's labels.
+
+    Precedence: gpu → build → general. A job that asks for both ``gpu`` and
+    ``docker-build`` shouldn't exist today; if it ever does we'd want a separate
+    image, not a coin-flip.
+    """
+    label_set = {label.lower() for label in labels}
+    if "gpu" in label_set:
+        return FAMILIES["gpu"]
+    if "docker-build" in label_set:
+        return FAMILIES["build"]
+    return FAMILIES["general"]
+
+
+def runner_labels_for(family: FamilySpec) -> list[str]:
+    """Compose the labels advertised to GitHub by this runner."""
+    return ["self-hosted", "linux", *family.extra_runner_labels]
+
+
+# ---------------------------------------------------------------------------
+# GitHub API helpers
+# ---------------------------------------------------------------------------
+
+
+def _github_request(method: str, path: str, pat: str, body: dict | None = None) -> dict | list | None:
+    """Make a GitHub REST API call. Returns parsed JSON or None for 204."""
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(
+        f"{GITHUB_API}{path}",
+        method=method,
+        data=data,
+        headers={
+            "Authorization": f"Bearer {pat}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=15) as response:
+        if response.status == 204:
+            return None
+        return json.loads(response.read().decode("utf-8"))
+
+
+def mint_jit_config(
+    pat: str,
+    runner_name: str,
+    family: FamilySpec,
+) -> str:
+    """Mint a just-in-time runner config for org-level ephemeral registration."""
+    payload = {
+        "name": runner_name,
+        "runner_group_id": RUNNER_GROUP_ID,
+        "labels": runner_labels_for(family),
+        "work_folder": "_work",
+    }
+    result = _github_request(
+        "POST",
+        f"/orgs/{GITHUB_ORG}/actions/runners/generate-jitconfig",
+        pat,
+        payload,
+    )
+    if not isinstance(result, dict) or "encoded_jit_config" not in result:
+        raise RuntimeError(f"JIT config response missing encoded_jit_config: {result!r}")
+    return result["encoded_jit_config"]
+
+
+def list_org_runners(pat: str) -> list[dict]:
+    """List all org-level self-hosted runners (paginated, up to 1000)."""
+    runners: list[dict] = []
+    per_page = 100
+    page = 1
+    while page <= 10:
+        result = _github_request(
+            "GET",
+            f"/orgs/{GITHUB_ORG}/actions/runners?per_page={per_page}&page={page}",
+            pat,
+        )
+        if not isinstance(result, dict):
+            break
+        chunk = result.get("runners", [])
+        runners.extend(chunk)
+        if len(chunk) < per_page:
+            break
+        page += 1
+    return runners
+
+
+def deregister_runner(pat: str, runner_id: int) -> None:
+    """Forcefully de-register a runner from the org (zombie cleanup)."""
+    try:
+        _github_request(
+            "DELETE",
+            f"/orgs/{GITHUB_ORG}/actions/runners/{runner_id}",
+            pat,
+        )
+    except urllib.error.HTTPError as exc:
+        # 404 = runner already gone; treat as success.
+        if exc.code != 404:
+            raise
+
+
+# ---------------------------------------------------------------------------
+# GCE VM creation
+# ---------------------------------------------------------------------------
+
+
+def _image_family_url(family: FamilySpec) -> str:
+    """Return the GCE image-family URL for use as a disk source_image.
+
+    Using the family URL means GCE selects the newest non-deprecated image
+    automatically, and we don't need ``compute.images.get`` on the dispatcher
+    SA — instanceAdmin's ``compute.images.useReadOnly`` is sufficient.
+    """
+    return f"projects/{PROJECT_ID}/global/images/family/{family.image_family}"
+
+
+def _build_instance(
+    *,
+    name: str,
+    family: FamilySpec,
+    zone: str,
+    jit_config: str,
+    image_self_link: str,
+    use_external_ip: bool,
+) -> compute_v1.Instance:
+    """Assemble the GCE Instance proto for an ephemeral runner."""
+    boot_disk = compute_v1.AttachedDisk(
+        auto_delete=True,
+        boot=True,
+        initialize_params=compute_v1.AttachedDiskInitializeParams(
+            disk_size_gb=family.disk_size_gb,
+            disk_type=f"projects/{PROJECT_ID}/zones/{zone}/diskTypes/pd-balanced",
+            source_image=image_self_link,
+        ),
+    )
+
+    network_interface = compute_v1.NetworkInterface(
+        network=f"projects/{PROJECT_ID}/global/networks/default",
+    )
+    if use_external_ip:
+        # Ephemeral external IP — costs nothing while the VM is running with
+        # one attached; not provisioned in advance.
+        network_interface.access_configs = [
+            compute_v1.AccessConfig(name="External NAT", type_="ONE_TO_ONE_NAT"),
+        ]
+
+    metadata = compute_v1.Metadata(
+        items=[
+            compute_v1.Items(key="jit-config", value=jit_config),
+            compute_v1.Items(key="startup-script", value=STARTUP_SCRIPT),
+            compute_v1.Items(key="enable-oslogin", value="TRUE"),
+        ]
+    )
+
+    scheduling = compute_v1.Scheduling(
+        automatic_restart=False,
+        # GPU VMs cannot live-migrate; everyone uses TERMINATE for simplicity.
+        on_host_maintenance="TERMINATE",
+        preemptible=False,
+    )
+
+    instance = compute_v1.Instance(
+        name=name,
+        machine_type=f"projects/{PROJECT_ID}/zones/{zone}/machineTypes/{family.machine_type}",
+        disks=[boot_disk],
+        network_interfaces=[network_interface],
+        metadata=metadata,
+        scheduling=scheduling,
+        service_accounts=[
+            compute_v1.ServiceAccount(
+                email=RUNNER_SERVICE_ACCOUNT,
+                scopes=["https://www.googleapis.com/auth/cloud-platform"],
+            )
+        ],
+        labels={
+            "purpose": VM_PURPOSE_LABEL,
+            "family": family.name,
+            "managed-by": "runner-dispatcher",
+        },
+        tags=compute_v1.Tags(items=["gha-runner", "github-runner"]),
+        shielded_instance_config=compute_v1.ShieldedInstanceConfig(
+            enable_secure_boot=True,
+            enable_vtpm=True,
+            enable_integrity_monitoring=True,
+        ),
+    )
+
+    if family.has_gpu:
+        instance.guest_accelerators = [
+            compute_v1.AcceleratorConfig(
+                accelerator_count=1,
+                accelerator_type=f"projects/{PROJECT_ID}/zones/{zone}/acceleratorTypes/nvidia-tesla-t4",
+            )
+        ]
+
+    return instance
+
+
+_ZONE_EXHAUSTED_TOKENS = (
+    "ZONE_RESOURCE_POOL_EXHAUSTED",
+    "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS",
+    "QUOTA_EXCEEDED",
+    "stockout",
+)
+
+
+def _is_zone_exhausted(exc: Exception) -> bool:
+    msg = str(exc)
+    return any(tok in msg for tok in _ZONE_EXHAUSTED_TOKENS)
+
+
+def create_ephemeral_runner(labels: Iterable[str], pat: str) -> dict:
+    """Mint a JIT config and launch a fresh GCE VM to run a single CI job.
+
+    Tries the primary zone first; on capacity-exhaustion errors falls back to
+    the secondary zone (with ephemeral external IP for variants that need it).
+    """
+    family = resolve_family(labels)
+    runner_name = f"gha-{family.name}-{uuid.uuid4().hex[:12]}"
+
+    jit_config = mint_jit_config(pat, runner_name, family)
+
+    image_url = _image_family_url(family)
+
+    zones = [PRIMARY_ZONE]
+    if FALLBACK_ZONE and FALLBACK_ZONE != PRIMARY_ZONE:
+        zones.append(FALLBACK_ZONE)
+
+    last_error: Exception | None = None
+    for zone in zones:
+        use_external_ip = (
+            family.needs_external_ip_in_fallback_zone and zone != PRIMARY_ZONE
+        )
+        instance = _build_instance(
+            name=runner_name,
+            family=family,
+            zone=zone,
+            jit_config=jit_config,
+            image_self_link=image_url,
+            use_external_ip=use_external_ip,
+        )
+        try:
+            operation = get_compute_client().insert(
+                project=PROJECT_ID,
+                zone=zone,
+                instance_resource=instance,
+            )
+            # Don't wait for the operation to fully resolve — fire and forget,
+            # the VM will boot in the background and pick up its queued job.
+            print(
+                f"Dispatched ephemeral runner: name={runner_name} "
+                f"family={family.name} zone={zone} image={image_url} "
+                f"operation={operation.name if hasattr(operation, 'name') else '<unknown>'}"
+            )
+            return {
+                "runner_name": runner_name,
+                "family": family.name,
+                "zone": zone,
+                "external_ip": use_external_ip,
+            }
+        except Exception as exc:  # noqa: BLE001 — surfacing to caller is the point
+            last_error = exc
+            if _is_zone_exhausted(exc) and zone != zones[-1]:
+                print(
+                    f"Zone {zone} exhausted for {family.name}; trying fallback. err={exc!r}"
+                )
+                continue
+            raise
+
+    raise RuntimeError(
+        f"Failed to create ephemeral runner {runner_name} in any zone: {last_error!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orphan cleanup
+# ---------------------------------------------------------------------------
+
+
+def _list_ephemeral_vms_in_zone(zone: str) -> list[compute_v1.Instance]:
+    client = get_compute_client()
+    request = compute_v1.ListInstancesRequest(
+        project=PROJECT_ID,
+        zone=zone,
+        filter=f'labels.purpose="{VM_PURPOSE_LABEL}"',
+    )
+    return list(client.list(request=request))
+
+
+def _list_all_ephemeral_vms() -> list[tuple[str, compute_v1.Instance]]:
+    """Return (zone, instance) for every ephemeral runner VM across known zones."""
+    pairs: list[tuple[str, compute_v1.Instance]] = []
+    zones = {PRIMARY_ZONE}
+    if FALLBACK_ZONE:
+        zones.add(FALLBACK_ZONE)
+    for zone in zones:
+        for instance in _list_ephemeral_vms_in_zone(zone):
+            pairs.append((zone, instance))
+    return pairs
+
+
+def _vm_age_minutes(instance: compute_v1.Instance) -> float:
+    if not instance.creation_timestamp:
+        return float("inf")
+    created = datetime.fromisoformat(instance.creation_timestamp.replace("Z", "+00:00"))
+    return (datetime.now(timezone.utc) - created).total_seconds() / 60
+
+
+def _delete_vm(zone: str, name: str) -> tuple[str, str]:
+    try:
+        get_compute_client().delete(project=PROJECT_ID, zone=zone, instance=name)
+        return name, "deleted"
+    except Exception as exc:  # noqa: BLE001
+        print(f"Failed to delete {name} in {zone}: {exc!r}")
+        return name, "delete_failed"
+
+
+def cleanup_orphans(pat: str) -> dict:
+    """Reconcile GCE VMs with org-runner registrations.
+
+    Deletes:
+      - VMs whose GHA runner has already de-registered and that are older than
+        ORPHAN_GRACE_MINUTES (catches startup failures + finished jobs whose
+        self-shutdown didn't fire).
+      - VMs older than MAX_VM_LIFETIME_MINUTES regardless (hung jobs).
+
+    De-registers:
+      - GHA runners with the dispatcher's name prefix that have no live VM
+        (zombie registrations).
+    """
+    result = {
+        "deleted_vms": [],
+        "kept_vms": [],
+        "delete_failed": [],
+        "deregistered_runners": [],
+        "deregister_failed": [],
+    }
+
+    vms = _list_all_ephemeral_vms()
+    runners = list_org_runners(pat)
+    runner_by_name = {r["name"]: r for r in runners}
+    vm_names = {instance.name for _, instance in vms}
+
+    to_delete: list[tuple[str, str]] = []
+    for zone, instance in vms:
+        age = _vm_age_minutes(instance)
+        registered = instance.name in runner_by_name
+
+        if age >= MAX_VM_LIFETIME_MINUTES:
+            print(f"{instance.name}: age={age:.1f}min > max, deleting")
+            to_delete.append((zone, instance.name))
+        elif not registered and age >= ORPHAN_GRACE_MINUTES:
+            print(
+                f"{instance.name}: age={age:.1f}min, no GHA runner registration — deleting"
+            )
+            to_delete.append((zone, instance.name))
+        else:
+            result["kept_vms"].append(instance.name)
+
+    if to_delete:
+        with ThreadPoolExecutor(max_workers=min(len(to_delete), 8)) as ex:
+            futures = {
+                ex.submit(_delete_vm, zone, name): (zone, name)
+                for zone, name in to_delete
+            }
+            for fut in as_completed(futures):
+                name, outcome = fut.result()
+                if outcome == "deleted":
+                    result["deleted_vms"].append(name)
+                else:
+                    result["delete_failed"].append(name)
+
+    # Zombie runners: ephemeral-named runners with no live VM.
+    for runner in runners:
+        name = runner["name"]
+        if not name.startswith("gha-"):
+            continue
+        if name in vm_names:
+            continue
+        # Allow GitHub a beat to garbage-collect a runner whose VM just died;
+        # only kill ones that are offline AND have no VM.
+        if runner.get("status") == "online":
+            continue
+        try:
+            deregister_runner(pat, runner["id"])
+            result["deregistered_runners"].append(name)
+        except Exception as exc:  # noqa: BLE001
+            print(f"Failed to deregister {name}: {exc!r}")
+            result["deregister_failed"].append(name)
+
+    return result

--- a/infrastructure/functions/runner_manager/main.py
+++ b/infrastructure/functions/runner_manager/main.py
@@ -1,20 +1,26 @@
 """
 GitHub Actions Runner Manager Cloud Function.
 
-Handles two types of triggers:
-1. GitHub Webhook (workflow_job.queued) - Starts runner VMs when CI jobs are queued
-2. Cloud Scheduler (every 15 min) - Stops idle runner VMs after IDLE_TIMEOUT_HOURS
+Two operating modes, selected by ``RUNNER_MODE``:
 
-Runner VMs are tracked by name via the RUNNER_NAMES environment variable, which is
-set by Pulumi from the list of all runner instance names.
+* ``legacy`` (default) — starts/stops the fixed pool of long-lived runner VMs
+  managed by Pulumi. Webhook ``workflow_job.queued`` starts them; Cloud
+  Scheduler ``check_idle`` stops them after ``IDLE_TIMEOUT_HOURS``.
 
-Environment variables:
+* ``ephemeral`` — creates a fresh single-use GCE VM per webhook via JIT
+  registration; orphan cleanup tears down whatever's left at each scheduler
+  tick. Implemented in ``ephemeral.py``.
+
+Environment variables (legacy):
 - GCP_PROJECT: GCP project ID
 - GCP_ZONE: Default zone where runner VMs are located
 - WEBHOOK_SECRET_NAME: Secret Manager secret name for webhook verification
 - RUNNER_PAT_SECRET_NAME: Secret Manager secret name for GitHub PAT
 - IDLE_TIMEOUT_HOURS: Hours of inactivity before stopping runners (default: 1)
 - RUNNER_NAMES: Comma-separated list of runner VM names to manage
+- GPU_RUNNER_NAMES: Subset of RUNNER_NAMES started only on ``gpu`` jobs
+
+Environment variables (ephemeral): see ``ephemeral.py``.
 """
 
 import hashlib
@@ -35,6 +41,10 @@ ZONE = os.environ.get("GCP_ZONE", "us-central1-a")
 WEBHOOK_SECRET_NAME = os.environ.get("WEBHOOK_SECRET_NAME", "github-webhook-secret")
 RUNNER_PAT_SECRET_NAME = os.environ.get("RUNNER_PAT_SECRET_NAME", "github-runner-pat")
 IDLE_TIMEOUT_HOURS = float(os.environ.get("IDLE_TIMEOUT_HOURS", "1"))
+RUNNER_MODE = os.environ.get("RUNNER_MODE", "legacy").lower()
+if RUNNER_MODE not in ("legacy", "ephemeral"):
+    print(f"WARNING: unknown RUNNER_MODE={RUNNER_MODE!r}, defaulting to 'legacy'")
+    RUNNER_MODE = "legacy"
 RUNNER_NAMES = os.environ.get(
     "RUNNER_NAMES",
     "github-runner-1,github-runner-2,github-runner-3,github-build-runner",
@@ -438,6 +448,39 @@ def check_and_stop_idle_runners() -> dict:
     return result
 
 
+def _handle_scheduler_tick() -> tuple[str, int, dict]:
+    """Run the idle-check (legacy) or orphan-cleanup (ephemeral) pass."""
+    if RUNNER_MODE == "ephemeral":
+        from ephemeral import cleanup_orphans
+
+        print("Scheduler trigger: ephemeral mode orphan cleanup")
+        result = cleanup_orphans(get_github_pat())
+    else:
+        print("Scheduler trigger: legacy idle check")
+        result = check_and_stop_idle_runners()
+    return json.dumps(result), 200, {"Content-Type": "application/json"}
+
+
+def _handle_workflow_job_queued(labels: list[str]) -> tuple[str, int, dict]:
+    """Dispatch a queued workflow job to the right runner backend."""
+    if RUNNER_MODE == "ephemeral":
+        from ephemeral import create_ephemeral_runner
+
+        try:
+            result = create_ephemeral_runner(labels, get_github_pat())
+            return json.dumps(result), 200, {"Content-Type": "application/json"}
+        except Exception as exc:  # noqa: BLE001
+            # Returning 503 keeps the queued job around for the next webhook
+            # (action=in_progress / cancelled) and for orphan-cleanup retries.
+            print(f"create_ephemeral_runner failed: {exc!r}")
+            return json.dumps({"error": str(exc)}), 503, {"Content-Type": "application/json"}
+
+    needs_gpu = "gpu" in labels
+    print(f"Legacy: starting pool runners (gpu={'yes' if needs_gpu else 'no'})")
+    result = start_runners(include_gpu=needs_gpu)
+    return json.dumps(result), 200, {"Content-Type": "application/json"}
+
+
 @functions_framework.http
 def handle_request(request: Request):
     """
@@ -447,12 +490,10 @@ def handle_request(request: Request):
     1. Cloud Scheduler triggers (action=check_idle parameter)
     2. GitHub webhook events (workflow_job.queued/completed)
     """
-    # Check if this is a scheduler trigger (idle check)
+    # Check if this is a scheduler trigger (idle check / orphan cleanup)
     action = request.args.get("action")
-    if action == "check_idle":
-        print("Scheduler trigger: checking for idle runners")
-        result = check_and_stop_idle_runners()
-        return json.dumps(result), 200, {"Content-Type": "application/json"}
+    if action in ("check_idle", "cleanup_orphans"):
+        return _handle_scheduler_tick()
 
     # Otherwise, this should be a GitHub webhook
     # Verify the webhook signature
@@ -480,7 +521,7 @@ def handle_request(request: Request):
     job = payload.get("workflow_job", {})
     labels = job.get("labels", [])
 
-    print(f"Received workflow_job.{action} event")
+    print(f"Received workflow_job.{action} event (mode={RUNNER_MODE})")
     print(f"Job labels: {labels}")
 
     # Check if this job requires our self-hosted runners
@@ -490,17 +531,15 @@ def handle_request(request: Request):
 
     # Handle different actions
     if action == "queued":
-        # Job is queued - ensure runners are started.
-        # Only start GPU runners if the job explicitly requests the "gpu" label.
-        needs_gpu = "gpu" in labels
-        print(f"Job queued - starting runners (gpu={'yes' if needs_gpu else 'no'})")
-        result = start_runners(include_gpu=needs_gpu)
-        return json.dumps(result), 200, {"Content-Type": "application/json"}
+        return _handle_workflow_job_queued(labels)
 
-    elif action == "completed":
-        # Job completed — update last-activity on the specific runner that ran it.
-        # Only update the specific runner to avoid fingerprint conflicts from
-        # concurrent webhook calls trying to update all instances simultaneously.
+    if action == "completed":
+        if RUNNER_MODE == "ephemeral":
+            # Ephemeral runners self-shutdown via --jitconfig + startup-script
+            # trap; nothing to record here. Orphan cleanup handles stragglers.
+            return "OK - ephemeral runner self-cleans", 200
+
+        # Legacy: refresh last-activity on the specific runner that ran the job.
         runner_name = job.get("runner_name", "")
         if runner_name:
             print(f"Job completed on {runner_name} - updating activity timestamp")

--- a/infrastructure/functions/runner_manager/main.py
+++ b/infrastructure/functions/runner_manager/main.py
@@ -481,6 +481,21 @@ def _handle_workflow_job_queued(labels: list[str]) -> tuple[str, int, dict]:
     return json.dumps(result), 200, {"Content-Type": "application/json"}
 
 
+def _looks_like_oidc_request(request: Request) -> bool:
+    """Cheap auth gate for the scheduler entry point.
+
+    The Cloud Scheduler job is configured with an OIDC token and sends
+    ``Authorization: Bearer <jwt>`` on every call; an external caller hitting
+    the public function URL without credentials does not. We don't verify the
+    JWT signature here (would need google-auth), but requiring a Bearer header
+    is enough to keep random internet callers out of the scheduler path —
+    which now performs destructive actions (VM deletions, runner
+    de-registrations) when RUNNER_MODE=ephemeral.
+    """
+    auth = request.headers.get("Authorization", "")
+    return auth.startswith("Bearer ") and len(auth) > len("Bearer ") + 20
+
+
 @functions_framework.http
 def handle_request(request: Request):
     """
@@ -490,9 +505,14 @@ def handle_request(request: Request):
     1. Cloud Scheduler triggers (action=check_idle parameter)
     2. GitHub webhook events (workflow_job.queued/completed)
     """
-    # Check if this is a scheduler trigger (idle check / orphan cleanup)
+    # Check if this is a scheduler trigger (idle check / orphan cleanup).
+    # In ephemeral mode the orphan-cleanup pass deletes VMs and de-registers
+    # runners — never let an unauthenticated caller reach it.
     action = request.args.get("action")
     if action in ("check_idle", "cleanup_orphans"):
+        if not _looks_like_oidc_request(request):
+            print(f"Scheduler action {action!r} rejected: missing Bearer token")
+            return "Forbidden", 403
         return _handle_scheduler_tick()
 
     # Otherwise, this should be a GitHub webhook

--- a/infrastructure/functions/runner_manager/test_ephemeral.py
+++ b/infrastructure/functions/runner_manager/test_ephemeral.py
@@ -36,6 +36,12 @@ for proto in (
 sys.modules.setdefault("google.cloud", MagicMock(name="google.cloud"))
 sys.modules["google.cloud.compute_v1"] = _compute_stub
 
+# Stub the rest of main.py's runtime deps so we can import it without the
+# Cloud Function runtime installed locally.
+for mod_name in ("functions_framework", "google.cloud.secretmanager", "flask"):
+    sys.modules.setdefault(mod_name, MagicMock(name=mod_name))
+sys.modules["functions_framework"].http = lambda f: f
+
 
 sys.path.insert(0, os.path.dirname(__file__))
 
@@ -315,3 +321,61 @@ class TestStartupScript:
         assert "config.sh" not in ep.STARTUP_SCRIPT
         # Should pull the JIT config from instance metadata
         assert "metadata.google.internal" in ep.STARTUP_SCRIPT
+
+
+class TestSchedulerAuthGate:
+    """The scheduler entry point in main.py must reject unauthenticated callers."""
+
+    def _import_main(self, **env):
+        for mod in ("main", "ephemeral"):
+            sys.modules.pop(mod, None)
+        base_env = {
+            "RUNNER_MODE": env.pop("RUNNER_MODE", "ephemeral"),
+            "GCP_PROJECT": "test-project",
+            "GCP_ZONE": "us-central1-a",
+            "GCP_FALLBACK_ZONE": "us-east4-c",
+            "GITHUB_ORG": "test-org",
+            "RUNNER_NAMES": "runner-1,runner-2",
+            **env,
+        }
+        with patch.dict(os.environ, base_env, clear=False):
+            import main
+
+            main._compute_client = None
+            main._secret_client = None
+            main._webhook_secret = "test-secret"
+            main._github_pat = "ghp_test"
+            return main
+
+    def _request(self, *, action, headers=None):
+        req = MagicMock()
+        req.args = {"action": action} if action else {}
+        req.args = MagicMock(get=lambda key, default=None: ({"action": action} if action else {}).get(key, default))
+        req.headers = MagicMock(get=lambda key, default=None: (headers or {}).get(key, default))
+        return req
+
+    def test_scheduler_without_bearer_token_returns_403(self):
+        main = self._import_main()
+        req = self._request(action="check_idle", headers={})
+        body, status = main.handle_request(req)
+        assert status == 403
+
+    def test_scheduler_with_short_bearer_token_returns_403(self):
+        main = self._import_main()
+        # "Bearer x" is too short to be a real JWT — defense against trivial spoof.
+        req = self._request(action="check_idle", headers={"Authorization": "Bearer x"})
+        body, status = main.handle_request(req)
+        assert status == 403
+
+    def test_scheduler_with_bearer_token_dispatches(self):
+        main = self._import_main(RUNNER_MODE="legacy")
+        req = self._request(
+            action="check_idle",
+            headers={"Authorization": "Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6ImFiYwoxMjM"},
+        )
+        # Patch the legacy implementation to confirm we reached it.
+        with patch.object(main, "check_and_stop_idle_runners", return_value={"stopped": [], "kept": []}) as fn:
+            result = main.handle_request(req)
+        fn.assert_called_once()
+        # response shape: (body, status, headers)
+        assert result[1] == 200

--- a/infrastructure/functions/runner_manager/test_ephemeral.py
+++ b/infrastructure/functions/runner_manager/test_ephemeral.py
@@ -1,0 +1,317 @@
+"""Tests for ephemeral.py — the new JIT/ephemeral-VM dispatcher.
+
+Mocks google-cloud-compute and the GitHub REST API. No GCP calls.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock, patch
+
+# Stub google.cloud.compute_v1 before importing ephemeral.py.
+# We attach attribute-style proto stubs so `compute_v1.AttachedDisk(...)` etc. work.
+_compute_stub = MagicMock(name="google.cloud.compute_v1")
+for proto in (
+    "AttachedDisk",
+    "AttachedDiskInitializeParams",
+    "NetworkInterface",
+    "AccessConfig",
+    "Metadata",
+    "Items",
+    "Scheduling",
+    "Instance",
+    "ServiceAccount",
+    "Tags",
+    "ShieldedInstanceConfig",
+    "AcceleratorConfig",
+    "ListInstancesRequest",
+    "InstancesClient",
+    "ImagesClient",
+):
+    setattr(_compute_stub, proto, MagicMock(name=proto))
+
+sys.modules.setdefault("google.cloud", MagicMock(name="google.cloud"))
+sys.modules["google.cloud.compute_v1"] = _compute_stub
+
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+
+def _fresh_module(**env):
+    """Reload ephemeral.py with isolated env + mocked clients."""
+    for mod in ("ephemeral",):
+        sys.modules.pop(mod, None)
+    base_env = {
+        "GCP_PROJECT": "test-project",
+        "GCP_ZONE": "us-central1-a",
+        "GCP_FALLBACK_ZONE": "us-east4-c",
+        "GITHUB_ORG": "test-org",
+        "RUNNER_GROUP_ID": "1",
+        "ORPHAN_GRACE_MINUTES": "30",
+        "MAX_VM_LIFETIME_MINUTES": "120",
+        **env,
+    }
+    with patch.dict(os.environ, base_env, clear=False):
+        import ephemeral
+
+        ephemeral._compute_client = None
+        return ephemeral
+
+
+class TestResolveFamily:
+    def test_gpu_label_wins(self):
+        ep = _fresh_module()
+        fam = ep.resolve_family(["self-hosted", "linux", "gpu"])
+        assert fam.name == "gpu"
+
+    def test_docker_build_label(self):
+        ep = _fresh_module()
+        fam = ep.resolve_family(["self-hosted", "linux", "gcp", "docker-build"])
+        assert fam.name == "build"
+
+    def test_default_is_general(self):
+        ep = _fresh_module()
+        fam = ep.resolve_family(["self-hosted", "linux", "gcp"])
+        assert fam.name == "general"
+
+    def test_gpu_precedence_over_docker_build(self):
+        ep = _fresh_module()
+        fam = ep.resolve_family(["self-hosted", "gpu", "docker-build"])
+        # GPU wins — image is fundamentally different
+        assert fam.name == "gpu"
+
+    def test_case_insensitive(self):
+        ep = _fresh_module()
+        fam = ep.resolve_family(["Self-Hosted", "Linux", "GPU"])
+        assert fam.name == "gpu"
+
+
+class TestRunnerLabelsFor:
+    def test_general_labels_include_existing_set(self):
+        ep = _fresh_module()
+        labels = ep.runner_labels_for(ep.FAMILIES["general"])
+        assert "self-hosted" in labels
+        assert "linux" in labels
+        assert "gcp" in labels
+        # x64 and large-disk preserved from existing config so jobs that
+        # still ask for those don't break.
+        assert "x64" in labels
+        assert "large-disk" in labels
+
+    def test_build_labels_include_docker_build(self):
+        ep = _fresh_module()
+        labels = ep.runner_labels_for(ep.FAMILIES["build"])
+        assert "docker-build" in labels
+
+    def test_gpu_labels_include_gpu(self):
+        ep = _fresh_module()
+        labels = ep.runner_labels_for(ep.FAMILIES["gpu"])
+        assert "gpu" in labels
+
+
+class TestJitMint:
+    def test_mints_with_correct_payload(self):
+        ep = _fresh_module()
+        with patch.object(ep, "_github_request") as gh:
+            gh.return_value = {"encoded_jit_config": "ZW5jb2RlZA=="}
+            token = ep.mint_jit_config(
+                "ghp_test", "gha-general-abc123", ep.FAMILIES["general"]
+            )
+            assert token == "ZW5jb2RlZA=="
+            method, path, pat, payload = gh.call_args[0]
+            assert method == "POST"
+            assert path == "/orgs/test-org/actions/runners/generate-jitconfig"
+            assert pat == "ghp_test"
+            assert payload["name"] == "gha-general-abc123"
+            assert payload["runner_group_id"] == 1
+            assert "self-hosted" in payload["labels"]
+            assert payload["work_folder"] == "_work"
+
+    def test_raises_on_missing_field(self):
+        ep = _fresh_module()
+        import pytest
+
+        with patch.object(ep, "_github_request") as gh:
+            gh.return_value = {"unexpected": "shape"}
+            with pytest.raises(RuntimeError):
+                ep.mint_jit_config("pat", "name", ep.FAMILIES["general"])
+
+
+class TestCreateEphemeralRunner:
+    def test_primary_zone_success(self):
+        ep = _fresh_module()
+
+        op = MagicMock(name="op")
+        op.name = "operation-123"
+
+        compute_client = MagicMock()
+        compute_client.insert.return_value = op
+        ep._compute_client = compute_client
+
+        with patch.object(ep, "mint_jit_config", return_value="JIT_TOKEN"):
+            result = ep.create_ephemeral_runner(
+                ["self-hosted", "linux", "gcp"], "ghp_test"
+            )
+
+        assert result["family"] == "general"
+        assert result["zone"] == "us-central1-a"
+        assert result["external_ip"] is False
+        assert result["runner_name"].startswith("gha-general-")
+        compute_client.insert.assert_called_once()
+
+    def test_zone_exhausted_falls_back(self):
+        ep = _fresh_module()
+
+        primary_failure = Exception("ZONE_RESOURCE_POOL_EXHAUSTED in us-central1-a")
+        op = MagicMock()
+        op.name = "operation-fallback"
+
+        compute_client = MagicMock()
+        compute_client.insert.side_effect = [primary_failure, op]
+        ep._compute_client = compute_client
+
+        with patch.object(ep, "mint_jit_config", return_value="JIT_TOKEN"):
+            result = ep.create_ephemeral_runner(["self-hosted", "gpu"], "ghp_test")
+
+        assert result["family"] == "gpu"
+        assert result["zone"] == "us-east4-c"
+        # GPU variant in fallback zone uses ephemeral external IP (no NAT in us-east4)
+        assert result["external_ip"] is True
+        assert compute_client.insert.call_count == 2
+
+    def test_unrelated_failure_does_not_fall_back(self):
+        ep = _fresh_module()
+        import pytest
+
+        compute_client = MagicMock()
+        compute_client.insert.side_effect = Exception("Permission denied")
+        ep._compute_client = compute_client
+
+        with patch.object(ep, "mint_jit_config", return_value="JIT_TOKEN"):
+            with pytest.raises(Exception, match="Permission denied"):
+                ep.create_ephemeral_runner(
+                    ["self-hosted", "linux", "gcp"], "ghp_test"
+                )
+        # Should NOT have retried in fallback zone
+        assert compute_client.insert.call_count == 1
+
+
+def _make_instance(name, age_minutes, zone="us-central1-a"):
+    inst = MagicMock()
+    inst.name = name
+    created = datetime.now(timezone.utc) - timedelta(minutes=age_minutes)
+    inst.creation_timestamp = created.isoformat().replace("+00:00", "Z")
+    return inst
+
+
+class TestCleanupOrphans:
+    """Test orphan-cleanup by patching the VM-listing helper directly.
+
+    The GCE listing call uses ListInstancesRequest which is fully mocked, so we
+    bypass that layer and patch _list_all_ephemeral_vms / _delete_vm to keep the
+    tests focused on the reconciliation logic.
+    """
+
+    def _patch_listing(self, ep, vms):
+        return patch.object(ep, "_list_all_ephemeral_vms", return_value=vms)
+
+    def test_keeps_vms_within_grace_window(self):
+        ep = _fresh_module()
+        vms = [("us-central1-a", _make_instance("gha-general-young", age_minutes=5))]
+        runners = []
+
+        with self._patch_listing(ep, vms), patch.object(
+            ep, "list_org_runners", return_value=runners
+        ), patch.object(ep, "_delete_vm") as delete_mock:
+            result = ep.cleanup_orphans("ghp_test")
+
+        assert "gha-general-young" in result["kept_vms"]
+        delete_mock.assert_not_called()
+
+    def test_deletes_unregistered_past_grace(self):
+        ep = _fresh_module()
+        vms = [("us-central1-a", _make_instance("gha-general-stuck", age_minutes=45))]
+        runners = []
+
+        with self._patch_listing(ep, vms), patch.object(
+            ep, "list_org_runners", return_value=runners
+        ), patch.object(ep, "_delete_vm", return_value=("gha-general-stuck", "deleted")):
+            result = ep.cleanup_orphans("ghp_test")
+
+        assert "gha-general-stuck" in result["deleted_vms"]
+
+    def test_deletes_hung_vm_even_when_registered(self):
+        ep = _fresh_module()
+        vms = [("us-central1-a", _make_instance("gha-general-hung", age_minutes=180))]
+        runners = [{"name": "gha-general-hung", "id": 7, "status": "online"}]
+
+        with self._patch_listing(ep, vms), patch.object(
+            ep, "list_org_runners", return_value=runners
+        ), patch.object(ep, "_delete_vm", return_value=("gha-general-hung", "deleted")):
+            result = ep.cleanup_orphans("ghp_test")
+
+        assert "gha-general-hung" in result["deleted_vms"]
+
+    def test_keeps_active_running_vm(self):
+        ep = _fresh_module()
+        vms = [("us-central1-a", _make_instance("gha-general-running", age_minutes=10))]
+        runners = [{"name": "gha-general-running", "id": 8, "status": "online"}]
+
+        with self._patch_listing(ep, vms), patch.object(
+            ep, "list_org_runners", return_value=runners
+        ), patch.object(ep, "_delete_vm") as delete_mock:
+            result = ep.cleanup_orphans("ghp_test")
+
+        assert "gha-general-running" in result["kept_vms"]
+        delete_mock.assert_not_called()
+
+    def test_deregisters_offline_zombie_runner(self):
+        ep = _fresh_module()
+        vms = []
+        runners = [
+            # Zombie: dispatcher-named, no live VM, offline
+            {"name": "gha-general-zombie", "id": 99, "status": "offline"},
+            # Non-dispatcher (legacy pool) — leave alone
+            {"name": "github-runner-1", "id": 1, "status": "offline"},
+            # Online runner with no VM — skip this pass (transient list lag)
+            {"name": "gha-build-recent", "id": 100, "status": "online"},
+        ]
+
+        with self._patch_listing(ep, vms), patch.object(
+            ep, "list_org_runners", return_value=runners
+        ), patch.object(ep, "deregister_runner") as dereg:
+            result = ep.cleanup_orphans("ghp_test")
+
+        dereg.assert_called_once_with("ghp_test", 99)
+        assert result["deregistered_runners"] == ["gha-general-zombie"]
+
+    def test_delete_failure_is_recorded(self):
+        ep = _fresh_module()
+        vms = [("us-central1-a", _make_instance("gha-general-stuck", age_minutes=60))]
+        runners = []
+
+        with self._patch_listing(ep, vms), patch.object(
+            ep, "list_org_runners", return_value=runners
+        ), patch.object(
+            ep, "_delete_vm", return_value=("gha-general-stuck", "delete_failed")
+        ):
+            result = ep.cleanup_orphans("ghp_test")
+
+        assert "gha-general-stuck" in result["delete_failed"]
+        assert "gha-general-stuck" not in result["deleted_vms"]
+
+
+class TestStartupScript:
+    """Sanity-check the inline startup script — it's tiny but failure modes are nasty."""
+
+    def test_startup_script_uses_jitconfig(self):
+        ep = _fresh_module()
+        assert "--jitconfig" in ep.STARTUP_SCRIPT
+        assert "shutdown -h" in ep.STARTUP_SCRIPT
+        # Should NOT use the PAT-based registration flow
+        assert "config.sh" not in ep.STARTUP_SCRIPT
+        # Should pull the JIT config from instance metadata
+        assert "metadata.google.internal" in ep.STARTUP_SCRIPT

--- a/infrastructure/modules/monitoring.py
+++ b/infrastructure/modules/monitoring.py
@@ -7,6 +7,8 @@ Manages alert policies for proactive monitoring and incident response.
 import pulumi
 import pulumi_gcp as gcp
 
+from config import PROJECT_ID
+
 
 def create_alert_policies() -> dict[str, gcp.monitoring.AlertPolicy]:
     """
@@ -157,3 +159,158 @@ def create_alert_policies() -> dict[str, gcp.monitoring.AlertPolicy]:
     )
 
     return alerts
+
+
+def create_ephemeral_runner_observability() -> dict:
+    """Log-based metrics + alerts for the ephemeral GHA runner dispatcher.
+
+    Adds two alerts that are useful during the Phase 3 soak and afterward:
+
+    1. Dispatcher VM-create failures (the dispatcher returns 503 + logs
+       ``create_ephemeral_runner failed`` — any occurrence in 10 min fires).
+    2. Long-running ephemeral runner VMs (uptime > 2 h on instances labelled
+       ``purpose=gha-ephemeral-runner`` — catches hung jobs or cleanup bugs).
+    """
+    resources: dict = {}
+
+    # ---- Log-based metric: dispatch failures -------------------------------
+    resources["dispatch_failure_metric"] = gcp.logging.Metric(
+        "runner-dispatcher-failures",
+        name="runner_dispatcher/create_failures",
+        description="Counts create_ephemeral_runner failures (any zone)",
+        # Function logs include the function name; runner-manager covers both
+        # legacy + ephemeral entry points.
+        filter=(
+            'resource.type="cloud_run_revision" '
+            'AND resource.labels.service_name="github-runner-manager" '
+            'AND textPayload:"create_ephemeral_runner failed"'
+        ),
+        metric_descriptor=gcp.logging.MetricMetricDescriptorArgs(
+            metric_kind="DELTA",
+            value_type="INT64",
+            unit="1",
+            display_name="Runner dispatcher create failures",
+        ),
+    )
+
+    # ---- Log-based metric: orphan kills (visibility, not alerting) ---------
+    resources["orphan_kill_metric"] = gcp.logging.Metric(
+        "runner-dispatcher-orphan-kills",
+        name="runner_dispatcher/orphan_kills",
+        description="Counts orphan VMs deleted by the dispatcher cleanup pass",
+        filter=(
+            'resource.type="cloud_run_revision" '
+            'AND resource.labels.service_name="github-runner-manager" '
+            'AND textPayload:"age=" AND textPayload:"deleting"'
+        ),
+        metric_descriptor=gcp.logging.MetricMetricDescriptorArgs(
+            metric_kind="DELTA",
+            value_type="INT64",
+            unit="1",
+            display_name="Runner dispatcher orphan-VM deletions",
+        ),
+    )
+
+    # ---- Alert: any dispatcher create failure in last 10 minutes -----------
+    resources["dispatch_failure_alert"] = gcp.monitoring.AlertPolicy(
+        "runner-dispatcher-failures-alert",
+        display_name="GHA Runner Dispatcher - Create Failures",
+        combiner="OR",
+        conditions=[
+            gcp.monitoring.AlertPolicyConditionArgs(
+                display_name="Any create_ephemeral_runner failure",
+                condition_threshold=gcp.monitoring.AlertPolicyConditionConditionThresholdArgs(
+                    filter=(
+                        'metric.type="logging.googleapis.com/user/runner_dispatcher/create_failures" '
+                        'AND resource.type="cloud_run_revision"'
+                    ),
+                    comparison="COMPARISON_GT",
+                    threshold_value=0,
+                    duration="0s",
+                    aggregations=[
+                        gcp.monitoring.AlertPolicyConditionConditionThresholdAggregationArgs(
+                            alignment_period="600s",
+                            per_series_aligner="ALIGN_SUM",
+                            cross_series_reducer="REDUCE_SUM",
+                        ),
+                    ],
+                    trigger=gcp.monitoring.AlertPolicyConditionConditionThresholdTriggerArgs(
+                        count=1,
+                    ),
+                ),
+            ),
+        ],
+        alert_strategy=gcp.monitoring.AlertPolicyAlertStrategyArgs(
+            auto_close="3600s",
+        ),
+        documentation=gcp.monitoring.AlertPolicyDocumentationArgs(
+            content=(
+                "Ephemeral runner dispatcher failed to create a VM.\n\n"
+                "Likely causes:\n"
+                "- GCE quota exhausted (CPU or NVIDIA_T4_GPUS in us-central1)\n"
+                "- GitHub JIT mint API rate-limited or PAT expired\n"
+                "- Image family deprecated/missing (gha-runner-{general,build,gpu})\n"
+                "- Both primary and fallback zones exhausted\n\n"
+                "Logs: filter `resource.labels.service_name=\"github-runner-manager\"` "
+                "in Cloud Logging for `create_ephemeral_runner failed`.\n\n"
+                "Rollback: `pulumi config set karaoke-gen-infrastructure:runnerMode legacy && pulumi up`"
+            ),
+            mime_type="text/markdown",
+        ),
+        enabled=True,
+        opts=pulumi.ResourceOptions(depends_on=[resources["dispatch_failure_metric"]]),
+    )
+
+    # ---- Alert: ephemeral VM uptime > 2h -----------------------------------
+    # `compute.googleapis.com/instance/uptime_total` is a cumulative count of
+    # seconds the VM has been up. We alert when it exceeds 7200s for VMs
+    # carrying the ephemeral-runner purpose label.
+    resources["long_lived_vm_alert"] = gcp.monitoring.AlertPolicy(
+        "runner-dispatcher-long-lived-vm-alert",
+        display_name="GHA Runner Dispatcher - VM Alive > 2h",
+        combiner="OR",
+        conditions=[
+            gcp.monitoring.AlertPolicyConditionArgs(
+                display_name="Ephemeral runner VM uptime > 2h",
+                condition_threshold=gcp.monitoring.AlertPolicyConditionConditionThresholdArgs(
+                    filter=(
+                        'metric.type="compute.googleapis.com/instance/uptime_total" '
+                        'AND resource.type="gce_instance" '
+                        'AND metadata.user_labels.purpose="gha-ephemeral-runner"'
+                    ),
+                    comparison="COMPARISON_GT",
+                    threshold_value=7200,
+                    duration="300s",
+                    aggregations=[
+                        gcp.monitoring.AlertPolicyConditionConditionThresholdAggregationArgs(
+                            alignment_period="300s",
+                            per_series_aligner="ALIGN_MAX",
+                            cross_series_reducer="REDUCE_MAX",
+                            group_by_fields=["resource.labels.instance_id"],
+                        ),
+                    ],
+                    trigger=gcp.monitoring.AlertPolicyConditionConditionThresholdTriggerArgs(
+                        count=1,
+                    ),
+                ),
+            ),
+        ],
+        alert_strategy=gcp.monitoring.AlertPolicyAlertStrategyArgs(
+            auto_close="3600s",
+        ),
+        documentation=gcp.monitoring.AlertPolicyDocumentationArgs(
+            content=(
+                "An ephemeral GHA runner VM has been alive for more than 2 hours.\n"
+                "Orphan-cleanup should kill VMs at that threshold — if this fires,\n"
+                "the cleanup pass is broken or the VM is escaping it.\n\n"
+                "Investigate:\n"
+                "1. `gcloud compute instances list --filter=labels.purpose=gha-ephemeral-runner`\n"
+                "2. Check Cloud Function logs for the cleanup pass\n"
+                "3. Manually delete: `gcloud compute instances delete <name> --zone=<zone>`"
+            ),
+            mime_type="text/markdown",
+        ),
+        enabled=True,
+    )
+
+    return resources

--- a/infrastructure/modules/runner_manager.py
+++ b/infrastructure/modules/runner_manager.py
@@ -195,6 +195,12 @@ def create_cloud_function(
                 storage_source=gcp.cloudfunctionsv2.FunctionBuildConfigSourceStorageSourceArgs(
                     bucket=bucket.name,
                     object=source_archive.name,
+                    # Pin to the current generation so Pulumi treats the source
+                    # bundle being replaced (new code commit) as a diff on the
+                    # Function itself, forcing a redeploy. Without this, the
+                    # bucket-object replaces in place and the live function
+                    # keeps serving the previous staged copy.
+                    generation=source_archive.generation,
                 ),
             ),
         ),

--- a/infrastructure/modules/runner_manager.py
+++ b/infrastructure/modules/runner_manager.py
@@ -40,6 +40,20 @@ from config import (
 )
 
 
+# Read at module load — controls dispatcher behaviour.
+# Set via: pulumi config set karaoke-backend:runnerMode ephemeral
+_pulumi_config = pulumi.Config()
+RUNNER_MODE = _pulumi_config.get("runnerMode", "legacy")
+if RUNNER_MODE not in ("legacy", "ephemeral"):
+    raise ValueError(
+        f"karaoke-backend:runnerMode must be 'legacy' or 'ephemeral', got {RUNNER_MODE!r}"
+    )
+
+# Optional fallback zone for ephemeral GPU runners when the primary zone is
+# exhausted. Default us-east4-c — uses ephemeral external IPs (no NAT there).
+RUNNER_FALLBACK_ZONE = _pulumi_config.get("runnerFallbackZone", "us-east4-c")
+
+
 def create_runner_manager_service_account() -> gcp.serviceaccount.Account:
     """Create service account for the runner manager Cloud Function."""
     return gcp.serviceaccount.Account(
@@ -140,15 +154,24 @@ def create_cloud_function(
     permissions: dict,
     runner_names: list[pulumi.Output] | None = None,
     gpu_runner_names: list[pulumi.Output] | None = None,
+    runner_service_account: gcp.serviceaccount.Account | None = None,
 ) -> gcp.cloudfunctionsv2.Function:
     """Create the Cloud Function (Gen2) for runner management."""
     env_vars = {
         "GCP_PROJECT": PROJECT_ID,
         "GCP_ZONE": ZONE,
+        "GCP_FALLBACK_ZONE": RUNNER_FALLBACK_ZONE,
         "WEBHOOK_SECRET_NAME": SecretNames.GITHUB_WEBHOOK_SECRET,
         "RUNNER_PAT_SECRET_NAME": SecretNames.GITHUB_RUNNER_PAT,
         "IDLE_TIMEOUT_HOURS": str(RunnerManagerConfig.IDLE_TIMEOUT_HOURS),
+        "RUNNER_MODE": RUNNER_MODE,
+        "GITHUB_ORG": "nomadkaraoke",
     }
+
+    # Service account used by ephemeral VMs at runtime (gcloud auth + secret reads).
+    # Required when RUNNER_MODE=ephemeral; harmless otherwise.
+    if runner_service_account is not None:
+        env_vars["RUNNER_SERVICE_ACCOUNT"] = runner_service_account.email
 
     if runner_names:
         env_vars["RUNNER_NAMES"] = pulumi.Output.all(*runner_names).apply(
@@ -308,6 +331,7 @@ def create_runner_manager_resources(
         permissions,
         runner_names,
         gpu_runner_names,
+        runner_service_account=runner_service_account,
     )
 
     # Allow unauthenticated invocation (GitHub webhooks)

--- a/infrastructure/scripts/runner-image-provision.sh
+++ b/infrastructure/scripts/runner-image-provision.sh
@@ -246,9 +246,10 @@ if [[ -x "$RUNNER_DIR/bin/installdependencies.sh" ]]; then
     "$RUNNER_DIR/bin/installdependencies.sh"
 fi
 
-# Drop a symlink that the runtime startup script expects.
-mkdir -p /opt/actions-runner
-ln -sfn "$RUNNER_DIR" /opt/actions-runner-link
+# Convenience symlink so external tooling (runbooks, ad-hoc SSH) can refer to
+# the runner installation by a stable path. The startup script in ephemeral.py
+# cds to $RUNNER_DIR directly and doesn't rely on this.
+ln -sfn "$RUNNER_DIR" /opt/actions-runner
 
 # ==================== Docker base-image pre-pull (build variant only) ====================
 if [[ "$VARIANT" == "build" ]]; then

--- a/infrastructure/scripts/runner-image-provision.sh
+++ b/infrastructure/scripts/runner-image-provision.sh
@@ -1,0 +1,396 @@
+#!/bin/bash
+# Image-time provisioning for ephemeral GitHub Actions runner images.
+# Builds one of three variants:
+#   general — Docker, Python 3.13, Node 20, Java 21, FFmpeg, gcloud, Poetry, runner binary
+#   build   — Same as general + pre-pulled Docker base images for deploy-backend
+#   gpu     — NVIDIA driver/CUDA, Python 3.13, FFmpeg+libsamplerate, gcloud, Poetry,
+#             runner binary, audio-separator models (~14GB)
+#
+# Runs on a fresh Debian 12 VM as root. Idempotent (safe to re-run).
+# Signals completion by writing /opt/runner-image-ready.
+
+set -euo pipefail
+
+VARIANT="${1:-${RUNNER_IMAGE_VARIANT:-}}"
+if [[ -z "$VARIANT" ]]; then
+    echo "ERROR: variant must be provided as \$1 or RUNNER_IMAGE_VARIANT env var" >&2
+    echo "Valid variants: general | build | gpu" >&2
+    exit 2
+fi
+
+case "$VARIANT" in
+    general|build|gpu) ;;
+    *) echo "ERROR: unknown variant '$VARIANT'" >&2; exit 2 ;;
+esac
+
+exec > >(tee /var/log/runner-image-provision.log) 2>&1
+echo "=== Runner image provision: variant=$VARIANT, started $(date -u +%FT%TZ) ==="
+
+export DEBIAN_FRONTEND=noninteractive
+
+# ==================== Network ====================
+# Cloud NAT doesn't support IPv6 — force apt to IPv4 to avoid hangs.
+echo 'Acquire::ForceIPv4 "true";' > /etc/apt/apt.conf.d/99force-ipv4
+
+# ==================== Helpers ====================
+install_gpg_key() {
+    local url="$1" dest="$2"
+    [[ -f "$dest" ]] && return 0
+    curl -fsSL "$url" | gpg --batch --dearmor -o "$dest"
+}
+
+retry() {
+    local n=0 max="${RETRIES:-3}" delay="${RETRY_DELAY:-5}"
+    until "$@"; do
+        n=$((n+1))
+        if (( n >= max )); then return 1; fi
+        echo "Retry $n/$max after failure: $*"
+        sleep "$delay"
+    done
+}
+
+# ==================== Base packages (all variants) ====================
+apt-get update
+apt-get install -y \
+    curl git jq unzip \
+    build-essential libssl-dev libffi-dev \
+    software-properties-common apt-transport-https ca-certificates gnupg lsb-release
+
+# ==================== Variant: GPU — kernel + NVIDIA + CUDA ====================
+if [[ "$VARIANT" == "gpu" ]]; then
+    RUNNING_KERNEL="$(uname -r)"
+    REBOOT_FLAG="/var/lib/gpu-image-kernel-upgraded"
+    echo "Running kernel: $RUNNING_KERNEL"
+
+    if ! apt-cache show "linux-headers-$RUNNING_KERNEL" &>/dev/null; then
+        if [[ -f "$REBOOT_FLAG" ]]; then
+            echo "ERROR: kernel headers still unavailable after upgrade+reboot" >&2
+            exit 1
+        fi
+        echo "Headers for $RUNNING_KERNEL unavailable — upgrading kernel and rebooting"
+        apt-get install -y linux-image-cloud-amd64 linux-headers-cloud-amd64
+        touch "$REBOOT_FLAG"
+        reboot
+        exit 0
+    fi
+    rm -f "$REBOOT_FLAG"
+
+    echo "Installing kernel headers for $RUNNING_KERNEL"
+    apt-get install -y "linux-headers-$RUNNING_KERNEL" dkms
+
+    # Strip stale kernel headers
+    for old in /usr/src/linux-headers-*; do
+        ver="$(basename "$old" | sed 's/^linux-headers-//')"
+        [[ "$ver" == "$RUNNING_KERNEL" || "$ver" == *common* ]] && continue
+        pkg="linux-headers-$ver"
+        if dpkg -l "$pkg" 2>/dev/null | grep -q '^ii'; then
+            apt-get remove -y "$pkg" 2>/dev/null || true
+        fi
+    done
+
+    if ! command -v nvidia-smi &>/dev/null; then
+        echo "Installing NVIDIA driver + CUDA 12.4"
+        install_gpg_key \
+            "https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/3bf863cc.pub" \
+            "/usr/share/keyrings/cuda-archive-keyring.gpg"
+        echo "deb [signed-by=/usr/share/keyrings/cuda-archive-keyring.gpg] https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/ /" \
+            > /etc/apt/sources.list.d/cuda.list
+        apt-get update
+        apt-get install -y cuda-drivers cuda-toolkit-12-4
+    fi
+fi
+
+# ==================== Docker (general + build only) ====================
+if [[ "$VARIANT" != "gpu" ]]; then
+    if ! command -v docker &>/dev/null; then
+        echo "Installing Docker"
+        install_gpg_key \
+            "https://download.docker.com/linux/debian/gpg" \
+            "/usr/share/keyrings/docker-archive-keyring.gpg"
+        echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
+            > /etc/apt/sources.list.d/docker.list
+        apt-get update
+        apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+    fi
+    systemctl enable docker
+fi
+
+# ==================== Python 3.13 ====================
+# General/build: pyenv (consistent with current setup)
+# GPU: compile from source (pyenv unreliable on Debian 12 with CUDA installed)
+if [[ "$VARIANT" == "gpu" ]]; then
+    PYTHON_PREFIX="/opt/python-3.13"
+    if [[ ! -f "$PYTHON_PREFIX/bin/python3.13" ]]; then
+        echo "Building Python 3.13 from source"
+        apt-get install -y make zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
+            wget llvm libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev liblzma-dev
+        cd /tmp
+        curl -sSL https://www.python.org/ftp/python/3.13.0/Python-3.13.0.tgz -o Python-3.13.0.tgz
+        tar xzf Python-3.13.0.tgz
+        cd Python-3.13.0
+        ./configure --prefix="$PYTHON_PREFIX" --enable-optimizations --with-ensurepip=install
+        make -j"$(nproc)"
+        make install
+        rm -rf /tmp/Python-3.13.0*
+        "$PYTHON_PREFIX/bin/python3.13" -m ensurepip --upgrade
+        ln -sf "$PYTHON_PREFIX/bin/python3.13" /usr/local/bin/python3.13
+        ln -sf "$PYTHON_PREFIX/bin/python3" /usr/local/bin/python3
+        ln -sf "$PYTHON_PREFIX/bin/pip3" /usr/local/bin/pip3
+    fi
+else
+    if [[ ! -f /opt/pyenv/versions/3.13.0/bin/python3.13 ]]; then
+        echo "Installing Python 3.13 via pyenv"
+        apt-get install -y make zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
+            wget llvm libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev liblzma-dev
+        [[ -d /opt/pyenv ]] || { export PYENV_ROOT=/opt/pyenv; curl https://pyenv.run | bash; }
+        export PATH="/opt/pyenv/bin:$PATH"
+        eval "$(/opt/pyenv/bin/pyenv init -)"
+        /opt/pyenv/bin/pyenv install 3.13.0
+        /opt/pyenv/bin/pyenv global 3.13.0
+        ln -sf /opt/pyenv/shims/python3.13 /usr/local/bin/python3.13
+        ln -sf /opt/pyenv/shims/python3 /usr/local/bin/python3
+        ln -sf /opt/pyenv/shims/pip3 /usr/local/bin/pip3
+    fi
+    cat > /etc/profile.d/pyenv.sh <<'EOF'
+export PYENV_ROOT=/opt/pyenv
+export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init -)"
+EOF
+fi
+
+# ==================== Node.js 20 + Java 21 (general/build only) ====================
+if [[ "$VARIANT" != "gpu" ]]; then
+    if ! command -v node &>/dev/null || ! node --version | grep -q "^v20"; then
+        echo "Installing Node.js 20"
+        retry curl -fsSL --retry 3 --retry-delay 5 https://deb.nodesource.com/setup_20.x -o /tmp/nodesource.sh
+        bash /tmp/nodesource.sh
+        apt-get install -y nodejs
+        rm -f /tmp/nodesource.sh
+    fi
+
+    if ! java -version 2>&1 | grep -q '"21\.'; then
+        echo "Installing Java 21 (Temurin)"
+        install_gpg_key \
+            "https://packages.adoptium.net/artifactory/api/gpg/key/public" \
+            "/usr/share/keyrings/adoptium.gpg"
+        echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(lsb_release -cs) main" \
+            > /etc/apt/sources.list.d/adoptium.list
+        apt-get update
+        apt-get install -y temurin-21-jdk
+    fi
+fi
+
+# ==================== FFmpeg (all variants) ====================
+if [[ "$VARIANT" == "gpu" ]]; then
+    apt-get install -y ffmpeg libsamplerate0 libsamplerate-dev
+else
+    apt-get install -y ffmpeg
+fi
+
+# ==================== Poetry + gcloud (all variants) ====================
+if ! command -v poetry &>/dev/null; then
+    echo "Installing Poetry"
+    if [[ "$VARIANT" == "gpu" ]]; then
+        # Install to /opt/poetry so the runner user can access it (default ~/.local is /root)
+        export POETRY_HOME="/opt/poetry"
+        curl -sSL https://install.python-poetry.org | python3 -
+        ln -sf /opt/poetry/bin/poetry /usr/local/bin/poetry
+    else
+        curl -sSL https://install.python-poetry.org | python3 -
+        ln -sf /root/.local/bin/poetry /usr/local/bin/poetry
+    fi
+fi
+
+if ! command -v gcloud &>/dev/null; then
+    echo "Installing Google Cloud SDK"
+    install_gpg_key \
+        "https://packages.cloud.google.com/apt/doc/apt-key.gpg" \
+        "/usr/share/keyrings/cloud.google.gpg"
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+        > /etc/apt/sources.list.d/google-cloud-sdk.list
+    apt-get update
+    if [[ "$VARIANT" != "gpu" ]]; then
+        apt-get install -y google-cloud-cli google-cloud-cli-firestore-emulator
+    else
+        apt-get install -y google-cloud-cli
+    fi
+fi
+
+# ==================== Runner user ====================
+useradd -m -s /bin/bash runner 2>/dev/null || true
+if [[ "$VARIANT" != "gpu" ]]; then
+    usermod -aG docker runner
+fi
+
+# ==================== GitHub Actions runner binary ====================
+RUNNER_VERSION="2.332.0"
+RUNNER_DIR="/home/runner/actions-runner"
+mkdir -p "$RUNNER_DIR"
+
+CURRENT_VERSION=""
+if [[ -f "$RUNNER_DIR/bin/Runner.Listener" ]]; then
+    CURRENT_VERSION="$("$RUNNER_DIR/bin/Runner.Listener" --version 2>/dev/null || echo unknown)"
+fi
+if [[ "$CURRENT_VERSION" != "$RUNNER_VERSION" ]]; then
+    echo "Downloading runner v$RUNNER_VERSION"
+    cd "$RUNNER_DIR"
+    curl -sLO "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+    tar xzf "actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+    rm -f "actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+fi
+chown -R runner:runner "$RUNNER_DIR"
+
+# Pre-install runner dependencies (avoids first-run apt cost).
+# installdependencies.sh is idempotent.
+if [[ -x "$RUNNER_DIR/bin/installdependencies.sh" ]]; then
+    "$RUNNER_DIR/bin/installdependencies.sh"
+fi
+
+# Drop a symlink that the runtime startup script expects.
+mkdir -p /opt/actions-runner
+ln -sfn "$RUNNER_DIR" /opt/actions-runner-link
+
+# ==================== Docker base-image pre-pull (build variant only) ====================
+if [[ "$VARIANT" == "build" ]]; then
+    echo "Pre-pulling Docker base images for deploy-backend"
+    systemctl start docker
+    # Image-build VM uses the gha-runner-image-builder@ SA which has artifactregistry.reader.
+    gcloud auth configure-docker us-central1-docker.pkg.dev --quiet || true
+    gcloud auth configure-docker us-east4-docker.pkg.dev --quiet || true
+    docker pull us-central1-docker.pkg.dev/nomadkaraoke/karaoke-repo/karaoke-backend-base:latest || true
+    docker pull us-central1-docker.pkg.dev/nomadkaraoke/karaoke-repo/karaoke-backend:latest || true
+    docker pull fsouza/fake-gcs-server:latest || true
+fi
+
+# ==================== Audio-separator models (GPU only) ====================
+# ~14GB of model weights baked into the image so jobs don't re-download.
+if [[ "$VARIANT" == "gpu" ]]; then
+    MODEL_DIR="/opt/audio-separator-models"
+    mkdir -p "$MODEL_DIR"
+    BASE_URL="https://github.com/TRvlvr/model_repo/releases/download/all_public_uvr_models"
+    CONFIG_URL="https://raw.githubusercontent.com/TRvlvr/application_data/main/mdx_model_data/mdx_c_configs"
+    META_URL="https://raw.githubusercontent.com/TRvlvr/application_data/main"
+    DEMUCS_URL="https://dl.fbaipublicfiles.com/demucs/hybrid_transformer"
+    FALLBACK_URL="https://github.com/nomadkaraoke/python-audio-separator/releases/download/model-configs"
+
+    dl() {
+        local url="$1" dest="$2" fb="${3:-}"
+        [[ -s "$dest" ]] && return 0
+        echo "  → $(basename "$dest")"
+        if curl -fSL --retry 3 --connect-timeout 30 -o "$dest" "$url" 2>/dev/null; then return 0; fi
+        if [[ -n "$fb" ]]; then
+            curl -fSL --retry 3 --connect-timeout 30 -o "$dest" "$fb" || return 1
+        fi
+    }
+
+    # Metadata
+    dl "$META_URL/filelists/download_checks.json" "$MODEL_DIR/download_checks.json"
+    dl "$META_URL/vr_model_data/model_data_new.json" "$MODEL_DIR/vr_model_data.json"
+    dl "$META_URL/mdx_model_data/model_data_new.json" "$MODEL_DIR/mdx_model_data.json"
+
+    # Core integration test models (8)
+    dl "$BASE_URL/mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956.ckpt" "$MODEL_DIR/mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956.ckpt"
+    dl "$FALLBACK_URL/mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956_config.yaml" "$MODEL_DIR/mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956_config.yaml"
+    dl "$BASE_URL/kuielab_b_vocals.onnx" "$MODEL_DIR/kuielab_b_vocals.onnx"
+    dl "$BASE_URL/MGM_MAIN_v4.pth" "$MODEL_DIR/MGM_MAIN_v4.pth"
+    dl "$BASE_URL/UVR-MDX-NET-Inst_HQ_4.onnx" "$MODEL_DIR/UVR-MDX-NET-Inst_HQ_4.onnx"
+    dl "$BASE_URL/2_HP-UVR.pth" "$MODEL_DIR/2_HP-UVR.pth"
+    dl "$BASE_URL/htdemucs_6s.yaml" "$MODEL_DIR/htdemucs_6s.yaml"
+    dl "$DEMUCS_URL/5c90dfd2-34c22ccb.th" "$MODEL_DIR/5c90dfd2-34c22ccb.th"
+    dl "$BASE_URL/model_bs_roformer_ep_937_sdr_10.5309.ckpt" "$MODEL_DIR/model_bs_roformer_ep_937_sdr_10.5309.ckpt"
+    dl "$CONFIG_URL/model_bs_roformer_ep_937_sdr_10.5309.yaml" "$MODEL_DIR/model_bs_roformer_ep_937_sdr_10.5309.yaml"
+    dl "$BASE_URL/model_bs_roformer_ep_317_sdr_12.9755.ckpt" "$MODEL_DIR/model_bs_roformer_ep_317_sdr_12.9755.ckpt"
+    dl "$CONFIG_URL/model_bs_roformer_ep_317_sdr_12.9755.yaml" "$MODEL_DIR/model_bs_roformer_ep_317_sdr_12.9755.yaml"
+
+    # Ensemble preset models (15, ~12GB)
+    for m in \
+        bs_roformer_instrumental_resurrection_unwa.ckpt \
+        bs_roformer_vocals_resurrection_unwa.ckpt \
+        bs_roformer_vocals_revive_v2_unwa.ckpt \
+        bs_roformer_vocals_revive_v3e_unwa.ckpt \
+        mel_band_roformer_instrumental_becruily.ckpt \
+        mel_band_roformer_instrumental_fv7z_gabox.ckpt \
+        mel_band_roformer_instrumental_instv8_gabox.ckpt \
+        mel_band_roformer_karaoke_becruily.ckpt \
+        mel_band_roformer_karaoke_gabox_v2.ckpt \
+        mel_band_roformer_kim_ft2_bleedless_unwa.ckpt \
+        mel_band_roformer_vocals_becruily.ckpt \
+        mel_band_roformer_vocals_fv4_gabox.ckpt \
+        melband_roformer_big_beta6x.ckpt \
+        melband_roformer_inst_v1e_plus.ckpt \
+        UVR-MDX-NET-Inst_HQ_5.onnx; do
+        dl "$FALLBACK_URL/$m" "$MODEL_DIR/$m"
+    done
+    for c in \
+        config_bs_roformer_instrumental_resurrection_unwa.yaml \
+        config_bs_roformer_vocals_resurrection_unwa.yaml \
+        config_bs_roformer_vocals_revive_unwa.yaml \
+        config_mel_band_roformer_instrumental_becruily.yaml \
+        config_mel_band_roformer_instrumental_gabox.yaml \
+        config_mel_band_roformer_karaoke_becruily.yaml \
+        config_mel_band_roformer_karaoke_gabox.yaml \
+        config_mel_band_roformer_kim_ft_unwa.yaml \
+        config_mel_band_roformer_vocals_becruily.yaml \
+        config_mel_band_roformer_vocals_gabox.yaml \
+        config_melbandroformer_big_beta6x.yaml \
+        config_melbandroformer_inst.yaml; do
+        dl "$FALLBACK_URL/$c" "$MODEL_DIR/$c"
+    done
+
+    # Multi-stem test models
+    dl "$BASE_URL/17_HP-Wind_Inst-UVR.pth" "$MODEL_DIR/17_HP-Wind_Inst-UVR.pth"
+    dl "$FALLBACK_URL/MDX23C-DrumSep-aufr33-jarredou.ckpt" "$MODEL_DIR/MDX23C-DrumSep-aufr33-jarredou.ckpt"
+    dl "$FALLBACK_URL/dereverb_mel_band_roformer_anvuew_sdr_19.1729.ckpt" "$MODEL_DIR/dereverb_mel_band_roformer_anvuew_sdr_19.1729.ckpt"
+    dl "$FALLBACK_URL/config_dereverb_mel_band_roformer_anvuew.yaml" "$MODEL_DIR/config_dereverb_mel_band_roformer_anvuew.yaml"
+
+    chown -R runner:runner "$MODEL_DIR"
+    echo "Audio-separator models: $(du -sh "$MODEL_DIR" | cut -f1)"
+fi
+
+# ==================== Tool cache for setup-python action ====================
+# setup-python@v5 looks for prebuilt Python in $RUNNER_TOOL_CACHE/Python/<ver>/x64
+TOOL_CACHE="/home/runner/actions-runner/_work/_tool"
+mkdir -p "$TOOL_CACHE/Python/3.13.0/x64"
+if [[ "$VARIANT" == "gpu" ]]; then
+    PY_SRC="/opt/python-3.13"
+else
+    PY_SRC="/opt/pyenv/versions/3.13.0"
+fi
+if [[ -d "$PY_SRC" && ! -f "$TOOL_CACHE/Python/3.13.0/x64.complete" ]]; then
+    cp -r "$PY_SRC"/* "$TOOL_CACHE/Python/3.13.0/x64/"
+    (cd "$TOOL_CACHE/Python/3.13.0/x64/bin"; [[ -f python ]] || ln -s python3.13 python; [[ -f python3 ]] || ln -s python3.13 python3)
+    touch "$TOOL_CACHE/Python/3.13.0/x64.complete"
+fi
+chown -R runner:runner /home/runner/actions-runner/_work
+
+# ==================== Docker disk-pressure cleanup cron ====================
+# Carried over from the legacy startup script. Useful even on ephemeral VMs
+# because deploy-backend can fill the disk during long Docker builds.
+if [[ "$VARIANT" != "gpu" ]]; then
+    cat > /etc/cron.hourly/docker-cleanup <<'EOF'
+#!/bin/bash
+exec 1> >(logger -t docker-cleanup) 2>&1
+THRESHOLD=70
+USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+if (( USAGE > THRESHOLD )); then
+    docker system prune -af
+    docker builder prune -af
+fi
+EOF
+    chmod +x /etc/cron.hourly/docker-cleanup
+fi
+
+# ==================== Cleanup before imaging ====================
+echo "Cleaning apt caches and journal logs to shrink image"
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+journalctl --vacuum-time=1s 2>/dev/null || true
+
+# Remove SSH host keys — regenerated on first boot of cloned VMs
+rm -f /etc/ssh/ssh_host_*
+
+# Mark image ready (the workflow polls for this file via gcloud ssh)
+date -u +%FT%TZ > /opt/runner-image-ready
+echo "$VARIANT" > /opt/runner-image-variant
+
+echo "=== Runner image provision complete: variant=$VARIANT, finished $(date -u +%FT%TZ) ==="


### PR DESCRIPTION
## Summary
- Implements Phases 1, 2, and 5 of the ephemeral GHA runner plan ([`docs/archive/2026-05-16-ephemeral-gha-runners-plan.md`](docs/archive/2026-05-16-ephemeral-gha-runners-plan.md) at the workspace root). Target saving when fully cut over: **~\$220/mo** (eliminates 7×200GB always-billed pd-ssd boot disks).
- **Default behaviour unchanged** — code lands with `RUNNER_MODE=legacy`. Flipping to `ephemeral` is a Pulumi config + targeted update, reversible in ~2 minutes.
- Operator runbook for the cutover at [`docs/EPHEMERAL-GHA-RUNNERS.md`](docs/EPHEMERAL-GHA-RUNNERS.md) including verification steps, rollback, and known gotchas.

## What's in this PR

**Phase 1 — image build infrastructure**
- `infrastructure/scripts/runner-image-provision.sh` — unified provisioner with `general` / `build` / `gpu` variants (extracts the existing `github_runner.sh` and `github_runner_gpu.sh` logic so it runs at image-build time, not per-VM boot).
- `.github/workflows/build-runner-images.yml` — monthly cron + manual trigger. Builds via temporary GCE VMs, snapshots to GCE image families `gha-runner-{general,build,gpu}`, deprecates all but the newest 3 per family.

**Phase 2 — dispatcher rewrite (behind a flag)**
- `infrastructure/functions/runner_manager/ephemeral.py` — picks image family from job labels, mints a GitHub JIT runner config, `compute.instances.insert` with auto-delete boot disk, falls back to `us-east4-c` on `ZONE_RESOURCE_POOL_EXHAUSTED`. Orphan-cleanup deletes VMs whose runner registration is gone or whose uptime exceeded 2h, and de-registers zombie runners.
- `infrastructure/functions/runner_manager/main.py` — routes on `RUNNER_MODE`. Legacy path untouched.
- `infrastructure/modules/runner_manager.py` — exposes `RUNNER_MODE` via Pulumi config (`karaoke-gen-infrastructure:runnerMode`).
- 20 new unit tests in `test_ephemeral.py` (label resolution, JIT mint, zone fallback, orphan reconciliation, zombie cleanup).

**Phase 5 — observability**
- 2 log-based metrics (`runner_dispatcher/create_failures`, `runner_dispatcher/orphan_kills`).
- 2 alert policies: any create failure in 10 min; any ephemeral VM uptime > 2h (orphan cleanup escape).

## Not in this PR (handed off)
- Triggering the image-build workflow for the first time (needs branch merged first).
- `pulumi up` — `GOOGLE_APPLICATION_CREDENTIALS` points at `claude-readonly@` per the workspace's operational guardrail; couldn't apply from this session. Targeted apply commands are in the runbook. Note that this repo's CI doesn't auto-apply Pulumi (see comment in `ci.yml`).
- Phase 3 cutover (`pulumi config set runnerMode ephemeral` + test PR + 1-week soak).
- Phase 4 destructive decommission of the 7 legacy VMs (requires soak first).

## Test plan
- [ ] `cd infrastructure/functions/runner_manager && pytest -v` — 20/20 new tests pass; 25/26 legacy tests pass (1 pre-existing failure documented in the runbook).
- [ ] `cd infrastructure && pulumi preview --diff` — expect 4 resource changes from this PR + 5 creates (log metrics + alerts).
- [ ] `pulumi up --target ...:runner-manager-source --target ...:runner-manager-function --target ...:runner-dispatcher-failures --target ...:runner-dispatcher-orphan-kills --target ...:runner-dispatcher-failures-alert --target ...:runner-dispatcher-long-lived-vm-alert` — applies dispatcher + monitoring.
- [ ] `gh workflow run build-runner-images.yml -f variants=general` — produces first image, ~25 min.
- [ ] Smoke test launching a one-off VM from `image-family=gha-runner-general` (runbook step).
- [ ] Repeat image build for `build` and `gpu` variants.
- [ ] Phase 3 cutover when ready (see runbook).

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)