### PR TITLE
test: harden auto-correct production E2E (session dialog + cold start)

### DIFF
--- a/frontend/e2e/production/auto-correct-suggestions.spec.ts
+++ b/frontend/e2e/production/auto-correct-suggestions.spec.ts
@@ -62,7 +62,17 @@ test.describe('AI auto-correct suggestions (production)', () => {
 
     await openReviewPage(page)
 
+    // Generous timeout: right after a deploy the first review-page load can
+    // exceed 30s (cold Cloud Run instance + uncached correction payload).
+    // A "Saved Review Sessions" dialog may open on load (it aria-hides the
+    // rest of the app); close it without restoring before proceeding.
     const suggestBtn = page.getByRole('button', { name: /AI Suggest/i })
+    const sessionDialog = page.getByRole('dialog', { name: /Saved Review Sessions/i })
+    await expect(suggestBtn.or(sessionDialog).first()).toBeVisible({ timeout: 90_000 })
+    if (await sessionDialog.isVisible().catch(() => false)) {
+      await sessionDialog.getByRole('button', { name: /^Close$/i }).click()
+      await expect(sessionDialog).not.toBeVisible()
+    }
     await expect(suggestBtn).toBeVisible({ timeout: 30_000 })
     await suggestBtn.click()
 


### PR DESCRIPTION
@coderabbitai ignore

Test-only follow-up to #811. The production E2E for AI auto-correct failed against a job that had a saved review session: the Saved Review Sessions dialog aria-hides the rest of the app, so role-based locators couldn't find the (visible) AI Suggest button. The spec now closes that dialog without restoring, and allows 90s for the first review-page load after a fresh deploy (cold Cloud Run + uncached correction payload). Verified passing against live prod (19.5s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)