### PR TITLE
fix(admin): allow regen-screens from in_review state + surface errors via toast

### DIFF
--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -2049,6 +2049,7 @@ REGENERATE_SCREENS_ALLOWED_STATES = {
     "complete",
     "failed",
     "awaiting_review",
+    "in_review",  # User opened the review UI but hasn't submitted yet
     "awaiting_instrumental_selection",
     "instrumental_selected",
     "prep_complete",

--- a/docs/API.md
+++ b/docs/API.md
@@ -1569,7 +1569,7 @@ Regenerates title and end screen videos using the **current** artist/title metad
 
 Requirements:
 - Job must have audio and lyrics processing complete
-- Job must be in an allowed state: `complete`, `failed`, `awaiting_review`, `awaiting_instrumental_selection`, `instrumental_selected`, `prep_complete`
+- Job must be in an allowed state: `complete`, `failed`, `awaiting_review`, `in_review`, `awaiting_instrumental_selection`, `instrumental_selected`, `prep_complete`
 
 The endpoint:
 1. Deletes existing screen files from GCS

--- a/frontend/app/admin/jobs/page.tsx
+++ b/frontend/app/admin/jobs/page.tsx
@@ -464,8 +464,8 @@ function AdminJobsPageContent() {
       loadLogs(selectedJobId)
     } catch (err: any) {
       toast({
-        title: "Error",
-        description: err.message || "Failed to regenerate screens",
+        title: "Screen Regeneration Failed",
+        description: err?.message || "Failed to regenerate screens. Please try again or check the job logs.",
         variant: "destructive",
       })
     } finally {

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -8,6 +8,7 @@ import { ImpersonationBannerWrapper } from "@/components/impersonation-banner-wr
 import { ServiceWorkerRegistration } from "@/components/service-worker-registration"
 import { GoogleAnalytics } from "@/components/google-analytics"
 import ClientErrorInit from "@/components/ClientErrorInit"
+import { Toaster } from "@/components/ui/toaster"
 import "./globals.css"
 
 // AvenirNext Bold - matches the font used in actual Nomad theme title card generation
@@ -53,6 +54,7 @@ export default function RootLayout({
               <ClientErrorInit />
               <ImpersonationBannerWrapper />
               {children}
+              <Toaster />
             </TenantProvider>
           </ThemeProvider>
         </DefaultIntlProvider>

--- a/frontend/components/__tests__/AdminJobActions.test.tsx
+++ b/frontend/components/__tests__/AdminJobActions.test.tsx
@@ -2,9 +2,9 @@
  * Tests for AdminJobActions component
  */
 
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { AdminJobActions } from '../job/AdminJobActions'
-import { Job } from '@/lib/api'
+import { Job, adminApi } from '@/lib/api'
 
 // Mock the API module
 jest.mock('@/lib/api', () => ({
@@ -17,6 +17,14 @@ jest.mock('@/lib/api', () => ({
     deleteJob: jest.fn(),
   }
 }))
+
+// Mock the toast hook so we can assert on what gets shown to the user
+const mockToast = jest.fn()
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}))
+
+const mockAdminApi = adminApi as jest.Mocked<typeof adminApi>
 
 describe('AdminJobActions', () => {
   const mockOnRefresh = jest.fn()
@@ -33,6 +41,12 @@ describe('AdminJobActions', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    // Auto-confirm the native confirm() dialogs the component uses
+    jest.spyOn(window, 'confirm').mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
   })
 
   it('renders all admin action buttons', () => {
@@ -56,6 +70,45 @@ describe('AdminJobActions', () => {
     render(<AdminJobActions job={mockJob} onRefresh={mockOnRefresh} />)
 
     expect(screen.getByText('Reset:')).toBeInTheDocument()
+  })
+
+  it('shows a useful error toast when regenerate screens fails', async () => {
+    mockAdminApi.regenerateScreens.mockRejectedValue(
+      new Error("Cannot regenerate screens for job in 'in_review' state.")
+    )
+
+    render(<AdminJobActions job={mockJob} onRefresh={mockOnRefresh} />)
+    fireEvent.click(screen.getByText('Regen Screens'))
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Regenerate Screens Failed',
+          description: "Cannot regenerate screens for job in 'in_review' state.",
+          variant: 'destructive',
+        })
+      )
+    })
+    // A failed action must not silently report success / refresh
+    expect(mockOnRefresh).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a human-readable error when the failure has no message', async () => {
+    mockAdminApi.regenerateScreens.mockRejectedValue(new Error(''))
+
+    render(<AdminJobActions job={mockJob} onRefresh={mockOnRefresh} />)
+    fireEvent.click(screen.getByText('Regen Screens'))
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Regenerate Screens Failed',
+          variant: 'destructive',
+        })
+      )
+    })
+    const { description } = mockToast.mock.calls[0][0]
+    expect(description).toContain('check the job logs')
   })
 
   it('stops event propagation on click', () => {

--- a/frontend/components/job/AdminJobActions.tsx
+++ b/frontend/components/job/AdminJobActions.tsx
@@ -27,7 +27,8 @@ export function AdminJobActions({ job, onRefresh }: AdminJobActionsProps) {
   async function handleAction(
     actionKey: string,
     action: () => Promise<void>,
-    confirmMessage: string
+    confirmMessage: string,
+    label: string
   ) {
     if (!confirm(confirmMessage)) return
     setLoading(actionKey)
@@ -36,8 +37,8 @@ export function AdminJobActions({ job, onRefresh }: AdminJobActionsProps) {
       onRefresh()
     } catch (error: any) {
       toast({
-        title: "Error",
-        description: error?.message || `Failed to ${actionKey}`,
+        title: `${label} Failed`,
+        description: error?.message || `${label} failed. Please try again or check the job logs.`,
         variant: "destructive",
       })
     } finally {
@@ -49,13 +50,13 @@ export function AdminJobActions({ job, onRefresh }: AdminJobActionsProps) {
     handleAction(`reset-${targetState}`, async () => {
       await adminApi.resetJob(job.job_id, targetState)
       toast({ title: "Job Reset", description: `Reset to ${label}` })
-    }, `Reset this job to "${label}"?`)
+    }, `Reset this job to "${label}"?`, "Job Reset")
 
   const handleDeleteOutputs = () =>
     handleAction("del-outputs", async () => {
       await adminApi.deleteJobOutputs(job.job_id)
       toast({ title: "Outputs Deleted", description: "Distribution files removed" })
-    }, "Delete all output files (YouTube, Dropbox, GDrive)?")
+    }, "Delete all output files (YouTube, Dropbox, GDrive)?", "Delete Outputs")
 
   const handleRegenScreens = () =>
     handleAction("regen-screens", async () => {
@@ -65,7 +66,7 @@ export function AdminJobActions({ job, onRefresh }: AdminJobActionsProps) {
       } else {
         toast({ title: "Regen Failed", description: result.error || result.message, variant: "destructive" })
       }
-    }, "Regenerate title/end screens with current metadata?")
+    }, "Regenerate title/end screens with current metadata?", "Regenerate Screens")
 
   const handleFullRestart = () =>
     handleAction("full-restart", async () => {
@@ -74,7 +75,7 @@ export function AdminJobActions({ job, onRefresh }: AdminJobActionsProps) {
         delete_outputs: true,
       })
       toast({ title: "Job Restarted", description: result.message })
-    }, "Fully restart this job? (preserves audio stems)")
+    }, "Fully restart this job? (preserves audio stems)", "Full Restart")
 
   const handleAudioSearch = () =>
     handleAction("audio-search", async () => {
@@ -82,13 +83,13 @@ export function AdminJobActions({ job, onRefresh }: AdminJobActionsProps) {
         source_type: "audio_search",
       })
       toast({ title: "Audio Source Changed", description: result.message })
-    }, "Switch this job to audio search mode?")
+    }, "Switch this job to audio search mode?", "Audio Source Change")
 
   const handleDeleteJob = () =>
     handleAction("delete", async () => {
       await adminApi.deleteJob(job.job_id)
       toast({ title: "Job Deleted", description: "Job permanently deleted" })
-    }, "Permanently delete this job and all files? This cannot be undone.")
+    }, "Permanently delete this job and all files? This cannot be undone.", "Delete Job")
 
   const isLoading = (key: string) => loading === key
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.174.12"
+version = "0.174.13"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"

