### PR TITLE
fix(storage): treat missing GCS object as no-op on best-effort deletes

### DIFF
--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -2132,7 +2132,7 @@ async def regenerate_screens(
         ]
         for path in screen_paths:
             try:
-                storage.delete_file(path)
+                storage.delete_file(path, ignore_missing=True)
             except Exception:
                 pass  # File may not exist
         screens_deleted = True
@@ -2287,16 +2287,16 @@ async def restart_job(
         for screen_file in ["title.mov", "title.jpg", "title.png", "end.mov", "end.jpg", "end.png"]:
             try:
                 path = f"jobs/{job_id}/screens/{screen_file}"
-                storage.delete_file(path)
-                deleted_paths.append(path)
+                if storage.delete_file(path, ignore_missing=True):
+                    deleted_paths.append(path)
             except Exception:
                 pass
         # Delete final outputs
         for output_file in ["final_4k.mp4", "final_720p.mp4", "with_vocals.mkv", "preview.mp4"]:
             try:
                 path = f"jobs/{job_id}/output/{output_file}"
-                storage.delete_file(path)
-                deleted_paths.append(path)
+                if storage.delete_file(path, ignore_missing=True):
+                    deleted_paths.append(path)
             except Exception:
                 pass
 

--- a/backend/services/job_manager.py
+++ b/backend/services/job_manager.py
@@ -338,7 +338,9 @@ class JobManager:
         if delete_files and job and job.output_files:
             for gcs_path in job.output_files.values():
                 try:
-                    self.storage.delete_file(gcs_path)
+                    # ignore_missing: a job being deleted whose recorded file is
+                    # already gone is not an error, just skip it quietly.
+                    self.storage.delete_file(gcs_path, ignore_missing=True)
                 except Exception as e:
                     logger.error(f"Error deleting file {gcs_path}: {e}")
 

--- a/backend/services/storage_service.py
+++ b/backend/services/storage_service.py
@@ -7,6 +7,7 @@ import json
 from typing import Optional, BinaryIO, Any, Dict
 from pathlib import Path
 from google.cloud import storage
+from google.cloud.exceptions import NotFound
 from datetime import timedelta
 
 from backend.config import settings
@@ -123,12 +124,31 @@ class StorageService:
             logger.error(f"Error generating signed {method} URL for {blob_path}: {e}")
             raise
     
-    def delete_file(self, blob_path: str) -> None:
-        """Delete a file from GCS."""
+    def delete_file(self, blob_path: str, ignore_missing: bool = False) -> bool:
+        """Delete a file from GCS.
+
+        Args:
+            blob_path: Path of the object to delete.
+            ignore_missing: If True, a missing object (404 NotFound) is treated as a
+                successful no-op and logged at debug level instead of error. Use for
+                best-effort deletes over a template of possible paths (e.g. job
+                restart/regen) where many files legitimately never existed.
+
+        Returns:
+            True if an object was actually deleted, False if it was already absent
+            (only possible when ignore_missing=True; otherwise a missing object raises).
+        """
         try:
             blob = self.bucket.blob(blob_path)
             blob.delete()
             logger.info(f"Deleted gs://{settings.gcs_bucket_name}/{blob_path}")
+            return True
+        except NotFound:
+            if ignore_missing:
+                logger.debug(f"File already absent, skipping delete: {blob_path}")
+                return False
+            logger.error(f"Error deleting file {blob_path}: 404 object not found")
+            raise
         except Exception as e:
             logger.error(f"Error deleting file {blob_path}: {e}")
             raise

--- a/backend/tests/test_storage_service.py
+++ b/backend/tests/test_storage_service.py
@@ -221,11 +221,54 @@ class TestStorageServiceDelete:
         mock_client_class.return_value = mock_client
         
         service = StorageService()
-        service.delete_file("uploads/job123/file.flac")
-        
+        result = service.delete_file("uploads/job123/file.flac")
+
         mock_bucket.blob.assert_called_once_with("uploads/job123/file.flac")
         mock_blob.delete.assert_called_once()
-    
+        assert result is True
+
+    @patch("backend.services.storage_service.storage.Client")
+    @patch("backend.services.storage_service.settings")
+    def test_delete_file_missing_raises_by_default(self, mock_settings, mock_client_class):
+        """A 404 on delete raises when ignore_missing is not set (default)."""
+        from google.cloud.exceptions import NotFound
+
+        mock_settings.google_cloud_project = "test-project"
+        mock_settings.gcs_bucket_name = "test-bucket"
+
+        mock_blob = Mock()
+        mock_blob.delete.side_effect = NotFound("No such object")
+        mock_bucket = Mock()
+        mock_bucket.blob.return_value = mock_blob
+        mock_client = Mock()
+        mock_client.bucket.return_value = mock_bucket
+        mock_client_class.return_value = mock_client
+
+        service = StorageService()
+        with pytest.raises(NotFound):
+            service.delete_file("jobs/abc/screens/title.mov")
+
+    @patch("backend.services.storage_service.storage.Client")
+    @patch("backend.services.storage_service.settings")
+    def test_delete_file_missing_ignored(self, mock_settings, mock_client_class):
+        """With ignore_missing=True, a 404 is a no-op returning False (no raise)."""
+        from google.cloud.exceptions import NotFound
+
+        mock_settings.google_cloud_project = "test-project"
+        mock_settings.gcs_bucket_name = "test-bucket"
+
+        mock_blob = Mock()
+        mock_blob.delete.side_effect = NotFound("No such object")
+        mock_bucket = Mock()
+        mock_bucket.blob.return_value = mock_blob
+        mock_client = Mock()
+        mock_client.bucket.return_value = mock_bucket
+        mock_client_class.return_value = mock_client
+
+        service = StorageService()
+        result = service.delete_file("jobs/abc/screens/title.mov", ignore_missing=True)
+        assert result is False
+
     @patch("backend.services.storage_service.storage.Client")
     @patch("backend.services.storage_service.settings")
     def test_delete_folder(self, mock_settings, mock_client_class):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.174.15"
+version = "0.174.16"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Recurring production error-monitor alerts — five sibling patterns of the form
`Error deleting file <path>: 404 DELETE ... No such object` (one each for
`.mov`, `.mp4`, `.png`, `.jpg`, `.mkv`) — were traced to routine **admin actions**, not a real failure.

The admin **Restart Job** (`admin.py`) and **Regenerate Screens** (`admin.py`) endpoints
speculatively delete a *hardcoded template* of every possible output path
(`screens/title.mov`, `screens/title.png`, `output/final_4k.mp4`, `output/with_vocals.mkv`, …)
before re-running a job. Any given job only produces a **subset** of those (e.g. a static
title screen has no `title.mov`; a 720p-only render has no `final_4k.mp4`), so the absent
variants return 404.

`StorageService.delete_file()` logged those 404s at **ERROR severity before re-raising** —
even though the callers already wrapped each call in `try/except: pass` with a
`# File may not exist` comment. The ERROR log line is what the error monitor ingested,
generating noise tied to every admin restart/regen.

Confirmed against the most recent occurrence: job `8e9df2c1` shows
"Admin … triggered screen regeneration" at 16:58, and the `.mov` 404 was last logged at 17:01.

## Changes

- `StorageService.delete_file(blob_path, ignore_missing=False)`: when `ignore_missing=True`,
  a `NotFound` (404) is treated as a successful no-op — logged at `debug`, returns `False`
  (vs `True` when an object was actually deleted). Default behaviour is **unchanged**: a
  genuine unexpected 404 still logs `ERROR` and raises.
- Wired `ignore_missing=True` into the three best-effort callers:
  - admin **Restart Job** output/screen cleanup (now only reports paths actually deleted)
  - admin **Regenerate Screens** cleanup
  - `JobManager.delete_job()` output-file cleanup
- Added unit tests: returns `True` on real delete, raises on 404 by default, returns `False`
  (no raise) on 404 when `ignore_missing=True`.

## Testing

- `test_storage_service.py`: 19 passed (incl. 3 new)
- `test_job_manager.py` + `test_credit_enforcement.py`: 69 passed
- All admin/restart/regen suites: 218 passed, 6 skipped (emulator-only)
- CodeRabbit (uncommitted): 0 findings

## Impact

Cosmetic / operational — deletions already succeeded and jobs regen fine; this removes the
recurring false-positive ERROR logs at the source. No behaviour change for genuine errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@coderabbitai ignore
