### PR TITLE
feat(downloads): route all URLs through flacfetch; remove Cloud Run yt-dlp

### DIFF
--- a/backend/api/routes/file_upload.py
+++ b/backend/api/routes/file_upload.py
@@ -10,12 +10,11 @@ Supports two upload flows:
    - Client uploads files directly to GCS using signed URLs (no size limit)
    - POST /api/jobs/{job_id}/uploads-complete - Validates uploads, triggers workers
 """
-import asyncio
 import json
 import logging
 import tempfile
 import os
-from fastapi import APIRouter, UploadFile, File, Form, HTTPException, BackgroundTasks, Request, Body, Depends
+from fastapi import APIRouter, UploadFile, File, Form, HTTPException, BackgroundTasks, Request, Depends
 from pathlib import Path
 from typing import Optional, List, Dict, Any, Tuple
 
@@ -336,16 +335,6 @@ def extract_request_metadata(request: Request, created_from: str = "upload", aut
 ALLOWED_AUDIO_EXTENSIONS = {'.mp3', '.wav', '.flac', '.m4a', '.ogg', '.aac'}
 ALLOWED_IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp'}
 ALLOWED_FONT_EXTENSIONS = {'.ttf', '.otf', '.woff', '.woff2'}
-
-
-async def _trigger_audio_worker_only(job_id: str) -> None:
-    """
-    Trigger only the audio worker.
-
-    Used for URL jobs where audio needs to be downloaded first.
-    The audio worker will trigger the lyrics worker after download completes.
-    """
-    await worker_service.trigger_audio_worker(job_id)
 
 
 def _prepare_theme_for_job(
@@ -1784,55 +1773,47 @@ async def create_job_from_url(
         if title:
             logger.info(f"  Title: {title}")
 
-        # For YouTube URLs, download audio NOW using YouTubeDownloadService
-        # This uses remote flacfetch (if configured) to avoid bot detection on Cloud Run
-        if _is_youtube_url(body.url):
-            logger.info(f"YouTube URL detected, downloading via YouTubeDownloadService")
-            try:
-                youtube_service = get_youtube_download_service()
-                audio_gcs_path = await youtube_service.download(
-                    url=body.url,
-                    job_id=job_id,
-                    artist=artist,
-                    title=title,
-                )
-
-                # Update job with the downloaded audio path
-                job_manager.update_job(job_id, {
-                    'input_media_gcs_path': audio_gcs_path,
-                    'filename': os.path.basename(audio_gcs_path),
-                })
-
-                logger.info(f"YouTube audio downloaded to GCS: {audio_gcs_path}")
-
-                # Use centralized start_job_processing which handles:
-                # 1. Validates job exists and has input_media_gcs_path
-                # 2. Transitions PENDING → DOWNLOADING (raises if invalid)
-                # 3. Triggers audio + lyrics workers in parallel
-                background_tasks.add_task(
-                    job_manager.start_job_processing,
-                    job_id,
-                    10,  # progress
-                    "Audio downloaded, starting processing"
-                )
-
-            except YouTubeDownloadError as e:
-                logger.error(f"YouTube download failed: {e}")
-                job_manager.fail_job(job_id, f"YouTube download failed: {e}")
-                raise HTTPException(
-                    status_code=500,
-                    detail=t(locale, "audioSearch.youtubeDownloadError", error=str(e))
-                )
-        else:
-            # For non-YouTube URLs, transition to DOWNLOADING and trigger audio worker
-            # The audio worker will download the URL and trigger lyrics worker after
-            job_manager.transition_to_state(
+        # Download audio NOW via the flacfetch service for ALL URLs (YouTube and
+        # any other yt-dlp-supported site, e.g. Facebook/SoundCloud/TikTok).
+        # flacfetch is the sole downloader — no yt-dlp ever runs on Cloud Run.
+        # Downloading up front (before the GPU worker starts) also keeps the GPU
+        # idle until the audio is in GCS.
+        logger.info(f"Downloading audio from URL via flacfetch: {body.url}")
+        try:
+            download_service = get_youtube_download_service()
+            audio_gcs_path = await download_service.download(
+                url=body.url,
                 job_id=job_id,
-                new_status=JobStatus.DOWNLOADING,
-                progress=5,
-                message="Starting audio download from URL"
+                artist=artist,
+                title=title,
             )
-            background_tasks.add_task(_trigger_audio_worker_only, job_id)
+
+            # Update job with the downloaded audio path
+            job_manager.update_job(job_id, {
+                'input_media_gcs_path': audio_gcs_path,
+                'filename': os.path.basename(audio_gcs_path),
+            })
+
+            logger.info(f"Audio downloaded to GCS: {audio_gcs_path}")
+
+            # Use centralized start_job_processing which handles:
+            # 1. Validates job exists and has input_media_gcs_path
+            # 2. Transitions PENDING → DOWNLOADING (raises if invalid)
+            # 3. Triggers audio + lyrics workers in parallel
+            background_tasks.add_task(
+                job_manager.start_job_processing,
+                job_id,
+                10,  # progress
+                "Audio downloaded, starting processing"
+            )
+
+        except YouTubeDownloadError as e:
+            logger.error(f"URL download failed: {e}")
+            job_manager.fail_job(job_id, f"Download failed: {e}")
+            raise HTTPException(
+                status_code=500,
+                detail=t(locale, "audioSearch.youtubeDownloadError", error=str(e))
+            )
 
         return CreateJobFromUrlResponse(
             status="success",

--- a/backend/services/youtube_download_service.py
+++ b/backend/services/youtube_download_service.py
@@ -13,16 +13,11 @@ The flow is:
 All entry points (audio search selection, direct URL submission) should use this
 service for YouTube downloads to ensure consistent behavior.
 """
-import asyncio
 import logging
-import mimetypes
-import os
 import re
-import tempfile
 from typing import Optional
 
 from .flacfetch_client import get_flacfetch_client, FlacfetchServiceError
