### PR TITLE
fix(lyrics): prevent over-long lines overlapping the slot below in rendered video

### DIFF
--- a/karaoke_gen/lyrics_transcriber/output/segment_resizer.py
+++ b/karaoke_gen/lyrics_transcriber/output/segment_resizer.py
@@ -191,10 +191,39 @@ class SegmentResizer:
                 segments.append(self._create_segment_from_words(line, line_words, singer=singer))
                 current_pos += len(line) + 1  # +1 for the space between lines
 
-        # If we have any remaining words, create a final segment with them
+        # If we have any remaining words (word-to-line matching desynced — e.g. a
+        # punctuation mark attached to a word token straddled a split boundary),
+        # pack them into lines that still respect max_line_length instead of one
+        # unbounded segment. An over-length line wraps at render time and overlaps
+        # the slot below it, so the length guarantee must hold here too.
         if words_to_process:
-            remaining_text = " ".join(self._clean_text(w.text) for w in words_to_process)
-            segments.append(self._create_segment_from_words(remaining_text, words_to_process, singer=singer))
+            segments.extend(self._pack_words_into_lines(words_to_process, singer=singer))
+
+        return segments
+
+    def _pack_words_into_lines(self, words: List[Word], singer: Optional[int] = None) -> List[LyricsSegment]:
+        """Greedily group words into segments no longer than max_line_length.
+
+        Works directly on word tokens (not re-matched text) so it cannot desync.
+        A single word longer than the limit is emitted on its own line.
+        """
+        segments: List[LyricsSegment] = []
+        current_words: List[Word] = []
+        current_text = ""
+
+        for word in words:
+            word_text = self._clean_text(word.text)
+            candidate = f"{current_text} {word_text}".strip() if current_text else word_text
+            if current_words and len(candidate) > self.max_line_length:
+                segments.append(self._create_segment_from_words(current_text, current_words, singer=singer))
+                current_words = [word]
+                current_text = word_text
+            else:
+                current_words.append(word)
+                current_text = candidate
+
+        if current_words:
+            segments.append(self._create_segment_from_words(current_text, current_words, singer=singer))
 
         return segments
 
@@ -398,9 +427,13 @@ class SegmentResizer:
 
         # Priority 2: Major clause breaks (semicolons, dashes)
         major_breaks = []
-        for punct in [";", " - "]:
-            for match in re.finditer(re.escape(punct), line):
-                major_breaks.append(match.start())  # Position before the punctuation
+        # A semicolon is attached to the preceding word token (e.g. "around;"),
+        # so break *after* it — otherwise the split line ends with "around" while
+        # the word is "around;", desyncing word-to-line matching downstream.
+        for match in re.finditer(re.escape(";"), line):
+            major_breaks.append(match.start() + 1)  # Position after the semicolon
+        for match in re.finditer(re.escape(" - "), line):
+            major_breaks.append(match.start())  # Position before the dash
         break_points.append(major_breaks)
 
         # Priority 3: Comma breaks, typically marking natural pauses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.174.13"
+version = "0.174.14"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"

