### PR TITLE
fix(tenant): stage instrumental under the name the GCE encoder globs for

### DIFF
--- a/backend/workers/video_worker_orchestrator.py
+++ b/backend/workers/video_worker_orchestrator.py
@@ -452,21 +452,26 @@ class VideoWorkerOrchestrator:
         if self.config.countdown_padding_seconds:
             self.job_log.info(f"Countdown padding: {self.config.countdown_padding_seconds}s - instrumental will be padded")
 
-        # The GCE encoder downloads its inputs from input_gcs_path (jobs/{job_id}/) and locates
-        # the instrumental via find_file("*Instrumental User*", "*existing_instrumental*", ...).
-        # For user-supplied instrumentals (existing_instrumental / custom) the file only exists
-        # locally (and under uploads/), never under jobs/{job_id}/ — so the encoder fails with
-        # "No instrumental audio found". Upload it into the input prefix so the encoder finds it.
-        if encoding_backend.name == "gce" and self.storage and self.config.instrumental_audio_path:
-            instr_basename = os.path.basename(self.config.instrumental_audio_path)
-            needs_staging = ("Instrumental User" in instr_basename) or ("Instrumental Custom" in instr_basename)
-            if needs_staging and os.path.isfile(self.config.instrumental_audio_path):
-                try:
-                    dest = f"jobs/{self.config.job_id}/{instr_basename}"
-                    self.storage.upload_file(self.config.instrumental_audio_path, dest)
-                    self.job_log.info(f"Staged instrumental for GCE encoder: {dest}")
-                except Exception as e:
-                    self.job_log.warning(f"Failed to stage instrumental for GCE encoder: {e}")
+        # The GCE encoder downloads its inputs from input_gcs_path (jobs/{job_id}/) and resolves
+        # the instrumental via find_file. For jobs that supply their own instrumental
+        # (existing_instrumental flow, e.g. tenant submissions), the file lives under
+        # uploads/{job_id}/audio/existing_instrumental.* — which is NOT under jobs/{job_id}/ and
+        # is NOT a name the encoder's 'custom' branch looks for. The encoder's 'custom' branch
+        # globs for "*custom_instrumental*.{flac,mp3}" / "*Instrumental Custom*", so copy the
+        # supplied instrumental into jobs/{job_id}/custom_instrumental.<ext> (server-side, from
+        # the authoritative GCS source — no dependency on local temp files). Without this,
+        # existing-instrumental jobs fail at the encoder with "No instrumental audio found".
+        if encoding_backend.name == "gce" and self.storage:
+            try:
+                srcs = self.storage.list_files(f"uploads/{self.config.job_id}/audio/existing_instrumental")
+                if srcs:
+                    src = srcs[0]
+                    ext = os.path.splitext(src)[1].lower() or ".mp3"
+                    dest = f"jobs/{self.config.job_id}/custom_instrumental{ext}"
+                    self.storage.copy_blob(src, dest)
+                    self.job_log.info(f"Staged custom instrumental for GCE encoder: {dest}")
+            except Exception as e:
+                self.job_log.warning(f"Failed to stage custom instrumental for GCE encoder: {e}")
 
         # Run encoding
         with job_span("encoding", self.config.job_id) as span:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.183.5"
+version = "0.183.6"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
@coderabbitai ignore

Third and decisive iteration on the GCE encode of existing-instrumental (tenant) jobs.

#828/#829 staged the instrumental but under names the **running** encoder doesn't look for. The live encoder VM (`encoding-worker-b`) boots the **2026-01-23 image**, whose `custom` instrumental branch globs only for `*custom_instrumental*.{flac,mp3}` / `*Instrumental Custom*` — **not** `*existing_instrumental*` / `*Instrumental User*` (those patterns were added 2026-03-04, after the image). Tenant jobs run with `instrumental_selection='custom'`, so they hit that branch and failed "No instrumental audio found".

**Fix:** in the orchestrator's `_run_encoding`, server-side copy the supplied instrumental from `uploads/{job}/audio/existing_instrumental.*` → `jobs/{job}/custom_instrumental.<ext>` — a name the encoder's `custom` branch finds — sourced from the authoritative GCS object (no local-temp dependency). Image-agnostic and verified against the old image's actual glob patterns.

> The encoder VM is also 5 months stale (boots a pre-existing-instrumental image). Recreating the `encoding-worker` VMs from the image family's newest image is a worthwhile separate Pulumi pass, but this fix unblocks tenant jobs on the current VM.

Validated by re-running the full prod E2E to completion after deploy.