### PR TITLE
fix(tenant): stage instrumental for the GCE encoder + daily tenant E2E

### DIFF
--- a/.github/workflows/e2e-tenant-daily.yml
+++ b/.github/workflows/e2e-tenant-daily.yml
@@ -1,0 +1,111 @@
+name: E2E Daily Test (Tenant Portals)
+
+# Full production E2E per white-label tenant: submit a job with the tenant's own
+# mixed + instrumental audio, approve the lyrics review, wait for the render, and assert
+# the tenant distribution (locked theme, no YouTube, no Google Drive, Dropbox folder +
+# downloadable outputs). Mirrors the consumer e2e-daily.yml. Each run cleans up its job.
+
+on:
+  schedule:
+    # Daily at 07:37 UTC (off-peak, off the :00 mark).
+    - cron: '37 7 * * *'
+  workflow_dispatch:
+    inputs:
+      tenant:
+        description: 'Tenant to test (blank = all)'
+        required: false
+        default: ''
+        type: choice
+        options:
+          - ''
+          - vocalstar
+          - singa
+
+permissions:
+  contents: read
+  id-token: write   # for Workload Identity Federation
+
+jobs:
+  e2e-tenant:
+    name: "Tenant E2E: ${{ matrix.tenant }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        tenant: [vocalstar, singa]
+    # On manual dispatch with a specific tenant, only run that one.
+    if: ${{ github.event.inputs.tenant == '' || github.event.inputs.tenant == matrix.tenant }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Install dependencies
+        run: pip install google-cloud-storage google-cloud-secret-manager
+
+      - name: Run tenant E2E
+        id: run_test
+        env:
+          KARAOKE_ADMIN_TOKEN: ${{ secrets.E2E_ADMIN_TOKEN }}
+        run: |
+          echo "=== Tenant E2E: ${{ matrix.tenant }} ==="
+          python scripts/e2e/tenant_e2e.py ${{ matrix.tenant }} 2>&1 | tee e2e-output.log
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-tenant-${{ matrix.tenant }}-${{ github.run_number }}
+          path: e2e-output.log
+          retention-days: 14
+
+      - name: Discord notification (failure)
+        if: ${{ steps.run_test.outputs.exit_code != '0' }}
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_ALERT_WEBHOOK_URL }}
+        run: |
+          if [ -n "$DISCORD_WEBHOOK" ]; then
+            curl -s -H "Content-Type: application/json" \
+              -d "{\"embeds\": [{\"title\": \"❌ Tenant E2E FAILED — ${{ matrix.tenant }}\", \"description\": \"Run: #${{ github.run_number }}\", \"color\": 15158332}]}" \
+              "$DISCORD_WEBHOOK" || true
+          fi
+
+      - name: Fail the job if the test failed
+        if: ${{ steps.run_test.outputs.exit_code != '0' }}
+        run: exit 1
+
+  notify-email:
+    name: "Email summary"
+    runs-on: ubuntu-latest
+    needs: e2e-tenant
+    if: ${{ always() && github.event_name == 'schedule' }}
+    steps:
+      - name: Send email notification
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.postmarkapp.com
+          server_port: 587
+          username: ${{ secrets.POSTMARK_SERVER_TOKEN }}
+          password: ${{ secrets.POSTMARK_SERVER_TOKEN }}
+          subject: "Tenant E2E Daily ${{ needs.e2e-tenant.result == 'success' && 'PASSED' || 'FAILED' }} - Run #${{ github.run_number }}"
+          to: andrew@nomadkaraoke.com
+          from: "Karaoke Gen CI <noreply@nomadkaraoke.com>"
+          body: |
+            Tenant E2E Daily Test (Vocal Star + Singa)
+            Result: ${{ needs.e2e-tenant.result }}
+            Run: #${{ github.run_number }}
+            Details: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/backend/services/storage_service.py
+++ b/backend/services/storage_service.py
@@ -59,6 +59,17 @@ class StorageService:
             logger.error(f"Error downloading file {source_path}: {e}")
             raise
     
