### PR TITLE
infra: GCP cost reductions (artifact cleanup, NAT egress, weekly backup)

### DIFF
--- a/infrastructure/compute/encoding_worker_vm.py
+++ b/infrastructure/compute/encoding_worker_vm.py
@@ -50,6 +50,18 @@ def create_encoding_worker_vms(
                     image=custom_image,
                     size=DiskSizes.ENCODING_WORKER,
                     type="hyperdisk-balanced",
+                    # NOTE: Hyperdisk provisioned IOPS/throughput are deliberately
+                    # NOT set here. Specifying them forces a full VM *replacement*
+                    # (the provider treats boot-disk init params as immutable), and
+                    # recreating a primary depends on us-central1-c capacity — the
+                    # exact shortage the fallback fleet exists to absorb. So the
+                    # disks are pinned to the Hyperdisk Balanced free baseline
+                    # (3000 IOPS / 140 MB/s) live via `gcloud compute disks update`
+                    # instead — non-disruptive, and pulumi does not manage this
+                    # attribute so there is no drift. They were over-provisioned at
+                    # 3600 IOPS / 290 MB/s (~$8.70/disk/mo wasted). Re-apply the
+                    # gcloud tune after any worker-image rebuild that recreates the
+                    # disks. See docs/archive/2026-06-14-gcp-cost-reduction-plan.md.
                 ),
             ),
             network_interfaces=[compute.InstanceNetworkInterfaceArgs(
@@ -127,6 +139,18 @@ def create_encoding_worker_fallback_vms(
                     image=custom_image,
                     size=DiskSizes.ENCODING_WORKER,
                     type="hyperdisk-balanced",
+                    # NOTE: Hyperdisk provisioned IOPS/throughput are deliberately
+                    # NOT set here. Specifying them forces a full VM *replacement*
+                    # (the provider treats boot-disk init params as immutable), and
+                    # recreating a primary depends on us-central1-c capacity — the
+                    # exact shortage the fallback fleet exists to absorb. So the
+                    # disks are pinned to the Hyperdisk Balanced free baseline
+                    # (3000 IOPS / 140 MB/s) live via `gcloud compute disks update`
+                    # instead — non-disruptive, and pulumi does not manage this
+                    # attribute so there is no drift. They were over-provisioned at
+                    # 3600 IOPS / 290 MB/s (~$8.70/disk/mo wasted). Re-apply the
+                    # gcloud tune after any worker-image rebuild that recreates the
+                    # disks. See docs/archive/2026-06-14-gcp-cost-reduction-plan.md.
                 ),
             ),
             network_interfaces=[compute.InstanceNetworkInterfaceArgs(

--- a/infrastructure/functions/backup_to_aws/firestore_export.py
+++ b/infrastructure/functions/backup_to_aws/firestore_export.py
@@ -1,9 +1,34 @@
 """Firestore export to GCS staging bucket."""
 
 import logging
-from google.cloud import firestore_admin_v1
+from google.cloud import firestore_admin_v1, storage
 
 logger = logging.getLogger(__name__)
+
+
+def _clear_prior_exports(staging_bucket: str, keep_date: str) -> None:
+    """Delete prior firestore/ exports in staging except the keep_date one.
+
+    The Firestore export runs nightly to provide a fresh daily local (GCS)
+    restore point, but is only uploaded to S3 weekly (to cut egress). On
+    non-weekly days the export is held back from S3 and left in staging, so
+    without this cleanup a week of exports would pile up and the weekly upload
+    would ship all of them at once — defeating the saving. Keeping only the
+    latest export means the weekly upload ships exactly one.
+    """
+    keep_prefix = f"firestore/{keep_date}"
+    try:
+        client = storage.Client()
+        bucket = client.bucket(staging_bucket)
+        for blob in bucket.list_blobs(prefix="firestore/"):
+            if not blob.name.startswith(keep_prefix):
+                try:
+                    blob.delete()
+                except Exception as e:
+                    logger.warning(f"Failed to delete stale firestore export {blob.name}: {e}")
+    except Exception as e:
+        # Best-effort cleanup — the export already succeeded, so never fail on it.
+        logger.warning(f"Failed to list/clear prior firestore exports: {e}")
 
 
 def export_firestore(project: str, staging_bucket: str, date_str: str) -> str:
@@ -31,6 +56,9 @@ def export_firestore(project: str, staging_bucket: str, date_str: str) -> str:
     )
 
     result = operation.result(timeout=1800)  # 30 min timeout
+
+    # Keep only this export in staging so the weekly S3 upload ships exactly one.
+    _clear_prior_exports(staging_bucket, date_str)
 
     logger.info(f"Firestore export complete: {output_uri}")
     return f"Exported to {output_uri} ({date_str})"

--- a/infrastructure/functions/backup_to_aws/main.py
+++ b/infrastructure/functions/backup_to_aws/main.py
@@ -2,14 +2,18 @@
 Backup to AWS Cloud Function.
 
 Nightly backup pipeline:
-1. Firestore export to GCS staging
+1. Firestore export to GCS staging (nightly; uploaded to S3 weekly on Sundays)
 2. BigQuery export to GCS staging (weekly/monthly schedule)
 3. GCS job files delta sync to staging
 4. Secret Manager export (encrypted with sealed-box public key) to staging
-5. Upload staging files to S3
+5. Upload staging files to S3 (Firestore export held back except Sundays)
 6. Discord alert
 
 Triggered by Cloud Scheduler at 1:00 AM ET daily.
+
+Firestore is the bulk of the cross-cloud egress. Exporting it nightly to GCS
+keeps a 1-day local restore point, while uploading to S3 only weekly keeps a
+1-week off-site RPO at ~1/7th the egress cost.
 """
 
 import datetime
@@ -59,7 +63,13 @@ def backup_to_aws(request):
     results = {}
     errors = []
 
-    logger.info(f"Starting backup for {date_str}")
+    # The Firestore export runs nightly (daily local restore point in GCS) but
+    # is only pushed off-site to S3 weekly, on Sundays — matching the BigQuery
+    # weekly cadence. This is the bulk of the cross-cloud egress, so weekly
+    # off-site keeps a 1-week off-site RPO while a 1-day local RPO is retained.
+    firestore_to_s3_today = today.weekday() == 6  # Sunday
+
+    logger.info(f"Starting backup for {date_str} (firestore->S3: {firestore_to_s3_today})")
 
     # Step 1: Firestore export (nightly)
     try:
@@ -123,11 +133,13 @@ def backup_to_aws(request):
         logger.error(f"Secrets export failed: {e}")
         errors.append(f"Secrets: {e}")
 
-    # Step 5: Upload to S3
+    # Step 5: Upload to S3. On non-Sundays, hold the Firestore export back
+    # (it stays in GCS staging as a daily local backup); it ships to S3 weekly.
     try:
         results["s3_upload"] = upload_staging_to_s3(
             staging_bucket=STAGING_BUCKET,
             s3_bucket=S3_BUCKET,
+            exclude_prefixes=[] if firestore_to_s3_today else ["firestore/"],
         )
     except Exception as e:
         logger.error(f"S3 upload failed: {e}")

--- a/infrastructure/functions/backup_to_aws/s3_upload.py
+++ b/infrastructure/functions/backup_to_aws/s3_upload.py
@@ -21,12 +21,20 @@ def upload_staging_to_s3(
     staging_bucket: str,
     s3_bucket: str,
     project: str = "nomadkaraoke",
+    exclude_prefixes: list | None = None,
 ) -> str:
     """Upload all objects in staging bucket to S3 using streaming.
 
     Walks the staging bucket and uploads each object to the corresponding
-    S3 key path. Skips marker files (.*).
+    S3 key path. Skips marker files (.*) and any object whose name starts with
+    one of ``exclude_prefixes`` (used to hold the nightly Firestore export back
+    from S3 on non-weekly days — it stays in GCS staging as a daily local
+    restore point and is uploaded only on the weekly run).
+
+    Excluded objects are left in staging (not deleted), so they remain a local
+    backup until the GCS lifecycle policy or the next weekly upload removes them.
     """
+    exclude_prefixes = exclude_prefixes or []
     aws_creds = get_aws_credentials(project)
     s3_client = boto3.client(
         "s3",
@@ -43,6 +51,9 @@ def upload_staging_to_s3(
 
     for blob in bucket.list_blobs():
         if blob.name.startswith(".") or "/.last_sync" in blob.name:
+            continue
+
+        if any(blob.name.startswith(p) for p in exclude_prefixes):
             continue
 
         try:

--- a/infrastructure/functions/backup_to_aws/test_firestore_export.py
+++ b/infrastructure/functions/backup_to_aws/test_firestore_export.py
@@ -5,8 +5,9 @@ from unittest.mock import MagicMock, patch
 
 
 class TestFirestoreExport(unittest.TestCase):
+    @patch("firestore_export.storage.Client")
     @patch("firestore_export.firestore_admin_v1.FirestoreAdminClient")
-    def test_export_firestore_calls_api(self, mock_client_class):
+    def test_export_firestore_calls_api(self, mock_client_class, mock_storage):
         from firestore_export import export_firestore
 
         mock_client = MagicMock()
@@ -14,6 +15,7 @@ class TestFirestoreExport(unittest.TestCase):
         mock_operation = MagicMock()
         mock_operation.result.return_value = MagicMock()
         mock_client.export_documents.return_value = mock_operation
+        mock_storage.return_value.bucket.return_value.list_blobs.return_value = []
 
         result = export_firestore(
             project="test-project",
@@ -27,8 +29,9 @@ class TestFirestoreExport(unittest.TestCase):
         assert request["name"] == "projects/test-project/databases/(default)"
         assert "gs://test-staging/firestore/2026-03-29" in request["output_uri_prefix"]
 
+    @patch("firestore_export.storage.Client")
     @patch("firestore_export.firestore_admin_v1.FirestoreAdminClient")
-    def test_export_firestore_returns_summary(self, mock_client_class):
+    def test_export_firestore_returns_summary(self, mock_client_class, mock_storage):
         from firestore_export import export_firestore
 
         mock_client = MagicMock()
@@ -36,10 +39,43 @@ class TestFirestoreExport(unittest.TestCase):
         mock_operation = MagicMock()
         mock_operation.result.return_value = MagicMock()
         mock_client.export_documents.return_value = mock_operation
+        mock_storage.return_value.bucket.return_value.list_blobs.return_value = []
 
         result = export_firestore("proj", "bucket", "2026-03-29")
         assert isinstance(result, str)
         assert "2026-03-29" in result
+
+
+class TestClearPriorExports(unittest.TestCase):
+    @patch("firestore_export.storage.Client")
+    def test_keeps_latest_deletes_others(self, mock_storage):
+        from firestore_export import _clear_prior_exports
+
+        def _blob(name):
+            b = MagicMock()
+            b.name = name
+            return b
+
+        today = _blob("firestore/2026-03-29/out.bin")
+        old1 = _blob("firestore/2026-03-22/out.bin")
+        old2 = _blob("firestore/2026-03-15/out.bin")
+        mock_storage.return_value.bucket.return_value.list_blobs.return_value = [
+            today, old1, old2,
+        ]
+
+        _clear_prior_exports("staging", "2026-03-29")
+
+        today.delete.assert_not_called()
+        old1.delete.assert_called_once()
+        old2.delete.assert_called_once()
+
+    @patch("firestore_export.storage.Client")
+    def test_cleanup_failure_is_swallowed(self, mock_storage):
+        from firestore_export import _clear_prior_exports
+
+        mock_storage.return_value.bucket.return_value.list_blobs.side_effect = RuntimeError("boom")
+        # Must not raise — cleanup is best-effort, the export already succeeded.
+        _clear_prior_exports("staging", "2026-03-29")
 
 
 if __name__ == "__main__":

--- a/infrastructure/functions/backup_to_aws/test_s3_upload.py
+++ b/infrastructure/functions/backup_to_aws/test_s3_upload.py
@@ -1,0 +1,52 @@
+"""Tests for s3_upload module, focused on the exclude_prefixes behavior."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+def _blob(name):
+    b = MagicMock()
+    b.name = name
+    return b
+
+
+class TestUploadStagingToS3(unittest.TestCase):
+    @patch("s3_upload.boto3.client")
+    @patch("s3_upload.storage.Client")
+    @patch("s3_upload.get_aws_credentials")
+    def test_excluded_prefix_not_uploaded_or_deleted(self, mock_creds, mock_storage, mock_boto):
+        from s3_upload import upload_staging_to_s3
+
+        mock_creds.return_value = {"access_key_id": "x", "secret_access_key": "y"}
+        fs = _blob("firestore/2026-03-29/out.bin")
+        sec = _blob("secrets/2026-03-29.bin")
+        mock_storage.return_value.bucket.return_value.list_blobs.return_value = [fs, sec]
+
+        upload_staging_to_s3("staging", "s3b", exclude_prefixes=["firestore/"])
+
+        # firestore held back: not uploaded, not deleted (stays as local backup)
+        fs.delete.assert_not_called()
+        # secrets uploaded then deleted
+        sec.delete.assert_called_once()
+        self.assertEqual(mock_boto.return_value.upload_fileobj.call_count, 1)
+
+    @patch("s3_upload.boto3.client")
+    @patch("s3_upload.storage.Client")
+    @patch("s3_upload.get_aws_credentials")
+    def test_no_exclude_uploads_everything(self, mock_creds, mock_storage, mock_boto):
+        from s3_upload import upload_staging_to_s3
+
+        mock_creds.return_value = {"access_key_id": "x", "secret_access_key": "y"}
+        fs = _blob("firestore/2026-03-29/out.bin")
+        sec = _blob("secrets/2026-03-29.bin")
+        mock_storage.return_value.bucket.return_value.list_blobs.return_value = [fs, sec]
+
+        upload_staging_to_s3("staging", "s3b")
+
+        self.assertEqual(mock_boto.return_value.upload_fileobj.call_count, 2)
+        fs.delete.assert_called_once()
+        sec.delete.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infrastructure/functions/runner_manager/ephemeral.py
+++ b/infrastructure/functions/runner_manager/ephemeral.py
@@ -370,9 +370,14 @@ def create_ephemeral_runner(labels: Iterable[str], pat: str) -> dict:
 
     last_error: Exception | None = None
     for zone in zones:
-        use_external_ip = (
-            family.needs_external_ip_in_fallback_zone and zone != PRIMARY_ZONE
-        )
+        # Always attach an ephemeral external IP so runner egress (Docker
+        # pulls, dependency downloads) leaves via the VM's own IP and bypasses
+        # the Cloud NAT data-processing charge (~$26/mo — runners were the
+        # NAT's only user). Ephemeral IPs are free while attached to a running
+        # VM, runners are short-lived, and us-central1 has ample IN_USE_ADDRESSES
+        # quota (limit 69). Supersedes the prior fallback-zone-only logic;
+        # `needs_external_ip_in_fallback_zone` is retained for documentation.
+        use_external_ip = True
         instance = _build_instance(
             name=runner_name,
             family=family,

--- a/infrastructure/functions/runner_manager/test_ephemeral.py
+++ b/infrastructure/functions/runner_manager/test_ephemeral.py
@@ -164,7 +164,9 @@ class TestCreateEphemeralRunner:
 
         assert result["family"] == "general"
         assert result["zone"] == "us-central1-a"
-        assert result["external_ip"] is False
+        # All runners now get an ephemeral external IP to bypass the Cloud NAT
+        # data-processing charge (runners were the NAT's only user).
+        assert result["external_ip"] is True
         assert result["runner_name"].startswith("gha-general-")
         compute_client.insert.assert_called_once()
 

--- a/infrastructure/modules/artifact_registry.py
+++ b/infrastructure/modules/artifact_registry.py
@@ -24,6 +24,27 @@ def create_repository() -> artifactregistry.Repository:
         location=REGION,
         format="DOCKER",
         description="Docker repository for karaoke backend images",
+        # Cost control: keep the 10 most recent versions for rollback, and
+        # delete untagged digests older than 7 days (orphaned layers left by
+        # repeated :latest pushes). Tagged images are never auto-deleted.
+        cleanup_policies=[
+            artifactregistry.RepositoryCleanupPolicyArgs(
+                id="keep-recent-10",
+                action="KEEP",
+                most_recent_versions=artifactregistry.RepositoryCleanupPolicyMostRecentVersionsArgs(
+                    keep_count=10,
+                ),
+            ),
+            artifactregistry.RepositoryCleanupPolicyArgs(
+                id="delete-untagged-after-7d",
+                action="DELETE",
+                condition=artifactregistry.RepositoryCleanupPolicyConditionArgs(
+                    tag_state="UNTAGGED",
+                    older_than="604800s",  # 7 days
+                ),
+            ),
+        ],
+        cleanup_policy_dry_run=False,
     )
 
     return artifact_repo

--- a/infrastructure/modules/audio_separator_service.py
+++ b/infrastructure/modules/audio_separator_service.py
@@ -30,6 +30,27 @@ def create_audio_separator_artifact_repo() -> artifactregistry.Repository:
         location=AUDIO_SEPARATOR_REGION,
         format="DOCKER",
         description="Docker repository for audio-separator GPU service",
+        # Cost control: audio-separator images bake ~14GB of models. Keep 10
+        # most recent versions for rollback; delete untagged digests older
+        # than 7 days.
+        cleanup_policies=[
+            artifactregistry.RepositoryCleanupPolicyArgs(
+                id="keep-recent-10",
+                action="KEEP",
+                most_recent_versions=artifactregistry.RepositoryCleanupPolicyMostRecentVersionsArgs(
+                    keep_count=10,
+                ),
+            ),
+            artifactregistry.RepositoryCleanupPolicyArgs(
+                id="delete-untagged-after-7d",
+                action="DELETE",
+                condition=artifactregistry.RepositoryCleanupPolicyConditionArgs(
+                    tag_state="UNTAGGED",
+                    older_than="604800s",  # 7 days
+                ),
+            ),
+        ],
+        cleanup_policy_dry_run=False,
     )
 
 

--- a/infrastructure/modules/gpu_artifact_registry.py
+++ b/infrastructure/modules/gpu_artifact_registry.py
@@ -21,4 +21,24 @@ def create_gpu_artifact_repo() -> artifactregistry.Repository:
         location=GPU_REGION,
         format="DOCKER",
         description="Docker repository for GPU-enabled karaoke-backend images (audio worker)",
+        # Cost control: GPU images are multi-GB. Keep 10 most recent versions
+        # for rollback; delete untagged digests older than 7 days.
+        cleanup_policies=[
+            artifactregistry.RepositoryCleanupPolicyArgs(
+                id="keep-recent-10",
+                action="KEEP",
+                most_recent_versions=artifactregistry.RepositoryCleanupPolicyMostRecentVersionsArgs(
+                    keep_count=10,
+                ),
+            ),
+            artifactregistry.RepositoryCleanupPolicyArgs(
+                id="delete-untagged-after-7d",
+                action="DELETE",
+                condition=artifactregistry.RepositoryCleanupPolicyConditionArgs(
+                    tag_state="UNTAGGED",
+                    older_than="604800s",  # 7 days
+                ),
+            ),
+        ],
+        cleanup_policy_dry_run=False,
     )


