### PR TITLE
fix(match-judge): raise AI timeout to fix Vertex 504 DEADLINE_EXCEEDED

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -111,8 +111,11 @@ class Settings(BaseSettings):
         "true", "1", "yes",
     )
     match_judge_model: str = os.getenv("MATCH_JUDGE_MODEL", "gemini-3.5-flash")
-    # Bounds the AI call so a hung model never strands the submission UI.
-    match_judge_timeout_ms: int = int(os.getenv("MATCH_JUDGE_TIMEOUT_MS", "3000"))
+    # Bounds the AI call so a hung model never strands the submission UI. Kept
+    # generous because Vertex returns 504 DEADLINE_EXCEEDED if generation can't
+    # finish within this deadline (3s was too tight for gemini-3.5-flash); the
+    # call still runs off the critical path and degrades to "none" on timeout.
+    match_judge_timeout_ms: int = int(os.getenv("MATCH_JUDGE_TIMEOUT_MS", "12000"))
 
     # Cloud Tasks (for scalable worker coordination)
     # When enabled, workers are triggered via Cloud Tasks for guaranteed delivery

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.184.0"
+version = "0.184.1"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
Bumps the match-judge AI timeout from 3s to 12s.

Prod verification of #836 confirmed the endpoint works (cosmetic tidy + catalog canonical correct, graceful fallback, no crashes), but the AI judge layer was failing with **504 DEADLINE_EXCEEDED** — `gemini-3.5-flash` could not finish generation within the 3s deadline. The model id is valid; the timeout was just too tight.

Fix: `MATCH_JUDGE_TIMEOUT_MS` default 3000 -> 12000ms. Still bounded and off the critical path (the call degrades to a `none` verdict on timeout); for comparison the auto_correct service uses 120s.

Verified locally: backend match-judge tests still green. Will re-verify the AI path live after deploy.

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)
