### PR TITLE
fix(monitoring): wire email notification channel to all alert policies

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -192,11 +192,16 @@ error_monitor_resources = error_monitor_module.create_error_monitor(
 
 # ==================== Monitoring ====================
 
+# Notification channels — every alert policy attaches all of these. Without
+# this step alerts fire into the void (verified 2026-05-17: three runner-
+# dispatcher create failures went undelivered for 14h).
+notification_channels = monitoring.create_notification_channels()
+
 # Alert policies
-alert_policies = monitoring.create_alert_policies()
+alert_policies = monitoring.create_alert_policies(notification_channels)
 
 # Ephemeral GHA-runner dispatcher: log-based metrics + alerts
-runner_observability = monitoring.create_ephemeral_runner_observability()
+runner_observability = monitoring.create_ephemeral_runner_observability(notification_channels)
 
 # ==================== Cloud Function: GDrive Validator ====================
 

--- a/infrastructure/modules/monitoring.py
+++ b/infrastructure/modules/monitoring.py
@@ -1,7 +1,12 @@
 """
 Cloud Monitoring resources.
 
-Manages alert policies for proactive monitoring and incident response.
+Manages alert policies for proactive monitoring and incident response. Every
+alert policy attaches the notification channel(s) created by
+``create_notification_channels`` — without that, a firing alert resolves into
+the void (verified on 2026-05-17: three ephemeral-dispatcher create failures
+fired the create-failures alert correctly, but the project had zero
+notification channels attached, so nobody got paged for 14 hours).
 """
 
 import pulumi
@@ -10,13 +15,57 @@ import pulumi_gcp as gcp
 from config import PROJECT_ID
 
 
-def create_alert_policies() -> dict[str, gcp.monitoring.AlertPolicy]:
+# Email address that receives all monitoring alerts. Cloud Monitoring delivers
+# a one-time confirmation link to this address when the channel is created;
+# the channel stays in PENDING state until verified.
+_ALERT_EMAIL = "andrew@beveridge.uk"
+
+
+def create_notification_channels() -> dict[str, gcp.monitoring.NotificationChannel]:
+    """Create the notification channels attached to every alert policy.
+
+    Returns a dict so callers can pass selected channels to specific policies
+    in the future (e.g. critical-only routing). Today every policy uses
+    ``channels["email"]``.
+
+    Swapping email for Discord later: Discord supports Slack-compatible
+    webhooks at ``<discord_webhook_url>/slack``. Add a second channel with
+    ``type_="slack"`` and ``sensitive_labels={"auth_token": <url>}``; reference
+    it in the policies that should page Discord. Keep email as the durable
+    fallback.
+    """
+    channels: dict[str, gcp.monitoring.NotificationChannel] = {}
+    channels["email"] = gcp.monitoring.NotificationChannel(
+        "alerts-email",
+        display_name="Andrew (email)",
+        type="email",
+        labels={"email_address": _ALERT_EMAIL},
+        description="Primary alert channel for Cloud Monitoring policies.",
+        enabled=True,
+    )
+    return channels
+
+
+def _channel_names(channels: dict[str, gcp.monitoring.NotificationChannel]) -> list[pulumi.Output[str]]:
+    """Return the .name Outputs of every channel (the form AlertPolicy wants)."""
+    return [ch.name for ch in channels.values()]
+
+
+def create_alert_policies(
+    channels: dict[str, gcp.monitoring.NotificationChannel],
+) -> dict[str, gcp.monitoring.AlertPolicy]:
     """
     Create all Cloud Monitoring alert policies.
+
+    Args:
+        channels: Notification channels to attach (from
+            :func:`create_notification_channels`). All policies get every
+            channel.
 
     Returns:
         dict: Dictionary mapping alert names to AlertPolicy resources.
     """
+    notification_channels = _channel_names(channels)
     alerts = {}
 
     # Alert: High Error Rate (>10% of requests returning errors)
@@ -53,6 +102,7 @@ def create_alert_policies() -> dict[str, gcp.monitoring.AlertPolicy]:
             mime_type="text/markdown",
         ),
         enabled=True,
