### PR TITLE
feat(divebar): on-demand pipeline refresh trigger (refresh action)

### DIFF
--- a/infrastructure/functions/divebar_lookup/main.py
+++ b/infrastructure/functions/divebar_lookup/main.py
@@ -15,10 +15,20 @@ Provides search and cross-reference endpoints for the KJ Controller:
   POST /  {"action": "download_url", "file_id": "abc123"}
     → Generate a signed Google Drive download URL
 
+  POST /  {"action": "refresh", "token": "..."}
+    → On-demand "refresh now": force-run the divebar scheduler jobs
+      (Drive→BigQuery index, Drive→GCS file sync, xref rebuild) so a track
+      just published to the Nomad Drive shows up without waiting for the
+      nightly 2/3/6 AM runs. Token-gated (shared bearer) since the endpoint
+      is otherwise public.
+
 Environment variables:
   GCP_PROJECT_ID: GCP project ID
+  GCP_REGION: region the divebar scheduler jobs live in (for `refresh`)
+  DIVEBAR_REFRESH_TOKEN: shared bearer token gating the `refresh` action
 """
 
+import hmac
 import json
 import logging
 import os
@@ -32,7 +42,16 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(messag
 logger = logging.getLogger(__name__)
 
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "nomadkaraoke")
+GCP_REGION = os.environ.get("GCP_REGION", "us-central1")
 DATASET = "karaoke_decide"
+
+# Cloud Scheduler jobs the `refresh` action force-runs, in pipeline order.
+# Each carries its own OIDC identity/target, so we only need run permission.
+REFRESH_SCHEDULER_JOBS = [
+    "divebar-mirror-daily",        # Drive -> BigQuery index (track first appears)
+    "divebar-sync-vm-daily",       # Drive -> GCS file sync (upgrades to fast URL)
+    "divebar-xref-rebuild-daily",  # KN <-> Divebar cross-reference rebuild
+]
 
 
 def _json_response(data: dict, status: int = 200):
@@ -379,6 +398,48 @@ def _get_full_stats() -> dict:
     }
 
 
+def _refresh(token: str) -> dict:
+    """Force-run the divebar pipeline scheduler jobs on demand.
+
+    Validates the shared bearer token, then triggers each job in
+    REFRESH_SCHEDULER_JOBS via the Cloud Scheduler API. Jobs run
+    asynchronously under their own identities; this returns as soon as they're
+    queued.
+
+    Returns {"triggered": [...]} on success. Raises PermissionError on a
+    bad/missing token.
+    """
+    expected = os.environ.get("DIVEBAR_REFRESH_TOKEN", "")
+    # Constant-time compare; also reject when the token isn't configured so a
+    # misconfigured deploy can't be bypassed with an empty token.
+    if not expected or not token or not hmac.compare_digest(str(token), expected):
+        raise PermissionError("invalid or missing refresh token")
+
+    from google.cloud import scheduler_v1
+
+    client = scheduler_v1.CloudSchedulerClient()
+    triggered, failed = [], []
+    for job in REFRESH_SCHEDULER_JOBS:
+        job_path = f"projects/{GCP_PROJECT_ID}/locations/{GCP_REGION}/jobs/{job}"
+        try:
+            client.run_job(name=job_path)
+            triggered.append(job)
+        except Exception as e:
+            # Best-effort: one job failing (e.g. already running) shouldn't
+            # block the others. Surface it so callers can see partial success.
+            logger.warning("Failed to run scheduler job %s: %s", job, e)
+            failed.append({"job": job, "error": str(e)})
+
+    return {
+        "triggered": triggered,
+        "failed": failed,
+        # The mirror/sync jobs run async (index ~minutes, GCS sync up to ~1h);
+        # the catalog reflects a newly-published track once the mirror index
+        # completes. xref fully reflects new tracks after the next mirror run.
+        "note": "Jobs queued. New tracks appear after the mirror index completes (~minutes).",
+    }
+
+
 @functions_framework.http
 def divebar_lookup(request):
     """HTTP Cloud Function entry point."""
@@ -433,6 +494,14 @@ def divebar_lookup(request):
         elif action == "stats":
             stats = _get_full_stats()
             return _json_response({"status": "ok", **stats})
+
+        elif action == "refresh":
+            try:
+                result = _refresh(body.get("token", ""))
+            except PermissionError:
+                # Don't leak whether the token exists; uniform 403.
+                return _json_response({"status": "error", "message": "forbidden"}, 403)
+            return _json_response({"status": "ok", **result})
 
         else:
             return _json_response({"status": "error", "message": f"Unknown action: {action}"}, 400)

--- a/infrastructure/functions/divebar_lookup/main.py
+++ b/infrastructure/functions/divebar_lookup/main.py
@@ -25,7 +25,9 @@ Provides search and cross-reference endpoints for the KJ Controller:
 Environment variables:
   GCP_PROJECT_ID: GCP project ID
   GCP_REGION: region the divebar scheduler jobs live in (for `refresh`)
-  DIVEBAR_REFRESH_TOKEN: shared bearer token gating the `refresh` action
+  DIVEBAR_REFRESH_SECRET_ID: Secret Manager secret holding the `refresh` bearer
+    token (read at runtime, so the function deploys before the secret has a
+    value — it just returns 403 until one is added)
 """
 
 import hmac
