### PR TITLE
fix(lyrics): sanitize invalid word timings to prevent overlapping screens

### DIFF
--- a/karaoke_gen/lyrics_transcriber/output/segment_resizer.py
+++ b/karaoke_gen/lyrics_transcriber/output/segment_resizer.py
@@ -63,6 +63,14 @@ class SegmentResizer:
             List of resized LyricsSegment objects
         """
         self._log_input_segments(segments)
+
+        # Guarantee valid, in-bounds word timing before doing anything else.
+        # Transcription occasionally emits words with missing/zero/negative
+        # timestamps; when a segment is later split, the derived sub-segment
+        # inherits words[0].start_time, so a bogus value (e.g. 0.0) becomes the
+        # sub-segment's start_time and corrupts downstream screen ordering.
+        segments = [self._sanitize_segment_timings(segment) for segment in segments]
+
         resized_segments: List[LyricsSegment] = []
 
         for segment_idx, segment in enumerate(segments):
@@ -122,6 +130,70 @@ class SegmentResizer:
             confidence=word.confidence if hasattr(word, "confidence") else None,
             created_during_correction=getattr(word, "created_during_correction", False),
             singer=word.singer,
+        )
+
+    def _sanitize_segment_timings(self, segment: LyricsSegment) -> LyricsSegment:
+        """Return a copy of ``segment`` whose word timings are valid and in-bounds.
+
+        A word is considered invalid if its ``start_time`` falls outside the
+        segment's ``[start_time, end_time]`` window, or if its ``end_time`` is
+        missing/before its ``start_time``/after the segment end. Only invalid
+        timings are corrected — already-valid words are left untouched — so the
+        karaoke highlight sweep is preserved wherever the source data is good.
+
+        A corrected start clamps to the later of the segment start and the
+        previous word's end (keeping words non-decreasing); a corrected end
+        clamps to ``[start, segment_end]``.
+        """
+        seg_start = segment.start_time
+        seg_end = segment.end_time if segment.end_time >= seg_start else seg_start
+
+        sanitized_words: List[Word] = []
+        prev_end = seg_start
+        changed = False
+        for word in segment.words:
+            start, end = word.start_time, word.end_time
+
+            if start is None or start < seg_start or start > seg_end:
+                start = min(max(prev_end, seg_start), seg_end)
+                changed = True
+
+            if end is None or end < start or end > seg_end:
+                end = min(max(start, end if end is not None else start), seg_end)
+                if end < start:
+                    end = start
+                changed = True
+
+            if start != word.start_time or end != word.end_time:
+                self.logger.debug(
+                    f"Sanitized word '{word.text}' timing {word.start_time}-{word.end_time} "
+                    f"-> {start}-{end} (segment {seg_start:.2f}-{seg_end:.2f})"
+                )
+                sanitized_words.append(
+                    Word(
+                        id=word.id,
+                        text=word.text,
+                        start_time=start,
+                        end_time=end,
+                        confidence=word.confidence if hasattr(word, "confidence") else None,
+                        created_during_correction=getattr(word, "created_during_correction", False),
+                        singer=word.singer,
+                    )
+                )
+            else:
+                sanitized_words.append(word)
+            prev_end = end
+
+        if not changed:
+            return segment
+
+        return LyricsSegment(
+            id=segment.id,
+            text=segment.text,
+            words=sanitized_words,
+            start_time=segment.start_time,
+            end_time=segment.end_time,
+            singer=segment.singer,
         )
 
     def _split_oversized_segment(self, segment_idx: int, segment: LyricsSegment) -> List[LyricsSegment]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.176.1"
+version = "0.176.2"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"

--- a/tests/unit/lyrics_transcriber/output/test_segment_resizer_timing.py
+++ b/tests/unit/lyrics_transcriber/output/test_segment_resizer_timing.py
@@ -1,0 +1,98 @@
+"""Regression tests: a resized (split) segment must never inherit a word
+timestamp that falls outside its parent segment's [start_time, end_time].
+
+Bug (job 17f7c313, "Atmosphere - Scalp"): the transcription emitted the segment
+
+    A whiskey and a beer, let's forget where we are   (start=15.18, end=18.04)
+
+but the four leading words ("A", "whiskey", "and", "a") had invalid timestamps
+(start_time=0.0, end_time=-0.005) — only "beer," onward carried real timing.
+``_create_segment_from_words`` sets a split line's ``start_time`` to
+``words[0].start_time``, so the line "A whiskey and a beer," inherited
+start_time=0.0.
+
+That zero start_time corrupts screen ordering downstream: a LyricsScreen sorts by
+``min(line.segment.start_time)``, so the screen jumped ahead of the INTRO section
+screen. The INTRO then wiped the active-line bookkeeping and the next screen
+faded in (post-instrumental) over the still-displayed previous screen — two full
+screens of lyrics rendered on top of each other for 7-12 seconds.
+
+The resizer must guarantee valid, in-bounds word timing so a split segment can
+never start before its parent segment does.
+"""
+import logging
+
+from karaoke_gen.lyrics_transcriber.output.segment_resizer import SegmentResizer
+from karaoke_gen.lyrics_transcriber.types import LyricsSegment, Word
+
+
+def _scalp_segment() -> LyricsSegment:
+    """The exact shape of the offending segment from job 17f7c313."""
+    words = [
+        Word(id="w0", text="A", start_time=0.0, end_time=-0.005),
+        Word(id="w1", text="whiskey", start_time=0.0, end_time=-0.005),
+        Word(id="w2", text="and", start_time=0.0, end_time=0.0),
+        Word(id="w3", text="a", start_time=0.0, end_time=0.0),
+        Word(id="w4", text="beer,", start_time=16.10, end_time=16.42),
+        Word(id="w5", text="let's", start_time=16.46, end_time=16.64),
+        Word(id="w6", text="forget", start_time=16.68, end_time=17.14),
+        Word(id="w7", text="where", start_time=17.20, end_time=17.44),
+        Word(id="w8", text="we", start_time=17.46, end_time=17.62),
+        Word(id="w9", text="are", start_time=17.66, end_time=18.04),
+    ]
+    return LyricsSegment(
+        id="s",
+        text="A whiskey and a beer, let's forget where we are",
+        words=words,
+        start_time=15.18,
+        end_time=18.04,
+    )
+
+
+def test_split_segment_start_time_not_before_parent():
+    """A split sub-segment must not start before its parent segment's start_time."""
+    resizer = SegmentResizer(max_line_length=36, logger=logging.getLogger("test"))
+
+    result = resizer.resize_segments([_scalp_segment()])
+
+    # The segment is over 36 chars, so it splits into multiple lines.
+    assert len(result) > 1, "expected the segment to be split"
+    for s in result:
+        assert s.start_time >= 15.18, f"sub-segment '{s.text}' starts at {s.start_time}, before parent 15.18"
+
+
+def test_resized_words_stay_within_parent_bounds():
+    """Every word in the output must have valid, in-bounds, non-inverted timing."""
+    resizer = SegmentResizer(max_line_length=36, logger=logging.getLogger("test"))
+
+    result = resizer.resize_segments([_scalp_segment()])
+
+    for s in result:
+        for w in s.words:
+            assert w.start_time >= 15.18, f"word '{w.text}' start {w.start_time} < parent start 15.18"
+            assert w.end_time >= w.start_time, f"word '{w.text}' end {w.end_time} < start {w.start_time}"
+            assert w.end_time <= 18.04 + 1e-6, f"word '{w.text}' end {w.end_time} > parent end 18.04"
+
+
+def test_valid_timings_are_left_untouched():
+    """Sanitation must not perturb already-valid word timings."""
+    resizer = SegmentResizer(max_line_length=36, logger=logging.getLogger("test"))
+    words = [
+        Word(id="w0", text="Filling", start_time=21.40, end_time=21.82),
+        Word(id="w1", text="up", start_time=21.86, end_time=22.10),
+        Word(id="w2", text="that", start_time=22.14, end_time=22.42),
+        Word(id="w3", text="cup", start_time=22.46, end_time=22.78),
+    ]
+    seg = LyricsSegment(id="s", text="Filling up that cup", words=words, start_time=21.40, end_time=22.78)
+
+    result = resizer.resize_segments([seg])
+
+    assert len(result) == 1
+    out = result[0]
+    assert out.start_time == 21.40
+    assert [(w.start_time, w.end_time) for w in out.words] == [
+        (21.40, 21.82),
+        (21.86, 22.10),
+        (22.14, 22.42),
+        (22.46, 22.78),
+    ]


