### PR TITLE
feat: cache AI auto-correct suggestions per job (free re-runs on unmodified lyrics)

### DIFF
--- a/backend/api/routes/review.py
+++ b/backend/api/routes/review.py
@@ -105,6 +105,7 @@ class AutoCorrectResponse(_PydBaseModel):
     elapsed_seconds: float
     settings_applied: dict
     warnings: list[str]
+    cached: bool = False
 
 
 def _get_custom_lyrics_service_dep() -> CustomLyricsService:
@@ -747,6 +748,7 @@ async def auto_correct_suggestions(
         elapsed_seconds=result.elapsed_seconds,
         settings_applied=result.settings_applied.to_dict(),
         warnings=result.warnings,
+        cached=result.cached,
     )
 
 

--- a/backend/services/auto_correct/service.py
+++ b/backend/services/auto_correct/service.py
@@ -1,11 +1,12 @@
 """Auto-correct suggestion service: one whole-song LLM call, validated output."""
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import time
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Any, Optional
 
 from google import genai
@@ -66,6 +67,8 @@ class AutoCorrectResult:
     elapsed_seconds: float
     settings_applied: AutoCorrectSettings
     warnings: list[str] = field(default_factory=list)
+    # True when served from the per-job GCS cache (no LLM call was made).
+    cached: bool = False
 
 
 class AutoCorrectService:
@@ -110,6 +113,22 @@ class AutoCorrectService:
         )
 
         models = self._models_for(settings)
+
+        # Re-running on byte-identical input (lyrics, references, settings,
+        # models) returns the previous result instead of paying for another
+        # LLM call. Word ids are part of the key, so cached suggestions
+        # always reference words that still exist.
+        cache_path = self._cache_path(
+            job_id, models, settings, flat, reference_lyrics, artist, title
+        )
+        cached = self._cache_get(cache_path)
+        if cached is not None:
+            logger.info(
+                "auto-correct cache hit job=%s suggestions=%d", job_id,
+                len(cached.suggestions),
+            )
+            return cached
+
         t0 = time.time()
         per_model: dict[str, list[Suggestion]] = {}
         warnings: list[str] = []
@@ -151,13 +170,86 @@ class AutoCorrectService:
             "auto-correct job=%s models=%s words=%d suggestions=%d dropped_warnings=%d elapsed=%.1fs",
             job_id, model_label, len(flat), len(merged), len(warnings), elapsed,
         )
-        return AutoCorrectResult(
+        result = AutoCorrectResult(
             suggestions=merged,
             model=model_label,
             elapsed_seconds=round(elapsed, 1),
             settings_applied=settings,
             warnings=warnings,
         )
+        self._cache_put(cache_path, result)
+        return result
+
+    # ---- suggestion cache (GCS, best-effort) ----
+
+    def _get_storage(self):
+        if not hasattr(self, "_storage"):
+            from backend.services.storage_service import StorageService
+
+            self._storage = StorageService()
+        return self._storage
+
+    @staticmethod
+    def _cache_path(
+        job_id: str,
+        models: list[str],
+        settings: AutoCorrectSettings,
+        flat: list[tuple[str, str, str]],
+        reference_lyrics: dict[str, dict],
+        artist: Optional[str],
+        title: Optional[str],
+    ) -> str:
+        payload = {
+            "v": 1,
+            "models": models,
+            "settings": settings.to_dict(),
+            "words": [[word_id, text] for word_id, text, _seg in flat],
+            "references": {
+                source: [seg.get("text", "") for seg in (ref.get("segments") or [])]
+                for source, ref in sorted((reference_lyrics or {}).items())
+            },
+            "artist": artist,
+            "title": title,
+        }
+        digest = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, ensure_ascii=False).encode()
+        ).hexdigest()[:24]
+        return f"jobs/{job_id}/lyrics/auto_correct_cache/{digest}.json"
+
+    def _cache_get(self, path: str) -> Optional[AutoCorrectResult]:
+        """Best-effort: any storage/shape problem is a cache miss, never an error."""
+        try:
+            storage = self._get_storage()
+            if not storage.bucket.blob(path).exists():
+                return None
+            data = storage.download_json(path)
+            return AutoCorrectResult(
+                suggestions=[Suggestion(**s) for s in data["suggestions"]],
+                model=data["model"],
+                elapsed_seconds=0.0,
+                settings_applied=AutoCorrectSettings(**data["settings_applied"]),
+                warnings=list(data.get("warnings") or []),
+                cached=True,
+            )
+        except Exception:
+            logger.warning("auto-correct cache read failed for %s", path, exc_info=True)
+            return None
+
+    def _cache_put(self, path: str, result: AutoCorrectResult) -> None:
+        """Best-effort: a failed cache write never fails the request."""
+        try:
+            self._get_storage().upload_json(
+                path,
+                {
+                    "suggestions": [asdict(s) for s in result.suggestions],
+                    "model": result.model,
+                    "settings_applied": result.settings_applied.to_dict(),
+                    "warnings": result.warnings,
+                    "elapsed_seconds": result.elapsed_seconds,
+                },
+            )
+        except Exception:
+            logger.warning("auto-correct cache write failed for %s", path, exc_info=True)
 
     def _models_for(self, settings: AutoCorrectSettings) -> list[str]:
         if settings.compare_models:

--- a/backend/tests/services/auto_correct/test_cache.py
+++ b/backend/tests/services/auto_correct/test_cache.py
@@ -1,0 +1,203 @@
+"""Tests for the per-job auto-correct suggestion cache."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from backend.services.auto_correct.service import (
+    AutoCorrectResult,
+    AutoCorrectService,
+    Suggestion,
+)
+from backend.services.auto_correct.settings import AutoCorrectSettings
+
+
+SEGMENTS = [
+    {
+        "id": "seg-1",
+        "words": [
+            {"id": "w0", "text": "straight"},
+            {"id": "w1", "text": "glory"},
+        ],
+    },
+]
+REFS = {"genius": {"segments": [{"text": "straight chlorine"}]}}
+RAW = {
+    "suggestions": [
+        {
+            "op": "replace",
+            "start_idx": 1,
+            "end_idx": 1,
+            "new_text": "chlorine",
+            "reason": "r",
+            "category": "mishearing",
+            "confidence": 0.9,
+        }
+    ]
+}
+
+FLAT = [("w0", "straight", "seg-1"), ("w1", "glory", "seg-1")]
+
+
+def _suggest(service, **overrides):
+    kwargs = dict(
+        job_id="job-1",
+        segments=SEGMENTS,
+        reference_lyrics=REFS,
+        artist="A",
+        title="T",
+        settings=AutoCorrectSettings(),
+    )
+    kwargs.update(overrides)
+    return service.suggest(**kwargs)
+
+
+def test_cache_hit_skips_model_call() -> None:
+    service = AutoCorrectService()
+    cached_result = AutoCorrectResult(
+        suggestions=[
+            Suggestion(
+                id="cached-1",
+                op="replace",
+                word_ids=["w1"],
+                segment_ids=["seg-1"],
+                original_text="glory",
+                new_text="chlorine",
+                reason="r",
+                category="mishearing",
+                confidence=0.9,
+            )
+        ],
+        model="claude-fable-5",
+        elapsed_seconds=0.0,
+        settings_applied=AutoCorrectSettings(),
+        cached=True,
+    )
+    with patch.object(service, "_cache_get", return_value=cached_result), \
+         patch.object(service, "_call_model") as call, \
+         patch.object(service, "_cache_put") as put:
+        result = _suggest(service)
+    call.assert_not_called()
+    put.assert_not_called()
+    assert result.cached is True
+    assert result.suggestions[0].id == "cached-1"
+
+
+def test_cache_miss_calls_model_and_writes_cache() -> None:
+    service = AutoCorrectService()
+    with patch.object(service, "_cache_get", return_value=None), \
+         patch.object(service, "_call_model", return_value=RAW) as call, \
+         patch.object(service, "_cache_put") as put:
+        result = _suggest(service)
+    call.assert_called_once()
+    put.assert_called_once()
+    assert result.cached is False
+    assert put.call_args.args[1] is result
+
+
+def test_cache_key_stable_for_identical_input() -> None:
+    s = AutoCorrectSettings()
+    k1 = AutoCorrectService._cache_path("j", ["m"], s, FLAT, REFS, "A", "T")
+    k2 = AutoCorrectService._cache_path("j", ["m"], s, FLAT, REFS, "A", "T")
+    assert k1 == k2
+    assert k1.startswith("jobs/j/lyrics/auto_correct_cache/")
+
+
+def test_cache_key_changes_with_input() -> None:
+    s = AutoCorrectSettings()
+    base = AutoCorrectService._cache_path("j", ["m"], s, FLAT, REFS, "A", "T")
+    edited_words = [("w0", "straight", "seg-1"), ("w1", "chlorine", "seg-1")]
+    assert AutoCorrectService._cache_path("j", ["m"], s, edited_words, REFS, "A", "T") != base
+    assert AutoCorrectService._cache_path("j", ["m", "m2"], s, FLAT, REFS, "A", "T") != base
+    other_settings = AutoCorrectSettings(min_confidence=0.8)
+    assert AutoCorrectService._cache_path("j", ["m"], other_settings, FLAT, REFS, "A", "T") != base
+    other_refs = {"genius": {"segments": [{"text": "different text"}]}}
+    assert AutoCorrectService._cache_path("j", ["m"], s, FLAT, other_refs, "A", "T") != base
+
+
+def test_cache_get_round_trips_via_storage_payload() -> None:
+    """_cache_put's payload must be readable by _cache_get."""
+    service = AutoCorrectService()
+    stored = {}
+
+    class FakeBlob:
+        def exists(self):
+            return bool(stored)
+
+    class FakeStorage:
+        class bucket:  # noqa: N801 - mimic attribute access
+            @staticmethod
+            def blob(path):
+                return FakeBlob()
+
+        @staticmethod
+        def upload_json(path, data):
+            stored[path] = data
+
+        @staticmethod
+        def download_json(path):
+            return stored[path]
+
+    with patch.object(service, "_get_storage", return_value=FakeStorage()):
+        original = AutoCorrectResult(
+            suggestions=[
+                Suggestion(
+                    id="s1",
+                    op="replace",
+                    word_ids=["w1"],
+                    segment_ids=["seg-1"],
+                    original_text="glory",
+                    new_text="chlorine",
+                    reason="r",
+                    category="mishearing",
+                    confidence=0.9,
+                    models=["m1", "m2"],
+                    consensus=2,
+                    total_models=2,
+                    conflict_group=None,
+                )
+            ],
+            model="m1, m2",
+            elapsed_seconds=5.0,
+            settings_applied=AutoCorrectSettings(compare_models=True),
+            warnings=["w"],
+        )
+        service._cache_put("p", original)
+        restored = service._cache_get("p")
+
+    assert restored is not None
+    assert restored.cached is True
+    assert restored.model == "m1, m2"
+    assert restored.warnings == ["w"]
+    assert restored.settings_applied == AutoCorrectSettings(compare_models=True)
+    s = restored.suggestions[0]
+    assert s.consensus == 2 and s.models == ["m1", "m2"]
+
+
+def test_corrupt_cache_entry_is_a_miss() -> None:
+    service = AutoCorrectService()
+
+    class FakeBlob:
+        def exists(self):
+            return True
+
+    class FakeStorage:
+        class bucket:  # noqa: N801
+            @staticmethod
+            def blob(path):
+                return FakeBlob()
+
+        @staticmethod
+        def download_json(path):
+            return {"suggestions": [{"bogus": True}], "model": "m"}
+
+    with patch.object(service, "_get_storage", return_value=FakeStorage()):
+        assert service._cache_get("p") is None
+
+
+def test_storage_failure_never_breaks_request() -> None:
+    service = AutoCorrectService()
+    with patch.object(service, "_get_storage", side_effect=RuntimeError("no gcs")), \
+         patch.object(service, "_call_model", return_value=RAW):
+        result = _suggest(service)
+    assert result.cached is False
+    assert len(result.suggestions) == 1