-from .storage_service import StorageService
 
 logger = logging.getLogger(__name__)
 
@@ -54,14 +49,13 @@ class YouTubeDownloadService:
 
     def __init__(self):
         self._flacfetch_client = get_flacfetch_client()
-        self._storage_service = StorageService()
 
         if self._flacfetch_client:
-            logger.info("YouTubeDownloadService using REMOTE flacfetch (recommended)")
+            logger.info("YouTubeDownloadService using REMOTE flacfetch")
         else:
             logger.warning(
-                "YouTubeDownloadService using LOCAL yt_dlp - "
-                "downloads may fail due to YouTube bot detection on Cloud Run IPs"
+                "YouTubeDownloadService: remote flacfetch NOT configured "
+                "(FLACFETCH_API_URL) - URL downloads will fail until it is set"
             )
 
     def is_remote_enabled(self) -> bool:
@@ -121,20 +115,24 @@ class YouTubeDownloadService:
         Raises:
             YouTubeDownloadError: If download fails
         """
-        video_id = self._extract_video_id(url)
-        if not video_id:
-            raise YouTubeDownloadError(f"Could not extract video ID from URL: {url}")
-
-        logger.info(f"YouTube download: video_id={video_id}, job_id={job_id}")
-
-        if self._flacfetch_client:
-            return await self._download_remote(video_id, job_id, artist, title)
-        else:
-            logger.warning(
-                "Remote flacfetch not configured. Attempting local download, "
-                "but this may fail due to YouTube bot detection on Cloud Run IPs."
+        # flacfetch is the SOLE downloader — never run yt-dlp on Cloud Run.
+        # If it isn't configured, fail loudly rather than silently falling back
+        # to a local download (which is blocked by bot detection on Cloud Run
+        # IPs anyway).
+        if not self._flacfetch_client:
+            raise YouTubeDownloadError(
+                "Remote flacfetch is not configured (FLACFETCH_API_URL). "
+                "URL downloads require the flacfetch service."
             )
-            return await self._download_local(url, job_id, artist, title)
+
+        video_id = self._extract_video_id(url)
+        if video_id:
+            logger.info(f"URL download (YouTube): video_id={video_id}, job_id={job_id}")
+            return await self._download_remote(video_id, job_id, artist, title)
+
+        # Any other yt-dlp-supported site (Facebook, SoundCloud, TikTok, ...).
+        logger.info(f"URL download (generic): url={url}, job_id={job_id}")
+        return await self._download_remote_url(url, job_id, artist, title)
 
     async def download_by_id(
         self,
@@ -265,7 +263,7 @@ class YouTubeDownloadService:
             logger.error(f"Remote YouTube download error: {e}", exc_info=True)
             raise YouTubeDownloadError(f"Remote download failed: {e}") from e
 
-    async def _download_local(
+    async def _download_remote_url(
         self,
         url: str,
         job_id: str,
@@ -273,92 +271,66 @@ class YouTubeDownloadService:
         title: Optional[str] = None,
     ) -> str:
         """
-        Download using local yt_dlp (fallback when remote not configured).
+        Download an arbitrary yt-dlp-supported URL via remote flacfetch.
 
-        Warning: This may fail on Cloud Run due to YouTube bot detection.
+        Used for non-YouTube sites (Facebook, SoundCloud, TikTok, Vimeo, ...).
+        The URL is handed to flacfetch's generic "URL" source, which downloads
+        on the VM and uploads to GCS.
         """
-        temp_dir = tempfile.mkdtemp(prefix=f"youtube_{job_id}_")
+        gcs_destination = f"uploads/{job_id}/audio/"
+
+        output_filename = None
+        if artist and title:
+            from karaoke_gen.utils import sanitize_filename
+            output_filename = f"{sanitize_filename(artist)} - {sanitize_filename(title)}"
+
+        logger.info(
+            f"Remote URL download: url={url}, "
+            f"gcs_path={gcs_destination}, filename={output_filename}"
+        )
 
         try:
-            from karaoke_gen.file_handler import FileHandler
-            from karaoke_gen.utils import sanitize_filename
-
-            # Create FileHandler
-            file_handler = FileHandler(
-                logger=logger,
-                ffmpeg_base_command="ffmpeg -hide_banner -loglevel error -nostats -y",
-                create_track_subfolders=False,
-                dry_run=False
+            download_id = await self._flacfetch_client.download_by_id(
+                source_name="URL",
+                source_id=url,
+                download_url=url,
+                output_filename=output_filename,
+                gcs_path=gcs_destination,
             )
 
-            # Build output filename
-            safe_artist = sanitize_filename(artist) if artist else "Unknown"
-            safe_title = sanitize_filename(title) if title else "Unknown"
-            output_filename_no_extension = os.path.join(
-                temp_dir, f"{safe_artist} - {safe_title}"
+            logger.info(f"Remote URL download started: {download_id}")
+
+            def log_progress(status):
+                progress = status.get("progress", 0)
+                logger.debug(f"Download progress: {progress:.1f}%")
+
+            final_status = await self._flacfetch_client.wait_for_download(
+                download_id,
+                timeout=300,
+                progress_callback=log_progress,
             )
 
-            # Get cookies from environment
-            cookies_str = os.environ.get("YOUTUBE_COOKIES")
-            if cookies_str:
-                logger.info("Using YouTube cookies for local download")
-
-            # Download
-            logger.info(f"Local YouTube download: {url}")
-            downloaded_file = file_handler.download_video(
-                url=url,
-                output_filename_no_extension=output_filename_no_extension,
-                cookies_str=cookies_str
-            )
-
-            if not downloaded_file or not os.path.exists(downloaded_file):
+            gcs_path = final_status.get("gcs_path")
+            if not gcs_path:
                 raise YouTubeDownloadError(
-                    f"Local download failed - no file returned. "
-                    "This is likely due to YouTube bot detection on Cloud Run IPs. "
-                    "Configure FLACFETCH_API_URL for remote downloads."
+                    "Remote download completed but no GCS path returned"
                 )
 
-            logger.info(f"Downloaded video: {downloaded_file}")
+            if gcs_path.startswith("gs://"):
+                parts = gcs_path.replace("gs://", "").split("/", 1)
+                if len(parts) == 2:
+                    gcs_path = parts[1]
 
-            # Convert to WAV for processing
-            wav_file = file_handler.convert_to_wav(
-                input_filename=downloaded_file,
-                output_filename_no_extension=output_filename_no_extension
-            )
-
-            if not wav_file or not os.path.exists(wav_file):
-                raise YouTubeDownloadError("WAV conversion failed")
-
-            logger.info(f"Converted to WAV: {wav_file}")
-
-            # Upload to GCS
-            filename = os.path.basename(wav_file)
-            gcs_path = f"uploads/{job_id}/audio/{filename}"
-
-            content_type, _ = mimetypes.guess_type(wav_file)
-            with open(wav_file, 'rb') as f:
-                self._storage_service.upload_fileobj(
-                    f,
-                    gcs_path,
-                    content_type=content_type or 'audio/wav'
-                )
-
-            logger.info(f"Uploaded to GCS: {gcs_path}")
+            logger.info(f"Remote URL download complete: {gcs_path}")
             return gcs_path
 
+        except FlacfetchServiceError as e:
+            raise YouTubeDownloadError(f"Remote download failed: {e}") from e
         except YouTubeDownloadError:
             raise
         except Exception as e:
-            logger.error(f"Local YouTube download error: {e}", exc_info=True)
-            raise YouTubeDownloadError(f"Local download failed: {e}") from e
-        finally:
-            # Cleanup temp directory
-            try:
-                import shutil
-                if os.path.exists(temp_dir):
-                    shutil.rmtree(temp_dir)
-            except Exception as cleanup_error:
-                logger.warning(f"Failed to cleanup temp dir: {cleanup_error}")
+            logger.error(f"Remote URL download error: {e}", exc_info=True)
+            raise YouTubeDownloadError(f"Remote download failed: {e}") from e
 
 
 # Singleton instance

--- a/backend/tests/integration/test_youtube_flow.py
+++ b/backend/tests/integration/test_youtube_flow.py
@@ -241,10 +241,10 @@ class TestYouTubeDownloadErrorHandling:
             assert "Remote download failed" in str(exc.value)
 
     @pytest.mark.asyncio
-    async def test_invalid_youtube_url_raises_clear_error(self):
+    async def test_download_without_flacfetch_raises_clear_error(self):
         """
