### PR TITLE
chore(infra): record runnerMode=ephemeral in Pulumi.prod.yaml

### DIFF
--- a/infrastructure/Pulumi.prod.yaml
+++ b/infrastructure/Pulumi.prod.yaml
@@ -2,3 +2,4 @@ config:
   gcp:project: nomadkaraoke
   gcp:region: us-central1
   karaoke-gen-infrastructure:backupEncryptionPubkey: 1e966a0693d4ab12f5ef570dd60b35137ec12c42cc12424e13e8c1e8e2dbc914
+  karaoke-gen-infrastructure:runnerMode: ephemeral


### PR DESCRIPTION
Syncs in-git stack config with deployed state post-cutover. No behavioural change.

@coderabbitai ignore