@@ -44,6 +46,7 @@ logger = logging.getLogger(__name__)
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "nomadkaraoke")
 GCP_REGION = os.environ.get("GCP_REGION", "us-central1")
 DATASET = "karaoke_decide"
+REFRESH_SECRET_ID = os.environ.get("DIVEBAR_REFRESH_SECRET_ID", "divebar-refresh-token")
 
 # Cloud Scheduler jobs the `refresh` action force-runs, in pipeline order.
 # Each carries its own OIDC identity/target, so we only need run permission.
@@ -398,20 +401,40 @@ def _get_full_stats() -> dict:
     }
 
 
+def _get_expected_token() -> str:
+    """Read the refresh bearer token from Secret Manager (latest version).
+
+    Read at call time rather than injected as an env var so the function can be
+    deployed before the secret has any version — until one is added this returns
+    "" and the gate below rejects every request. Returns "" on any access error
+    (missing secret/version, no permission) so failures fail closed.
+    """
+    from google.cloud import secretmanager
+
+    name = f"projects/{GCP_PROJECT_ID}/secrets/{REFRESH_SECRET_ID}/versions/latest"
+    try:
+        client = secretmanager.SecretManagerServiceClient()
+        resp = client.access_secret_version(name=name)
+        return resp.payload.data.decode("utf-8").strip()
+    except Exception as e:
+        logger.warning("Could not read refresh token secret: %s", e)
+        return ""
+
+
 def _refresh(token: str) -> dict:
     """Force-run the divebar pipeline scheduler jobs on demand.
 
-    Validates the shared bearer token, then triggers each job in
-    REFRESH_SCHEDULER_JOBS via the Cloud Scheduler API. Jobs run
+    Validates the shared bearer token (from Secret Manager), then triggers each
+    job in REFRESH_SCHEDULER_JOBS via the Cloud Scheduler API. Jobs run
     asynchronously under their own identities; this returns as soon as they're
     queued.
 
     Returns {"triggered": [...]} on success. Raises PermissionError on a
     bad/missing token.
     """
-    expected = os.environ.get("DIVEBAR_REFRESH_TOKEN", "")
+    expected = _get_expected_token()
     # Constant-time compare; also reject when the token isn't configured so a
-    # misconfigured deploy can't be bypassed with an empty token.
+    # function deployed before the secret has a value can't be bypassed.
     if not expected or not token or not hmac.compare_digest(str(token), expected):
         raise PermissionError("invalid or missing refresh token")
 

--- a/infrastructure/functions/divebar_lookup/requirements.txt
+++ b/infrastructure/functions/divebar_lookup/requirements.txt
@@ -4,5 +4,9 @@ google-cloud-bigquery>=3.13.0
 # Cloud Storage (for signed download URLs)
 google-cloud-storage>=2.13.0
 