-        When given an invalid YouTube URL (no video ID extractable),
-        should raise a clear error.
+        With no flacfetch configured, download must fail clearly (no local
+        yt-dlp fallback on Cloud Run).
         """
         from backend.services.youtube_download_service import (
             YouTubeDownloadService,
@@ -261,11 +261,11 @@ class TestYouTubeDownloadErrorHandling:
 
             with pytest.raises(YouTubeDownloadError) as exc:
                 await service.download(
-                    url="not-a-valid-youtube-url",
+                    url="https://youtu.be/abcDEF12345",
                     job_id="job123",
                 )
 
-            assert "Could not extract video ID" in str(exc.value)
+            assert "flacfetch" in str(exc.value).lower()
 
 
 class TestRemoteVsLocalDownload:
@@ -306,13 +306,20 @@ class TestRemoteVsLocalDownload:
             assert "uploads/job_test/audio/" in result
 
     @pytest.mark.asyncio
-    async def test_local_download_when_remote_not_configured(self):
+    async def test_non_youtube_url_uses_generic_url_source(self):
         """
-        When FLACFETCH_API_URL is not configured, should fall back to local.
+        A non-YouTube URL is routed through flacfetch's generic 'URL' source.
         """
+        mock_client = MagicMock()
+        mock_client.download_by_id = AsyncMock(return_value="download_123")
+        mock_client.wait_for_download = AsyncMock(return_value={
+            "status": "complete",
+            "gcs_path": "gs://bucket/uploads/job_test/audio/test.m4a",
+        })
+
         with patch(
             'backend.services.youtube_download_service.get_flacfetch_client',
-            return_value=None  # No remote client
+            return_value=mock_client
         ):
             from backend.services.youtube_download_service import (
                 YouTubeDownloadService,
@@ -321,18 +328,10 @@ class TestRemoteVsLocalDownload:
             reset_youtube_download_service()
 
             service = YouTubeDownloadService()
-            assert service.is_remote_enabled() is False
+            sc_url = "https://soundcloud.com/forss/flickermood"
+            result = await service.download(url=sc_url, job_id="job_test")
 
-            # Mock the local download to avoid actually calling yt_dlp
-            with patch.object(
-                service, '_download_local',
-                new_callable=AsyncMock,
-                return_value="uploads/job/audio/test.wav"
-            ) as mock_local:
-                result = await service.download(
-                    url="https://youtu.be/abcDEF12345",
-                    job_id="job_test",
-                )
-
-                mock_local.assert_called_once()
-                assert result == "uploads/job/audio/test.wav"
+            call_kwargs = mock_client.download_by_id.call_args.kwargs
+            assert call_kwargs["source_name"] == "URL"
+            assert call_kwargs["download_url"] == sc_url
+            assert "uploads/job_test/audio/" in result

--- a/backend/tests/test_job_creation_regression.py
+++ b/backend/tests/test_job_creation_regression.py
@@ -241,30 +241,13 @@ class TestUserEmailExtraction:
 
 class TestUrlJobWorkerSequencing:
     """
-    Issue 2: YouTube URL download race condition.
+    URL job worker triggering.
 
