### PR TITLE
fix(tenant): make white-label B2B portals attribute jobs to the tenant (Vocal Star + Singa)

### DIFF
--- a/backend/api/routes/file_upload.py
+++ b/backend/api/routes/file_upload.py
@@ -67,12 +67,20 @@ def _apply_tenant_overrides(
     """
     Apply tenant-specific overrides to distribution settings and job options.
 
+    White-label tenant config is AUTHORITATIVE: it replaces (not just fills in) the
+    distribution settings, so tenant outputs never inherit the global consumer defaults
+    (DEFAULT_BRAND_PREFIX / DEFAULT_DROPBOX_PATH / DEFAULT_GDRIVE_FOLDER_ID) that
+    ``get_effective_distribution_settings`` seeds into ``dist``. Without this, every
+    tenant job would land in the shared consumer Dropbox folder and upload to the global
+    Google Drive, regardless of the tenant's own config.
+
     For tenant jobs:
-    - Overlays brand_prefix, dropbox_path, gdrive_folder_id from tenant defaults
-      (only when not already set in the request body / dist)
+    - Sets brand_prefix, dropbox_path, gdrive_folder_id authoritatively from tenant config
+    - Routes Dropbox / Google Drive only when the matching feature flag is enabled;
+      otherwise disables that channel entirely (no global-default leak)
     - Forces is_private = True
     - Applies locked_theme as effective theme
-    - Disables YouTube upload
+    - Disables YouTube upload (tenants never publish to YouTube)
 
     Returns:
         Tuple of (dist, effective_theme_id, is_private, enable_youtube_upload)
@@ -81,14 +89,12 @@ def _apply_tenant_overrides(
         return dist, effective_theme_id, is_private, enable_youtube_upload
 
     defaults = tenant_config.defaults
+    features = tenant_config.features
 
-    # Overlay tenant distribution defaults (request-level values take precedence)
-    if defaults.brand_prefix and not dist.brand_prefix:
-        dist.brand_prefix = defaults.brand_prefix
-    if defaults.dropbox_path and not dist.dropbox_path:
-        dist.dropbox_path = defaults.dropbox_path
-    if defaults.gdrive_folder_id and not dist.gdrive_folder_id:
-        dist.gdrive_folder_id = defaults.gdrive_folder_id
+    # Authoritative distribution routing (overrides any global defaults in `dist`).
+    dist.brand_prefix = defaults.brand_prefix
+    dist.dropbox_path = defaults.dropbox_path if features.dropbox_upload else None
+    dist.gdrive_folder_id = defaults.gdrive_folder_id if features.gdrive_upload else None
 
     # Force private for all tenant jobs
     is_private = True

--- a/backend/tests/test_tenant_job_defaults.py
+++ b/backend/tests/test_tenant_job_defaults.py
@@ -125,24 +125,70 @@ class TestApplyTenantOverrides:
         _, _, _, yt_upload = apply_fn(dist, tenant_config, "default", False, True)
         assert yt_upload is False
 
-    def test_request_values_take_precedence(self):
-        """Explicit request-level values are not overridden by tenant defaults."""
+    def test_tenant_config_overrides_global_defaults(self):
+        """Tenant config is authoritative: it overrides any global/consumer default
+        distribution settings already seeded into `dist`.
+
+        Regression guard: prod sets DEFAULT_DROPBOX_PATH / DEFAULT_GDRIVE_FOLDER_ID /
+        DEFAULT_BRAND_PREFIX globally, which get_effective_distribution_settings seeds
+        into `dist`. If tenant overrides only filled in *unset* fields, every tenant job
+        would leak into the shared consumer Dropbox folder and global Google Drive.
+        """
         apply_fn = self._get_apply_fn()
         tenant_config = _make_tenant_config()
 
+        # `dist` arrives pre-seeded with the GLOBAL consumer defaults.
         dist = EffectiveDistributionSettings(
-            dropbox_path="/Custom/Path",
-            gdrive_folder_id="custom-folder",
+            dropbox_path="/MediaUnsynced/Karaoke/Tracks-Organized",  # global default
+            gdrive_folder_id="global-consumer-folder",               # global default
             discord_webhook_url=None,
-            brand_prefix="CUSTOM",
+            brand_prefix="NOMAD",                                    # global default
             enable_youtube_upload=True,
             youtube_description=None,
         )
 
         new_dist, _, _, _ = apply_fn(dist, tenant_config, "default", False, True)
-        assert new_dist.brand_prefix == "CUSTOM"
-        assert new_dist.dropbox_path == "/Custom/Path"
-        assert new_dist.gdrive_folder_id == "custom-folder"
+        # Tenant config wins on every distribution field.
+        assert new_dist.brand_prefix == "VSTAR"
+        assert new_dist.dropbox_path == "/Karaoke/Vocal-Star"
+        assert new_dist.gdrive_folder_id == "gdrive-folder-123"
+
+    def test_gdrive_disabled_clears_global_default(self):
+        """When the tenant disables gdrive_upload, the global default GDrive folder is
+        cleared so the tenant job never publishes to Google Drive (the B2B requirement)."""
+        apply_fn = self._get_apply_fn()
+        # Tenant has a gdrive folder configured but the feature is OFF — the disabled
+        # flag must win, clearing both the configured folder and any global default.
+        tenant_config = _make_tenant_config()
+        tenant_config.features.gdrive_upload = False
+
+        dist = EffectiveDistributionSettings(
+            dropbox_path=None,
+            gdrive_folder_id="global-consumer-folder",  # would otherwise leak
+            discord_webhook_url=None,
+            brand_prefix=None,
+            enable_youtube_upload=True,
+            youtube_description=None,
+        )
+
+        new_dist, _, _, yt_upload = apply_fn(dist, tenant_config, "default", False, True)
+        assert new_dist.gdrive_folder_id is None
+        assert yt_upload is False
+
+    def test_dropbox_disabled_clears_path(self):
+        """When the tenant disables dropbox_upload, the Dropbox path is cleared."""
+        apply_fn = self._get_apply_fn()
+        tenant_config = _make_tenant_config()
+        tenant_config.features.dropbox_upload = False
+
+        dist = EffectiveDistributionSettings(
+            dropbox_path="/MediaUnsynced/Karaoke/Tracks-Organized",
+            gdrive_folder_id=None, discord_webhook_url=None,
+            brand_prefix=None, enable_youtube_upload=True, youtube_description=None,
+        )
+
+        new_dist, _, _, _ = apply_fn(dist, tenant_config, "default", False, True)
+        assert new_dist.dropbox_path is None
 
     def test_no_tenant_config_passthrough(self):
         """When no tenant config, all values pass through unchanged."""

--- a/frontend/__tests__/api-tenant-headers.test.ts
+++ b/frontend/__tests__/api-tenant-headers.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests that the API client attaches the X-Tenant-ID header on white-label tenant
+ * portals (sourced from window.__TENANT_CONFIG__) and omits it on the consumer build.
+ *
+ * Regression guard for the root-cause bug: the frontend never sent X-Tenant-ID, so the
+ * shared api.nomadkaraoke.com backend could not detect the tenant and every tenant-portal
+ * job/sign-in silently fell back to consumer behavior (0 tenant jobs ever ran in prod).
+ */
+
+import { api, getTenantId } from '@/lib/api'
+
+function setEdgeTenant(id: string | null) {
+  if (id) {
+    ;(window as any).__TENANT_CONFIG__ = {
+      tenant: { id, name: id, subdomain: `${id}.nomadkaraoke.com` },
+      is_default: false,
+    }
+  } else {
+    delete (window as any).__TENANT_CONFIG__
+  }
+}
+
+describe('getTenantId', () => {
+  afterEach(() => setEdgeTenant(null))
+
+  it('returns null when no tenant config is present (consumer build)', () => {
+    setEdgeTenant(null)
+    expect(getTenantId()).toBeNull()
+  })
+
+  it('returns the tenant id from window.__TENANT_CONFIG__', () => {
+    setEdgeTenant('vocalstar')
+    expect(getTenantId()).toBe('vocalstar')
+  })
+
+  it('returns null when the injected config has no tenant (default/consumer domain)', () => {
+    ;(window as any).__TENANT_CONFIG__ = { tenant: null, is_default: true }
+    expect(getTenantId()).toBeNull()
+  })
+})
+
+describe('X-Tenant-ID header attachment', () => {
+  const fetchMock = jest.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    ;(global as any).fetch = fetchMock
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) })
+  })
+
+  afterEach(() => setEdgeTenant(null))
+
+  it('attaches X-Tenant-ID to authenticated requests (createJobWithUploadUrls) on a tenant portal', async () => {
+    setEdgeTenant('vocalstar')
+    window.localStorage.setItem('karaoke_access_token', 'tok-123')
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ job_id: 'j1', upload_urls: [] }),
+    })
+
+    await api.createJobWithUploadUrls('Adele', 'Hello', [], {
+      is_private: true,
+      existing_instrumental: true,
+    })
+
+    const [, init] = fetchMock.mock.calls[0]
+    expect(init.headers['X-Tenant-ID']).toBe('vocalstar')
+    expect(init.headers['Authorization']).toBe('Bearer tok-123')
+
+    window.localStorage.removeItem('karaoke_access_token')
+  })
+
+  it('attaches X-Tenant-ID to the magic-link request on a tenant portal', async () => {
+    setEdgeTenant('singa')
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ success: true }) })
+
+    await api.sendMagicLink('user@singa.com')
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toMatch(/\/api\/users\/auth\/magic-link$/)
+    expect(init.headers['X-Tenant-ID']).toBe('singa')
+  })
+
+  it('does NOT attach X-Tenant-ID on the consumer build', async () => {
+    setEdgeTenant(null)
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ success: true }) })
+
+    await api.sendMagicLink('user@example.com')
+
+    const [, init] = fetchMock.mock.calls[0]
+    expect(init.headers['X-Tenant-ID']).toBeUndefined()
+  })
+})

--- a/frontend/lib/__tests__/tenant.test.ts
+++ b/frontend/lib/__tests__/tenant.test.ts
@@ -76,6 +76,9 @@ function resetStore() {
     error: null,
     isInitialized: false,
   })
+  // The store now mirrors resolved config onto window.__TENANT_CONFIG__ (so lib/api.ts
+  // can read it synchronously). Clear it between tests to keep them isolated.
+  delete (window as { __TENANT_CONFIG__?: unknown }).__TENANT_CONFIG__
 }
 
 describe("useTenant store", () => {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -55,10 +55,45 @@ function getLocaleFromPath(): string {
   return 'en';
 }
 
-function getAuthHeaders(): HeadersInit {
-  const headers: HeadersInit = {
+/**
+ * Resolve the current white-label tenant id, if any.
+ *
+ * On tenant portals the Cloudflare Pages edge function (frontend/functions/[[path]].ts)
+ * injects `window.__TENANT_CONFIG__` into the HTML before any app JS runs, and the
+ * tenant store (lib/tenant.ts) mirrors the same shape there in dev/preview. Reading it
+ * directly here keeps api.ts free of an import cycle with tenant.ts (which imports
+ * API_BASE_URL from this module).
+ *
+ * Returns null on the consumer build / consumer domain, so no tenant header is sent and
+ * existing consumer behavior is unchanged.
+ */
+export function getTenantId(): string | null {
+  if (typeof window === 'undefined') return null;
+  const injected = (window as { __TENANT_CONFIG__?: { tenant?: { id?: string } | null } }).__TENANT_CONFIG__;
+  const id = injected?.tenant?.id;
+  return typeof id === 'string' && id ? id : null;
+}
+
+/**
+ * Base headers attached to every API request: locale, and the X-Tenant-ID header when
+ * on a white-label tenant portal. The shared backend (api.nomadkaraoke.com) cannot infer
+ * the tenant from the Host (it's not the tenant subdomain) or from the prod-disabled
+ * `?tenant=` query param, so this header is the primary tenant-detection signal that lets
+ * the backend apply tenant config (locked theme, Dropbox path, no YouTube/GDrive).
+ */
+function getBaseHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
     'Accept-Language': getLocaleFromPath(),
   };
+  const tenantId = getTenantId();
+  if (tenantId) {
+    headers['X-Tenant-ID'] = tenantId;
+  }
+  return headers;
+}
+
+function getAuthHeaders(): HeadersInit {
+  const headers: Record<string, string> = getBaseHeaders();
   const token = getAccessToken();
   if (token) {
     headers['Authorization'] = `Bearer ${token}`;
@@ -1285,6 +1320,11 @@ export const api = {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        // Carry tenant context so the backend validates the email domain against the
+        // tenant, embeds tenant_id in the magic-link token, and uses the tenant's
+        // sender email + portal URL. Without this, tenant sign-in silently falls back
+        // to the consumer (nomad) flow.
+        ...getBaseHeaders(),
       },
       body: JSON.stringify(body),
     });

--- a/frontend/lib/tenant.ts
+++ b/frontend/lib/tenant.ts
@@ -238,6 +238,11 @@ const useTenantStore = create<TenantStore>()((set, get) => ({
         isInitialized: true,
       })
 
+      // Mirror to the edge-config global so synchronous, import-cycle-free consumers
+      // (e.g. getTenantId() in lib/api.ts) can read the tenant in dev/preview where the
+      // Cloudflare edge function does not inject __TENANT_CONFIG__.
+      mirrorTenantConfigToWindow(data)
+
       // Apply tenant branding to CSS variables
       if (data.tenant) {
         applyTenantBranding(data.tenant.branding)
@@ -256,6 +261,7 @@ const useTenantStore = create<TenantStore>()((set, get) => ({
 
   setTenant: (tenant, isDefault) => {
     set({ tenant, isDefault, isInitialized: true })
+    mirrorTenantConfigToWindow({ tenant, is_default: isDefault })
     if (tenant) {
       applyTenantBranding(tenant.branding)
     }
@@ -346,6 +352,19 @@ function applyTenantBranding(branding: TenantBranding) {
       link.href = branding.favicon_url
     }
   }
+}
+
+/**
+ * Mirror the resolved tenant config onto `window.__TENANT_CONFIG__`.
+ *
+ * The Cloudflare edge function injects this global on tenant subdomains in production,
+ * but not in local dev or admin preview (where the tenant is resolved by fetch or
+ * setTenant). Mirroring it here gives lib/api.ts a single synchronous, import-cycle-free
+ * source of truth for attaching the X-Tenant-ID header in every environment.
+ */
+function mirrorTenantConfigToWindow(data: TenantConfigResponse) {
+  if (typeof window === "undefined") return
+  ;(window as { __TENANT_CONFIG__?: TenantConfigResponse }).__TENANT_CONFIG__ = data
 }
 
 /**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.182.2"
+version = "0.183.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"

--- a/scripts/setup-singa-tenant.py
+++ b/scripts/setup-singa-tenant.py
@@ -565,9 +565,9 @@ def create_tenant_config() -> dict:
             "audio_search": False,
             "file_upload": True,
             "youtube_url": False,
-            "youtube_upload": False,
-            "dropbox_upload": False,
-            "gdrive_upload": False,
+            "youtube_upload": False,  # B2B: never publish to YouTube
+            "dropbox_upload": True,   # Outputs delivered to the tenant's Dropbox folder
+            "gdrive_upload": False,   # B2B: never publish to Google Drive
             "theme_selection": False,
             "color_overrides": False,
             "enable_cdg": True,
@@ -579,6 +579,8 @@ def create_tenant_config() -> dict:
             "locked_theme": THEME_ID,
             "distribution_mode": "download_only",
             "brand_prefix": "SINGA",
+            "dropbox_path": "/MediaUnsynced/Karaoke/Tracks-Singa",
+            "gdrive_folder_id": None,  # No Google Drive for white-label tenants
             "youtube_description_template": None,
         },
         "auth": {

--- a/scripts/setup-vocalstar-tenant.py
+++ b/scripts/setup-vocalstar-tenant.py
@@ -246,9 +246,9 @@ def create_tenant_config() -> dict:
             "audio_search": False,  # Vocal Star provides their own audio
             "file_upload": True,
             "youtube_url": False,
-            "youtube_upload": False,  # Download only
-            "dropbox_upload": False,
-            "gdrive_upload": False,
+            "youtube_upload": False,  # B2B: never publish to YouTube
+            "dropbox_upload": True,   # Outputs delivered to the tenant's Dropbox folder
+            "gdrive_upload": False,   # B2B: never publish to Google Drive
             "theme_selection": False,  # Always use Vocal Star theme
             "color_overrides": False,
             "enable_cdg": True,
@@ -260,6 +260,8 @@ def create_tenant_config() -> dict:
             "locked_theme": THEME_ID,  # Lock to Vocal Star theme - users cannot change
             "distribution_mode": "download_only",
             "brand_prefix": "VSTAR",
+            "dropbox_path": "/MediaUnsynced/Karaoke/Tracks-VocalStar",
+            "gdrive_folder_id": None,  # No Google Drive for white-label tenants
             "youtube_description_template": None
         },
         "auth": {


### PR DESCRIPTION
@coderabbitai ignore

## Problem

The white-label tenant portals (`vocalstar.nomadkaraoke.com`, `singa.nomadkaraoke.com`) looked "done" but **had never worked end-to-end**: 0 of the last 484 production jobs carried a `tenant_id`. No tenant job had ever run.

**Root cause:** the frontend API client never sent the `X-Tenant-ID` header. Tenant portals call the shared `api.nomadkaraoke.com`, whose Host isn't the tenant subdomain, and the `?tenant=` query param is disabled in prod — so the backend could never detect the tenant. Every tenant sign-in and job submission silently fell back to consumer behavior (default theme, no tenant Dropbox, etc.). The `getTenantHeaders()` helper existed and was unit-tested, but was never wired into requests.

## Changes

**Frontend** (`lib/api.ts`, `lib/tenant.ts`)
- Attach `X-Tenant-ID` on all authenticated requests **and** the magic-link request, sourced from `window.__TENANT_CONFIG__` (edge-injected by the Cloudflare function; mirrored from the tenant store for dev/preview). Consumer build resolves no tenant → no header → **behavior unchanged**.

**Backend** (`_apply_tenant_overrides` in `file_upload.py`)
- Make tenant config **authoritative** over global distribution defaults. Prod sets `DEFAULT_DROPBOX_PATH` / `DEFAULT_GDRIVE_FOLDER_ID` / `DEFAULT_BRAND_PREFIX` globally; these seed `dist`, and the old "fill only when unset" overlay let them leak — so every tenant job would have landed in the **shared consumer Dropbox folder** and uploaded to the **global Google Drive**. Now Dropbox/GDrive routing is gated by the tenant feature flags and cleared when disabled.

**Tenant configs** (GCS + setup scripts, Vocal Star + Singa)
- Disable Google Drive (`gdrive_upload=false`, `gdrive_folder_id=null`), keep YouTube off, enable Dropbox to each tenant's own folder. B2B = locked theme, no YouTube/GDrive, Dropbox + portal download only.

## Why it's consumer-safe
- Frontend: header only attached when a tenant is resolved (never on `gen.nomadkaraoke.com`).
- Backend: `_apply_tenant_overrides` early-returns when `tenant_config is None` (all consumer jobs).

## Testing
- New: frontend header-attachment tests (tenant build vs consumer); backend authoritative-override + feature-flag-gating regression guards (incl. the global-default-leak case).
- Full suites green: **3466 backend**, **1013 frontend**.
- Verified live tenant configs via API after update.

Manual prod E2E (real track through each portal) + a daily per-tenant E2E workflow follow in a second PR, once this deploys and is verified in prod.