### PR TITLE
fix(encoding,ci): silence self-healing warmup 503 alert + robust E2E result check

### DIFF
--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -83,6 +83,7 @@ jobs:
             -d '{"domain": "inbox.testmail.app"}' || echo "Warning: allowlist may already exist"
 
       - name: Run Credit Purchase Test
+        id: run_test
         working-directory: frontend
         env:
           TESTMAIL_API_KEY: ${{ secrets.TESTMAIL_API_KEY }}
@@ -102,16 +103,18 @@ jobs:
             --reporter=list \
             --timeout=600000 \
             2>&1 | tee test-output-payment.log
+          # Capture Playwright's real exit code, not tee's (0) — the
+          # authoritative pass/fail signal. See Stage 2 for rationale.
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
         continue-on-error: true
 
       - name: Check test result
         id: test_result
-        working-directory: frontend
         run: |
-          if grep -q "CREDIT PURCHASE TEST PASSED" test-output-payment.log; then
-            echo "result=success" >> $GITHUB_OUTPUT
+          if [ "${{ steps.run_test.outputs.exit_code }}" = "0" ]; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
           else
-            echo "result=failure" >> $GITHUB_OUTPUT
+            echo "result=failure" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Extract session token
@@ -209,6 +212,7 @@ jobs:
           echo "token=$TOKEN" >> $GITHUB_OUTPUT
 
       - name: Run Happy Path Test
+        id: run_test
         working-directory: frontend
         env:
           TESTMAIL_API_KEY: ${{ secrets.TESTMAIL_API_KEY }}
@@ -234,16 +238,20 @@ jobs:
             --reporter=list \
             --timeout=3600000 \
             2>&1 | tee test-output-happy-path.log
+          # Capture Playwright's real exit code, not tee's (0). This is the
+          # authoritative pass/fail signal — grepping the log for "failed" is
+          # fragile because benign retry warnings (e.g. "goto attempt 1/3
+          # failed") contain that substring and produce false alarms.
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
         continue-on-error: true
 
       - name: Check test result
         id: test_result
-        working-directory: frontend
         run: |
-          if grep -q "passed" test-output-happy-path.log && ! grep -q "failed" test-output-happy-path.log; then
-            echo "result=success" >> $GITHUB_OUTPUT
+          if [ "${{ steps.run_test.outputs.exit_code }}" = "0" ]; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
           else
-            echo "result=failure" >> $GITHUB_OUTPUT
+            echo "result=failure" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Upload test artifacts

--- a/backend/api/routes/encoding_worker.py
+++ b/backend/api/routes/encoding_worker.py
@@ -10,6 +10,7 @@ import logging
 from fastapi import APIRouter, Depends
 from backend.api.dependencies import require_admin
 from backend.services.encoding_worker_manager import EncodingWorkerManager