-    Root cause: Both audio and lyrics workers were triggered in parallel.
-    For URL jobs, lyrics worker would timeout waiting for audio to download.
-
-    These tests verify that URL jobs trigger workers sequentially.
+    URL jobs are now downloaded by the flacfetch service in create_from_url
+    BEFORE any worker runs, so `input_media_gcs_path` is already set and both
+    workers can start in parallel (no sequential audio→lyrics handoff, no local
+    yt-dlp fallback in the worker).
     """
-
-    @pytest.mark.asyncio
-    async def test_url_job_triggers_only_audio_worker_initially(self):
-        """
-        create-from-url must only trigger audio worker, not lyrics worker.
-        The audio worker will trigger lyrics after download completes.
-        """
-        from backend.api.routes.file_upload import _trigger_audio_worker_only
-
-        with patch('backend.api.routes.file_upload.worker_service') as mock_ws:
-            mock_ws.trigger_audio_worker = AsyncMock()
-            mock_ws.trigger_lyrics_worker = AsyncMock()
-
-            await _trigger_audio_worker_only("test-job-id")
-
-            mock_ws.trigger_audio_worker.assert_called_once_with("test-job-id")
-            mock_ws.trigger_lyrics_worker.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_parallel_worker_triggers_both_workers(self):
@@ -283,39 +266,6 @@ class TestUrlJobWorkerSequencing:
 
             mock_ws.trigger_audio_worker.assert_called_once_with("test-job-id")
             mock_ws.trigger_lyrics_worker.assert_called_once_with("test-job-id")
-
-    @pytest.mark.asyncio
-    async def test_audio_worker_triggers_lyrics_after_url_download(self):
-        """
-        Audio worker must trigger lyrics worker after successful URL download.
-        """
-        from backend.workers.audio_worker import _trigger_lyrics_worker_after_url_download
-
-        # Mock at the source module where it's imported from
-        with patch('backend.services.worker_service.get_worker_service') as mock_get_ws:
-            mock_ws = Mock()
-            mock_ws.trigger_lyrics_worker = AsyncMock()
-            mock_get_ws.return_value = mock_ws
-
-            await _trigger_lyrics_worker_after_url_download("test-job-id")
-
-            mock_ws.trigger_lyrics_worker.assert_called_once_with("test-job-id")
-
-    @pytest.mark.asyncio
-    async def test_audio_worker_lyrics_trigger_handles_errors_gracefully(self):
-        """
-        If lyrics worker trigger fails, audio processing should continue.
-        """
-        from backend.workers.audio_worker import _trigger_lyrics_worker_after_url_download
-
-        # Mock at the source module where it's imported from
-        with patch('backend.services.worker_service.get_worker_service') as mock_get_ws:
-            mock_ws = Mock()
-            mock_ws.trigger_lyrics_worker = AsyncMock(side_effect=Exception("Network error"))
-            mock_get_ws.return_value = mock_ws
-
-            # Should not raise exception
-            await _trigger_lyrics_worker_after_url_download("test-job-id")
 
 
 class TestAudioSearchCacheIndependence:

--- a/backend/tests/test_workers.py
+++ b/backend/tests/test_workers.py
@@ -780,61 +780,16 @@ class TestAudioWorkerModelConfiguration:
                 assert call_kwargs['other_stems_models'] == []
 
 
-class TestDownloadFromUrl:
-    """Tests for download_from_url function - URL-based audio download."""
-    
-    def test_download_from_url_function_exists(self):
-        """Test that download_from_url function exists in audio_worker."""
-        from backend.workers.audio_worker import download_from_url
-        assert callable(download_from_url)
-    
-    def test_download_from_url_signature(self):
-        """Test that download_from_url has the expected signature."""
-        import inspect
-        from backend.workers.audio_worker import download_from_url
-        
-        sig = inspect.signature(download_from_url)
-        params = list(sig.parameters.keys())
-        
-        # Should have these parameters
-        assert 'url' in params
-        assert 'temp_dir' in params
-        assert 'artist' in params
-        assert 'title' in params
-        assert 'job_manager' in params
-        assert 'job_id' in params
-    
-    def test_download_from_url_is_async(self):
-        """Test that download_from_url is an async function."""
-        import inspect
-        from backend.workers.audio_worker import download_from_url
-        
-        assert inspect.iscoroutinefunction(download_from_url)
-    
-    @pytest.mark.asyncio
-    async def test_download_from_url_returns_none_for_invalid_url(self):
-        """Test that download_from_url handles errors gracefully."""
-        from backend.workers.audio_worker import download_from_url
-        
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # This should fail gracefully (no yt-dlp in test env or invalid URL)
-            result = await download_from_url(
-                url='not-a-valid-url',
-                temp_dir=temp_dir,
-                artist='Test',
-                title='Test'
-            )
-            
-            # Should return None on error (graceful failure)
-            assert result is None
-
-
 class TestDownloadAudioWithUrl:
-    """Tests for download_audio function with URL-based jobs."""
-    
+    """Tests for download_audio: it only ever consumes a pre-downloaded GCS file.
+
+    URLs are downloaded by the flacfetch service in create_job_from_url before
+    any worker runs — the audio worker never runs yt-dlp on Cloud Run.
+    """
+
     @pytest.fixture
     def mock_job_with_url(self):
-        """Create a mock job with a URL."""
+        """A URL job that (incorrectly) reached the worker without a GCS path."""
         return Job(
             job_id="test123",
             status=JobStatus.PROCESSING,
@@ -844,7 +799,7 @@ class TestDownloadAudioWithUrl:
             title="Test Song",
             url="https://www.youtube.com/watch?v=test123"
         )
-    
+
     @pytest.fixture
     def mock_job_manager(self, mock_job_with_url):
         """Create a mock JobManager."""
@@ -852,40 +807,34 @@ class TestDownloadAudioWithUrl:
         manager.get_job.return_value = mock_job_with_url
         manager.update_job.return_value = None
         return manager
-    
+
     @pytest.fixture
     def mock_storage(self):
         """Create a mock StorageService."""
         storage = MagicMock()
         return storage
-    
+
     @pytest.mark.asyncio
-    async def test_download_audio_from_url(self, mock_job_with_url, mock_job_manager, mock_storage):
-        """Test download_audio routes to URL download when job has URL."""
-        with patch('backend.workers.audio_worker.download_from_url', return_value='/tmp/test.wav') as mock_download:
-            from backend.workers.audio_worker import download_audio
-            
-            with tempfile.TemporaryDirectory() as temp_dir:
-                result = await download_audio(
-                    "test123",
-                    temp_dir,
-                    mock_storage,
-                    mock_job_with_url,
-                    job_manager_instance=mock_job_manager
-                )
-                
-                # Should have called download_from_url
-                mock_download.assert_called_once()
-                # Check positional args
-                args = mock_download.call_args[0]
-                assert args[0] == "https://www.youtube.com/watch?v=test123"  # url
-                assert args[1] == temp_dir  # temp_dir
-                assert args[2] == "Test Artist"  # artist
-                assert args[3] == "Test Song"  # title
-    
+    async def test_download_audio_url_without_gcs_path_refuses(self, mock_job_with_url, mock_job_manager, mock_storage):
+        """A URL job with no GCS file must fail (no local yt-dlp fallback)."""
+        from backend.workers.audio_worker import download_audio
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result = await download_audio(
+                "test123",
+                temp_dir,
+                mock_storage,
+                mock_job_with_url,
+                job_manager_instance=mock_job_manager
+            )
+
+            # Refuses to download locally → returns None, never touches storage
+            assert result is None
+            mock_storage.download_file.assert_not_called()
+
     @pytest.mark.asyncio
-    async def test_download_audio_from_gcs_when_no_url(self, mock_job_manager, mock_storage):
-        """Test download_audio downloads from GCS when job has no URL."""
+    async def test_download_audio_from_gcs(self, mock_job_manager, mock_storage):
+        """Test download_audio downloads from GCS when input_media_gcs_path is set."""
         mock_job_no_url = Job(
             job_id="test123",
             status=JobStatus.PROCESSING,
@@ -895,24 +844,20 @@ class TestDownloadAudioWithUrl:
             title="Test Song",
             input_media_gcs_path="uploads/test123/song.flac"
         )
-        
-        with patch('backend.workers.audio_worker.download_from_url') as mock_url_download:
-            from backend.workers.audio_worker import download_audio
-            
-            with tempfile.TemporaryDirectory() as temp_dir:
-                result = await download_audio(
-                    "test123",
-                    temp_dir,
-                    mock_storage,
-                    mock_job_no_url,
-                    job_manager_instance=mock_job_manager
-                )
-                
-                # Should NOT have called download_from_url
-                mock_url_download.assert_not_called()
-                
-                # Should have called storage.download_file
-                mock_storage.download_file.assert_called()
+
+        from backend.workers.audio_worker import download_audio
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            await download_audio(
+                "test123",
+                temp_dir,
+                mock_storage,
+                mock_job_no_url,
+                job_manager_instance=mock_job_manager
+            )
+
+            # Should have downloaded the pre-existing GCS file
+            mock_storage.download_file.assert_called()
 
 
 class TestBackingVocalsAnalysis:

--- a/backend/tests/test_youtube_download_service.py
+++ b/backend/tests/test_youtube_download_service.py
@@ -4,7 +4,6 @@ Unit tests for YouTubeDownloadService.
 Tests the consolidated YouTube download service that handles all YouTube
 downloads in the cloud backend.
 """
