### PR TITLE
fix(runner-images): GPU NVIDIA load + Secure Boot off; runbook updated

### DIFF
--- a/infrastructure/functions/runner_manager/ephemeral.py
+++ b/infrastructure/functions/runner_manager/ephemeral.py
@@ -312,8 +312,16 @@ def _build_instance(
             "managed-by": "runner-dispatcher",
         },
         tags=compute_v1.Tags(items=["gha-runner", "github-runner"]),
+        # Secure Boot is incompatible with GPU VMs: the NVIDIA kernel module is
+        # built locally via DKMS (from the upstream CUDA repo, not Debian's
+        # signed nvidia-driver) and is therefore unsigned. With Secure Boot on,
+        # the kernel is in lockdown=integrity mode and rejects unsigned modules
+        # ("Key was rejected by service"), so /dev/nvidia* never appears and
+        # nvidia-persistenced fails. Legacy GPU runners ran without Secure Boot
+        # for the same reason. Keep it on for general/build where there's no
+        # unsigned-module requirement.
         shielded_instance_config=compute_v1.ShieldedInstanceConfig(
-            enable_secure_boot=True,
+            enable_secure_boot=not family.has_gpu,
             enable_vtpm=True,
             enable_integrity_monitoring=True,
         ),

--- a/infrastructure/functions/runner_manager/test_ephemeral.py
+++ b/infrastructure/functions/runner_manager/test_ephemeral.py
@@ -239,6 +239,43 @@ class TestSchedulingPerFamily:
         assert kwargs.get("on_host_maintenance") == "TERMINATE"
 
 
+class TestSecureBootPerFamily:
+    """Secure Boot blocks unsigned DKMS-built NVIDIA modules.
+
+    With Secure Boot on, the kernel is in lockdown=integrity mode and rejects
+    unsigned modules ("Key was rejected by service"). The NVIDIA kernel module
+    we install from the upstream CUDA repo is built by DKMS and unsigned, so
+    Secure Boot must be off on GPU VMs. Non-GPU families don't have this
+    constraint and keep Secure Boot on for defense in depth.
+    """
+
+    def _build_for(self, family_name):
+        ep = _fresh_module()
+        ep._build_instance(
+            name=f"gha-{family_name}-test",
+            family=ep.FAMILIES[family_name],
+            zone="us-central1-a",
+            jit_config="JIT",
+            image_self_link="projects/p/global/images/family/x",
+            use_external_ip=False,
+        )
+        return _compute_stub.ShieldedInstanceConfig.call_args.kwargs
+
+    def test_general_has_secure_boot_on(self):
+        assert self._build_for("general")["enable_secure_boot"] is True
+
+    def test_build_has_secure_boot_on(self):
+        assert self._build_for("build")["enable_secure_boot"] is True
+
+    def test_gpu_has_secure_boot_off(self):
+        assert self._build_for("gpu")["enable_secure_boot"] is False
+
+    def test_vtpm_and_integrity_stay_on_for_gpu(self):
+        kwargs = self._build_for("gpu")
+        assert kwargs["enable_vtpm"] is True
+        assert kwargs["enable_integrity_monitoring"] is True
+
+
 def _make_instance(name, age_minutes, zone="us-central1-a"):
     inst = MagicMock()
     inst.name = name

--- a/infrastructure/scripts/runner-image-provision.sh
+++ b/infrastructure/scripts/runner-image-provision.sh
@@ -173,6 +173,96 @@ if [[ "$VARIANT" == "gpu" ]]; then
         apt-get update
         apt-get install -y cuda-drivers cuda-toolkit-12-4
     fi