### PR DESCRIPTION
Part of the June 2026 cost-reduction effort (`docs/archive/2026-06-14-gcp-cost-reduction-plan.md`). Targets the post-credit-expiry (2026-09-19) bill.

## Changes
- **Item 4 — Artifact Registry cleanup** (~$6/mo + caps growth): keep 10 most-recent versions + delete untagged digests >7d, on all 3 repos (karaoke-repo, karaoke-backend-gpu, audio-separator; 92 GiB, previously no policy). In-place update.
- **Item 5 — NAT egress** (~$26/mo): ephemeral GHA runners now always get an external IP, so egress bypasses the Cloud NAT data-processing charge (runners were the NAT's only user; us-central1 IN_USE_ADDRESSES quota is 69, usage 1).
- **Item 6 — backup cadence** (~$15/mo): Firestore export stays nightly to GCS (1-day local restore point) but uploads to S3 only on Sundays (1-week off-site RPO) — Firestore is the bulk of the cross-cloud egress. Staging keeps only the latest export so the weekly upload ships exactly one.
- **Item 1 — encoding disks** (~$35/mo): pinned the 4 worker hyperdisks to the free baseline (3000 IOPS / 140 MB/s) **live via `gcloud`**, not IaC — setting it in IaC forces a capacity-risky VM replacement. A code comment documents this.

## Deploy status
- `pulumi up` (artifact policies + runner function): **applied** locally (prod, update 751).
- Backup function source: shipped via `functions/backup_to_aws/deploy.sh` (pulumi doesn't manage the source zip).
- Encoding disks: tuned live via gcloud.

## Tests
- `backup_to_aws`: 13 pass (added firestore-cleanup + s3-exclude coverage).
- `runner_manager/ephemeral`: 32 pass (updated external-IP assertion).

Item 7 (fallback disks on-demand) intentionally deferred — reliability tradeoff not worth ~$20/mo. See plan doc.

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)