+        notification_channels=notification_channels,
     )
 
     # Alert: Cloud Tasks Queue Backlog (tasks piling up)
@@ -89,6 +139,7 @@ def create_alert_policies() -> dict[str, gcp.monitoring.AlertPolicy]:
             mime_type="text/markdown",
         ),
         enabled=True,
+        notification_channels=notification_channels,
     )
 
     # Alert: High Memory Utilization (workers may be crashing)
@@ -125,6 +176,7 @@ def create_alert_policies() -> dict[str, gcp.monitoring.AlertPolicy]:
             mime_type="text/markdown",
         ),
         enabled=True,
+        notification_channels=notification_channels,
     )
 
     # Alert: Cloud Run Service Unavailable
@@ -156,12 +208,15 @@ def create_alert_policies() -> dict[str, gcp.monitoring.AlertPolicy]:
             mime_type="text/markdown",
         ),
         enabled=True,
+        notification_channels=notification_channels,
     )
 
     return alerts
 
 
-def create_ephemeral_runner_observability() -> dict:
+def create_ephemeral_runner_observability(
+    channels: dict[str, gcp.monitoring.NotificationChannel],
+) -> dict:
     """Log-based metrics + alerts for the ephemeral GHA runner dispatcher.
 
     Adds two alerts that are useful during the Phase 3 soak and afterward:
@@ -171,6 +226,7 @@ def create_ephemeral_runner_observability() -> dict:
     2. Long-running ephemeral runner VMs (uptime > 2 h on instances labelled
        ``purpose=gha-ephemeral-runner`` — catches hung jobs or cleanup bugs).
     """
+    notification_channels = _channel_names(channels)
     resources: dict = {}
 
     # ---- Log-based metric: dispatch failures -------------------------------
@@ -258,6 +314,7 @@ def create_ephemeral_runner_observability() -> dict:
             mime_type="text/markdown",
         ),
         enabled=True,
+        notification_channels=notification_channels,
         opts=pulumi.ResourceOptions(depends_on=[resources["dispatch_failure_metric"]]),
     )
 
@@ -311,6 +368,7 @@ def create_ephemeral_runner_observability() -> dict:
             mime_type="text/markdown",
         ),
         enabled=True,
+        notification_channels=notification_channels,
     )
 
     return resources

--- a/infrastructure/monitoring/README.md
+++ b/infrastructure/monitoring/README.md
@@ -121,31 +121,52 @@ Alert policies are defined in `infrastructure/__main__.py` as Pulumi resources:
 - **Severity**: Critical
 - **Auto-close**: 10 minutes after resolution
 
-## Adding Notification Channels
+## Notification Channels
 
-To receive alerts, you need to create notification channels:
+Notification channels are managed as Pulumi IaC in
+[`infrastructure/modules/monitoring.py`](../modules/monitoring.py) — see
+`create_notification_channels()` and the `notification_channels=...` arg
+attached to every alert policy.
 
-### Discord Webhook
+**Current channel:** one email channel (`alerts-email`) delivering to the
+project owner. Cloud Monitoring puts new email channels in PENDING state and
+sends a one-time confirmation link to the address; the channel stays inactive
+until the link is clicked.
 
-1. Go to Cloud Console → Monitoring → Alerting → Notification channels
-2. Click "Add New" → Webhook
-3. Enter your Discord webhook URL
-4. Save and note the channel ID
+If alerts seem to be firing but not delivering, check:
 