--- a/tests/unit/test_regenerate_screens.py
+++ b/tests/unit/test_regenerate_screens.py
@@ -1,0 +1,109 @@
+"""Tests for the admin regenerate-screens endpoint.
+
+Regression coverage for the bug where a job in the `in_review` state (user has
+opened the review UI but not yet submitted) returned 400 from
+POST /api/admin/jobs/{job_id}/regenerate-screens because `in_review` was
+missing from REGENERATE_SCREENS_ALLOWED_STATES.
+"""
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.services.auth_service import AuthResult, UserType
+from backend.api.routes.admin import REGENERATE_SCREENS_ALLOWED_STATES
+
+
+@pytest.fixture
+def admin_auth_result():
+    return AuthResult(
+        is_valid=True,
+        user_type=UserType.ADMIN,
+        remaining_uses=-1,
+        message="Admin access granted",
+        user_email="admin@nomadkaraoke.com",
+        is_admin=True,
+    )
+
+
+def _make_job(status):
+    """A job that satisfies every regenerate-screens precondition except (maybe) status."""
+    job = MagicMock()
+    job.status = status
+    job.artist = "Lin-Manuel Miranda"
+    job.title = "Alexander Hamilton"
+    job.state_data = {
+        "audio_progress": {"stage": "audio_complete"},
+        "lyrics_progress": {"stage": "lyrics_complete"},
+    }
+    return job
+
+
+@pytest.fixture
+def client(admin_auth_result):
+    """Test client with JobManager / StorageService / worker_service mocked.
+
+    The job returned by get_job is configured per-test via
+    mock_job_manager.get_job.return_value.
+    """
+    mock_creds = MagicMock()
+    mock_creds.universe_domain = "googleapis.com"
+
+    mock_job_manager = MagicMock()
+    # firestore.db.collection(...).document(...).update(...) chain
+    mock_job_manager.firestore.db.collection.return_value.document.return_value.update.return_value = None
+
+    mock_storage = MagicMock()
+
+    mock_worker_service = MagicMock()
+    mock_worker_service.trigger_screens_worker = AsyncMock(return_value=True)
+
+    with patch("backend.services.firestore_service.firestore"), \
+         patch("backend.services.storage_service.storage"), \
+         patch("google.auth.default", return_value=(mock_creds, "test-project")), \
+         patch("backend.api.routes.admin.JobManager", return_value=mock_job_manager), \
+         patch("backend.api.routes.admin.StorageService", return_value=mock_storage), \
+         patch("backend.services.worker_service.get_worker_service", return_value=mock_worker_service):
+        from backend.api.routes.admin import router
+        from backend.api.dependencies import require_admin
+
+        app = FastAPI()
+        app.include_router(router, prefix="/api")
+        app.dependency_overrides[require_admin] = lambda: admin_auth_result
+
+        test_client = TestClient(app)
+        test_client.mock_job_manager = mock_job_manager  # expose for per-test config
+        yield test_client
+
+
+class TestRegenerateScreensStateValidation:
+    def test_in_review_is_allowed(self):
+        """Regression: in_review must be an allowed state."""
+        assert "in_review" in REGENERATE_SCREENS_ALLOWED_STATES
+
+    def test_in_review_job_succeeds(self, client):
+        """A job mid-review should regenerate screens instead of returning 400."""
+        client.mock_job_manager.get_job.return_value = _make_job("in_review")
+
+        response = client.post("/api/admin/jobs/8e9df2c1/regenerate-screens")
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["worker_triggered"] is True
+
+    def test_disallowed_state_returns_400(self, client):
+        """A genuinely-invalid state (e.g. mid-rendering) still returns 400."""
+        client.mock_job_manager.get_job.return_value = _make_job("rendering_video")
+
+        response = client.post("/api/admin/jobs/8e9df2c1/regenerate-screens")
+
+        assert response.status_code == 400
+        assert "rendering_video" in response.json()["detail"]
+
+    def test_missing_job_returns_404(self, client):
+        client.mock_job_manager.get_job.return_value = None
+
+        response = client.post("/api/admin/jobs/missing/regenerate-screens")
+
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary
- Fixes a 400 when regenerating title/end screens for a job the user has opened in the review UI (`in_review` state).
- Fixes the root cause behind "click Regenerate Screens → modal just closes, no error": `<Toaster />` was never mounted, so **all** `toast()` calls (success and error) silently no-op'd.

## Changes
- **Backend:** add `in_review` to `REGENERATE_SCREENS_ALLOWED_STATES` in `backend/api/routes/admin.py`. The sibling `/restart` endpoint already allows `in_review`; this restores parity. Updated `docs/API.md`.
- **Frontend:** mount the shadcn `<Toaster />` (same `@/hooks/use-toast` store) in the root `app/layout.tsx` so admin toasts render app-wide.
- **Frontend:** give the regen-screens handlers specific, human-readable failure titles/messages (admin dashboard + compact `AdminJobActions` toolbar).
- Version bump `0.174.12` → `0.174.13`.

## Testing
- [x] Backend: `tests/unit/test_regenerate_screens.py` — allow-list membership, `in_review` → 200, invalid state → 400, missing job → 404 (4 pass).
- [x] Frontend: `AdminJobActions.test.tsx` — error-toast path now covered (5 pass).
- [x] CodeRabbit CLI review: 0 findings.
- [x] Typecheck: no new errors from these changes (pre-existing errors unrelated).

## Review
- [x] CodeRabbit CLI review completed locally
- [x] Issues addressed

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)