### PR TITLE
fix(monitoring): autoClose minimum is 30min — raise from 600s to 1800s

### DIFF
--- a/infrastructure/modules/monitoring.py
+++ b/infrastructure/modules/monitoring.py
@@ -363,7 +363,8 @@ def create_ephemeral_runner_observability(
             ),
         ],
         alert_strategy=gcp.monitoring.AlertPolicyAlertStrategyArgs(
-            auto_close="600s",
+            # GCP minimum is 30 minutes — anything lower returns 400.
+            auto_close="1800s",
         ),
         documentation=gcp.monitoring.AlertPolicyDocumentationArgs(
             content=(


### PR DESCRIPTION
## Summary

Follow-up to #787. GCP Monitoring rejects \`autoClose\` values below 30 minutes — \`pulumi up\` for #787 failed with:

\`\`\`
Error 400: Field alertStrategy.autoClose had an invalid value of "seconds: 600":
the autoclose duration should be at least 30 minutes
\`\`\`

PR #787 didn't apply atomically, so prod alert policy is still on the old values (threshold=7200, autoClose=3600s). This PR sets autoClose to the GCP minimum (1800s = 30min). Combined with #787's threshold bump to 9000s, the noise alert from this morning will be killed once \`pulumi up\` lands.

## Changes

- \`auto_close\`: \`600s\` → \`1800s\` (GCP minimum)
- Added comment explaining the floor so the next agent doesn't try to lower it

## Test plan

- [x] \`ast.parse\` clean
- [ ] \`pulumi preview\` shows in-place update to \`runner-dispatcher-long-lived-vm-alert\` only
- [ ] \`pulumi up\` succeeds (no GCP 400)
- [ ] Cloud Console shows policy with threshold=9000, autoClose=1800s

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)