--- a/backend/tests/services/auto_correct/test_multi_model.py
+++ b/backend/tests/services/auto_correct/test_multi_model.py
@@ -55,7 +55,9 @@ def _run_compare(responses_by_model, compare_models_env="model-a;model-b",
         service.settings, "auto_correct_compare_models", compare_models_env
     ), patch.object(
         service.settings, "auto_correct_model", single_model
-    ), patch.object(service, "_call_model", side_effect=fake_call):
+    ), patch.object(service, "_cache_get", return_value=None), \
+        patch.object(service, "_cache_put"), \
+        patch.object(service, "_call_model", side_effect=fake_call):
         return service.suggest(
             job_id="job-1",
             segments=SEGMENTS,

--- a/backend/tests/services/auto_correct/test_service.py
+++ b/backend/tests/services/auto_correct/test_service.py
@@ -35,7 +35,9 @@ REFS = {"genius": {"segments": [{"text": "Sippin' on straight chlorine"}]}}
 
 def _suggest(raw_response, settings=None):
     service = AutoCorrectService()
-    with patch.object(service, "_call_model", return_value=raw_response):
+    with patch.object(service, "_call_model", return_value=raw_response), \
+         patch.object(service, "_cache_get", return_value=None), \
+         patch.object(service, "_cache_put"):
         return service.suggest(
             job_id="job-1",
             segments=SEGMENTS,

--- a/docs/API.md
+++ b/docs/API.md
@@ -606,9 +606,18 @@ Returns:
   "model": "claude-fable-5, gemini-3.1-pro-preview",
   "elapsed_seconds": 27.4,
   "settings_applied": { "suggest_adlib_removal": true, "allow_insertions": true, "min_confidence": 0.0 },
-  "warnings": []
+  "warnings": [],
+  "cached": false
 }
 ```
+
+Results are cached per job in GCS
+(`jobs/{job_id}/lyrics/auto_correct_cache/{hash}.json`), keyed on the exact
+input: word ids + texts, reference lyrics texts, settings, and the resolved
+model list. Re-running on unmodified lyrics returns the previous result with
+`"cached": true` and incurs no LLM cost; any edit to the lyrics, references,
+or settings produces a new key and a fresh run. Cache reads/writes are
+best-effort — storage failures degrade to a normal uncached run.
 
 `op` is `replace` | `delete` | `insert_after` (for `insert_after`, `word_ids`
 holds the anchor word). Errors: `422` when no reference lyrics are available,

--- a/frontend/components/lyrics-review/AutoCorrectPanel.tsx
+++ b/frontend/components/lyrics-review/AutoCorrectPanel.tsx
@@ -58,6 +58,7 @@ export default function AutoCorrectPanel({
     suggestions,
     decisions,
     model,
+    cached,
     pendingCount,
     acceptedCount,
     accept,
@@ -88,6 +89,23 @@ export default function AutoCorrectPanel({
           <Badge variant="outline" className="hidden sm:inline-flex text-xs">
             {model}
           </Badge>
+          {cached && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Badge
+                    variant="outline"
+                    className="shrink-0 text-xs border-teal-500/50 text-teal-600 dark:text-teal-400"
+                  >
+                    {t('cachedBadge')}
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs">
+                  {t('cachedTooltip')}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
         </div>
         <div className="flex items-center gap-1 shrink-0">
           {!isReadOnly && pendingCount > 0 && (

--- a/frontend/hooks/useAutoCorrect.ts
+++ b/frontend/hooks/useAutoCorrect.ts
@@ -51,6 +51,7 @@ export function useAutoCorrect({
   const [suggestions, setSuggestions] = useState<AiSuggestion[]>([])
   const [decisions, setDecisions] = useState<Record<string, SuggestionDecision>>({})
   const [model, setModel] = useState<string>('')
+  const [cached, setCached] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const undoInfos = useRef<Record<string, SuggestionUndoInfo>>({})
   const abortRef = useRef<AbortController | null>(null)
@@ -91,10 +92,12 @@ export function useAutoCorrect({
         )
         undoInfos.current = {}
         setModel(response.model)
+        setCached(response.cached)
         setStatus('reviewing')
         addEditEntry(editLog, 'ai_suggestion_run', {
           details: {
             model: response.model,
+            cached: response.cached,
             suggestion_count: response.suggestions.length,
             elapsed_seconds: response.elapsed_seconds,
             settings: response.settings_applied as unknown as Record<string, unknown>,
@@ -273,6 +276,7 @@ export function useAutoCorrect({
     suggestions,
     decisions,
     model,
+    cached,
     error,
     hasReferences,
     pendingCount,

--- a/frontend/lib/api/autoCorrect.ts
+++ b/frontend/lib/api/autoCorrect.ts
@@ -64,6 +64,8 @@ export interface AutoCorrectResponse {
   elapsed_seconds: number
   settings_applied: AutoCorrectSettings
   warnings: string[]
+  /** Served from the per-job cache — no AI cost was incurred. */
+  cached: boolean
 }
 
 export class AutoCorrectApiError extends Error {
@@ -138,5 +140,6 @@ export async function fetchAutoCorrectSuggestions(
     elapsed_seconds: data.elapsed_seconds,
     settings_applied: data.settings_applied,
     warnings: data.warnings ?? [],
+    cached: data.cached ?? false,
   }
 }

--- a/frontend/messages/ar.json
+++ b/frontend/messages/ar.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "بديل",
       "conflictTooltip": "تختلف النماذج حول هذه الكلمات — قبول أحد البدائل يعني رفض الأخرى.",
       "consensusBadge": "{consensus}/{total} من النماذج",
-      "consensusTooltip": "مقترح من: {models}"
+      "consensusTooltip": "مقترح من: {models}",
+      "cachedBadge": "مخزن مؤقتاً",
+      "cachedTooltip": "تمت الاستعادة من معالجة سابقة لنفس الكلمات — لم يتم احتساب أي تكلفة للذكاء الاصطناعي."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/ca.json
+++ b/frontend/messages/ca.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "variant",
       "conflictTooltip": "Els models no coincideixen en aquestes paraules — si acceptes una variant, rebutges les altres.",
       "consensusBadge": "{consensus}/{total} models",
-      "consensusTooltip": "Proposat per: {models}"
+      "consensusTooltip": "Proposat per: {models}",
+      "cachedBadge": "en memòria cau",
+      "cachedTooltip": "Restaurat a partir d'una execució anterior amb la mateixa lletra — no s'ha generat cap cost d'IA."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/cs.json
+++ b/frontend/messages/cs.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "varianta",
       "conflictTooltip": "Modely se na těchto slovech neshodují — přijetím jedné varianty odmítneš ostatní.",
       "consensusBadge": "{consensus}/{total} modelů",
-      "consensusTooltip": "Navrženo: {models}"
+      "consensusTooltip": "Navrženo: {models}",
+      "cachedBadge": "z mezipaměti",
+      "cachedTooltip": "Obnoveno z předchozího zpracování stejného textu — nevznikly žádné náklady na AI."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "variant",
       "conflictTooltip": "Modellerne er uenige om disse ord — hvis du accepterer én variant, afvises de andre.",
       "consensusBadge": "{consensus}/{total} modeller",
-      "consensusTooltip": "Foreslået af: {models}"
+      "consensusTooltip": "Foreslået af: {models}",
+      "cachedBadge": "cachet",
+      "cachedTooltip": "Gendannet fra en tidligere kørsel med de samme sangtekster — der påløb ingen AI-omkostninger."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "Variante",
       "conflictTooltip": "Die Modelle sind sich bei diesen Wörtern uneinig — wenn du eine Variante akzeptierst, werden die anderen abgelehnt.",
       "consensusBadge": "{consensus}/{total} Modelle",
-      "consensusTooltip": "Vorgeschlagen von: {models}"
+      "consensusTooltip": "Vorgeschlagen von: {models}",
+      "cachedBadge": "zwischengespeichert",
+      "cachedTooltip": "Wiederhergestellt aus einem vorherigen Durchlauf mit demselben Text — es sind keine KI-Kosten angefallen."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/el.json
+++ b/frontend/messages/el.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "παραλλαγή",
       "conflictTooltip": "Τα μοντέλα διαφωνούν για αυτές τις λέξεις — αν αποδεχτείς μια παραλλαγή, απορρίπτεις τις υπόλοιπες.",
       "consensusBadge": "{consensus}/{total} μοντέλα",
-      "consensusTooltip": "Προτάθηκε από: {models}"
+      "consensusTooltip": "Προτάθηκε από: {models}",
+      "cachedBadge": "προσωρινά αποθηκευμένο",
+      "cachedTooltip": "Ανακτήθηκε από προηγούμενη επεξεργασία των ίδιων στίχων — δεν υπήρξε χρέωση AI."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1323,7 +1323,9 @@
       "consensusBadge": "{consensus}/{total} models",
       "consensusTooltip": "Proposed by: {models}",
       "conflictBadge": "variant",
-      "conflictTooltip": "Models disagree about these words — accepting one variant rejects the others."
+      "conflictTooltip": "Models disagree about these words — accepting one variant rejects the others.",
+      "cachedBadge": "cached",
+      "cachedTooltip": "Restored from a previous run on the same lyrics — no AI cost was incurred."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "variante",
       "conflictTooltip": "Los modelos no coinciden en estas palabras; al aceptar una variante, se rechazan las demás.",
       "consensusBadge": "{consensus}/{total} modelos",
-      "consensusTooltip": "Propuesto por: {models}"
+      "consensusTooltip": "Propuesto por: {models}",
+      "cachedBadge": "en caché",
+      "cachedTooltip": "Restaurado de una ejecución anterior con las mismas letras — no generó costos de IA."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/fi.json
+++ b/frontend/messages/fi.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "vaihtoehto",
       "conflictTooltip": "Mallit ovat eri mieltä näistä sanoista — yhden vaihtoehdon hyväksyminen hylkää muut.",
       "consensusBadge": "{consensus}/{total} mallia",
-      "consensusTooltip": "Ehdottanut: {models}"
+      "consensusTooltip": "Ehdottanut: {models}",
+      "cachedBadge": "välimuistissa",
+      "cachedTooltip": "Palautettu aiemmasta ajosta samoilla sanoituksilla — tekoälykustannuksia ei syntynyt."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "variante",
       "conflictTooltip": "Les modèles ne sont pas d'accord sur ces mots — accepter une variante rejette les autres.",
       "consensusBadge": "{consensus}/{total} modèles",
-      "consensusTooltip": "Proposé par : {models}"
+      "consensusTooltip": "Proposé par : {models}",
+      "cachedBadge": "en cache",
+      "cachedTooltip": "Restauré depuis un traitement précédent sur les mêmes paroles — aucun coût d'IA n'a été engagé."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/he.json
+++ b/frontend/messages/he.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "גרסה",
       "conflictTooltip": "המודלים לא מסכימים לגבי המילים האלו — אישור גרסה אחת ידחה את האחרות.",
       "consensusBadge": "{consensus}/{total} מודלים",
-      "consensusTooltip": "הוצע על ידי: {models}"
+      "consensusTooltip": "הוצע על ידי: {models}",
+      "cachedBadge": "שמור במטמון",
+      "cachedTooltip": "שוחזר מהרצה קודמת על אותן מילים — ללא חיוב עלות AI."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/hi.json
+++ b/frontend/messages/hi.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "विकल्प",
       "conflictTooltip": "इन शब्दों पर मॉडल असहमत हैं — एक विकल्प को स्वीकार करने से बाकी अस्वीकार हो जाते हैं।",
       "consensusBadge": "{consensus}/{total} मॉडल",
-      "consensusTooltip": "इनके द्वारा प्रस्तावित: {models}"
+      "consensusTooltip": "इनके द्वारा प्रस्तावित: {models}",
+      "cachedBadge": "कैश्ड",
+      "cachedTooltip": "इन्हीं लिरिक्स पर पिछले रन से रीस्टोर किया गया — कोई AI लागत नहीं आई।"
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/hr.json
+++ b/frontend/messages/hr.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "varijanta",
       "conflictTooltip": "Modeli se ne slažu oko ovih riječi — prihvaćanje jedne varijante odbacuje ostale.",
       "consensusBadge": "{consensus}/{total} modela",
-      "consensusTooltip": "Predložili: {models}"
+      "consensusTooltip": "Predložili: {models}",
+      "cachedBadge": "predmemorirano",
+      "cachedTooltip": "Obnovljeno iz prethodnog pokretanja s istim tekstom pjesme — nije bilo troškova za AI."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/hu.json
+++ b/frontend/messages/hu.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "változat",
       "conflictTooltip": "A modellek nem értenek egyet ezeknél a szavaknál — egy változat elfogadásával elutasítod a többit.",
       "consensusBadge": "{consensus}/{total} modell",
-      "consensusTooltip": "Javasolta: {models}"
+      "consensusTooltip": "Javasolta: {models}",
+      "cachedBadge": "gyorsítótárazott",
+      "cachedTooltip": "Egy korábbi, azonos dalszövegen végzett futtatásból visszaállítva — nem merült fel AI-költség."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/id.json
+++ b/frontend/messages/id.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "varian",
       "conflictTooltip": "Model memberikan hasil berbeda untuk kata-kata ini — menerima satu varian akan menolak varian lainnya.",
       "consensusBadge": "{consensus}/{total} model",
-      "consensusTooltip": "Diusulkan oleh: {models}"
+      "consensusTooltip": "Diusulkan oleh: {models}",
+      "cachedBadge": "di-cache",
+      "cachedTooltip": "Dipulihkan dari proses sebelumnya untuk lirik yang sama — tidak ada biaya AI yang dikenakan."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/it.json
+++ b/frontend/messages/it.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "variante",
       "conflictTooltip": "I modelli non concordano su queste parole — accettare una variante esclude le altre.",
       "consensusBadge": "{consensus}/{total} modelli",
-      "consensusTooltip": "Proposto da: {models}"
+      "consensusTooltip": "Proposto da: {models}",
+      "cachedBadge": "in cache",
+      "cachedTooltip": "Ripristinato da un'elaborazione precedente dello stesso testo — non ha comportato alcun costo per l'IA."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "別案",
       "conflictTooltip": "モデル間でこれらの単語の認識が異なります。1つの案を採用すると、他の案は破棄されます。",
       "consensusBadge": "{consensus}/{total} モデル",
-      "consensusTooltip": "提案元: {models}"
+      "consensusTooltip": "提案元: {models}",
+      "cachedBadge": "キャッシュ済み",
+      "cachedTooltip": "同じ歌詞の過去のデータから復元されました。AIのコストは発生していません。"
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "다른 버전",
       "conflictTooltip": "이 단어들에 대해 모델마다 제안이 달라요. 하나의 버전을 수락하면 나머지는 반영되지 않아요.",
       "consensusBadge": "{consensus}/{total}개 모델",
-      "consensusTooltip": "제안한 모델: {models}"
+      "consensusTooltip": "제안한 모델: {models}",
+      "cachedBadge": "캐시됨",
+      "cachedTooltip": "동일한 가사로 진행한 이전 작업에서 복원되었습니다 — AI 비용이 발생하지 않았습니다."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/ms.json
+++ b/frontend/messages/ms.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "varian",
       "conflictTooltip": "Model tidak bersetuju tentang perkataan ini — menerima satu varian akan menolak varian yang lain.",
       "consensusBadge": "{consensus}/{total} model",
-      "consensusTooltip": "Dicadangkan oleh: {models}"
+      "consensusTooltip": "Dicadangkan oleh: {models}",
+      "cachedBadge": "dicache",
+      "cachedTooltip": "Dipulihkan daripada proses sebelumnya untuk lirik yang sama — tiada kos AI dikenakan."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "variant",
       "conflictTooltip": "Modellene er uenige om disse ordene — hvis du godtar én variant, avvises de andre.",
       "consensusBadge": "{consensus}/{total} modeller",
-      "consensusTooltip": "Foreslått av: {models}"
+      "consensusTooltip": "Foreslått av: {models}",
+      "cachedBadge": "bufret",
+      "cachedTooltip": "Hentet fra en tidligere kjøring på samme sangtekst — det påløp ingen AI-kostnader."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "variant",
       "conflictTooltip": "De modellen zijn het niet eens over deze woorden — als je één variant accepteert, wijs je de andere af.",
       "consensusBadge": "{consensus}/{total} modellen",
-      "consensusTooltip": "Voorgesteld door: {models}"
+      "consensusTooltip": "Voorgesteld door: {models}",
+      "cachedBadge": "gecached",
+      "cachedTooltip": "Hersteld uit een eerdere verwerking van dezelfde songtekst — er zijn geen AI-kosten gemaakt."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "wariant",
       "conflictTooltip": "Modele nie są zgodne co do tych słów — zaakceptowanie jednego wariantu odrzuca pozostałe.",
       "consensusBadge": "{consensus}/{total} modeli",
-      "consensusTooltip": "Zaproponowane przez: {models}"
+      "consensusTooltip": "Zaproponowane przez: {models}",
+      "cachedBadge": "zbuforowane",
+      "cachedTooltip": "Przywrócono z poprzedniego przetworzenia tego samego tekstu — nie poniesiono kosztów AI."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "variante",
       "conflictTooltip": "Os modelos discordam sobre estas palavras — aceitar uma variante rejeita as outras.",
       "consensusBadge": "{consensus}/{total} modelos",
-      "consensusTooltip": "Proposto por: {models}"
+      "consensusTooltip": "Proposto por: {models}",
+      "cachedBadge": "em cache",
+      "cachedTooltip": "Restaurado de uma execução anterior da mesma letra — nenhum custo de IA foi gerado."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/ro.json
+++ b/frontend/messages/ro.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "variantă",
       "conflictTooltip": "Modelele au variante diferite pentru aceste cuvinte — dacă accepți o variantă, le respingi pe celelalte.",
       "consensusBadge": "{consensus}/{total} modele",
-      "consensusTooltip": "Propus de: {models}"
+      "consensusTooltip": "Propus de: {models}",
+      "cachedBadge": "din cache",
+      "cachedTooltip": "Restaurat dintr-o rulare anterioară pentru aceleași versuri — nu a generat niciun cost AI."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/ru.json
+++ b/frontend/messages/ru.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "вариант",
       "conflictTooltip": "Модели расходятся во мнении насчет этих слов — приняв один вариант, ты отклонишь остальные.",
       "consensusBadge": "{consensus}/{total} моделей",
-      "consensusTooltip": "Предложено: {models}"
+      "consensusTooltip": "Предложено: {models}",
+      "cachedBadge": "кэшировано",
+      "cachedTooltip": "Восстановлено из предыдущей обработки этого же текста песни — без затрат на ИИ."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/sk.json
+++ b/frontend/messages/sk.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "variant",
       "conflictTooltip": "Modely sa nezhodujú na týchto slovách — prijatím jedného variantu odmietneš ostatné.",
       "consensusBadge": "{consensus}/{total} modelov",
-      "consensusTooltip": "Navrhli: {models}"
+      "consensusTooltip": "Navrhli: {models}",
+      "cachedBadge": "z cache",
+      "cachedTooltip": "Obnovené z predchádzajúceho spustenia na rovnakom texte — nevznikli žiadne náklady na AI."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "variant",
       "conflictTooltip": "Modellerna är oense om dessa ord — om du accepterar en variant väljs de andra bort.",
       "consensusBadge": "{consensus}/{total} modeller",
-      "consensusTooltip": "Föreslaget av: {models}"
+      "consensusTooltip": "Föreslaget av: {models}",
+      "cachedBadge": "cachad",
+      "cachedTooltip": "Återställd från en tidigare körning på samma låttext — ingen AI-kostnad tillkom."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/th.json
+++ b/frontend/messages/th.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "ตัวเลือก",
       "conflictTooltip": "โมเดลให้ผลลัพธ์คำเหล่านี้ไม่ตรงกัน — การเลือกตัวเลือกหนึ่งจะเป็นการปฏิเสธตัวเลือกอื่นๆ",
       "consensusBadge": "{consensus}/{total} โมเดล",
-      "consensusTooltip": "เสนอโดย: {models}"
+      "consensusTooltip": "เสนอโดย: {models}",
+      "cachedBadge": "แคชไว้",
+      "cachedTooltip": "กู้คืนจากการประมวลผลเนื้อเพลงเดียวกันในครั้งก่อนหน้า — ไม่มีการคิดค่าใช้จ่าย AI"
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/tl.json
+++ b/frontend/messages/tl.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "variant",
       "conflictTooltip": "Hindi magkakatugma ang mga modelo sa mga salitang ito — kapag tinanggap ang isang variant, tatanggihan ang iba.",
       "consensusBadge": "{consensus}/{total} modelo",
-      "consensusTooltip": "Iminungkahi ng: {models}"
+      "consensusTooltip": "Iminungkahi ng: {models}",
+      "cachedBadge": "naka-cache",
+      "cachedTooltip": "Na-restore mula sa nakaraang pag-proseso ng parehong lyrics — walang nagastos na AI cost."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/tr.json
+++ b/frontend/messages/tr.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "varyant",
       "conflictTooltip": "Modeller bu kelimeler konusunda uyuşmuyor — bir varyantı kabul ettiğinde diğerlerini reddetmiş olursun.",
       "consensusBadge": "{consensus}/{total} model",
-      "consensusTooltip": "Öneren: {models}"
+      "consensusTooltip": "Öneren: {models}",
+      "cachedBadge": "önbellekten",
+      "cachedTooltip": "Aynı şarkı sözleriyle yapılan önceki bir işlemden geri yüklendi — yapay zeka maliyeti oluşmadı."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/uk.json
+++ b/frontend/messages/uk.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "варіант",
       "conflictTooltip": "Моделі розійшлися щодо цих слів — обравши один варіант, ти відхилиш інші.",
       "consensusBadge": "{consensus}/{total} моделей",
-      "consensusTooltip": "Запропоновано: {models}"
+      "consensusTooltip": "Запропоновано: {models}",
+      "cachedBadge": "кешовано",
+      "cachedTooltip": "Відновлено з попереднього запуску для цього ж тексту пісні — без витрат на ШІ."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/vi.json
+++ b/frontend/messages/vi.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "biến thể",
       "conflictTooltip": "Các mô hình không đồng nhất về những từ này — chấp nhận một biến thể sẽ loại bỏ các biến thể khác.",
       "consensusBadge": "{consensus}/{total} mô hình",
-      "consensusTooltip": "Đề xuất bởi: {models}"
+      "consensusTooltip": "Đề xuất bởi: {models}",
+      "cachedBadge": "đã lưu cache",
+      "cachedTooltip": "Được khôi phục từ lần chạy trước với cùng lời bài hát — không phát sinh chi phí AI."
     }
   },
   "instrumentalReview": {

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -1323,7 +1323,9 @@
       "conflictBadge": "选项",
       "conflictTooltip": "各模型对这些词存在分歧 —— 接受其中一个选项将放弃其他选项。",
       "consensusBadge": "{consensus}/{total} 个模型",
-      "consensusTooltip": "推荐模型：{models}"
+      "consensusTooltip": "推荐模型：{models}",
+      "cachedBadge": "已缓存",
+      "cachedTooltip": "已从之前相同歌词的处理记录中恢复 —— 未产生 AI 费用。"
     }
   },
   "instrumentalReview": {


### PR DESCRIPTION
@coderabbitai ignore

Per Andrew: clicking AI Suggest twice on the same unmodified lyrics shouldn't spend AI tokens twice.

Suggestions are now cached per job in GCS (`jobs/{job_id}/lyrics/auto_correct_cache/{hash}.json`), keyed on the exact input — word ids + texts, reference lyrics texts, settings knobs, and the resolved model list. A repeat run on byte-identical input returns the previous suggestions instantly with `cached: true` (teal "cached" badge in the panel) and incurs no LLM cost. Any edit to the lyrics, references, or settings produces a new key and a fresh run; word ids in the key guarantee cached suggestions always reference words that still exist.

Cache reads/writes are strictly best-effort — any storage failure degrades to a normal uncached run (tested). 7 new backend tests (hit skips model call, miss writes cache, key stability/sensitivity, payload round-trip, corrupt entry = miss, storage failure never breaks the request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)