-import os
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -179,43 +178,42 @@ class TestYouTubeDownloadService:
             assert "Remote download failed" in str(exc.value)
 
     # =========================================================================
-    # Local Fallback Tests
+    # Generic (non-YouTube) URL Tests
     # =========================================================================
 
     @pytest.mark.asyncio
-    async def test_download_falls_back_to_local_when_remote_disabled(self):
-        """When remote not configured, should use local yt_dlp."""
-        mock_storage = MagicMock()
-        mock_storage.upload_fileobj = MagicMock()
+    async def test_download_generic_url_uses_url_source(self):
+        """Non-YouTube URLs route through flacfetch's generic 'URL' source."""
+        mock_client = MagicMock()
+        mock_client.download_by_id = AsyncMock(return_value="download_123")
+        mock_client.wait_for_download = AsyncMock(return_value={
+            "status": "complete",
+            "gcs_path": "gs://bucket/uploads/job123/audio/Artist - Title.m4a",
+        })
 
-        mock_file_handler = MagicMock()
-        mock_file_handler.download_video = MagicMock(return_value="/tmp/test.webm")
-        mock_file_handler.convert_to_wav = MagicMock(return_value="/tmp/test.wav")
-
+        fb_url = "https://www.facebook.com/share/v/1EnC8Bi5Uq/"
         with patch(
             'backend.services.youtube_download_service.get_flacfetch_client',
-            return_value=None  # No remote client
-        ), patch(
-            'backend.services.youtube_download_service.StorageService',
-            return_value=mock_storage
-        ), patch(
-            'backend.services.youtube_download_service.YouTubeDownloadService._download_local',
-            new_callable=AsyncMock,
-            return_value="uploads/job123/audio/test.wav"
-        ) as mock_local:
+            return_value=mock_client
+        ):
             service = YouTubeDownloadService()
 
             result = await service.download(
-                url="https://youtu.be/dQw4w9WgXcQ",
+                url=fb_url,
                 job_id="job123",
+                artist="Artist",
+                title="Title",
             )
 
-            assert result == "uploads/job123/audio/test.wav"
-            mock_local.assert_called_once()
+            assert result == "uploads/job123/audio/Artist - Title.m4a"
+            call_kwargs = mock_client.download_by_id.call_args.kwargs
+            assert call_kwargs["source_name"] == "URL"
+            assert call_kwargs["download_url"] == fb_url
+            assert call_kwargs["source_id"] == fb_url
 
     @pytest.mark.asyncio