+# Cloud Scheduler (for the on-demand `refresh` action — force-runs the
+# divebar mirror/sync/xref scheduler jobs)
+google-cloud-scheduler>=2.13.0
+
 # Cloud Functions framework
 functions-framework>=3.0.0

--- a/infrastructure/functions/divebar_lookup/requirements.txt
+++ b/infrastructure/functions/divebar_lookup/requirements.txt
@@ -8,5 +8,8 @@ google-cloud-storage>=2.13.0
 # divebar mirror/sync/xref scheduler jobs)
 google-cloud-scheduler>=2.13.0
 
+# Secret Manager (reads the `refresh` action's bearer token at runtime)
+google-cloud-secret-manager>=2.16.0
+
 # Cloud Functions framework
 functions-framework>=3.0.0

--- a/infrastructure/functions/divebar_lookup/test_main.py
+++ b/infrastructure/functions/divebar_lookup/test_main.py
@@ -14,9 +14,9 @@ from unittest.mock import MagicMock
 import pytest
 
 # Stub out Cloud Function deps that aren't installed in the test env. The
-# scheduler client is imported lazily inside _refresh, so stub it here too.
-# functions_framework.http must be an identity decorator so the real entry
-# point stays callable (a bare MagicMock would replace it).
+# scheduler/secret clients are imported lazily inside the refresh helpers, so
+# stub them here too. functions_framework.http must be an identity decorator so
+# the real entry point stays callable (a bare MagicMock would replace it).
 _functions_framework = MagicMock()
 _functions_framework.http = lambda fn: fn
 _scheduler_mod = MagicMock()
@@ -25,6 +25,7 @@ for name, mod in (
     ("google.cloud.bigquery", MagicMock()),
     ("google.cloud.storage", MagicMock()),
     ("google.cloud.scheduler_v1", _scheduler_mod),
+    ("google.cloud.secretmanager", MagicMock()),
 ):
     sys.modules.setdefault(name, mod)
 
@@ -37,8 +38,9 @@ TOKEN = "s3cret-refresh-token"
 
 @pytest.fixture(autouse=True)
 def _reset_scheduler(monkeypatch):
-    """Fresh scheduler client mock + configured token for each test."""
-    monkeypatch.setenv("DIVEBAR_REFRESH_TOKEN", TOKEN)
+    """Fresh scheduler client mock + a configured token (read from Secret
+    Manager at runtime, mocked here) for each test."""
+    monkeypatch.setattr(main, "_get_expected_token", lambda: TOKEN)
     client = MagicMock()
     _scheduler_mod.CloudSchedulerClient = MagicMock(return_value=client)
     yield client
@@ -69,9 +71,9 @@ class TestRefreshTokenGate:
         _reset_scheduler.run_job.assert_not_called()
 
     def test_unconfigured_server_token_raises(self, monkeypatch, _reset_scheduler):
-        # Even if the caller sends a token, an unconfigured server rejects it
-        # (can't be bypassed with a blank expected value).
-        monkeypatch.delenv("DIVEBAR_REFRESH_TOKEN", raising=False)
+        # Secret has no value yet (read returns "") — even if the caller sends a
+        # token, an unconfigured server rejects it (fails closed).
+        monkeypatch.setattr(main, "_get_expected_token", lambda: "")
         with pytest.raises(PermissionError):
             main._refresh("anything")
         _reset_scheduler.run_job.assert_not_called()