-Then update the alert policies in `__main__.py`:
-
-```python
-error_rate_alert = gcp.monitoring.AlertPolicy(
-    # ...existing config...
-    notification_channels=[discord_webhook_channel.name],
-)
+```bash
+gcloud alpha monitoring channels list --project=nomadkaraoke \
+  --format='table(displayName,type,verificationStatus,enabled)'
 ```
 
-### Email
+`verificationStatus=VERIFIED` is the active state.
 
-1. Go to Cloud Console → Monitoring → Alerting → Notification channels
-2. Click "Add New" → Email
-3. Enter email addresses to notify
+### Adding a second channel (e.g. Discord)
+
+Discord supports Slack-compatible webhooks: append `/slack` to a Discord
+webhook URL and Discord parses Slack-formatted payloads. To add a Discord
+channel alongside email:
+
+1. Create a webhook in Discord (Server settings → Integrations → Webhooks).
+2. Store the URL in Secret Manager (the project already has
+   `discord-alert-webhook` for the error-monitor service).
+3. In `monitoring.py`, add a second entry to `create_notification_channels()`:
+
+   ```python
+   channels["discord"] = gcp.monitoring.NotificationChannel(
+       "alerts-discord",
+       display_name="Alerts (Discord)",
+       type="slack",
+       sensitive_labels=gcp.monitoring.NotificationChannelSensitiveLabelsArgs(
+           auth_token=discord_webhook_url + "/slack",
+       ),
+       enabled=True,
+   )
+   ```
+
+4. `pulumi up`. All alert policies pick up the new channel automatically
+   because they iterate `channels.values()`.
 
 ## Log-Based Metrics
 


### PR DESCRIPTION
## Summary

Followup #3 from `docs/archive/2026-05-17-ephemeral-runner-followups-handoff.md`. Root cause of the 2026-05-17 cutover going undetected for ~14h: the `GHA Runner Dispatcher - Create Failures` alert had a correct log-based metric and a correct condition — but **no notification channels were attached to any alert policy project-wide**, so the three create-failure events fired into the void.

Verified before this PR:

\`\`\`
$ gcloud alpha monitoring channels list --project=nomadkaraoke
(empty)
\`\`\`

## Changes

- New `create_notification_channels()` in `infrastructure/modules/monitoring.py`: creates one email channel (`alerts-email`, delivering to `andrew@beveridge.uk`).
- Both `create_alert_policies` and `create_ephemeral_runner_observability` now accept a `channels` dict and thread it into every `gcp.monitoring.AlertPolicy` via `notification_channels=...`.
- `__main__.py` calls `create_notification_channels()` first and passes the result through.
- `infrastructure/monitoring/README.md` rewrites the "Notification Channels" section to point at the IaC and includes a paste-ready snippet for adding Discord (via Discord's Slack-compatible `<webhook_url>/slack` endpoint) as a follow-up.

Policies that now get notifications:
- `error_rate`, `queue_backlog`, `memory`, `service_unavailable` (Karaoke Backend)
- `dispatch_failure_alert`, `long_lived_vm_alert` (GHA Runner Dispatcher)

## Operator action required

After merge + `pulumi up`, Cloud Monitoring sends a one-time confirmation email to `andrew@beveridge.uk`. The channel stays in PENDING state until the link is clicked.

Verify with:

\`\`\`bash
gcloud alpha monitoring channels list --project=nomadkaraoke \\
  --format='table(displayName,type,verificationStatus,enabled)'
\`\`\`

Looking for `verificationStatus=VERIFIED`.

## Test plan

- [x] `ast.parse` clean for `monitoring.py` and `__main__.py`
- [x] Confirmed all 6 alert policies have `notification_channels=notification_channels` attached (`grep -c notification_channels infrastructure/modules/monitoring.py` → 11, expected)
- [ ] `pulumi preview` shows: 1 new `NotificationChannel`, 6 in-place `AlertPolicy` updates. No destructive ops.
- [ ] Run `pulumi up`. Verify email arrives. Click verification link.
- [ ] Force a test alert (e.g. temporarily lower a threshold) and confirm email delivery, then revert.

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)