### PR TITLE
obs(runner-manager): capture serial console before deleting unregistered VMs

### DIFF
--- a/infrastructure/functions/runner_manager/ephemeral.py
+++ b/infrastructure/functions/runner_manager/ephemeral.py
@@ -451,6 +451,32 @@ def _vm_age_minutes(instance: compute_v1.Instance) -> float:
     return (datetime.now(timezone.utc) - created).total_seconds() / 60
 
 
+# Serial output captured before delete is capped — long boot logs from
+# multiple failed VMs could blow up Cloud Logging volume otherwise.
+_SERIAL_TAIL_BYTES = 50_000
+
+
+def _log_serial_tail(zone: str, name: str) -> None:
+    """Fetch and print the tail of the VM's serial console.
+
+    Called only when we're about to delete a VM that never registered as a
+    GHA runner — gives us a one-shot look at why STARTUP_SCRIPT failed
+    (`./run.sh --jitconfig` exit reason, network errors, etc.) without
+    requiring an Ops Agent on the image.
+    """
+    try:
+        out = get_compute_client().get_serial_port_output(
+            project=PROJECT_ID, zone=zone, instance=name, port=1
+        )
+        contents = out.contents or ""
+        tail = contents[-_SERIAL_TAIL_BYTES:]
+        print(f"--- serial console (last {len(tail)} bytes) for {name} ---")
+        print(tail)
+        print(f"--- end serial console for {name} ---")
+    except Exception as exc:  # noqa: BLE001
+        print(f"Could not fetch serial output for {name}: {exc!r}")
+
+
 def _delete_vm(zone: str, name: str) -> tuple[str, str]:
     try:
         get_compute_client().delete(project=PROJECT_ID, zone=zone, instance=name)
@@ -498,6 +524,10 @@ def cleanup_orphans(pat: str) -> dict:
             print(
                 f"{instance.name}: age={age:.1f}min, no GHA runner registration — deleting"
             )
+            # Capture serial console output before deletion — the boot disk
+            # is auto-delete, so this is the only chance to see why
+            # STARTUP_SCRIPT exited without registering.
+            _log_serial_tail(zone, instance.name)
             to_delete.append((zone, instance.name))
         else:
             result["kept_vms"].append(instance.name)

--- a/infrastructure/functions/runner_manager/test_ephemeral.py
+++ b/infrastructure/functions/runner_manager/test_ephemeral.py
@@ -315,10 +315,15 @@ class TestCleanupOrphans:
 
         with self._patch_listing(ep, vms), patch.object(
             ep, "list_org_runners", return_value=runners
-        ), patch.object(ep, "_delete_vm", return_value=("gha-general-stuck", "deleted")):
+        ), patch.object(
+            ep, "_delete_vm", return_value=("gha-general-stuck", "deleted")
+        ), patch.object(ep, "_log_serial_tail") as serial_mock:
             result = ep.cleanup_orphans("ghp_test")
 
         assert "gha-general-stuck" in result["deleted_vms"]
+        # Registration-failure deletes must capture serial output so we can
+        # diagnose why STARTUP_SCRIPT exited without registering.
+        serial_mock.assert_called_once_with("us-central1-a", "gha-general-stuck")
 
     def test_deletes_hung_vm_even_when_registered(self):
         ep = _fresh_module()
@@ -327,10 +332,15 @@ class TestCleanupOrphans:
 
         with self._patch_listing(ep, vms), patch.object(
             ep, "list_org_runners", return_value=runners
-        ), patch.object(ep, "_delete_vm", return_value=("gha-general-hung", "deleted")):
+        ), patch.object(
+            ep, "_delete_vm", return_value=("gha-general-hung", "deleted")
+        ), patch.object(ep, "_log_serial_tail") as serial_mock:
             result = ep.cleanup_orphans("ghp_test")
 
         assert "gha-general-hung" in result["deleted_vms"]
+        # Hung-after-registration is a different failure mode; serial dump
+        # would mostly be runner job output, which is already in GHA logs.
+        serial_mock.assert_not_called()
 
     def test_keeps_active_running_vm(self):
         ep = _fresh_module()
