### PR TITLE
fix: honor "use official formatting" correction on search-created jobs

### DIFF
--- a/backend/api/routes/jobs.py
+++ b/backend/api/routes/jobs.py
@@ -2434,11 +2434,21 @@ async def create_job_from_search(
         from backend.services.job_defaults_service import resolve_cdg_txt_defaults
         resolved_cdg, resolved_txt = resolve_cdg_txt_defaults(effective_theme_id, None, None)
 
-        # Determine display values
+        # Determine display values.
+        # The session stores the ORIGINAL search query (e.g. "hard-fi"). body.artist/
+        # body.title carry whatever is currently in the wizard's artist/title fields,
+        # which reflect a "Use official formatting" correction the user may have applied
+        # after searching. The displayed job name must honour that correction, so prefer
+        # the request body over the stored query. An explicit display override wins above all.
         session_artist = session.get('artist', body.artist)
         session_title = session.get('title', body.title)
-        effective_display_artist = body.display_artist or session_artist
-        effective_display_title = body.display_title or session_title
+        # body.artist/body.title are required but unvalidated for whitespace, so strip
+        # them and fall back to the stored query if blank (display_* is pre-stripped to
+        # None by its validator). This keeps a stray "   " from becoming the job name.
+        body_artist = (body.artist or "").strip()
+        body_title = (body.title or "").strip()
+        effective_display_artist = body.display_artist or body_artist or session_artist
+        effective_display_title = body.display_title or body_title or session_title
 
         tenant_id = session.get('tenant_id') or ""
 

--- a/backend/tests/test_standalone_search.py
+++ b/backend/tests/test_standalone_search.py
@@ -545,6 +545,57 @@ class TestCreateJobFromSearch:
         assert job_create.artist == "Abba (Display)"
         assert job_create.title == "Waterloo (Karaoke)"
 
+    def test_corrected_artist_title_wins_over_session_query(self, create_from_search_client, auth_headers):
+        """Regression: when the user clicks "Use official formatting", the corrected
+        artist/title sent in the request body must win over the original (raw) search
+        query stored in the session. Previously the job was named with the raw query,
+        so the official formatting selection was silently ignored."""
+        # Session was created from the raw lowercase query the user typed...
+        raw_session = _make_search_session(user_email="test@example.com")
+        raw_session["artist"] = "hard-fi"
+        raw_session["title"] = "hard to beat"
+        create_from_search_client._mock_firestore.get_search_session.return_value = raw_session
+        create_from_search_client._mock_firestore.consume_search_session.return_value = raw_session
+
+        # ...then the user picked the official formatting, so the frontend sends the
+        # corrected artist/title (no separate display override).
+        create_from_search_client.post(
+            "/api/jobs/create-from-search",
+            json={
+                "search_session_id": "sess-abc-123",
+                "selection_index": 0,
+                "artist": "Hard-Fi",
+                "title": "Hard to Beat",
+            },
+            headers=auth_headers,
+        )
+        call_args = create_from_search_client._mock_jm.create_job.call_args
+        job_create = call_args[0][0]
+        assert job_create.artist == "Hard-Fi"
+        assert job_create.title == "Hard to Beat"
+        # The original query is still preserved for audio-search matching metadata.
+        assert job_create.audio_search_artist == "hard-fi"
+        assert job_create.audio_search_title == "hard to beat"
+
+    def test_blank_body_artist_title_falls_back_to_session_query(self, create_from_search_client, auth_headers):
+        """Whitespace-only artist/title in the body must not become the job name —
+        fall back to the stored search query instead."""
+        create_from_search_client.post(
+            "/api/jobs/create-from-search",
+            json={
+                "search_session_id": "sess-abc-123",
+                "selection_index": 0,
+                "artist": "   ",
+                "title": "\t",
+            },
+            headers=auth_headers,
+        )
+        call_args = create_from_search_client._mock_jm.create_job.call_args
+        job_create = call_args[0][0]
+        # Session stores "ABBA" / "Waterloo" (see _make_search_session).
+        assert job_create.artist == "ABBA"
+        assert job_create.title == "Waterloo"
+
     def test_session_consumed_atomically(self, create_from_search_client, auth_headers):
         """Session is consumed (atomically read+deleted) via consume_search_session."""
         create_from_search_client.post(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.182.0"
+version = "0.182.1"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Problem

When a user searches for a song, selects **"Use the official formatting"** (e.g. picks `Hard-Fi — Hard to Beat` over their typed `hard-fi - hard to beat`), and creates the job, the job was still named with their raw lowercase query. The official-formatting selection was silently discarded.

## Root cause

`create_job_from_search` (`backend/api/routes/jobs.py`) derived the display name from the **original search query stored in the session**, not from the corrected `artist`/`title` the frontend sends in the request body:

```python
session_artist = session.get('artist', body.artist)   # always the raw query
effective_display_artist = body.display_artist or session_artist  # body.artist never used
```

Since the session always has an `artist` key, `body.artist` was only ever an unreachable fallback. The frontend's "Use official formatting" click correctly updates its state and sends the corrected values — they were just ignored server-side.

## Fix

Prefer `body.artist`/`body.title` (the wizard's current, possibly-corrected values) over the stored query, with an explicit display override still winning above all. Whitespace-only body values are stripped and fall back to the stored query so a stray `"   "` can't become the job name. The original query is preserved for `audio_search_artist`/`audio_search_title` matching metadata.

## Tests

- New regression test: corrected artist/title wins over the session query (fails on old code: `'hard-fi' == 'Hard-Fi'`).
- New test: whitespace-only body artist/title falls back to the stored query.
- `test_standalone_search.py`: **33 passed**; broader job route/api/regression suites: **123 passed**.
- Existing `test_display_overrides_applied_when_provided` still passes (override precedence intact).

Version bumped `0.181.0 → 0.181.1`.

@coderabbitai ignore