--- a/infrastructure/functions/divebar_lookup/test_main.py
+++ b/infrastructure/functions/divebar_lookup/test_main.py
@@ -1,0 +1,137 @@
+"""
+Tests for divebar_lookup/main.py — focused on the on-demand `refresh` action.
+
+`refresh` force-runs the divebar pipeline scheduler jobs (mirror index, GCS
+file sync, xref rebuild) so a just-published track shows up without waiting for
+the nightly runs. The endpoint is otherwise public, so the action is gated by a
+shared bearer token (constant-time compare).
+"""
+import os
+import sys
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+# Stub out Cloud Function deps that aren't installed in the test env. The
+# scheduler client is imported lazily inside _refresh, so stub it here too.
+# functions_framework.http must be an identity decorator so the real entry
+# point stays callable (a bare MagicMock would replace it).
+_functions_framework = MagicMock()
+_functions_framework.http = lambda fn: fn
+_scheduler_mod = MagicMock()
+for name, mod in (
+    ("functions_framework", _functions_framework),
+    ("google.cloud.bigquery", MagicMock()),
+    ("google.cloud.storage", MagicMock()),
+    ("google.cloud.scheduler_v1", _scheduler_mod),
+):
+    sys.modules.setdefault(name, mod)
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import main  # noqa: E402
+
+TOKEN = "s3cret-refresh-token"
+
+
+@pytest.fixture(autouse=True)
+def _reset_scheduler(monkeypatch):
+    """Fresh scheduler client mock + configured token for each test."""
+    monkeypatch.setenv("DIVEBAR_REFRESH_TOKEN", TOKEN)
+    client = MagicMock()
+    _scheduler_mod.CloudSchedulerClient = MagicMock(return_value=client)
+    yield client
+
+
+class MockRequest:
+    def __init__(self, body, method="POST"):
+        self.method = method
+        self._body = body
+
+    def get_json(self, silent=False):
+        return self._body
+
+
+# ---------------------------------------------------------------------------
+# _refresh — token gate
+# ---------------------------------------------------------------------------
+
+class TestRefreshTokenGate:
+    def test_wrong_token_raises(self, _reset_scheduler):
+        with pytest.raises(PermissionError):
+            main._refresh("nope")
+        _reset_scheduler.run_job.assert_not_called()
+
+    def test_empty_token_raises(self, _reset_scheduler):
+        with pytest.raises(PermissionError):
+            main._refresh("")
+        _reset_scheduler.run_job.assert_not_called()
+
+    def test_unconfigured_server_token_raises(self, monkeypatch, _reset_scheduler):
+        # Even if the caller sends a token, an unconfigured server rejects it
+        # (can't be bypassed with a blank expected value).
+        monkeypatch.delenv("DIVEBAR_REFRESH_TOKEN", raising=False)
+        with pytest.raises(PermissionError):
+            main._refresh("anything")
+        _reset_scheduler.run_job.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _refresh — job triggering
+# ---------------------------------------------------------------------------
+
+class TestRefreshTriggers:
+    def test_runs_all_pipeline_jobs_in_order(self, _reset_scheduler):
+        result = main._refresh(TOKEN)
+
+        assert result["triggered"] == main.REFRESH_SCHEDULER_JOBS
+        assert result["failed"] == []
+        # Each job referenced by its full path in the configured region.
+        called_paths = [c.kwargs["name"] for c in _reset_scheduler.run_job.call_args_list]
+        assert called_paths == [
+            f"projects/{main.GCP_PROJECT_ID}/locations/{main.GCP_REGION}/jobs/{j}"
+            for j in main.REFRESH_SCHEDULER_JOBS
+        ]
+
+    def test_one_job_failing_does_not_block_others(self, _reset_scheduler):
+        # First job raises (e.g. already running); the rest still fire.
+        _reset_scheduler.run_job.side_effect = [
+            RuntimeError("already running"), None, None,
+        ]
+        result = main._refresh(TOKEN)
+
+        assert result["triggered"] == main.REFRESH_SCHEDULER_JOBS[1:]
+        assert len(result["failed"]) == 1
+        assert result["failed"][0]["job"] == main.REFRESH_SCHEDULER_JOBS[0]
+
+
+# ---------------------------------------------------------------------------
+# divebar_lookup dispatch — refresh action
+# ---------------------------------------------------------------------------
+
+class TestRefreshDispatch:
+    def test_good_token_returns_200(self, _reset_scheduler):
+        body, status, _ = main.divebar_lookup(
+            MockRequest({"action": "refresh", "token": TOKEN})
+        )
+        assert status == 200
+        payload = json.loads(body)
+        assert payload["status"] == "ok"
+        assert payload["triggered"] == main.REFRESH_SCHEDULER_JOBS
+
+    def test_bad_token_returns_403_uniform_message(self, _reset_scheduler):
+        body, status, _ = main.divebar_lookup(
+            MockRequest({"action": "refresh", "token": "wrong"})
+        )
+        assert status == 403
+        payload = json.loads(body)
+        assert payload["status"] == "error"
+        # Uniform message — doesn't leak whether the token is configured.
+        assert payload["message"] == "forbidden"
+        _reset_scheduler.run_job.assert_not_called()
+
+    def test_missing_token_returns_403(self, _reset_scheduler):
+        body, status, _ = main.divebar_lookup(MockRequest({"action": "refresh"}))
+        assert status == 403
+        _reset_scheduler.run_job.assert_not_called()

