### PR TITLE
fix(review): serve preview video via signed GCS URL redirect (Cloud Run 32 MiB limit)

### DIFF
--- a/backend/api/routes/review.py
+++ b/backend/api/routes/review.py
@@ -22,8 +22,7 @@ from pathlib import Path
 from typing import Dict, Any, List, Optional, Set, Tuple
 
 from fastapi import APIRouter, HTTPException, Request, Depends, Form, File, UploadFile
-from fastapi.responses import FileResponse, RedirectResponse, StreamingResponse
-from starlette.background import BackgroundTask
+from fastapi.responses import RedirectResponse
 
 from backend.models.job import JobStatus
 from backend.models.review_session import ReviewSession, ReviewSessionSummary
@@ -1125,9 +1124,19 @@ async def get_preview_video(
     preview_hash: str,
     auth_info: Tuple[str, str] = Depends(require_review_auth)
 ):
-    """Stream the generated preview video."""
+    """Serve the generated preview video via a signed GCS URL redirect.
+
+    We redirect to a signed URL rather than proxying the bytes through Cloud
+    Run because Cloud Run caps response bodies at 32 MiB. Long songs (e.g. a
+    30+ minute mashup) produce a 360p preview larger than that, which the proxy
+    path truncated mid-stream — the response started as 206 but the client
+    received a 500, so the browser reported "no supported format". The signed
+    URL lets the browser fetch the mp4 directly from GCS (with byte-range
+    support intact), bypassing the limit entirely. Mirrors the audio-review
+    endpoint above.
+    """
     storage = StorageService()
-    
+
     # Check in-memory cache first
     preview_gcs_path = None
     if job_id in _preview_videos and preview_hash in _preview_videos[job_id]:
@@ -1137,30 +1146,14 @@ async def get_preview_video(
         preview_gcs_path = f"jobs/{job_id}/previews/{preview_hash}.mp4"
         if not storage.file_exists(preview_gcs_path):
             raise HTTPException(status_code=404, detail=t("en", "review.previewVideoNotFound"))
-    
+
     try:
-        # Download to temp file and stream
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".mp4") as tmp:
-            tmp_path = tmp.name
-        
-        storage.download_file(preview_gcs_path, tmp_path)
-        
-        logger.info(f"Job {job_id}: Streaming preview video {preview_hash}")
-        
-        return FileResponse(
-            tmp_path,
-            media_type="video/mp4",
-            filename=f"preview_{preview_hash}.mp4",
-            headers={
-                "Accept-Ranges": "bytes",
-                "Content-Disposition": "inline",
-                "Cache-Control": "no-cache",
-            },
-            background=BackgroundTask(os.unlink, tmp_path),
-        )
-        
+        signed_url = storage.generate_signed_url(preview_gcs_path, expiration_minutes=120)
+        logger.info(f"Job {job_id}: Redirecting to signed URL for preview video {preview_hash}")
+        return RedirectResponse(url=signed_url, status_code=302)
+
     except Exception as e:
-        logger.error(f"Job {job_id}: Error streaming preview video: {e}", exc_info=True)
+        logger.error(f"Job {job_id}: Error serving preview video: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=t("en", "review.previewVideoStreamError", error=str(e)))
 
 

--- a/backend/tests/test_routes_review.py
+++ b/backend/tests/test_routes_review.py
@@ -1046,3 +1046,51 @@ class TestPreviewVideoDuetFlag:
                 asyncio.run(_run())
             assert exc_info.value.status_code == 400
             assert "is_duet" in exc_info.value.detail
+
+
+class TestGetPreviewVideoRedirect:
+    """get_preview_video must redirect to a signed GCS URL, not proxy the bytes.
+
+    Cloud Run caps response bodies at 32 MiB. A long song's 360p preview exceeds
+    that, so streaming it through Cloud Run (the old FileResponse path) truncated
+    mid-stream — the response started 206 but the client got a 500, and the
+    browser reported "no supported format". Serving a 302 to a signed URL lets
+    the browser fetch the mp4 directly from GCS, bypassing the limit.
+    """
+
+    def _call(self, mock_storage, job_id="job-x", preview_hash="abc123"):
+        import asyncio
+        from backend.api.routes.review import get_preview_video, _preview_videos
+        _preview_videos.clear()  # force the standard-path / file_exists branch
+        with patch("backend.api.routes.review.StorageService", return_value=mock_storage):
+            return asyncio.run(get_preview_video(
+                job_id=job_id,
+                preview_hash=preview_hash,
+                auth_info=("user@test.com", "job_owner"),
+            ))
+
+    def test_returns_302_redirect_to_signed_url(self):
+        from starlette.responses import RedirectResponse
+        mock_storage = MagicMock()
+        mock_storage.file_exists.return_value = True
+        mock_storage.generate_signed_url.return_value = "https://signed.example/preview.mp4?sig=xyz"
+
+        resp = self._call(mock_storage)
+
+        assert isinstance(resp, RedirectResponse)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "https://signed.example/preview.mp4?sig=xyz"
+        # Signed URL must be generated for the preview GCS object — never proxied.
+        mock_storage.generate_signed_url.assert_called_once()
+        assert mock_storage.generate_signed_url.call_args[0][0] == "jobs/job-x/previews/abc123.mp4"
+        mock_storage.download_file.assert_not_called()
+
+    def test_returns_404_when_preview_missing(self):
+        from fastapi import HTTPException
+        mock_storage = MagicMock()
+        mock_storage.file_exists.return_value = False
+
+        with pytest.raises(HTTPException) as exc_info:
+            self._call(mock_storage)
+        assert exc_info.value.status_code == 404
+        mock_storage.generate_signed_url.assert_not_called()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.174.14"
+version = "0.174.15"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
The preview-video endpoint failed for long songs because the 360p preview exceeds Cloud Run's 32 MiB response-body limit. Surfaced while testing the recovered job `9a12cf0f` (a 32-minute mashup whose preview is **32.4 MiB**): the modal showed *"No video with supported format and MIME type found."*

## Root cause
`get_preview_video` downloaded the mp4 and streamed it **through Cloud Run** via `FileResponse`. For short songs previews are a few MB, but this preview was >32 MiB, so Cloud Run truncated the response — uvicorn logged `206` while the client received a `500` (confirmed in LB logs). The browser got a broken body and couldn't decode it.

## Fix
Return a **302 redirect to a signed GCS URL** (matching the existing audio-review endpoint at `review.py:372`), so the browser fetches the mp4 directly from GCS with byte-range support intact — Cloud Run's body limit never applies. Also removes the now-unused `FileResponse`/`BackgroundTask` imports.

## Testing
- [x] Backend suite: **3186 passed, 36 skipped**
- [x] New tests: `TestGetPreviewVideoRedirect` (302 → signed URL, never proxies; 404 when missing)
- [x] Verified the deployed mp4 for `9a12cf0f` is valid (h264/aac, 480x270) — the file was always fine; only the delivery path was broken.

## Review
- [x] CodeRabbit CLI review completed locally (0 findings)

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)