+from backend.services.encoding_errors import EncodingWorkerStartError
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,18 @@ async def warmup_encoding_worker(
         if result["started"]:
             logger.info(f"Started encoding worker VM: {result['vm_name']}")
         return result
+    except EncodingWorkerStartError as e:
+        # The primary VM couldn't start (capacity exhaustion or a transient
+        # 503 SERVICE_UNAVAILABLE from the GCE backend). This is NOT fatal:
+        # the encoding flow's own warmup (ensure_any_running) falls back to
+        # the alternate-zone workers, so the job still completes. Log at
+        # WARNING so it doesn't trip the production error monitor and page us
+        # for self-healing capacity events.
+        logger.warning(
+            f"Primary encoding worker warmup failed ({e}); "
+            f"encoding will fall back to an alternate-zone worker"
+        )
+        return {"started": False, "error": str(e)}
     except Exception as e:
         logger.error(f"Failed to warm up encoding worker: {e}")
         return {"started": False, "error": str(e)}

--- a/backend/tests/test_encoding_worker_routes.py
+++ b/backend/tests/test_encoding_worker_routes.py
@@ -3,12 +3,18 @@ Unit tests for encoding worker lifecycle endpoints.
 
 Tests the warmup and heartbeat API endpoints.
 """
+import logging
+
 import pytest
 from unittest.mock import MagicMock
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from backend.api.routes.encoding_worker import router, get_worker_manager
 from backend.api.dependencies import require_admin
+from backend.services.encoding_errors import (
+    EncodingWorkerCapacityError,
+    EncodingWorkerStartError,
+)
 
 
 def get_mock_admin():
@@ -55,6 +61,75 @@ class TestWarmupEndpoint:
         assert response.status_code == 200
         assert response.json()["started"] is False
         assert "error" in response.json()
+
+    def test_warmup_503_start_failure_logged_as_warning(self, caplog):
+        """A transient 503/start failure must NOT log at ERROR.
+
+        The encoding flow falls back to alternate-zone workers, so this is a
+        self-healing event. Logging it at ERROR trips the production error
+        monitor (severity>=ERROR) and pages us for a non-incident.
+        """
+        self.mock_manager.ensure_primary_running.side_effect = (
+            EncodingWorkerStartError(
+                "VM encoding-worker-b start failed in us-central1-c: "
+                "503 — SERVICE UNAVAILABLE",
+                vm_name="encoding-worker-b",
+                zone="us-central1-c",
+            )
+        )
+        with caplog.at_level(logging.WARNING):
+            response = self.client.post("/api/internal/encoding-worker/warmup")
+        assert response.status_code == 200
+        assert response.json()["started"] is False
+        warmup_records = [
+            r for r in caplog.records if "warmup failed" in r.getMessage()
+        ]
+        assert warmup_records, "expected a warmup-failure log record"
+        assert all(r.levelno == logging.WARNING for r in warmup_records)
+        # And nothing from this endpoint should be at ERROR.
+        assert not [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.ERROR
+            and r.name == "backend.api.routes.encoding_worker"
+        ]
+
+    def test_warmup_capacity_error_logged_as_warning(self, caplog):
+        """Capacity exhaustion is also self-healing → WARNING, not ERROR."""
+        self.mock_manager.ensure_primary_running.side_effect = (
+            EncodingWorkerCapacityError(
+                "VM encoding-worker-b could not be started in us-central1-c: "
+                "ZONE_RESOURCE_POOL_EXHAUSTED",
+                vm_name="encoding-worker-b",
+                zone="us-central1-c",
+                code="ZONE_RESOURCE_POOL_EXHAUSTED",
+            )
+        )
+        with caplog.at_level(logging.WARNING):
+            response = self.client.post("/api/internal/encoding-worker/warmup")
+        assert response.status_code == 200
+        assert not [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.ERROR
+            and r.name == "backend.api.routes.encoding_worker"
+        ]
+
+    def test_warmup_unexpected_error_still_logged_as_error(self, caplog):
+        """Genuinely unexpected failures must still surface at ERROR."""
+        self.mock_manager.ensure_primary_running.side_effect = RuntimeError(
+            "misconfigured service account"
+        )
+        with caplog.at_level(logging.WARNING):
+            response = self.client.post("/api/internal/encoding-worker/warmup")
+        assert response.status_code == 200
+        error_records = [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.ERROR
+            and r.name == "backend.api.routes.encoding_worker"
+        ]
+        assert error_records, "unexpected errors must remain at ERROR severity"
 
 
 class TestHeartbeatEndpoint:

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -228,6 +228,8 @@ done
 
 **Configuration knobs:** `MAX_PER_TICK = 1` and `MAX_WAIT_SECONDS = 24*3600` constants in `backend/api/routes/internal.py::retry_pending_render_jobs`.
 
+**Not an incident:** a *primary* warmup hitting `503 SERVICE_UNAVAILABLE` / capacity exhaustion is self-healing — the encoding flow's `ensure_any_running()` falls back to an alternate-zone worker and the job completes. As of 0.174.12 the `/internal/encoding-worker/warmup` endpoint logs this at **WARNING** (`"Primary encoding worker warmup failed (...); encoding will fall back..."`), specifically so it stays below the error monitor's `severity>=ERROR` filter and does **not** page Discord. Only a genuine, unexpected warmup failure (non-`EncodingWorkerStartError`) logs at ERROR. If you see the WARNING in logs with a job that still completed, no action is needed.
+
 ---
 
 ## Job failed: "Video render failed: TimeoutError()"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.174.11"
+version = "0.174.12"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
Two unrelated production alert-noise fixes, prompted by two false-alarm Discord alerts on 2026-05-24:

- **Encoding worker 503 → WARNING.** A primary-VM warmup hitting `503 SERVICE_UNAVAILABLE` (or capacity exhaustion) is self-healing — the encoding flow's `ensure_any_running()` falls back to an alternate-zone worker and the job completes (verified live on job `a40f3024`). It no longer logs at ERROR, so it stays below the error monitor's `severity>=ERROR` filter and stops paging Discord for a non-incident.
- **E2E daily test result check.** Both stages now derive pass/fail from Playwright's real exit code instead of grepping the log for `"failed"`. The old check matched the word "failed" inside a benign retry warning (`goto attempt 1/3 failed`) and reported failure on a run where the job completed and Playwright printed `1 passed`.

## Changes
- `backend/api/routes/encoding_worker.py` — catch `EncodingWorkerStartError` in `/warmup` and log at WARNING with a clear fallback message; genuine unexpected errors still log at ERROR.
- `.github/workflows/e2e-daily.yml` — capture `${PIPESTATUS[0]}` (the pipe to `tee` was masking Playwright's exit code as 0) and gate the result on it, for both Stage 1 and Stage 2.
- `backend/tests/test_encoding_worker_routes.py` — 3 regression tests: 503 start failure → WARNING, capacity error → WARNING, unexpected error → still ERROR.
- `docs/TROUBLESHOOTING.md` — note that a WARNING-level warmup 503 is benign/self-healing.
- `pyproject.toml` — bump 0.174.11 → 0.174.12.

## Testing
- [x] `pytest backend/tests/test_encoding_worker_routes.py backend/tests/test_encoding_worker_manager.py` — 46 passed
- [x] YAML validated
- [x] CodeRabbit CLI review — 0 findings

## Review
- [x] Local CodeRabbit review completed
- [x] Issues addressed

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)