### PR TITLE
fix(runner-images): bump actions/runner 2.332.0 → 2.334.0 (deprecated, broke ephemeral CI)

### DIFF
--- a/docs/EPHEMERAL-GHA-RUNNERS.md
+++ b/docs/EPHEMERAL-GHA-RUNNERS.md
@@ -394,6 +394,24 @@ Savings realised: ~$220/mo (7×200GB pd-ssd at $32/mo each).
 
 ## Known gotchas
 
+* **A stale baked runner version silently kills every ephemeral runner** (incident
+  2026-05-24). GitHub deprecates older `actions/runner` versions and returns
+  **HTTP 403 on the broker poll** (`"Runner version vX.Y.Z is deprecated and
+  cannot receive messages"`). Ephemeral/JIT runners run with `disableUpdate`, so
+  they CANNOT self-update — the runner registers, gets rejected, the listener
+  exits "no retry needed", and the EXIT-trap halts the VM. Net effect: VMs
+  dispatch and boot fine, but **CI jobs sit `queued` forever** and each leaves a
+  zombie `offline` JIT registration in the org runner list. **Diagnosis:** read a
+  failed VM's `/home/runner/actions-runner/_diag/Runner_*.log` for the 403. (Note:
+  serial console is unavailable once a VM self-halts, so capture logs by setting a
+  dump startup-script and starting the stopped VM.) **Fix:** bump `RUNNER_VERSION`
+  in `infrastructure/scripts/runner-image-provision.sh` (and legacy
+  `compute/startup_scripts/github_runner.sh`) to the current release from
+  <https://github.com/actions/runner/releases/latest>, then re-run
+  `build-runner-images.yml` (workflow_dispatch — runs on GitHub-hosted runners, so
+  it's not blocked by the broken self-hosted ones). The monthly rebuild cron
+  (`0 2 1 * *`) is too slow vs. GitHub's deprecation pace — consider resolving
+  "latest" at build time and/or alerting on deprecation 403s.
 * **Source-bundle replacement doesn't auto-redeploy the Cloud Function** (fixed
   forward, but worth knowing). The original code uploaded a new source bundle
   via `BucketObject` replace, but the `cloudfunctionsv2.Function` resource

--- a/infrastructure/compute/startup_scripts/__init__.py
+++ b/infrastructure/compute/startup_scripts/__init__.py
@@ -22,7 +22,7 @@ def read_script(name: str, **substitutions) -> str:
 
     Example:
         script = read_script("github_runner.sh",
-            RUNNER_VERSION="2.332.0",
+            RUNNER_VERSION="2.334.0",
             RUNNER_LABELS="self-hosted,linux,x64"
         )
     """

--- a/infrastructure/compute/startup_scripts/github_runner.sh
+++ b/infrastructure/compute/startup_scripts/github_runner.sh
@@ -163,7 +163,9 @@ usermod -aG docker runner
 # ==================== GitHub Actions Runner ====================
 # This section ALWAYS runs — it handles version upgrades and re-registration
 echo "Setting up GitHub Actions Runner..."
-RUNNER_VERSION="2.332.0"
+# Keep current with actions/runner releases — GitHub deprecates old versions
+# (HTTP 403 on broker poll). See runner-image-provision.sh for the full note.
+RUNNER_VERSION="2.334.0"
 RUNNER_DIR="/home/runner/actions-runner"
 
 mkdir -p $RUNNER_DIR

--- a/infrastructure/compute/startup_scripts/github_runner_gpu.sh
+++ b/infrastructure/compute/startup_scripts/github_runner_gpu.sh
@@ -229,7 +229,9 @@ useradd -m -s /bin/bash runner 2>/dev/null || true
 # ==================== GitHub Actions Runner ====================
 # This section ALWAYS runs — it handles version upgrades and re-registration
 echo "Setting up GitHub Actions Runner..."
-RUNNER_VERSION="2.332.0"
+# Keep current with actions/runner releases — GitHub deprecates old versions
+# (HTTP 403 on broker poll). See runner-image-provision.sh for the full note.
+RUNNER_VERSION="2.334.0"
 RUNNER_DIR="/home/runner/actions-runner"
 
 mkdir -p $RUNNER_DIR

--- a/infrastructure/scripts/runner-image-provision.sh
+++ b/infrastructure/scripts/runner-image-provision.sh
@@ -384,8 +384,14 @@ chmod 0440 /etc/sudoers.d/runner
 visudo -cf /etc/sudoers.d/runner
 
 # ==================== GitHub Actions runner binary ====================
+# Keep current with actions/runner releases. GitHub deprecates older runner
+# versions and returns HTTP 403 ("deprecated and cannot receive messages") on
+# the broker poll — and ephemeral/JIT runners run with disableUpdate, so they
+# CANNOT self-update. A stale pin silently breaks every ephemeral runner: it
+# registers, gets rejected, and self-halts, leaving CI jobs queued forever.
+# When bumping, check https://github.com/actions/runner/releases/latest.
 ck "phase: github actions runner binary"
-RUNNER_VERSION="2.332.0"
+RUNNER_VERSION="2.334.0"
 RUNNER_DIR="/home/runner/actions-runner"
 mkdir -p "$RUNNER_DIR"
 


### PR DESCRIPTION
## Summary
GitHub deprecated **actions/runner v2.332.0** and now returns **HTTP 403** on the broker poll (`"Runner version v2.332.0 is deprecated and cannot receive messages"`). Ephemeral/JIT runners run with `disableUpdate`, so they **cannot self-update** — each dispatched VM registered, got rejected, exited, and self-halted, leaving CI jobs **queued indefinitely** plus zombie `offline` runner registrations.

Nothing in our code changed; this is GitHub-side deprecation enforcement that hit after the May 17 image build. Root-caused from a failed VM's `_diag/Runner_*.log`.

## Changes
- Bump `RUNNER_VERSION` `2.332.0 → 2.334.0` (current latest) in:
  - `infrastructure/scripts/runner-image-provision.sh` (ephemeral image — the one that matters)
  - `infrastructure/compute/startup_scripts/github_runner.sh` + `github_runner_gpu.sh` (legacy)
  - `infrastructure/compute/startup_scripts/__init__.py` (docstring example)
- Document the failure mode + runbook in `docs/EPHEMERAL-GHA-RUNNERS.md`.

## Why this broke CI
Dispatch + VM boot worked fine, so it looked like the jobs were just "stuck queued." Ruled out (with evidence): label match, runner-group access, Cloud NAT egress, manager env config, dirty runner dir, fresh-image regression, JIT mint. The `_diag` log showed the 403.

## Follow-up (not in this PR)
- Rebuild cadence (`0 2 1 * *`, monthly) is too slow vs. GitHub's deprecation pace — resolve "latest" at build time and/or alert on deprecation 403s.
- Two secondary bugs found: #789's serial-capture can't read self-halted (stopped) VMs; zombie offline JIT registrations make `cleanup_orphans` treat dead VMs as "registered" until the 120-min cap.

## Testing
- [x] No remaining `2.332.0` refs in repo
- [x] CodeRabbit CLI review — 0 findings
- [ ] **Takes effect only after `build-runner-images.yml` rebuild** (runs on GitHub-hosted runners, not blocked)

## Review
- [x] Local CodeRabbit review completed

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)