+    def copy_blob(self, source_path: str, destination_path: str) -> str:
+        """Server-side copy of a blob within the bucket (no download/upload)."""
+        try:
+            src = self.bucket.blob(source_path)
+            self.bucket.copy_blob(src, self.bucket, destination_path)
+            logger.info(f"Copied gs://{settings.gcs_bucket_name}/{source_path} -> {destination_path}")
+            return destination_path
+        except Exception as e:
+            logger.error(f"Error copying blob {source_path} -> {destination_path}: {e}")
+            raise
+
     def generate_signed_url(self, blob_path: str, expiration_minutes: int = 60) -> str:
         """Generate a signed URL for downloading a file.
         

--- a/backend/tests/test_storage_service.py
+++ b/backend/tests/test_storage_service.py
@@ -38,9 +38,36 @@ class TestStorageServiceInit:
         assert service.bucket == mock_bucket
 
 
+class TestStorageServiceCopy:
+    """Test server-side copy (used to stage the tenant instrumental for the GCE encoder)."""
+
+    @patch("backend.services.storage_service.storage.Client")
+    @patch("backend.services.storage_service.settings")
+    def test_copy_blob(self, mock_settings, mock_client_class):
+        mock_settings.gcs_bucket_name = "test-bucket"
+        mock_src_blob = Mock()
+        mock_bucket = Mock()
+        mock_bucket.blob.return_value = mock_src_blob
+        mock_client = Mock()
+        mock_client.bucket.return_value = mock_bucket
+        mock_client_class.return_value = mock_client
+
+        service = StorageService()
+        result = service.copy_blob(
+            "uploads/job123/audio/existing_instrumental.mp3",
+            "jobs/job123/existing_instrumental.mp3",
+        )
+
+        mock_bucket.blob.assert_called_once_with("uploads/job123/audio/existing_instrumental.mp3")
+        mock_bucket.copy_blob.assert_called_once_with(
+            mock_src_blob, mock_bucket, "jobs/job123/existing_instrumental.mp3"
+        )
+        assert result == "jobs/job123/existing_instrumental.mp3"
+
+
 class TestStorageServiceUpload:
     """Test upload operations."""
-    
+
     @patch("backend.services.storage_service.storage.Client")
     @patch("backend.services.storage_service.settings")
     def test_upload_file(self, mock_settings, mock_client_class):

--- a/backend/workers/video_worker.py
+++ b/backend/workers/video_worker.py
@@ -107,6 +107,21 @@ async def _encode_via_gce(
     instrumental_selection = job.state_data.get('instrumental_selection', 'clean')
     existing_instrumental = getattr(job, 'existing_instrumental_gcs_path', None)
 
+    # Stage the user-provided instrumental into the encoder's input prefix (jobs/{job_id}/).
+    # It is uploaded under uploads/, which the GCE encoder does NOT pull via input_gcs_path;
+    # copying it here makes the encoder's recursive find_file("*existing_instrumental*")
+    # locate it regardless of the worker image version (older encoder images predate the
+    # encoding_config "existing_instrumental" download path). Without this, tenant /
+    # existing-instrumental jobs fail with "No instrumental audio found".
+    if existing_instrumental:
+        try:
+            ext = os.path.splitext(existing_instrumental)[1].lower() or ".mp3"
+            staged_path = f"jobs/{job_id}/existing_instrumental{ext}"
+            storage.copy_blob(existing_instrumental, staged_path)
+            job_log.info(f"Staged existing instrumental for encoder: {staged_path}")
+        except Exception as e:
+            job_log.warning(f"Failed to stage existing instrumental into jobs/ prefix: {e}")
+
     encoding_config = {
         "formats": ["mp4_4k_lossless", "mp4_4k_lossy", "mp4_720p"],
         "base_name": base_name,

--- a/docs/archive/2026-06-15-tenant-portals-e2e.md
+++ b/docs/archive/2026-06-15-tenant-portals-e2e.md
@@ -1,0 +1,83 @@
+# White-Label Tenant Portals: Made Working End-to-End (Jun 2026)
+
+## Context
+
+The two B2B white-label tenant portals (`vocalstar.nomadkaraoke.com`, `singa.nomadkaraoke.com`)
+had full data models, middleware, GCS config, themes, a simplified job form, a separate
+Cloudflare deployment, and 280+ unit tests — and were documented as "production ready."
+**But no tenant job had ever actually completed:** 0 of the 484 most recent prod jobs
+carried a `tenant_id`. The feature looked done but was broken at every stage that had
+never been exercised by a real end-to-end tenant job.
+
+This session drove a real Vocal Star track (`Eddy Grant - I Don't Wanna Dance`, from their
+bulk batch) through the full pipeline in production, fixing each blocker in turn, until a
+tenant job completed: correct attribution → transcription → screens → review → render →
+Dropbox delivery, with the locked theme and **no** YouTube / Google Drive.
+
+## The seven blockers (each was the next never-exercised stage)
+
+1. **Tenant attribution never happened (root cause).** The frontend API client never sent
+   the `X-Tenant-ID` header (`getTenantHeaders()` existed but was unwired). Tenant portals
+   call the shared `api.nomadkaraoke.com`, whose Host isn't the tenant subdomain, and the
+   `?tenant=` param is prod-disabled — so the backend never detected the tenant and every
+   sign-in/job silently became a consumer job. Fix: attach `X-Tenant-ID` from
+   `window.__TENANT_CONFIG__` in `lib/api.ts` (`getBaseHeaders`), incl. the magic-link
+   request. PR #824.
+
+2. **Tenant config not authoritative.** Prod sets global `DEFAULT_DROPBOX_PATH` /
+   `DEFAULT_GDRIVE_FOLDER_ID` / `DEFAULT_BRAND_PREFIX`; `_apply_tenant_overrides` only
+   filled unset fields, so tenant jobs leaked into the shared consumer Dropbox folder and
+   uploaded to the global Google Drive. Fix: tenant config is authoritative, gated by
+   feature flags (gdrive/dropbox cleared when disabled). PR #824.
+
+3. **Wrong file transcribed.** existing-instrumental jobs upload mixed + instrumental into
+   the same `uploads/{job}/audio/` dir; `uploads-complete` resolved the `audio` slot via
+   `files[0]`, which sorts to `existing_instrumental.mp3`. Transcription ran on the
+   instrumental. Fix: `_select_mixed_audio_files` excludes the instrumental. PR #825.
+
+4. **AudioShake rejected the audio.** Vocal Star's MP3s begin with ~731 leading null bytes
+   before the first frame; ffmpeg tolerates it, AudioShake 400s ("Error fetching or
+   processing asset"). Consumer jobs never hit this (they transcribe re-encoded stems).
+   Fix: detect leading null padding on `.mp3/.aac` and losslessly remux (`ffmpeg -c copy`)
+   before upload. Verified against the live AudioShake API. PR #826.
+
+5. **Theme incomplete.** The strict theme validator requires every field; the tenant
+   themes (created Jan 2026) were missing `extra_text_text_transform` (intro + end),
+   added to the schema later → "Title screen generation failed." Fix: added the field to
+   the live GCS themes and the setup scripts. PR #827.
+
+6. **Theme assets not downloaded.** The setup scripts wrote full `gs://bucket/themes/.../assets/X`
+   URLs, but `theme_service._build_style_assets_mapping` only resolves bare basenames (the
+   consumer convention) → `style_assets` empty → assets never localized → encoder failed
+   with "Video background image not found". Fix: rewrote the live themes + setup scripts to
+   bare basenames. PR #827.
+
+7. **Render prerequisites — "No instrumental selected".** existing-instrumental jobs have
+   no instrumental-selection UI step; the orchestrator defaults to `'clean'` (a stem never
+   produced) and `_validate_prerequisites` rejected the job. Fix: `complete-review`
+   defaults `instrumental_selection` to `'custom'` when `existing_instrumental_gcs_path`
+   is set. PR #827.
+
+## Tenant config (final, both tenants)
+
+- Locked theme (`vocalstar` / `singa`), no theme selection.
+- `youtube_upload=false`, `gdrive_upload=false` (folder cleared), `dropbox_upload=true`.
+- Dropbox: `/MediaUnsynced/Karaoke/Tracks-VocalStar`, `/MediaUnsynced/Karaoke/Tracks-Singa`.
+- Jobs forced `is_private=true`; CDG + 4K enabled.
+
+## Daily E2E
+
+`scripts/e2e/tenant_e2e.py` + `.github/workflows/e2e-tenant-daily.yml` run a full job per
+tenant daily (07:37 UTC, matrix vocalstar/singa): submit → approve review → render →
+assert (completes, Dropbox link present, no YouTube, downloads available) → clean up the
+job + uploads. Auth via WIF + `E2E_ADMIN_TOKEN`; test audio in `gs://.../e2e-tests/shared/`.
+
+## Gotchas / lessons
+
+- The tenant pipeline had never run end-to-end, so every stage hid a latent bug. "Has a
+  real job of this shape ever completed in prod?" is a better readiness question than test
+  count.
+- Theme asset paths must be **bare basenames** (consumer convention), not `gs://` URLs.
+- AudioShake needs clean audio at offset 0; user-provided files vary — remux defensively.
+- Public tenant config API redacts `dropbox_path`/`gdrive_folder_id`/`brand_prefix`; read
+  the stored GCS config for the real values.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.183.3"
+version = "0.183.4"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"

--- a/scripts/e2e/tenant_e2e.py
+++ b/scripts/e2e/tenant_e2e.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+Production end-to-end health check for a white-label tenant portal.
+
+Drives the exact path a tenant uses: submit a job with X-Tenant-ID + the tenant's own
+mixed/instrumental audio, let it transcribe, approve the lyrics review, wait for the
+render, and assert the tenant distribution was applied (locked theme, no YouTube, no
+Google Drive, Dropbox folder + downloadable outputs). Cleans up the job and its uploads.
+
+Designed to run daily per tenant in GitHub Actions (see .github/workflows/e2e-tenant-daily.yml)
+and locally for ad-hoc verification.
+
+Auth / credentials:
+  - Admin token: env KARAOKE_ADMIN_TOKEN, else Secret Manager (admin-tokens) via ADC.
+  - Test audio + cleanup: Google Cloud Storage via ADC.
+In CI these are provided by Workload Identity Federation (google-github-actions/auth).
+
+Usage:
+  python scripts/e2e/tenant_e2e.py vocalstar
+  python scripts/e2e/tenant_e2e.py singa
+"""
+import os
+import sys
+import time
+import json
+import tempfile
+import urllib.request
+import urllib.error
+
+API = os.environ.get("KARAOKE_API_URL", "https://api.nomadkaraoke.com")
+BUCKET = os.environ.get("KARAOKE_GCS_BUCKET", "karaoke-gen-storage-nomadkaraoke")
+# Shared test pair (real audio with vocals so transcription has something to align).
+TEST_MIXED = f"gs://{BUCKET}/e2e-tests/shared/e2e-mixed.mp3"
+TEST_INSTRUMENTAL = f"gs://{BUCKET}/e2e-tests/shared/e2e-instrumental.mp3"
+# Clearly-labelled so the daily output is identifiable in the tenant's Dropbox folder.
+ARTIST = "Nomad Karaoke"
+TITLE = "E2E Health Check"
+
+EXPECTED = {
+    "vocalstar": {"theme": "vocalstar"},
+    "singa": {"theme": "singa"},
+}
+
+REVIEW_TIMEOUT = int(os.environ.get("E2E_REVIEW_TIMEOUT", "900"))    # 15 min to transcription/review
+RENDER_TIMEOUT = int(os.environ.get("E2E_RENDER_TIMEOUT", "1800"))   # 30 min to full render
+
+
+def log(msg):
+    print(msg, flush=True)
+
+
+def admin_token():
+    tok = os.environ.get("KARAOKE_ADMIN_TOKEN")
+    if tok:
+        return tok.split(",")[0].strip()
+    from google.cloud import secretmanager
+    c = secretmanager.SecretManagerServiceClient()
+    resp = c.access_secret_version(request={
+        "name": "projects/nomadkaraoke/secrets/admin-tokens/versions/latest"})
+    return resp.payload.data.decode().split(",")[0].strip()
+
+
+def gcs_download(gs_uri, local_path):
+    from google.cloud import storage
+    bucket, _, blob = gs_uri[5:].partition("/")
+    storage.Client().bucket(bucket).blob(blob).download_to_filename(local_path)
+
+
+def gcs_delete_prefix(prefix):
+    from google.cloud import storage
+    client = storage.Client()
+    b = client.bucket(BUCKET)
+    for blob in b.list_blobs(prefix=prefix):
+        blob.delete()
+
+
+TENANT = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("E2E_TENANT", "vocalstar")
+if TENANT not in EXPECTED:
+    log(f"Unknown tenant: {TENANT}")
+    sys.exit(2)
+TOKEN = admin_token()
+
+
+def req(method, path, body=None, timeout=180):
+    url = path if path.startswith("http") else API + path
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {"Authorization": f"Bearer {TOKEN}", "X-Tenant-ID": TENANT}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    r = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(r, timeout=timeout) as resp:
+            raw = resp.read().decode()
+            return resp.status, (json.loads(raw) if raw else {})
+    except urllib.error.HTTPError as e:
+        return e.code, {"error": e.read().decode()[:400]}
+
+
+def put_file(signed_url, local_path, content_type):
+    with open(local_path, "rb") as f:
+        data = f.read()
+    r = urllib.request.Request(signed_url, data=data, headers={"Content-Type": content_type}, method="PUT")
+    with urllib.request.urlopen(r, timeout=600) as resp:
+        return resp.status
+
+
+def poll_until(job_id, statuses, timeout, label):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        st, job = req("GET", f"/api/jobs/{job_id}")
+        s = job.get("status")
+        if s != last:
+            log(f"  [{time.strftime('%H:%M:%S')}] status={s} progress={job.get('progress')}")
+            last = s
+        if s in statuses:
+            return job
+        if s in ("failed", "error"):
+            raise RuntimeError(f"Job failed during {label}: {job.get('error_message')}")
+        time.sleep(15)
+    raise TimeoutError(f"Timed out waiting for {label} (last status={last})")
+
+
+def main():
+    log(f"=== Tenant E2E health check: {TENANT} ===")
+    tmp = tempfile.mkdtemp()
+    mixed = os.path.join(tmp, "mixed.mp3")
+    instrumental = os.path.join(tmp, "instrumental.mp3")
+    gcs_download(TEST_MIXED, mixed)
+    gcs_download(TEST_INSTRUMENTAL, instrumental)
+
+    files = [
+        {"file_type": "audio", "filename": "mixed.mp3", "content_type": "audio/mpeg"},
+        {"file_type": "existing_instrumental", "filename": "instrumental.mp3", "content_type": "audio/mpeg"},
+    ]
+    st, resp = req("POST", "/api/jobs/create-with-upload-urls",
+                   {"artist": ARTIST, "title": TITLE, "files": files,
+                    "is_private": True, "existing_instrumental": True})
+    if st != 200:
+        raise RuntimeError(f"create failed: {st} {resp}")
+    job_id = resp["job_id"]
+    log(f"job_id: {job_id}")
+
+    failed = True
+    try:
+        urls = {u["file_type"]: u for u in resp["upload_urls"]}
+        put_file(urls["audio"]["upload_url"], mixed, urls["audio"]["content_type"])
+        put_file(urls["existing_instrumental"]["upload_url"], instrumental, urls["existing_instrumental"]["content_type"])
+        req("POST", f"/api/jobs/{job_id}/uploads-complete", {"uploaded_files": ["audio", "existing_instrumental"]})
+
+        poll_until(job_id, ("awaiting_review", "in_review"), REVIEW_TIMEOUT, "review gate")
+        log("approving review")
+        st, _ = req("POST", f"/api/jobs/{job_id}/complete-review", {})
+        if st != 200:
+            raise RuntimeError(f"complete-review failed: {st}")
+
+        job = poll_until(job_id, ("complete",), RENDER_TIMEOUT, "render")
+
+        # Assertions: tenant distribution applied end-to-end.
+        sd = job.get("state_data") or {}
+        dropbox = sd.get("dropbox_link") or job.get("dropbox_link")
+        youtube = sd.get("youtube_url") or job.get("youtube_url")
+        downloads = job.get("download_urls") or {}
+        log(f"  dropbox_link: {dropbox}")
+        log(f"  youtube_url: {youtube}")
+        log(f"  download_urls: {sorted(downloads.keys())}")
+
+        errors = []
+        if not dropbox:
+            errors.append("no dropbox_link (tenant Dropbox distribution did not run)")
+        if youtube:
+            errors.append(f"unexpected youtube_url={youtube} (tenant must not publish to YouTube)")
+        if not downloads:
+            errors.append("no download_urls (outputs not downloadable from portal)")
+        if errors:
+            raise RuntimeError("Assertions failed: " + "; ".join(errors))
+
+        log(f"\n✅ {TENANT} E2E PASSED — job completed, Dropbox link present, no YouTube, downloads available")
+        failed = False
+    finally:
+        # Always clean up the test job and its uploads.
+        try:
+            req("DELETE", f"/api/jobs/{job_id}")
+            gcs_delete_prefix(f"uploads/{job_id}/")
+            gcs_delete_prefix(f"jobs/{job_id}/")
+            log(f"cleaned up job {job_id}")
+        except Exception as e:
+            log(f"cleanup warning: {e}")
+
+    if failed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
@coderabbitai ignore

