### PR TITLE
fix(tenant): transcribe the mixed audio, not the supplied instrumental

### DIFF
--- a/backend/api/routes/file_upload.py
+++ b/backend/api/routes/file_upload.py
@@ -57,6 +57,19 @@ def _is_youtube_url(url: str) -> bool:
 router = APIRouter(tags=["jobs"])
 
 
+def _select_mixed_audio_files(files):
+    """Filter a listing of ``uploads/{job_id}/audio/`` down to the mixed (with-vocals) audio.
+
+    When a job supplies its own instrumental (existing_instrumental flow, e.g. tenant
+    submissions), that file is uploaded into the SAME ``audio/`` directory as the mixed
+    audio (``existing_instrumental.*``). The ``audio/`` prefix therefore matches both, and
+    because ``existing_instrumental`` sorts before most filenames, ``files[0]`` would pick
+    the instrumental — so transcription would run on the backing track instead of the
+    vocals. Excluding it here ensures the mixed audio is selected as the transcription input.
+    """
+    return [f for f in files if not Path(f).name.startswith('existing_instrumental')]
+
+
 def _apply_tenant_overrides(
     dist: EffectiveDistributionSettings,
     tenant_config,
@@ -1388,12 +1401,14 @@ async def mark_uploads_complete(
             
             # List files with this prefix to find the actual uploaded file
             files = storage_service.list_files(prefix)
+            if file_type == 'audio':
+                files = _select_mixed_audio_files(files)
             if not files:
                 raise HTTPException(
                     status_code=400,
                     detail=f"File for '{file_type}' was not uploaded to GCS. Expected prefix: {prefix}"
                 )
-            
+
             # Use the first (and should be only) file found
             gcs_path = files[0]
             

--- a/backend/tests/test_tenant_job_defaults.py
+++ b/backend/tests/test_tenant_job_defaults.py
@@ -56,6 +56,43 @@ def _make_job_mock(**kwargs):
     return job
 
 
+class TestSelectMixedAudioFiles:
+    """Regression tests for _select_mixed_audio_files() in file_upload.py.
+
+    The existing-instrumental file shares the uploads/{job}/audio/ directory with the
+    mixed audio, so the 'audio/' prefix matches both. Before the fix, files[0] resolved to
+    'existing_instrumental.mp3' (it sorts first) and transcription ran on the instrumental.
+    """
+
+    def _fn(self):
+        from backend.api.routes.file_upload import _select_mixed_audio_files
+        return _select_mixed_audio_files
+
+    def test_excludes_existing_instrumental(self):
+        fn = self._fn()
+        # Listing is sorted alphabetically by GCS, so the instrumental comes first.
+        files = [
+            "uploads/job123/audio/existing_instrumental.mp3",
+            "uploads/job123/audio/mixed.mp3",
+        ]
+        result = fn(files)
+        assert result == ["uploads/job123/audio/mixed.mp3"]
+        assert result[0] == "uploads/job123/audio/mixed.mp3"
+
+    def test_plain_audio_only_unchanged(self):
+        fn = self._fn()
+        files = ["uploads/job123/audio/My Song.flac"]
+        assert fn(files) == files
+
+    def test_real_filenames_with_instrumental(self):
+        fn = self._fn()
+        files = [
+            "uploads/job123/audio/existing_instrumental.mp3",
+            "uploads/job123/audio/Eddy Grant - I Don't Wanna Dance Guide.mp3",
+        ]
+        assert fn(files) == ["uploads/job123/audio/Eddy Grant - I Don't Wanna Dance Guide.mp3"]
+
+
 class TestApplyTenantOverrides:
     """Tests for _apply_tenant_overrides() in file_upload.py."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.183.0"
+version = "0.183.1"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
@coderabbitai ignore

## Problem (found by the first real tenant E2E)

After #824 made tenant jobs attribute correctly, the first real Vocal Star job **failed at transcription**: `Lyrics transcription failed: 400 ... audioshake.ai/tasks`. Firestore showed `input_media_gcs_path` pointing at `existing_instrumental.mp3` — transcription was running on the **instrumental**, not the vocals.

**Root cause:** in the `existing_instrumental` flow (every tenant submission), the mixed audio and the instrumental are uploaded into the **same** `uploads/{job_id}/audio/` directory:
- mixed → `audio/<filename>`
- instrumental → `audio/existing_instrumental.*`

On `uploads-complete`, resolving the `'audio'` slot listed the whole `audio/` dir and took `files[0]` — which sorts to `existing_instrumental.mp3` (`e` < most letters). So the instrumental became the transcription input.

This was a **latent bug never hit in prod** because no existing-instrumental job had ever run end-to-end (0 tenant jobs ever, per #824).

## Fix
Extract `_select_mixed_audio_files()` to exclude the existing-instrumental file when selecting the `'audio'` (mixed, with-vocals) input. Regression tests added (incl. real filenames).

## Testing
- New regression tests + `test_file_upload.py`/`test_upload_api.py` green (156).
- Re-running the real Vocal Star E2E to completion after this deploys.