### PR TITLE
fix(monitoring): raise long-lived VM alert threshold to 2h30m (kill false positives)

### DIFF
--- a/docs/EPHEMERAL-GHA-RUNNERS.md
+++ b/docs/EPHEMERAL-GHA-RUNNERS.md
@@ -344,7 +344,7 @@ After apply, `RUNNER_MODE` is still `legacy` — no behavioural change yet.
 
 4. Monitor the new alert policies for a week before Phase 4:
    - `GHA Runner Dispatcher - Create Failures` (any failure = page)
-   - `GHA Runner Dispatcher - VM Alive > 2h` (orphan cleanup didn't work)
+   - `GHA Runner Dispatcher - VM Alive > 2h30m` (orphan cleanup didn't work)
 
 **Rollback:** `pulumi config set karaoke-gen-infrastructure:runnerMode legacy && pulumi up --target ...:runner-manager-function`.
 Legacy VMs are still in Pulumi state; the next workflow_job webhook will

--- a/infrastructure/modules/monitoring.py
+++ b/infrastructure/modules/monitoring.py
@@ -223,7 +223,7 @@ def create_ephemeral_runner_observability(
 
     1. Dispatcher VM-create failures (the dispatcher returns 503 + logs
        ``create_ephemeral_runner failed`` — any occurrence in 10 min fires).
-    2. Long-running ephemeral runner VMs (uptime > 2 h on instances labelled
+    2. Long-running ephemeral runner VMs (uptime > 2h30m on instances labelled
        ``purpose=gha-ephemeral-runner`` — catches hung jobs or cleanup bugs).
     """
     notification_channels = _channel_names(channels)
@@ -321,17 +321,24 @@ def create_ephemeral_runner_observability(
         opts=pulumi.ResourceOptions(depends_on=[resources["dispatch_failure_metric"]]),
     )
 
-    # ---- Alert: ephemeral VM uptime > 2h -----------------------------------
+    # ---- Alert: ephemeral VM uptime > 2h30m --------------------------------
     # `compute.googleapis.com/instance/uptime_total` is a cumulative count of
-    # seconds the VM has been up. We alert when it exceeds 7200s for VMs
-    # carrying the ephemeral-runner purpose label.
+    # seconds the VM has been up. The orphan-cleanup pass kills VMs at
+    # MAX_VM_LIFETIME_MINUTES=120 on a 15-min scheduler tick, so worst-case
+    # lifetime is ~135min. ALIGN_MAX over a 5-min window plus the 300s
+    # duration means a threshold of exactly 7200s fires on every normal
+    # cleanup (the window containing the pre-delete sample still reports
+    # max>threshold for 5min after the VM is gone). Threshold set to 9000s
+    # (150min = worst-case + 15min buffer) so this alert only fires when
+    # cleanup is genuinely broken, not on routine cleanups that land within
+    # the expected window.
     resources["long_lived_vm_alert"] = gcp.monitoring.AlertPolicy(
         "runner-dispatcher-long-lived-vm-alert",
-        display_name="GHA Runner Dispatcher - VM Alive > 2h",
+        display_name="GHA Runner Dispatcher - VM Alive > 2h30m",
         combiner="OR",
         conditions=[
             gcp.monitoring.AlertPolicyConditionArgs(
-                display_name="Ephemeral runner VM uptime > 2h",
+                display_name="Ephemeral runner VM uptime > 2h30m",
                 condition_threshold=gcp.monitoring.AlertPolicyConditionConditionThresholdArgs(
                     filter=(
                         'metric.type="compute.googleapis.com/instance/uptime_total" '
@@ -339,7 +346,7 @@ def create_ephemeral_runner_observability(
                         'AND metadata.user_labels.purpose="gha-ephemeral-runner"'
                     ),
                     comparison="COMPARISON_GT",
-                    threshold_value=7200,
+                    threshold_value=9000,
                     duration="300s",
                     aggregations=[
                         gcp.monitoring.AlertPolicyConditionConditionThresholdAggregationArgs(
@@ -356,13 +363,15 @@ def create_ephemeral_runner_observability(
             ),
         ],
         alert_strategy=gcp.monitoring.AlertPolicyAlertStrategyArgs(
-            auto_close="3600s",
+            auto_close="600s",
         ),
         documentation=gcp.monitoring.AlertPolicyDocumentationArgs(
             content=(
-                "An ephemeral GHA runner VM has been alive for more than 2 hours.\n"
-                "Orphan-cleanup should kill VMs at that threshold — if this fires,\n"
-                "the cleanup pass is broken or the VM is escaping it.\n\n"
+                "An ephemeral GHA runner VM has been alive for more than 2h30m.\n"
+                "Orphan-cleanup should kill VMs at MAX_VM_LIFETIME_MINUTES (120)\n"
+                "on a 15-min scheduler tick — worst-case lifetime is ~135min.\n"
+                "If this alert fires, the cleanup pass is broken or the VM is\n"
+                "escaping it.\n\n"
                 "Investigate:\n"
                 "1. `gcloud compute instances list --filter=labels.purpose=gha-ephemeral-runner`\n"
                 "2. Check Cloud Function logs for the cleanup pass\n"


### PR DESCRIPTION
## Summary

Last night's alert (`VM Alive > 2h` firing at 06:40 UTC, recovering at ~07:41 UTC) was a false positive. The cleanup pass worked correctly — the alert policy is too tight.

## Root cause

Orphan-cleanup deletes VMs at `MAX_VM_LIFETIME_MINUTES=120` on a 15-min scheduler tick. Worst-case lifetime = **135min**. The alert threshold was set to exactly **120min (7200s)** with `ALIGN_MAX` over a 5-min window and a 300s duration — so the 5-min window containing the last pre-delete sample reports `max > 7200` for ~5min after the VM is already gone, and `autoClose=3600s` dragged recovery out for ~1h.

### Evidence (instance `6379757481209834386` = `gha-general-1b8a7c29c8e2`)

| Time (UTC) | Event |
|---|---|
| 04:28:53 | VM created (workflow_job.queued webhook) |
| 06:28:53 | uptime crossed 7200s (exact 2h) |
| 06:30:03 | scheduler tick fires orphan cleanup |
| 06:30:04 | function logs `gha-general-1b8a7c29c8e2: age=121.3min > max, deleting` |
| 06:31:24 | delete operation completes (`last=True`) — **VM gone** |
| 06:40:27 | **alert fires** (9 min after VM was deleted) |
| ~07:41 | alert auto-closes |

The alert hadn't fired before because notification channels were unwired across all policies until PR #783 merged ~12 min before this VM was born — this was the first cleanup cycle observed via email, not the first false positive.

## Changes

- `threshold_value`: `7200` → `9000` (150 min = worst-case 135 min + 15 min buffer)
- `auto_close`: `3600s` → `600s` (faster recovery if it ever does legitimately fire)
- `display_name` + docs updated to `VM Alive > 2h30m`

Real cleanup-broken cases (VMs stuck at 3h+) still trigger.

## Operator action required

Per memory `feedback_claude_readonly_adc`: claude-readonly ADC can't push Pulumi state, so this needs a manual `pulumi up --target` after merge:

\`\`\`bash
pulumi up --target 'urn:pulumi:prod::karaoke-gen-infrastructure::gcp:monitoring/alertPolicy:AlertPolicy::runner-dispatcher-long-lived-vm-alert'
\`\`\`

Expected diff: in-place update — `displayName`, `conditions[0].displayName`, `conditions[0].conditionThreshold.thresholdValue` (7200 → 9000), `alertStrategy.autoClose` (3600s → 600s), `documentation.content`.

## Test plan

- [x] `ast.parse` clean for `monitoring.py`
- [x] No tests reference the alert policy displayName/threshold (`grep -rn "long_lived\|VM Alive" infrastructure/` only hits this file)
- [ ] `pulumi preview` shows an in-place update to `runner-dispatcher-long-lived-vm-alert` only — no creates/deletes
- [ ] After `pulumi up`, verify policy in Cloud Console shows threshold=9000 and autoClose=600s

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)