### PR TITLE
docs(monitoring): document email-channel verification gap (Pulumi vs Console)

### DIFF
--- a/infrastructure/monitoring/README.md
+++ b/infrastructure/monitoring/README.md
@@ -154,8 +154,20 @@ curl -sS -X POST -d '{}' \
   "https://monitoring.googleapis.com/v3/projects/nomadkaraoke/notificationChannels/${CHANNEL_ID}:sendVerificationCode"
 ```
 
-The verification email arrives within a minute or two. Click the link, then
-confirm:
+The email arrives within a minute or two. Subject is something like
+"Verify your email address for Google Cloud Alerting" and the body contains
+a code in the form `G-NNNNNN` plus a clickable link. Either path completes
+the verification — clicking the link is simplest, or POST the code to
+`:verify`:
+
+```bash
+curl -sS -X POST -d '{"code":"G-NNNNNN"}' \
+  -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+  -H "Content-Type: application/json" \
+  "https://monitoring.googleapis.com/v3/projects/nomadkaraoke/notificationChannels/${CHANNEL_ID}:verify"
+```
+
+Confirm afterwards:
 
 ```bash
 curl -sS -H "Authorization: Bearer $(gcloud auth print-access-token)" \
@@ -163,10 +175,10 @@ curl -sS -H "Authorization: Bearer $(gcloud auth print-access-token)" \
   | python3 -c "import json,sys; print(json.load(sys.stdin).get('verificationStatus','(missing)'))"
 ```
 
-Expected output: `VERIFIED`. Until then, `gcloud alpha monitoring channels list
---format='table(...,verificationStatus,...)'` returns an empty
-`verificationStatus` column (which is itself a tell — verified channels
-populate the field).
+Expected output: `VERIFIED`. Until that's true, `gcloud alpha monitoring
+channels list --format='table(...,verificationStatus,...)'` returns an
+empty `verificationStatus` column (which is itself a tell — verified
+channels populate the field).
 
 ### Adding a second channel (e.g. Discord)
 

--- a/infrastructure/monitoring/README.md
+++ b/infrastructure/monitoring/README.md
@@ -129,18 +129,44 @@ Notification channels are managed as Pulumi IaC in
 attached to every alert policy.
 
 **Current channel:** one email channel (`alerts-email`) delivering to the
-project owner. Cloud Monitoring puts new email channels in PENDING state and
-sends a one-time confirmation link to the address; the channel stays inactive
-until the link is clicked.
+project owner.
 
-If alerts seem to be firing but not delivering, check:
+### Gotcha: Pulumi-created email channels don't auto-send the verification email
+
+When an email channel is created through the **Cloud Console**, Cloud Monitoring
+automatically sends a verification link to the address. When it's created
+through the **API or Pulumi**, that auto-send does **not** happen — the channel
+lands in `verificationStatus=UNVERIFIED` and stays there silently. Alerts will
+fire and resolve but no email gets delivered.
+
+After `pulumi up` creates a new email channel, trigger the verification email
+explicitly:
 
 ```bash
-gcloud alpha monitoring channels list --project=nomadkaraoke \
-  --format='table(displayName,type,verificationStatus,enabled)'
+unset GOOGLE_APPLICATION_CREDENTIALS   # need admin creds, not claude-readonly
+CHANNEL_ID=$(gcloud alpha monitoring channels list --project=nomadkaraoke \
+  --filter='type=email AND displayName="Andrew (email)"' \
+  --format='value(name.basename())')
+
+curl -sS -X POST -d '{}' \
+  -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+  -H "Content-Type: application/json" \
+  "https://monitoring.googleapis.com/v3/projects/nomadkaraoke/notificationChannels/${CHANNEL_ID}:sendVerificationCode"
 ```
 
-`verificationStatus=VERIFIED` is the active state.
+The verification email arrives within a minute or two. Click the link, then
+confirm:
+
+```bash
+curl -sS -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+  "https://monitoring.googleapis.com/v3/projects/nomadkaraoke/notificationChannels/${CHANNEL_ID}" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin).get('verificationStatus','(missing)'))"
+```
+
+Expected output: `VERIFIED`. Until then, `gcloud alpha monitoring channels list
+--format='table(...,verificationStatus,...)'` returns an empty
+`verificationStatus` column (which is itself a tell — verified channels
+populate the field).
 
 ### Adding a second channel (e.g. Discord)
 


### PR DESCRIPTION
## Summary

Followup to PR #783. The PR claimed Cloud Monitoring would deliver a verification email to `andrew@beveridge.uk` automatically after `pulumi up`. It didn't — the channel sat in `UNVERIFIED` state silently, exactly as if no channel had been created.

The actual GCP behaviour: the auto-send only fires when a channel is created through the **Cloud Console**. Channels created through the **API/Pulumi** require an explicit call to the `:sendVerificationCode` REST endpoint to trigger the email.

I discovered this when running `getVerificationCode` against the channel and getting `"Cannot generate a verification code from an unverified channel."` despite `enabled: true`. The right endpoint is `sendVerificationCode` (no admin-flow restrictions), which returned `{}` (success) and the email arrived shortly after.

## Change

Rewrite the "Gotcha" callout in `infrastructure/monitoring/README.md` to explain this, with a copy-paste-ready curl invocation for triggering the email after any future `pulumi up` that adds a new email channel.

No code change.

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)