### PR TITLE
feat(lyrics-review): show song artist + title in header

### DIFF
--- a/frontend/app/[locale]/app/jobs/[[...slug]]/client.tsx
+++ b/frontend/app/[locale]/app/jobs/[[...slug]]/client.tsx
@@ -387,6 +387,11 @@ function LyricsReviewWrapper({ job, isLocalMode = false }: { job: Job; isLocalMo
               style={{ height: 40 }}
             />
             <h1 className="text-lg font-bold">Lyrics Transcription Review</h1>
+            {(job.artist || job.title) && (
+              <span className="text-xs md:text-sm text-muted-foreground truncate">
+                {job.artist} {job.artist && job.title ? "-" : ""} {job.title}
+              </span>
+            )}
           </div>
           <ThemeToggle />
         </div>

--- a/frontend/app/[locale]/app/jobs/[[...slug]]/client.tsx
+++ b/frontend/app/[locale]/app/jobs/[[...slug]]/client.tsx
@@ -389,7 +389,7 @@ function LyricsReviewWrapper({ job, isLocalMode = false }: { job: Job; isLocalMo
             <h1 className="text-lg font-bold">Lyrics Transcription Review</h1>
             {(job.artist || job.title) && (
               <span className="text-xs md:text-sm text-muted-foreground truncate">
-                {job.artist} {job.artist && job.title ? "-" : ""} {job.title}
+                {[job.artist, job.title].filter(Boolean).join(" - ")}
               </span>
             )}
           </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.175.1"
+version = "0.175.2"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

The Lyrics Transcription Review header showed only the static title "Lyrics Transcription Review". The Instrumental Review header already displays the song (artist + title). This adds the same song display to the lyrics review header so reviewers can see which song they're working on at a glance.

## Changes

- `frontend/app/[locale]/app/jobs/[[...slug]]/client.tsx`: render `artist - title` (from the existing `job` prop) next to the header title, mirroring the Instrumental Review pattern (`InstrumentalSelector.tsx`). Uses `[job.artist, job.title].filter(Boolean).join(" - ")` so it degrades cleanly when a field is missing, with `truncate` to protect the layout.
- `pyproject.toml`: version bump 0.175.1 → 0.175.2.

## Testing

- ESLint clean on the changed file.
- `tsc` reports no new errors (the 39 pre-existing errors are all in unrelated files).
- No new user-facing strings — only renders existing `job` data — so no i18n/translation changes (won't trip CI's locale-completeness check).
- CodeRabbit reviewed locally (1 minor finding, fixed: cleaner artist/title join).

## Notes

Display-only, low-risk change. No existing test covers either review header's artist/title display (the instrumental review precedent has none either); a meaningful test would require mocking the full lyrics data-loading lifecycle, so none was added.

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)