--- a/tests/unit/lyrics_transcriber/output/test_segment_resizer_line_length.py
+++ b/tests/unit/lyrics_transcriber/output/test_segment_resizer_line_length.py
@@ -1,0 +1,96 @@
+"""Regression tests: SegmentResizer must never emit a line longer than
+``max_line_length``.
+
+Bug (job 5c631108): the segment
+
+    Well the word got around; they said "Steph, she's the real one,"
+
+was split correctly by ``_process_segment_text`` into three short lines, but
+``_create_segments_from_lines`` re-assigns Word objects to those lines via
+substring matching. The break point for ``;`` was placed *before* the
+semicolon, so the line ended with ``...around`` while the word token was
+``around;``. The substring match (``"around;" in "...around"``) failed, the
+matcher gave up, and every remaining word fell into the unbounded catch-all
+branch — producing a single 46-char line. At 4K that line is too wide, so
+libass wraps it onto a second physical row that overlaps the slot below
+(two lines of lyrics rendered on top of each other).
+"""
+import logging
+
+from karaoke_gen.lyrics_transcriber.output.segment_resizer import SegmentResizer
+from karaoke_gen.lyrics_transcriber.types import LyricsSegment, Word
+
+
+def _segment_from_text(text: str, words_text=None) -> LyricsSegment:
+    words_text = words_text or text.split()
+    words = []
+    t = 0.0
+    for i, w in enumerate(words_text):
+        words.append(Word(id=f"w{i}", text=w, start_time=t, end_time=t + 0.3))
+        t += 0.35
+    return LyricsSegment(id="s", text=text, words=words, start_time=0.0, end_time=t)
+
+
+def test_semicolon_segment_never_exceeds_max_line_length():
+    resizer = SegmentResizer(max_line_length=36, logger=logging.getLogger("test"))
+    seg = _segment_from_text(
+        'Well the word got around; they said "Steph, she\'s the real one,"',
+        words_text=["Well", "the", "word", "got", "around;", "they", "said", '"Steph,', "she's", "the", "real", "one,\""],
+    )
+
+    result = resizer.resize_segments([seg])
+
+    # A single word longer than the limit is allowed on its own line (it cannot be
+    # split further); only multi-word lines must respect max_line_length.
+    too_long = [s.text for s in result if len(s.text) > resizer.max_line_length and len(s.words) > 1]
+    assert not too_long, f"Lines exceeding {resizer.max_line_length} chars: {too_long}"
+
+
+def test_dash_segment_never_exceeds_max_line_length():
+    """The word-assignment desync is a class of bug, not specific to ';'. A
+    space-dash-space clause break attaches the dash to the preceding word token
+    ('around -'), so any character-position split orphans it and dumps the rest
+    into the catch-all. The catch-all must still respect max_line_length."""
+    resizer = SegmentResizer(max_line_length=36, logger=logging.getLogger("test"))
+    seg = _segment_from_text(
+        'Well the word got around - they said "Steph, she\'s the real one,"',
+        words_text=["Well", "the", "word", "got", "around -", "they", "said", '"Steph,', "she's", "the", "real", "one,\""],
+    )
+
+    result = resizer.resize_segments([seg])
+
+    # A single word longer than the limit is allowed on its own line (it cannot be
+    # split further); only multi-word lines must respect max_line_length.
+    too_long = [s.text for s in result if len(s.text) > resizer.max_line_length and len(s.words) > 1]
+    assert not too_long, f"Lines exceeding {resizer.max_line_length} chars: {too_long}"
+
+
+def test_single_word_longer_than_limit_is_emitted_alone():
+    """A word that is itself longer than max_line_length cannot be split, so it is
+    emitted on its own line. This is the one allowed way to exceed the limit."""
+    resizer = SegmentResizer(max_line_length=10, logger=logging.getLogger("test"))
+    seg = _segment_from_text(
+        "supercalifragilisticexpialidocious is long",
+        words_text=["supercalifragilisticexpialidocious", "is", "long"],
+    )
+
+    result = resizer.resize_segments([seg])
+
+    over = [s for s in result if len(s.text) > resizer.max_line_length]
+    assert len(over) == 1
+    assert over[0].text == "supercalifragilisticexpialidocious"
+    assert len(over[0].words) == 1
+
+
+def test_split_preserves_all_words_in_order():
+    resizer = SegmentResizer(max_line_length=36, logger=logging.getLogger("test"))
+    original_words = ["Well", "the", "word", "got", "around;", "they", "said", '"Steph,', "she's", "the", "real", "one,\""]
+    seg = _segment_from_text(
+        'Well the word got around; they said "Steph, she\'s the real one,"',
+        words_text=original_words,
+    )
+
+    result = resizer.resize_segments([seg])
+
+    out_words = [w.text for s in result for w in s.words]
+    assert out_words == original_words, f"Words lost/reordered: {out_words}"


### PR DESCRIPTION
## Summary
- Fixes overlapping lyric lines in rendered karaoke videos (preview and final 4K).
- Root cause: `SegmentResizer` could emit a line longer than `max_line_length`, which **libass word-wraps onto a second physical row at render time**, colliding with the lyric line in the slot below (two lines drawn on top of each other).
- This lives in the shared `lyrics_transcriber` package, so it fixes the overlap for **all jobs**, not just the one reported.

## Root cause
In `_create_segments_from_lines`, word objects are re-assigned to the splitter's lines via fragile substring matching. A `;` break was positioned *before* the semicolon, so the line ended with `around` while the word token was `around;`; the match failed and every remaining word fell into an **unbounded catch-all** that joined them into one over-long line. Space-dash-space (` - `) breaks orphaned the dash the same way.

## Changes
- `;` break now splits **after** the semicolon, keeping it attached to its word token (also reads better).
- The catch-all now **greedily packs leftover words into ≤ `max_line_length` lines** instead of one unbounded segment — a length guarantee that holds regardless of which punctuation desyncs word-to-line matching.
- Added regression tests (`test_segment_resizer_line_length.py`): semicolon case, dash case, single-long-word edge case, word-order preservation.

## Testing
- [x] New regression tests pass; full backend unit suite green (the only failures are pre-existing `audio-separator`-not-installed env errors, unrelated to this change).
- [x] Verified against job `5c631108` + all 22 saved review sessions: over-length output lines → **0**, no word loss/reorder.
- [x] Re-rendered the 4K overlap moment locally — confirmed the collision is gone.

## Review
- [x] Local CodeRabbit CLI review completed; 1 minor finding addressed.

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)