### PR TITLE
fix(ci): run tenant E2E matrix sequentially

### DIFF
--- a/.github/workflows/e2e-tenant-daily.yml
+++ b/.github/workflows/e2e-tenant-daily.yml
@@ -22,6 +22,9 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
+      # Run tenants sequentially: the GCE encoder is a single shared worker, and two
+      # concurrent full renders overwhelm it ("lost contact with worker"). One at a time.
+      max-parallel: 1
       matrix:
         tenant: [vocalstar, singa]
 


### PR DESCRIPTION
@coderabbitai ignore

The daily tenant E2E ran both tenants concurrently and overwhelmed the single shared GCE encoder ("Encoding job lost contact with worker... not found"). Both tenants pass individually (verified). Serialize the matrix (`max-parallel: 1`) so the daily run doesn't self-inflict encoder contention. CI-config only.