--- a/infrastructure/modules/divebar_lookup.py
+++ b/infrastructure/modules/divebar_lookup.py
@@ -118,22 +118,17 @@ def create_divebar_lookup_resources(all_secrets: dict) -> dict:
                 # Region the divebar scheduler jobs live in — the `refresh`
                 # action builds job paths from it to run them on demand.
                 "GCP_REGION": REGION,
+                # Secret holding the `refresh` bearer token. Read at runtime
+                # (not injected as a secret env var) so the function deploys
+                # cleanly before the secret has a version — it just returns 403
+                # until one is added. Avoids a deploy-ordering gotcha.
+                "DIVEBAR_REFRESH_SECRET_ID": all_secrets["divebar-refresh-token"].secret_id,
             },
-            # Shared bearer token gating the `refresh` action (anti-abuse on an
-            # otherwise-public endpoint). Injected from Secret Manager.
-            secret_environment_variables=[
-                cloudfunctionsv2.FunctionServiceConfigSecretEnvironmentVariableArgs(
-                    key="DIVEBAR_REFRESH_TOKEN",
-                    project_id=PROJECT_ID,
-                    secret=all_secrets["divebar-refresh-token"].secret_id,
-                    version="latest",
-                ),
-            ],
         ),
     )
     resources["function"] = function
 
-    # Allow the function SA to read the refresh-token secret.
+    # Allow the function SA to read the refresh-token secret at runtime.
     resources["refresh_token_accessor"] = gcp.secretmanager.SecretIamMember(
         "divebar-lookup-refresh-token-accessor",
         secret_id=all_secrets["divebar-refresh-token"].secret_id,

--- a/infrastructure/modules/divebar_lookup.py
+++ b/infrastructure/modules/divebar_lookup.py
@@ -115,10 +115,31 @@ def create_divebar_lookup_resources(all_secrets: dict) -> dict:
             service_account_email=sa.email,
             environment_variables={
                 "GCP_PROJECT_ID": PROJECT_ID,
+                # Region the divebar scheduler jobs live in — the `refresh`
+                # action builds job paths from it to run them on demand.
+                "GCP_REGION": REGION,
             },
+            # Shared bearer token gating the `refresh` action (anti-abuse on an
+            # otherwise-public endpoint). Injected from Secret Manager.
+            secret_environment_variables=[
+                cloudfunctionsv2.FunctionServiceConfigSecretEnvironmentVariableArgs(
+                    key="DIVEBAR_REFRESH_TOKEN",
+                    project_id=PROJECT_ID,
+                    secret=all_secrets["divebar-refresh-token"].secret_id,
+                    version="latest",
+                ),
+            ],
         ),
     )
     resources["function"] = function
+
+    # Allow the function SA to read the refresh-token secret.
+    resources["refresh_token_accessor"] = gcp.secretmanager.SecretIamMember(
+        "divebar-lookup-refresh-token-accessor",
+        secret_id=all_secrets["divebar-refresh-token"].secret_id,
+        role="roles/secretmanager.secretAccessor",
+        member=sa.email.apply(lambda email: f"serviceAccount:{email}"),
+    )
 
     # ==================== IAM: Allow unauthenticated access ====================
     # The KJ Controller calls this from a LAN device without GCP credentials.
@@ -187,6 +208,33 @@ def create_divebar_lookup_resources(all_secrets: dict) -> dict:
             min_backoff_duration="60s",
             max_backoff_duration="300s",
         ),
