### PR TITLE
fix(ci): revert lyrics-transcription-job to image-only deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1676,17 +1676,18 @@ jobs:
             --quiet
 
           # Lyrics transcription job (CPU, us-central1)
-          # Also wire the auto-correct env + Anthropic key so the worker can
-          # proactively pre-generate multi-model suggestions (cached for the
-          # review UI). --update-* merges, preserving the job's existing vars.
-          # Same service account as the API service, which already reads
-          # anthropic-api-key, so no new IAM is required.
+          # NOTE: image-only update. Adding --update-secrets here crashed gcloud
+          # ("Invalid secret path ... in annotation") because this job's existing
+          # secrets are stored via Cloud Run secret *aliases* that --update-secrets
+          # re-validates and rejects. Proactive auto-correct env/secret
+          # (AUTO_CORRECT_PROACTIVE_ENABLED + ANTHROPIC_API_KEY) must be wired by a
+          # method that handles the alias format (see proactive-autocorrect plan
+          # doc); until then the proactive flag stays unset and the worker's
+          # _run_proactive_auto_correct() returns early (no-op).
           gcloud run jobs update lyrics-transcription-job \
             --image "$IMAGE" \
             --region us-central1 \
             --project ${{ env.PROJECT_ID }} \
-            --update-env-vars "AUTO_CORRECT_MODEL=claude-fable-5,AUTO_CORRECT_COMPARE_MODELS=claude-fable-5;gemini-3.1-pro-preview,AUTO_CORRECT_PROACTIVE_ENABLED=true" \
-            --update-secrets "ANTHROPIC_API_KEY=anthropic-api-key:latest" \
             --quiet
 
           # Audio separation job (GPU, us-east4) — uses GPU image


### PR DESCRIPTION
## Why

PR #816's deploy **failed** at the "Update Cloud Run Jobs" step:

```
ERROR: gcloud crashed (ValueError): Invalid secret path 'projects/nomadkaraoke/secrets/audioshake-api-key' in annotation
```

The `--update-secrets ANTHROPIC_API_KEY=…` I added to `lyrics-transcription-job` made gcloud re-validate the job's *existing* secrets, which are stored via Cloud Run **secret aliases** (`secret-alias-N`) in a format `--update-secrets` rejects. That crash stranded **lyrics + audio jobs on the previous image** (the API service deployed fine and is healthy; the video-encoding-job updated fine).

## Fix

Revert the lyrics-job step to **image-only** (proven to work — same form the video/audio job steps use). This makes deploys succeed and brings lyrics + audio jobs onto the current image, so prod is consistent again.

Proactive auto-correct ships dormant: the worker's `_run_proactive_auto_correct()` is gated by `AUTO_CORRECT_PROACTIVE_ENABLED`, which is unset, so it returns early (no-op, zero risk). Wiring that env + the Anthropic secret onto the job via an alias-safe method is a tracked follow-up.

## Testing
- No code change; CI-only. The reverted step matches the working video-encoding-job step exactly.

@coderabbitai ignore