+
+    # ============== Boot-time NVIDIA module load / DKMS rebuild ==============
+    # The NVIDIA kernel module installed above only loads cleanly when (a) the
+    # baked .ko matches the running kernel and (b) udev / something else
+    # actually modprobes it. Neither is guaranteed on ephemeral VMs:
+    #
+    #   1. `apt-get install cuda-drivers` can pull in a newer kernel image
+    #      (linux-image-cloud-amd64 is a meta-package). The build VM keeps
+    #      running the kernel it booted with, so DKMS builds nvidia.ko for
+    #      *that* kernel — but a fresh VM from this image boots whichever
+    #      kernel GRUB picks (usually the newest installed), leading to a
+    #      module-not-found mismatch. Confirmed on gha-runner-gpu-20260517:
+    #      image baked nvidia.ko for 6.1.0-47, fresh VMs boot 6.1.0-48.
+    #   2. There's no udev rule or modules-load.d entry that asks the kernel
+    #      to load nvidia at boot, so even when the .ko exists for the running
+    #      kernel nothing triggers a modprobe — nvidia-persistenced just fails
+    #      with "Failed to query NVIDIA devices" because /dev/nvidia* never
+    #      gets created.
+    #
+    # Fix: bake a systemd unit that runs at every boot, before
+    # nvidia-persistenced and the GCE startup-script. It checks for the
+    # running-kernel .ko, runs `dkms autoinstall` if missing (installing
+    # matching headers first), then modprobes. Legacy long-lived GPU runners
+    # had this logic in their startup-script; ephemeral VMs need it baked
+    # into the image.
+    ck "phase: gpu boot-time modprobe systemd unit"
+
+    install -m 0755 /dev/stdin /usr/local/sbin/gha-gpu-modprobe <<'GPU_MODPROBE_SCRIPT'
+#!/bin/bash
+# Build (if needed) and load NVIDIA kernel modules.
+# Idempotent — fast no-op when nvidia is already loaded.
+set -eu
+export DEBIAN_FRONTEND=noninteractive
+
+if lsmod | grep -q '^nvidia '; then
+    echo "[gha-gpu-modprobe] nvidia already loaded"
+    exit 0
+fi
+
+KR="$(uname -r)"
+DKMS_KO="/lib/modules/${KR}/updates/dkms/nvidia.ko"
+
+if [[ ! -f "$DKMS_KO" ]]; then
+    echo "[gha-gpu-modprobe] nvidia.ko missing for ${KR}; rebuilding via DKMS"
+    if ! dpkg -s "linux-headers-${KR}" >/dev/null 2>&1; then
+        echo "[gha-gpu-modprobe] installing linux-headers-${KR}"
+        apt-get update -qq
+        apt-get install -y --no-upgrade "linux-headers-${KR}"
+    fi
+    dkms autoinstall -k "${KR}"
+fi
+
+echo "[gha-gpu-modprobe] modprobing nvidia kernel modules"
+modprobe nvidia
+modprobe nvidia_uvm
+modprobe nvidia_drm
+
+echo "[gha-gpu-modprobe] verifying with nvidia-smi"
+nvidia-smi >/dev/null
+echo "[gha-gpu-modprobe] OK"
+GPU_MODPROBE_SCRIPT
+
+    install -m 0644 /dev/stdin /etc/systemd/system/gha-gpu-modprobe.service <<'GPU_MODPROBE_UNIT'
+[Unit]
+Description=Build (if needed) and load NVIDIA kernel modules at boot
+DefaultDependencies=yes
+After=network-online.target
+Wants=network-online.target
+Before=nvidia-persistenced.service google-startup-scripts.service
+ConditionPathExists=/usr/local/sbin/gha-gpu-modprobe
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/gha-gpu-modprobe
+StandardOutput=journal+console
+StandardError=journal+console
+TimeoutStartSec=600
+
+[Install]
+WantedBy=multi-user.target
+GPU_MODPROBE_UNIT
+
+    # systemctl enable creates the symlink in /etc/systemd/system/multi-user.target.wants/.
+    # Falling back to a direct symlink keeps this idempotent if systemd's daemon
+    # bus isn't reachable mid-image-build (rare, but observed once on a slow
+    # build VM).
+    systemctl enable gha-gpu-modprobe.service 2>/dev/null \
+        || ln -sf /etc/systemd/system/gha-gpu-modprobe.service \
+                  /etc/systemd/system/multi-user.target.wants/gha-gpu-modprobe.service
 fi
 
 # ==================== Docker (general + build only) ====================


### PR DESCRIPTION
## Summary

Followup #1 + #4 from `docs/archive/2026-05-17-ephemeral-runner-followups-handoff.md`. Fixes the GPU-image cutover bug that blocked python-audio-separator integration tests, and brings the operator runbook in line with what actually shipped.

### Root cause (validated with two GPU smoke VMs against the broken image)

Two compounding bugs:

1. **Kernel skew**: `apt-get install cuda-drivers` pulls a newer kernel image via the `linux-image-cloud-amd64` meta-package, but DKMS only builds nvidia.ko against the build-VM's currently-running kernel. Fresh ephemeral VMs boot the newer kernel (GRUB default) and find no nvidia module for `uname -r` — `nvidia-persistenced` fails with "Failed to query NVIDIA devices". Confirmed on `gha-runner-gpu-20260517-183755`: image baked nvidia for `6.1.0-47`, fresh VMs boot `6.1.0-48`.
2. **Secure Boot lockdown**: `enable_secure_boot=True` puts the kernel in `lockdown=integrity` mode and rejects unsigned modules with "Key was rejected by service". Legacy GPU runners had no `shielded_instance_config` (SB off by default) and weren't affected.

### Fixes

- `infrastructure/scripts/runner-image-provision.sh`: bake `gha-gpu-modprobe.service` (GPU variant only). Runs before `nvidia-persistenced.service` and the GCE startup script. Idempotent — no-op when nvidia is loaded; otherwise installs matching `linux-headers-$(uname -r)`, runs `dkms autoinstall`, and modprobes nvidia / nvidia_uvm / nvidia_drm.
- `infrastructure/functions/runner_manager/ephemeral.py`: `enable_secure_boot=not family.has_gpu`. Keeps Secure Boot on for general/build.
- `docs/EPHEMERAL-GHA-RUNNERS.md`: rewrite STATUS to reflect the actual cutover history (3 bug-fix iterations in PR #776, Phase 4 already done in PR #780), remove the now-stale Phase-4 followups walkthrough, add 7 new lessons-learned entries.

### Verification

- Manual fix sequence on a no-SB smoke VM produced working `nvidia-smi` (Tesla T4, driver 595.71.05, CUDA 13.2) as root and as the `runner` user.
- An SB-on smoke VM failed with "Key was rejected by service" at modprobe even after `dkms autoinstall`, confirming the second fix.
- Image rebuild (run [26012660753](https://github.com/nomadkaraoke/karaoke-gen/actions/runs/26012660753)) is in flight on this branch.

End-to-end verification will be a follow-up PR in `python-audio-separator` once the new image is `READY` and a smoke VM from it auto-loads nvidia.

## Test plan

- [x] All 30 tests in `test_ephemeral.py` pass (4 new in `TestSecureBootPerFamily`)
- [x] Bash syntax check on `runner-image-provision.sh`
- [ ] Smoke-test new image: fresh GPU VM with `--no-shielded-secure-boot` from `gha-runner-gpu` family, `nvidia-smi` works at boot
- [ ] PR in `python-audio-separator` triggers all 3 GPU integration jobs, all green

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)