### PR DESCRIPTION
## Summary
- Fixes overlapping rendered lyrics on job `17f7c313` ("Atmosphere - Scalp") — two full screens of lyrics displayed on the same 4 vertical slots for 7-12s.
- **Distinct root cause** from the earlier libass-wrap overlap (PR #794), which is why it recurred. This one is a genuine same-Y / same-time overlap caused by invalid word timestamps.

## Root cause
The transcription left the 4 leading words of a segment ("A whiskey and a") with invalid timestamps (`start=0.0`, `end=-0.005`) while the segment itself correctly started at 15.18s. `SegmentResizer._create_segment_from_words` derives a split line's `start_time` from `words[0].start_time`, so the split line `"A whiskey and a beer,"` inherited `start_time=0.0`. A `LyricsScreen` sorts by `min(line.segment.start_time)`, so the screen jumped ahead of the INTRO section screen; the INTRO then wiped the active-line bookkeeping and the next screen faded in (post-instrumental) over the still-displayed previous screen.

## Changes
- Add `SegmentResizer._sanitize_segment_timings`, run at the top of `resize_segments` (covers all output paths via `generator.py`).
- Clamps **only invalid** word timings into the segment's `[start, end]` window and keeps them non-decreasing; valid words are left untouched so the karaoke highlight sweep is preserved.
- New regression tests in `tests/unit/lyrics_transcriber/output/test_segment_resizer_timing.py`.
- Bump version `0.176.1` → `0.176.2`.

## Testing
- [x] New timing regression tests + prior line-length regression tests pass
- [x] Full `lyrics_transcriber` unit suite: 110 passed
- [x] End-to-end against job `17f7c313`: **4 same-Y overlaps before → 0 after**

## Review
- [x] Local CodeRabbit review completed (0 findings)

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)