+    )
+
+    # ==================== IAM: on-demand scheduler-job runner ====================
+    # The `refresh` action forces the existing divebar scheduler jobs
+    # (mirror index, file-sync VM start, xref rebuild) to run immediately,
+    # reusing their own OIDC identities and targets. The function SA therefore
+    # only needs permission to *run* those jobs — not to invoke the mirror
+    # function or start the VM directly. Least-privilege custom role rather than
+    # the broad roles/cloudscheduler.admin.
+
+    scheduler_runner_role = gcp.projects.IAMCustomRole(
+        "divebar-scheduler-runner-role",
+        role_id="divebarSchedulerRunner",
+        title="Divebar Scheduler Job Runner",
+        description="Run (force-trigger) Divebar Cloud Scheduler jobs on demand",
+        permissions=[
+            "cloudscheduler.jobs.run",
+            "cloudscheduler.jobs.get",
+        ],
+    )
+    resources["scheduler_runner_role"] = scheduler_runner_role
+
+    resources["scheduler_runner_binding"] = gcp.projects.IAMMember(
+        "divebar-lookup-scheduler-runner",
+        project=PROJECT_ID,
+        role=scheduler_runner_role.id,
+        member=sa.email.apply(lambda email: f"serviceAccount:{email}"),
     )
 
     return resources

--- a/infrastructure/modules/secrets.py
+++ b/infrastructure/modules/secrets.py
@@ -68,6 +68,12 @@ def create_secrets() -> dict[str, secretmanager.Secret]:
 
         # Notifications (Discord)
         "discord-alert-webhook",
+
+        # Divebar on-demand refresh trigger (shared bearer token: kjbox's
+        # "Refresh catalog" button -> divebar-lookup `refresh` action). Gates
+        # an otherwise-public endpoint that re-runs the mirror/sync/xref
+        # scheduler jobs on demand, so it's anti-abuse, not data-sensitive.
+        "divebar-refresh-token",
     ]
 
     secrets = {}


### PR DESCRIPTION
## Why

A track made via gen.nomadkaraoke.com is uploaded to the Nomad Google Drive immediately, but the Divebar/GCS community mirror only ingests it on the nightly schedule (mirror index 2 AM, GCS file sync 3 AM, xref rebuild 6 AM ET). Until then, kjbox's link flow can't find a mirror copy and falls back to a YouTube download.

This adds an **on-demand "refresh now"** path so a freshly-published track can be pulled into the catalog within minutes.

## What

New `refresh` action on the **public `divebar-lookup`** Cloud Function:

- Force-runs the three existing scheduler jobs in pipeline order — `divebar-mirror-daily` (Drive→BigQuery index, makes the track appear) → `divebar-sync-vm-daily` (Drive→GCS, fast URL) → `divebar-xref-rebuild-daily` — via `CloudSchedulerClient.run_job`. Reuses each job's own OIDC identity/target.
- **Least privilege:** the function SA gets a custom `divebarSchedulerRunner` role (`cloudscheduler.jobs.run` + `.get`) only — no new function-invoke or compute perms.
- **Token-gated:** the endpoint is public, so the action requires a shared bearer token (constant-time compare). The token is read from the `divebar-refresh-token` Secret Manager secret **at runtime** (not injected as a secret env var) so the function deploys cleanly before the secret has a version — it just returns a uniform `403` until one is added, and picks up rotations without a redeploy. Fails closed.

Consumed by kjbox's new "Refresh catalog" button (kjbox#107).

## Tests

`infrastructure/functions/divebar_lookup/test_main.py` — 8 tests: token gate (wrong/empty/unconfigured), all-jobs-triggered-in-order, partial-failure tolerance, dispatch 200/403. All green.

## Deploy status — ✅ applied to prod

Applied locally (provider pinned to prod's 9.22.0 so the apply contained only these 5 resources — no unrelated provider-upgrade churn): `4 created, 1 updated, 262 unchanged`. Function source rebuilt from the new zip. Secret version set. Verified live: no/wrong token → 403; valid token → 200 triggering all three jobs.

**Remaining (kjbox#107):** put the same token in the kjbox device `config.json` as `divebar_refresh_token`, then deploy kjbox.

@coderabbitai ignore