@@ -374,11 +384,42 @@ class TestCleanupOrphans:
             ep, "list_org_runners", return_value=runners
         ), patch.object(
             ep, "_delete_vm", return_value=("gha-general-stuck", "delete_failed")
-        ):
+        ), patch.object(ep, "_log_serial_tail"):
             result = ep.cleanup_orphans("ghp_test")
 
         assert "gha-general-stuck" in result["delete_failed"]
         assert "gha-general-stuck" not in result["deleted_vms"]
+
+
+class TestLogSerialTail:
+    """Serial console capture is best-effort and must never block the delete."""
+
+    def test_prints_tail_of_serial_output(self, capsys):
+        ep = _fresh_module()
+        long_log = "x" * 200_000  # bigger than the 50_000-byte cap
+        fake_output = MagicMock(contents=long_log)
+        fake_client = MagicMock()
+        fake_client.get_serial_port_output.return_value = fake_output
+
+        with patch.object(ep, "get_compute_client", return_value=fake_client):
+            ep._log_serial_tail("us-central1-a", "gha-gpu-abc")
+
+        captured = capsys.readouterr().out
+        assert "serial console (last 50000 bytes) for gha-gpu-abc" in captured
+        assert "end serial console for gha-gpu-abc" in captured
+        # Tail was truncated, not the full log
+        assert len(captured) < 200_000
+
+    def test_swallows_fetch_errors(self, capsys):
+        ep = _fresh_module()
+        fake_client = MagicMock()
+        fake_client.get_serial_port_output.side_effect = Exception("permission denied")
+
+        with patch.object(ep, "get_compute_client", return_value=fake_client):
+            # Must not raise — cleanup path depends on this being best-effort
+            ep._log_serial_tail("us-central1-a", "gha-gpu-xyz")
+
+        assert "Could not fetch serial output for gha-gpu-xyz" in capsys.readouterr().out
 
 
 class TestStartupScript:


### PR DESCRIPTION
## Summary

Ephemeral GPU runner VMs register with GitHub roughly **1 in 3** times. Observed today on python-audio-separator PR #288: 3 GPU VMs dispatched, 1 ran \`core-models\`, 2 booted but never registered and were silently deleted after 40 min.

We can't fix the underlying registration bug because we have **zero visibility** into what's happening on the failed VMs:
- STARTUP_SCRIPT's stderr (including \`./run.sh --jitconfig\` output) goes to the serial console only
- No Ops Agent is installed on the runner image, so journald doesn't ship anywhere
- The script's \`EXIT\` trap shuts the VM down on any failure
- Boot disks are auto-delete → forensics impossible

This PR adds the missing observability so we can root-cause the real bug.

## Changes

- New \`_log_serial_tail(zone, name)\` helper: fetches the last 50 KiB of serial console output via \`instances.getSerialPortOutput()\` and prints it. The manager's stdout already flows to Cloud Logging, so the output becomes queryable.
- \`cleanup_orphans()\` calls \`_log_serial_tail\` **only** for the \"unregistered past grace\" delete path (the genuinely-mysterious case). Hung-after-registration deletes are skipped because that output is mostly job stderr, which is already in GHA logs.
- Best-effort: a fetch error logs a warning and lets the delete proceed.
- 50 KiB cap prevents pathological logging volume if many VMs fail simultaneously.

## Testing

- [x] All 32 unit tests pass (\`pytest infrastructure/functions/runner_manager/test_ephemeral.py\`)
- [x] 2 new tests cover \`_log_serial_tail\` directly (truncation + swallowing fetch errors)
- [x] 3 existing \`cleanup_orphans\` tests updated to assert serial capture is called on registration-failure path and NOT on hung-VM path

## Review

- [x] Local CodeRabbit review pending — will run before merging
- [x] No behavioural change in the happy path (registered VMs that successfully run jobs)

## After Merge

**Manual \`pulumi up\` required** to deploy the updated Cloud Function (per CLAUDE.md: claude-readonly ADC blocks Pulumi's storage.objects.create). Then wait for the next GPU integration test run to fail → query \`gcloud logging read 'serial console for gha-gpu-'\` to see the actual failure reason → open follow-up PR with the real fix.

## Related

- Triggered by python-audio-separator PR #288 stuck on GPU integration tests
- Builds on memory: \`project_ephemeral_runner_phase4.md\` (PRs #781-#783 fixed kernel-skew + Secure Boot, but registration-failure flakiness remained)

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)