-    async def test_download_invalid_url_raises_error(self):
-        """Should raise error for URLs that can't extract video ID."""
+    async def test_download_raises_when_remote_not_configured(self):
+        """No silent local fallback: hard-fail when flacfetch isn't configured."""
         with patch(
             'backend.services.youtube_download_service.get_flacfetch_client',
             return_value=None
@@ -224,11 +222,11 @@ class TestYouTubeDownloadService:
 
             with pytest.raises(YouTubeDownloadError) as exc:
                 await service.download(
-                    url="https://vimeo.com/123456",
+                    url="https://youtu.be/dQw4w9WgXcQ",
                     job_id="job123",
                 )
 
-            assert "Could not extract video ID" in str(exc.value)
+            assert "flacfetch" in str(exc.value).lower()
 
     # =========================================================================
     # Singleton Tests

--- a/backend/workers/audio_worker.py
+++ b/backend/workers/audio_worker.py
@@ -21,9 +21,7 @@ import shutil
 import tempfile
 import time
 from typing import Optional, Dict, Any
-from pathlib import Path
 
-from backend.models.job import JobStatus
 from backend.services.job_manager import JobManager
 from backend.services.storage_service import StorageService
 from backend.services.job_health_service import validate_worker_can_run
@@ -38,29 +36,6 @@ from karaoke_gen.audio_processor import AudioProcessor
 
 
 logger = logging.getLogger(__name__)
-
-
-async def _trigger_lyrics_worker_after_url_download(job_id: str) -> None:
-    """
-    Trigger lyrics worker after URL audio download completes.
-
-    For URL jobs, we use sequential triggering:
-    1. Audio worker downloads and uploads audio to GCS
-    2. Audio worker triggers lyrics worker (this function)
-    3. Both workers then proceed in parallel (audio separation + lyrics transcription)
-
-    This prevents the race condition where lyrics worker times out waiting for audio.
-    """
-    from backend.services.worker_service import get_worker_service
-
-    try:
-        worker_service = get_worker_service()
-        await worker_service.trigger_lyrics_worker(job_id)
-        logger.info(f"Job {job_id}: Triggered lyrics worker after URL download")
-    except Exception as e:
-        # Log but don't fail - audio processing can still continue
-        # The job will eventually timeout if lyrics worker doesn't run
-        logger.error(f"Job {job_id}: Failed to trigger lyrics worker: {e}")
 
 
 # Default ensemble presets — resolved by audio-separator package into models + algorithm.
@@ -78,126 +53,6 @@ DEFAULT_OTHER_MODELS = []  # Demucs 6-stem dropped — no longer separating indi
 AUDIO_WORKER_LOGGERS = [
     "karaoke_gen.audio_processor",
 ]
-
-
-async def download_from_url(url: str, temp_dir: str, artist: str, title: str, job_manager: JobManager = None, job_id: str = None) -> Optional[str]:
-    """
-    Download audio from a URL using local yt_dlp.
-
-    IMPORTANT: This is a LEGACY FALLBACK for non-YouTube URLs only!
-
-    For YouTube URLs, use YouTubeDownloadService instead, which:
-    - Uses remote flacfetch when configured (avoids Cloud Run bot detection)
-    - Has proper error handling and GCS upload
-
-    This function uses local yt_dlp and will likely FAIL for YouTube URLs
-    on Cloud Run due to bot detection (YouTube blocks Cloud Run IP ranges).
-
-    Uses the FileHandler from karaoke_gen which includes:
-    - Anti-detection options (user agent, headers, delays)
-    - Cookie support for authenticated downloads
-    - Retry logic
-
-    If artist and/or title are not provided, attempts to extract them from
-    the URL metadata.
-
-    Args:
-        url: URL to download from (NOT recommended for YouTube - use YouTubeDownloadService)
-        temp_dir: Temporary directory to save to
-        artist: Artist name for filename (can be None for auto-detection)
-        title: Song title for filename (can be None for auto-detection)
-        job_manager: Optional JobManager to update job with detected metadata
-        job_id: Optional job ID to update
-
-    Returns:
-        Path to downloaded audio file, or None if failed
-    """
-    try:
-        from karaoke_gen.file_handler import FileHandler
-        from karaoke_gen.utils import sanitize_filename
-        
-        # Create FileHandler instance
-        file_handler = FileHandler(
-            logger=logger,
-            ffmpeg_base_command="ffmpeg -hide_banner -loglevel error -nostats -y",
-            create_track_subfolders=False,
-            dry_run=False
-        )
-        
-        # Try to extract metadata if artist or title not provided
-        if not artist or not title:
-            logger.info(f"Extracting metadata from URL: {url}")
-            metadata = file_handler.extract_metadata_from_url(url)
-            
-            if metadata:
-                if not artist:
-                    artist = metadata.get('artist', 'Unknown')
-                    logger.info(f"Auto-detected artist: {artist}")
-                if not title:
-                    title = metadata.get('title', 'Unknown')
-                    logger.info(f"Auto-detected title: {title}")
-                
-                # Update job with detected metadata if job_manager provided
-                if job_manager and job_id:
-                    update_data = {}
-                    if artist:
-                        update_data['artist'] = artist
-                    if title:
-                        update_data['title'] = title
-                    if update_data:
-                        job_manager.update_job(job_id, update_data)
-                        logger.info(f"Updated job {job_id} with detected metadata")
-            else:
-                logger.warning("Could not extract metadata from URL, using defaults")
-                artist = artist or "Unknown"
-                title = title or "Unknown"
-        
-        # Create output filename (without extension)
-        safe_artist = sanitize_filename(artist) if artist else "Unknown"
-        safe_title = sanitize_filename(title) if title else "Unknown"
-        output_filename_no_extension = os.path.join(temp_dir, f"{safe_artist} - {safe_title}")
-        
-        # Get YouTube cookies from environment variable if available
-        # This helps bypass "Sign in to confirm you're not a bot" errors
-        cookies_str = os.environ.get("YOUTUBE_COOKIES")
-        if cookies_str:
-            logger.info("Using YouTube cookies for download authentication")
-        else:
-            logger.info("No YOUTUBE_COOKIES env var set - attempting download without cookies")
-        
-        # Download using FileHandler (includes anti-detection features)
-        logger.info(f"Downloading from URL: {url}")
-        downloaded_file = file_handler.download_video(
-            url=url,
-            output_filename_no_extension=output_filename_no_extension,
-            cookies_str=cookies_str
-        )
-        
-        if downloaded_file and os.path.exists(downloaded_file):
-            logger.info(f"Downloaded video: {downloaded_file}")
-            
-            # Convert to WAV for processing
-            wav_file = file_handler.convert_to_wav(
-                input_filename=downloaded_file,
-                output_filename_no_extension=output_filename_no_extension
-            )
-            
-            if wav_file and os.path.exists(wav_file):
-                logger.info(f"Converted to WAV: {wav_file}")
-                return wav_file
-            else:
-                logger.error("WAV conversion failed")
-                return None
-        else:
-            logger.error("Download failed - no file returned")
-            return None
-            
-    except ImportError as e:
-        logger.error(f"Import error: {e}. Check karaoke_gen installation.")
-        return None
-    except Exception as e:
-        logger.error(f"Failed to download from URL {url}: {e}", exc_info=True)
-        return None
 
 
 def create_audio_processor(
@@ -543,12 +398,16 @@ async def download_audio(
     job_manager_instance: JobManager = None
 ) -> Optional[str]:
     """
-    Download or fetch audio file to local temp directory.
-    
-    Handles two cases:
-    1. Uploaded file: Download from GCS using input_media_gcs_path
-    2. URL (YouTube, etc.): Download using yt-dlp or other tools
-    
+    Fetch the job's audio file from GCS to a local temp directory.
+
+    All inputs are expected to already be in GCS by the time this worker runs:
+    - Uploaded files: at input_media_gcs_path
+    - URL jobs: downloaded by the flacfetch service in create_job_from_url
+      before any worker is triggered
+
+    This worker never downloads from a URL itself (no yt-dlp on Cloud Run); a
+    URL job arriving without a GCS file is treated as an upstream bug.
+
     Args:
         job_id: Job ID
         temp_dir: Temporary directory to save to
@@ -594,55 +453,20 @@ async def download_audio(
             logger.info(f"Job {job_id}: Downloaded audio from GCS: {input_url}")
             return local_path
         
-        # Case 3: Fresh URL that needs downloading (legacy fallback)
-        # NOTE: YouTube URLs should be downloaded by YouTubeDownloadService in file_upload.py
-        # BEFORE triggering this worker. If we reach here with a YouTube URL, it means
-        # the download was not done upfront, which will likely fail due to bot detection.
+        # A URL job that reached this worker WITHOUT a pre-downloaded GCS file is
+        # an upstream bug: all URLs are downloaded by the flacfetch service in
+        # create_job_from_url before any worker runs. We never run yt-dlp on
+        # Cloud Run, so there is no local fallback — fail clearly instead.
         if job.url:
-            # Check if this is a YouTube URL that should have been handled earlier
-            is_youtube = any(domain in job.url.lower() for domain in ['youtube.com', 'youtu.be'])
-            if is_youtube:
-                logger.warning(
-                    f"Job {job_id}: YouTube URL reached download_audio() fallback. "
-                    "This may fail due to bot detection. YouTube URLs should be "
-                    "downloaded via YouTubeDownloadService before triggering workers."
-                )
-
-            logger.info(f"Job {job_id}: Downloading from URL: {job.url}")
-
-            # Use provided job_manager or create new one
-            jm = job_manager_instance or JobManager()
-
-            local_path = await download_from_url(
-                job.url,
-                temp_dir,
-                job.artist,
-                job.title,
-                job_manager=jm,
-                job_id=job_id
+            logger.error(
+                f"Job {job_id}: URL job reached the audio worker without a "
+                f"downloaded input_media_gcs_path (url={job.url}). URLs must be "
+                "fetched via the flacfetch service before processing; refusing to "
+                "download locally."
             )
+            return None
 
-            if local_path and os.path.exists(local_path):
-                # Upload to GCS and update job
-                gcs_path = f"jobs/{job_id}/input/{os.path.basename(local_path)}"
-                url = storage.upload_file(local_path, gcs_path)
-
-                # Update job with GCS path for lyrics worker
-                jm.update_job(job_id, {'input_media_gcs_path': gcs_path})
-                jm.update_file_url(job_id, 'input', 'audio', url)
-
-                logger.info(f"Job {job_id}: Downloaded and uploaded audio to GCS: {gcs_path}")
-
-                # For URL jobs, trigger lyrics worker now that audio is available
-                # This is the sequential trigger pattern - audio first, then lyrics
-                await _trigger_lyrics_worker_after_url_download(job_id)
-
-                return local_path
-            else:
-                logger.error(f"Job {job_id}: Failed to download from URL: {job.url}")
-                return None
-        
-        logger.error(f"Job {job_id}: No input source found (no GCS path, file_urls, or URL)")
+        logger.error(f"Job {job_id}: No input source found (no GCS path or file_urls)")
         return None
         
     except Exception as e:

--- a/docs/archive/2026-06-08-fallback-logic-audit-prompt.md
+++ b/docs/archive/2026-06-08-fallback-logic-audit-prompt.md
@@ -1,0 +1,78 @@
+# Prompt: Audit karaoke-gen for legacy "fallback" logic
+
+**Purpose:** A lot of this codebase was written by an earlier LLM that, when
+unsure what should happen in some situation, tended to invent a silent
+*fallback* path rather than (a) asking the human what the desired behaviour was,
+or (b) failing loudly with a clear error. These fallbacks hide bugs: the system
+appears to "work" while doing the wrong thing, and the real failure only surfaces
+much later (or never).
+
+**Motivating example (2026-06-08):** A job submitted from a Facebook share URL
+failed with a generic `Failed to download audio file`. The non-YouTube URL path
+silently fell back to running yt-dlp *locally inside the Cloud Run container*,
+which then died in a buggy `convert_to_wav` (ffmpeg given both `-y` and `-n`).
+The download had actually succeeded — the fallback path was both unintended
+(flacfetch was supposed to be the sole downloader) and broken. See
+`docs/archive/2026-06-08-flacfetch-sole-downloader-plan.md` (workspace root) and
+the memory note `project_flacfetch_sole_downloader`. The fix deleted the
+fallback rather than patching it.
+
+## Your task
+
+Systematically find every "fallback" in karaoke-gen, and for each one bring it to
+the user (Andrew) with a crisp question about intended behaviour. Do **not**
+change any behaviour without his answer — fallbacks sometimes ARE the right call
+(e.g. graceful degradation of an optional feature). The goal is to make each one
+an explicit, intentional decision.
+
+### 1. Discover candidates (cast a wide net)
+
+Search code, comments, docstrings, and docs. Suggested sweeps (run several):
+
+- Literal: `rg -in "fallback|fall back|fall-back" backend/ karaoke_gen/ frontend/`
+- Intent words near logic: `rg -in "best effort|best-effort|silently|swallow|ignore (the )?error|just in case|legacy|deprecated path|for now|TODO|HACK|workaround"`
+- Defensive swallowing: `except Exception` / bare `except:` that `pass`, `return None`, `return`, or log-and-continue without re-raising.
+- Silent defaults: `\.get\(.*,\s*['\"]?(unknown|default|none)` style, `or "Unknown"`, `or {}`, env-var defaults that mask misconfiguration.
+- "If not configured, do X instead" branches (the most dangerous class — like the yt-dlp one).
+- Try-import / optional-dependency fallbacks that change behaviour rather than failing.
+
+Record each candidate with `file:line`, a one-line description, and which class
+it falls into.
+
+### 2. Triage each candidate
+
+For each, classify and note evidence:
+- **A — Legitimate graceful degradation** (optional feature, clearly intended, fails safe and visible). Likely keep; confirm it's logged/observable.
+- **B — Silent fallback masking a bug / misconfiguration** (like the yt-dlp case). Candidate for: delete, or convert to fail-fast with a clear error.
+- **C — Ambiguous** — needs the user's intent.
+
+Don't trust comments that *say* a path is a safe fallback — verify what actually
+happens when it triggers (what does the user see? does the job silently produce
+wrong output?).
+
+### 3. Interview the user
+
+Present findings grouped by class, B and C first. For each B/C item ask a
+focused question, e.g.:
+> `audio_worker.py:NN` falls back to <X> when <Y>. Today that means <observable
+> consequence>. Should this (a) fail loudly with a clear error, (b) keep the
+> fallback but log/alert, or (c) something else?
+
+Batch related items. Capture his answers as direct quotes in a plan doc
+(`docs/archive/YYYY-MM-DD-fallback-audit-plan.md`) — he values verbatim
+decisions.
+
+### 4. Execute
+
+Implement the agreed changes in small, reviewable PRs (one logical area each),
+with tests. Prefer fail-fast + clear error messages over silent fallbacks.
+Update `docs/LESSONS-LEARNED.md` with the principle and notable examples.
+
+## Guardrails
+
+- This is an audit, not a rewrite — minimise behaviour change until the user
+  decides per item.
+- Some "fallbacks" are load-bearing; deleting blindly will cause incidents.
+- Pay special attention to anything touching: audio/lyrics download, payment,
+  job state transitions, and worker triggering — silent wrong behaviour there is
+  most costly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.175.2"
+version = "0.176.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Phase 2 of making **flacfetch the sole audio downloader** — no yt-dlp ever runs on Cloud Run. Fixes the original Facebook-URL job failure and removes a class of legacy silent-fallback behaviour.

**Root cause of the reported bug** (job `34e60208`, `facebook.com/share/v/...`): non-YouTube URLs were downloaded by local yt-dlp *inside the Cloud Run container*, which succeeded but then died in `convert_to_wav` (ffmpeg given both `-y` and `-n`), surfacing as a generic `Failed to download audio file`. Rather than patch the flags, this removes the path entirely.

## Changes

- **`youtube_download_service.py`** — `download()` now handles **any** yt-dlp-supported URL: YouTube via the existing video-id path; everything else (Facebook, SoundCloud, TikTok, Vimeo, …) via flacfetch's generic `URL` source (`download_by_id(source_name="URL", download_url=url)`). **Deleted `_download_local`** (local yt-dlp fallback); with no flacfetch configured it now **hard-fails with a clear error** instead of silently falling back.
- **`file_upload.create_job_from_url`** — downloads audio up front via the service for **all** URLs (not just YouTube), then `start_job_processing`. Removed the non-YouTube branch that triggered the GPU worker to download locally, and the now-dead `_trigger_audio_worker_only`. (Keeps GPU idle until audio is in GCS.)
- **`audio_worker.py`** — deleted `download_from_url` (the buggy local path) and `download_audio`'s URL-download fallback + the dead `_trigger_lyrics_worker_after_url_download`. The worker now only consumes a pre-downloaded GCS file; a URL job arriving without one fails clearly.
- **Docs** — added `docs/archive/2026-06-08-fallback-logic-audit-prompt.md` (a prompt for a future session to audit all legacy "fallback" logic).

Net **−331 lines**.

## Testing

- Updated/replaced tests for the removed fallbacks; added tests for generic-URL routing (`source_name="URL"`) and the no-flacfetch hard-fail. Affected suites green (410 passed across the touched files); full backend collection clean.
- Depends on **flacfetch ≥ 0.21.0** (generic `URL` source) — already shipped & deployed (flacfetch #28), and verified end-to-end: the original Facebook URL downloads through flacfetch to GCS.

Requires no infra change. Plan: `nomadkaraoke/docs/archive/2026-06-08-flacfetch-sole-downloader-plan.md`.

@coderabbitai ignore