## Final render blocker (bug #8)

With #824/#825/#826/#827, tenant jobs now render the karaoke video — but the GCE encoder failed with **"No instrumental audio found"**.

**Root cause:** the user-supplied instrumental lives under `uploads/{job}/audio/`, but the encoder only pulls input from `jobs/{job}/` (`input_gcs_path`) and locates the instrumental via `find_file("*existing_instrumental*", "*Instrumental User*")`. On top of that, the running encoder VM (`encoding-worker-b`) boots a **2026-01-23 image** that predates the encoder's own `existing_instrumental` config-download path (added 2026-03-04), so it could never fetch it from `uploads/` either.

**Fix (image-agnostic — no risky shared-VM recreation, no consumer impact):** `_encode_via_gce` server-side copies the instrumental into `jobs/{job_id}/existing_instrumental.<ext>` before submitting. The encoder downloads `jobs/{job}/` and its **recursive** `find_file` then locates it on any image version. Added `StorageService.copy_blob` + unit test.

> Note: the stale encoder VM image is a separate infra item — the `encoding-worker` VMs should be recreated from the image family's newest image (which has 3 months of encoder fixes). Tracked for a Pulumi pass; not required for this fix.

## Daily tenant E2E (second ask)
- `scripts/e2e/tenant_e2e.py` — full per-tenant prod health check: submit → approve review → render → assert (completes, Dropbox link present, no YouTube, downloads available) → clean up job + uploads.
- `.github/workflows/e2e-tenant-daily.yml` — daily matrix (vocalstar, singa), WIF auth, Discord + email on failure.
- `docs/archive/2026-06-15-tenant-portals-e2e.md` — the full story (8 bugs, all fixed).

## Testing
- `copy_blob` unit test; storage suite green (20).
- Full tenant E2E re-run to completion after deploy.