### PR TITLE
fix: restore missing (Title/End).mov + original audio in Dropbox folders

### DIFF
--- a/backend/scripts/__init__.py
+++ b/backend/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Operational and maintenance scripts for the karaoke-gen backend."""

--- a/backend/scripts/backfill_original_audio.py
+++ b/backend/scripts/backfill_original_audio.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Backfill original input audio into past jobs' Dropbox folders.
+
+Restores files like ``<artist> - <title> (flacfetch).flac`` / ``(uploaded).mp3`` to
+the organised Dropbox track folders for completed jobs that predate the pipeline fix
+(the distributed pipeline stopped copying the source audio into the output folder).
+
+Dry-run by default; pass ``--live`` to actually upload. NOTE: this cannot backfill the
+screen ``.mov`` files — those require re-encoding the job.
+
+Usage:
+    python -m backend.scripts.backfill_original_audio                 # dry-run, since 2026-03-01
+    python -m backend.scripts.backfill_original_audio --live          # actually upload
+    python -m backend.scripts.backfill_original_audio --since 2026-02-01 --limit 50 -v
+"""
+import argparse
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+
+from backend.models.job import JobStatus
+from backend.services.original_audio import (
+    original_audio_gcs_path,
+    original_audio_output_filename,
+)
+
+logger = logging.getLogger("backfill_original_audio")
+
+# The regression window: screen/audio files stopped reaching Dropbox once the
+# distributed pipeline took over (last known-good folder ~Feb; PR #647/#650 Mar 31).
+DEFAULT_SINCE = "2026-03-01"
+
+
+def plan_job_backfill(job, *, storage, dropbox):
+    """Decide what to do for one job (existence checks only — no uploads).
+
+    Returns ``(action, detail)`` where action is one of:
+      - ``"skip-no-dropbox"``        — job was never uploaded to Dropbox
+      - ``"skip-no-audio-record"``   — no original-audio reference on the job
+      - ``"skip-audio-missing-gcs"`` — original audio no longer in GCS (detail=gcs_path)
+      - ``"skip-already-present"``   — file already in the Dropbox folder (detail=remote_path)
+      - ``"upload"``                 — detail={gcs_path, remote_path, filename}
+    """
+    from karaoke_gen.utils import sanitize_filename
+
+    state = getattr(job, "state_data", None) or {}
+    brand_code = state.get("brand_code")
+    dropbox_path = getattr(job, "dropbox_path", None)
+    if not brand_code or not dropbox_path:
+        return ("skip-no-dropbox", None)
+
+    gcs_path = original_audio_gcs_path(job)
+    if not gcs_path:
+        return ("skip-no-audio-record", None)
+    if not storage.file_exists(gcs_path):
+        return ("skip-audio-missing-gcs", gcs_path)
+
+    safe_artist = sanitize_filename(job.artist) if job.artist else "Unknown"
+    safe_title = sanitize_filename(job.title) if job.title else "Unknown"
+    base_name = f"{safe_artist} - {safe_title}"
+    filename = original_audio_output_filename(job, base_name)
+    folder = f"{dropbox_path.rstrip('/')}/{brand_code} - {base_name}"
+    remote_path = f"{folder}/{filename}"
+
+    if dropbox.file_exists(remote_path):
+        return ("skip-already-present", remote_path)
+
+    return ("upload", {"gcs_path": gcs_path, "remote_path": remote_path, "filename": filename})
+
+
+def _execute_upload(detail, *, storage, dropbox):
+    """Download the original audio from GCS and upload it to the Dropbox folder."""
+    with tempfile.TemporaryDirectory() as td:
+        local = os.path.join(td, detail["filename"])
+        storage.download_file(detail["gcs_path"], local)
+        dropbox.upload_file(local, detail["remote_path"])
+
+
+def run_backfill(*, since, until=None, limit, environment, live):
+    from backend.services.job_manager import JobManager
+    from backend.services.storage_service import StorageService
+    from backend.services.dropbox_service import get_dropbox_service
+
+    jm = JobManager()
+    storage = StorageService()
+    dropbox = get_dropbox_service()
+    if not dropbox.is_configured:
+        logger.error("Dropbox not configured; aborting.")
+        return
+
+    jobs = jm.list_jobs(
+        status=JobStatus.COMPLETE,
+        environment=environment,
+        created_after=since,
+        created_before=until,
+        limit=limit,
+    )
+    logger.info(
+        "Considering %d completed jobs since %s (env=%s)",
+        len(jobs), since.date(), environment,
+    )
+
+    tally = {}
+    for job in jobs:
+        action, detail = plan_job_backfill(job, storage=storage, dropbox=dropbox)
+        tally[action] = tally.get(action, 0) + 1
+        if action == "upload":
+            verb = "uploading" if live else "[DRY-RUN] would upload"
+            logger.info("%s: %s -> %s", verb, job.job_id, detail["remote_path"])
+            if live:
+                try:
+                    _execute_upload(detail, storage=storage, dropbox=dropbox)
+                except Exception as e:
+                    logger.error("  upload failed for %s: %s", job.job_id, e)
+                    tally["upload"] -= 1
+                    tally["error"] = tally.get("error", 0) + 1
+        else:
+            logger.debug("%s: %s (%s)", action, job.job_id, detail)
+
+    logger.info("=== Backfill summary (%s) ===", "LIVE" if live else "DRY-RUN")
+    for k in sorted(tally):
+        logger.info("  %-24s %d", k, tally[k])
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--since", default=DEFAULT_SINCE, help="Only jobs created on/after YYYY-MM-DD")
+    parser.add_argument("--until", default=None, help="Only jobs created before YYYY-MM-DD")
+    parser.add_argument("--limit", type=int, default=1000)
+    parser.add_argument("--env", default="production", dest="environment")
+    parser.add_argument("--live", action="store_true", help="Actually upload (default: dry-run)")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(message)s",
+    )
+
+    since = datetime.strptime(args.since, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    until = (
+        datetime.strptime(args.until, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        if args.until else None
+    )
+    run_backfill(since=since, until=until, limit=args.limit, environment=args.environment, live=args.live)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/backfill_original_audio.py
+++ b/backend/scripts/backfill_original_audio.py
@@ -103,7 +103,13 @@ def run_backfill(*, since, until=None, limit, environment, live):
 
     tally = {}
     for job in jobs:
-        action, detail = plan_job_backfill(job, storage=storage, dropbox=dropbox)
+        try:
+            action, detail = plan_job_backfill(job, storage=storage, dropbox=dropbox)
+        except Exception as e:
+            # A transient GCS/Dropbox error while planning shouldn't abort the whole run.
+            logger.error("  planning failed for %s: %s", getattr(job, "job_id", "?"), e)
+            tally["error"] = tally.get("error", 0) + 1
+            continue
         tally[action] = tally.get(action, 0) + 1
         if action == "upload":
             verb = "uploading" if live else "[DRY-RUN] would upload"

--- a/backend/services/dropbox_service.py
+++ b/backend/services/dropbox_service.py
@@ -169,8 +169,18 @@ class DropboxService:
         try:
             self.client.files_get_metadata(remote_path)
             return True
-        except ApiError:
-            return False
+        except ApiError as e:
+            # Only a genuine "not found" means the file is absent. Re-raise other
+            # API errors (auth, network, rate limit) so callers don't mistake a
+            # transient failure for "missing" (e.g. the backfill uploading a dup).
+            err = e.error
+            if (
+                hasattr(err, "is_path")
+                and err.is_path()
+                and err.get_path().is_not_found()
+            ):
+                return False
+            raise
 
     def upload_file(self, local_path: str, remote_path: str) -> None:
         """

--- a/backend/services/dropbox_service.py
+++ b/backend/services/dropbox_service.py
@@ -151,6 +151,27 @@ class DropboxService:
             logger.info(f"Next brand code for {brand_prefix}: {next_code} (max existing: {max_existing})")
         return next_code
 
+    def file_exists(self, remote_path: str) -> bool:
+        """
+        Check whether a file exists at the given Dropbox path.
+
+        Args:
+            remote_path: Dropbox path (must start with /)
+
+        Returns:
+            True if a file exists at the path, False otherwise.
+        """
+        from dropbox.exceptions import ApiError
+
+        if not remote_path.startswith("/"):
+            remote_path = f"/{remote_path}"
+
+        try:
+            self.client.files_get_metadata(remote_path)
+            return True
+        except ApiError:
+            return False
+
     def upload_file(self, local_path: str, remote_path: str) -> None:
         """
         Upload a single file to Dropbox.

--- a/backend/services/encoding_interface.py
+++ b/backend/services/encoding_interface.py
@@ -65,6 +65,12 @@ class EncodingOutput:
     lossless_mkv_path: Optional[str] = None  # MKV with FLAC (for YouTube)
     lossy_720p_mp4_path: Optional[str] = None  # 720p web version
 
+    # Standalone 5-second screen videos generated from the title/end images.
+    # Kept so they land in the Dropbox folder (regression after #647/#650 moved
+    # screen generation to the encoder). Not used downstream.
+    title_mov_path: Optional[str] = None  # "<artist> - <title> (Title).mov"
+    end_mov_path: Optional[str] = None  # "<artist> - <title> (End).mov"
+
     # All output files as a dict for convenience
     output_files: Dict[str, str] = field(default_factory=dict)
 
@@ -385,6 +391,10 @@ class GCEEncodingBackend(EncodingBackend):
                         output_files["mp4_720p"] = path
                     elif "with vocals" in filename_lower and filename.endswith(".mp4"):
                         output_files["with_vocals_mp4"] = path
+                    elif filename_lower.endswith("(title).mov"):
+                        output_files["title_mov"] = path
+                    elif filename_lower.endswith("(end).mov"):
+                        output_files["end_mov"] = path
                 self.logger.info(f"Converted output_files list to dict: {output_files}")
             else:
                 output_files = raw_output_files if isinstance(raw_output_files, dict) else {}
@@ -396,6 +406,8 @@ class GCEEncodingBackend(EncodingBackend):
                 lossless_mkv_path=output_files.get("mkv_4k"),
                 lossy_720p_mp4_path=output_files.get("mp4_720p"),
                 with_vocals_mp4_path=output_files.get("with_vocals_mp4"),
+                title_mov_path=output_files.get("title_mov"),
+                end_mov_path=output_files.get("end_mov"),
                 output_files=output_files,
                 encoding_time_seconds=encoding_time,
                 encoding_backend=self.name

--- a/backend/services/gce_encoding/main.py
+++ b/backend/services/gce_encoding/main.py
@@ -827,6 +827,20 @@ def run_encoding(job_id: str, work_dir: Path, config: dict):
 
         jobs[job_id]["progress"] = 90
 
+        # Include the standalone 5-second screen videos in the uploaded outputs so they
+        # land in the Dropbox folder. They are generated above (or passed in) purely as
+        # concat inputs and used to live only in screens/; copy them into outputs/ with
+        # the canonical names. Regression fix: screen MOVs disappeared from Dropbox after
+        # #647/#650 moved screen generation to this encoder.
+        for screen_video, suffix in ((title_video, "Title"), (end_video, "End")):
+            if screen_video and Path(screen_video).is_file():
+                dest = output_dir / f"{base_name} ({suffix}).mov"
+                try:
+                    shutil.copy2(screen_video, dest)
+                    logger.info(f"Staged screen video for upload: {dest.name}")
+                except Exception as e:
+                    logger.warning(f"Failed to stage {suffix} MOV into outputs: {e}")
+
         # Collect output files
         output_files = [str(f) for f in output_dir.glob("*") if f.is_file()]
         jobs[job_id]["output_files"] = output_files

--- a/backend/services/original_audio.py
+++ b/backend/services/original_audio.py
@@ -1,0 +1,73 @@
+"""Helpers for locating and naming a job's original input audio.
+
+The original downloaded/uploaded audio (the source used for separation,
+transcription and the With Vocals video) is stored in GCS but is no longer
+copied into the final output folder by the distributed pipeline. These helpers
+let the orchestrator (and the backfill script) restore it to the Dropbox track
+folder with the historical source-tagged name, e.g.::
+
+    <artist> - <title> (flacfetch).flac
+    <artist> - <title> (uploaded).mp3
+    <artist> - <title> (YouTube).webm
+
+The naming mirrors the legacy monolith convention.
+"""
+
+import os
+from typing import Optional
+
+# Map a job's audio_source_type to the historical filename suffix.
+_SOURCE_TAGS = {
+    "file_upload": "uploaded",
+    "youtube_url": "YouTube",
+    "audio_search": "flacfetch",
+}
+
+
+def original_audio_source_tag(job) -> str:
+    """Return the parenthesised source suffix for a job's original audio.
+
+    Falls back gracefully for older jobs that predate ``audio_source_type``.
+    """
+    tag = _SOURCE_TAGS.get(getattr(job, "audio_source_type", None))
+    if tag:
+        return tag
+    # Fallbacks for legacy jobs without an explicit source type.
+    if getattr(job, "url", None):
+        return "YouTube"
+    if getattr(job, "filename", None) or getattr(job, "input_media_gcs_path", None):
+        return "uploaded"
+    return "input"
+
+
+def original_audio_gcs_path(job) -> Optional[str]:
+    """Return the GCS blob path of the original input audio, or None.
+
+    Prefers ``input_media_gcs_path`` (uploads are persisted under jobs/ and URL
+    jobs record their downloaded file here), then falls back to
+    ``file_urls['input']`` which may be a plain string or a nested
+    ``{'audio': ...}`` dict depending on the code path that wrote it.
+    """
+    path = getattr(job, "input_media_gcs_path", None)
+    if path:
+        return path
+    file_urls = getattr(job, "file_urls", None) or {}
+    inp = file_urls.get("input")
+    if isinstance(inp, dict):
+        return inp.get("audio")
+    if isinstance(inp, str):
+        return inp
+    return None
+
+
+def original_audio_output_filename(job, base_name: str) -> Optional[str]:
+    """Return the output filename for the original audio, or None if absent.
+
+    e.g. ``"<artist> - <title> (flacfetch).flac"``. The extension is preserved
+    from the GCS path.
+    """
+    gcs_path = original_audio_gcs_path(job)
+    if not gcs_path:
+        return None
+    ext = os.path.splitext(gcs_path)[1]
+    return f"{base_name} ({original_audio_source_tag(job)}){ext}"

--- a/backend/tests/test_audio_download_worker.py
+++ b/backend/tests/test_audio_download_worker.py
@@ -124,6 +124,11 @@ class TestProcessAudioDownload:
                 'input_media_gcs_path': "uploads/test-job-123/audio/song.mp3",
                 'filename': "song.mp3",
             })
+            # Original audio recorded in file_urls so it shows in the admin files
+            # manifest (and can be staged into the Dropbox folder) for URL/search jobs.
+            mock_jm.update_file_url.assert_any_call(
+                "test-job-123", 'input', 'audio', "uploads/test-job-123/audio/song.mp3"
+            )
             mock_jm.transition_to_state.assert_called_once()
             mock_ws.trigger_audio_worker.assert_awaited_once_with("test-job-123")
             mock_ws.trigger_lyrics_worker.assert_awaited_once_with("test-job-123")

--- a/backend/tests/test_backfill_original_audio.py
+++ b/backend/tests/test_backfill_original_audio.py
@@ -1,0 +1,80 @@
+"""Tests for the original-audio backfill planner (backend/scripts/backfill_original_audio.py)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from backend.scripts.backfill_original_audio import plan_job_backfill
+
+
+def _job(**kwargs):
+    base = dict(
+        job_id="job-1",
+        artist="Eddie Money",
+        title="I'll Get By",
+        audio_source_type="audio_search",
+        url=None,
+        filename=None,
+        input_media_gcs_path="jobs/job-1/input/track.flac",
+        file_urls={},
+        dropbox_path="/Karaoke/Tracks-Organized",
+        state_data={"brand_code": "NOMAD-1184"},
+    )
+    base.update(kwargs)
+    return SimpleNamespace(**base)
+
+
+def _services(gcs_exists=True, dropbox_exists=False):
+    storage = MagicMock()
+    storage.file_exists.return_value = gcs_exists
+    dropbox = MagicMock()
+    dropbox.file_exists.return_value = dropbox_exists
+    return storage, dropbox
+
+
+class TestPlanJobBackfill:
+    def test_upload_when_audio_present_and_not_yet_uploaded(self):
+        storage, dropbox = _services(gcs_exists=True, dropbox_exists=False)
+        action, detail = plan_job_backfill(_job(), storage=storage, dropbox=dropbox)
+        assert action == "upload"
+        assert detail["gcs_path"] == "jobs/job-1/input/track.flac"
+        assert detail["remote_path"] == (
+            "/Karaoke/Tracks-Organized/NOMAD-1184 - Eddie Money - I'll Get By/"
+            "Eddie Money - I'll Get By (flacfetch).flac"
+        )
+        assert detail["filename"] == "Eddie Money - I'll Get By (flacfetch).flac"
+
+    def test_skip_when_no_brand_code(self):
+        storage, dropbox = _services()
+        action, _ = plan_job_backfill(_job(state_data={}), storage=storage, dropbox=dropbox)
+        assert action == "skip-no-dropbox"
+
+    def test_skip_when_no_dropbox_path(self):
+        storage, dropbox = _services()
+        action, _ = plan_job_backfill(_job(dropbox_path=None), storage=storage, dropbox=dropbox)
+        assert action == "skip-no-dropbox"
+
+    def test_skip_when_no_audio_record(self):
+        storage, dropbox = _services()
+        job = _job(input_media_gcs_path=None, file_urls={})
+        action, _ = plan_job_backfill(job, storage=storage, dropbox=dropbox)
+        assert action == "skip-no-audio-record"
+
+    def test_skip_when_audio_missing_from_gcs(self):
+        storage, dropbox = _services(gcs_exists=False)
+        action, detail = plan_job_backfill(_job(), storage=storage, dropbox=dropbox)
+        assert action == "skip-audio-missing-gcs"
+        assert detail == "jobs/job-1/input/track.flac"
+
+    def test_skip_when_already_present_in_dropbox(self):
+        storage, dropbox = _services(gcs_exists=True, dropbox_exists=True)
+        action, _ = plan_job_backfill(_job(), storage=storage, dropbox=dropbox)
+        assert action == "skip-already-present"
+
+    def test_sanitizes_artist_title_for_paths(self):
+        storage, dropbox = _services(gcs_exists=True, dropbox_exists=False)
+        job = _job(artist="AC/DC", title="T:N/T")
+        action, detail = plan_job_backfill(job, storage=storage, dropbox=dropbox)
+        assert action == "upload"
+        # No raw slashes/colons leak into the Dropbox path beyond real separators
+        tail = detail["remote_path"].split("/NOMAD-1184 - ", 1)[1]
+        assert ":" not in tail

--- a/backend/tests/test_dropbox_service.py
+++ b/backend/tests/test_dropbox_service.py
@@ -488,18 +488,39 @@ class TestFileExists:
             "/Karaoke/NOMAD-1 - A - B/A - B (flacfetch).flac"
         )
 
-    def test_returns_false_on_api_error(self):
+    def test_returns_false_on_not_found(self):
         from dropbox.exceptions import ApiError
         from backend.services.dropbox_service import DropboxService
 
         service = DropboxService()
         mock_client = MagicMock()
+        # Genuine "not found": is_path() -> get_path().is_not_found() == True
+        not_found_err = MagicMock()
+        not_found_err.is_path.return_value = True
+        not_found_err.get_path.return_value.is_not_found.return_value = True
         mock_client.files_get_metadata.side_effect = ApiError(
-            request_id="r", error=MagicMock(), user_message_text=None, user_message_locale=None
+            request_id="r", error=not_found_err, user_message_text=None, user_message_locale=None
         )
         service._client = mock_client
 
         assert service.file_exists("/missing.flac") is False
+
+    def test_reraises_non_not_found_api_error(self):
+        """Auth/network/rate-limit errors must NOT be masked as 'file missing'."""
+        from dropbox.exceptions import ApiError
+        from backend.services.dropbox_service import DropboxService
+
+        service = DropboxService()
+        mock_client = MagicMock()
+        other_err = MagicMock()
+        other_err.is_path.return_value = False
+        mock_client.files_get_metadata.side_effect = ApiError(
+            request_id="r", error=other_err, user_message_text=None, user_message_locale=None
+        )
+        service._client = mock_client
+
+        with pytest.raises(ApiError):
+            service.file_exists("/some.flac")
 
     def test_prepends_leading_slash(self):
         from backend.services.dropbox_service import DropboxService

--- a/backend/tests/test_dropbox_service.py
+++ b/backend/tests/test_dropbox_service.py
@@ -471,3 +471,42 @@ class TestCreateSharedLink:
         
         assert url == "https://dropbox.com/s/existing/file.mp4"
 
+
+
+class TestFileExists:
+    """Test DropboxService.file_exists (used by the original-audio backfill)."""
+
+    def test_returns_true_when_metadata_found(self):
+        from backend.services.dropbox_service import DropboxService
+
+        service = DropboxService()
+        mock_client = MagicMock()
+        service._client = mock_client
+
+        assert service.file_exists("/Karaoke/NOMAD-1 - A - B/A - B (flacfetch).flac") is True
+        mock_client.files_get_metadata.assert_called_once_with(
+            "/Karaoke/NOMAD-1 - A - B/A - B (flacfetch).flac"
+        )
+
+    def test_returns_false_on_api_error(self):
+        from dropbox.exceptions import ApiError
+        from backend.services.dropbox_service import DropboxService
+
+        service = DropboxService()
+        mock_client = MagicMock()
+        mock_client.files_get_metadata.side_effect = ApiError(
+            request_id="r", error=MagicMock(), user_message_text=None, user_message_locale=None
+        )
+        service._client = mock_client
+
+        assert service.file_exists("/missing.flac") is False
+
+    def test_prepends_leading_slash(self):
+        from backend.services.dropbox_service import DropboxService
+
+        service = DropboxService()
+        mock_client = MagicMock()
+        service._client = mock_client
+
+        service.file_exists("Karaoke/x.flac")
+        mock_client.files_get_metadata.assert_called_once_with("/Karaoke/x.flac")

--- a/backend/tests/test_encoding_interface.py
+++ b/backend/tests/test_encoding_interface.py
@@ -394,6 +394,48 @@ class TestGCEEncodingBackend:
         assert output.lossless_mkv_path == "jobs/test/finals/Artist - Title (Final Karaoke Lossless 4k).mkv"
         assert output.lossy_720p_mp4_path == "jobs/test/finals/Artist - Title (Final Karaoke Lossy 720p).mp4"
 
+    @patch.object(GCEEncodingBackend, "_get_service")
+    @pytest.mark.asyncio
+    async def test_encode_maps_screen_movs_from_list(self, mock_get_service):
+        """Test GCE encoding maps the standalone (Title).mov / (End).mov from output_files list.
+
+        The GCE worker now copies the 5-second screen videos into its outputs/ dir so they
+        upload to GCS finals. The mapper must recognise them and populate
+        title_mov_path / end_mov_path so the orchestrator downloads them into output_dir
+        (and thus into the Dropbox folder). Regression for: screen MOVs lost from Dropbox
+        after #647/#650 moved screen generation to the encoder.
+        """
+        mock_service = MagicMock()
+        mock_service.encode_videos = AsyncMock(return_value={
+            "status": "complete",
+            "output_files": [
+                "jobs/test/finals/Artist - Title (Final Karaoke Lossless 4k).mp4",
+                "jobs/test/finals/Artist - Title (Title).mov",
+                "jobs/test/finals/Artist - Title (End).mov",
+            ]
+        })
+        mock_get_service.return_value = mock_service
+
+        backend = GCEEncodingBackend()
+        input_config = EncodingInput(
+            title_video_path="/input/title.png",
+            karaoke_video_path="/input/karaoke.mkv",
+            instrumental_audio_path="/input/audio.flac",
+            artist="Artist",
+            title="Title",
+            options={
+                "job_id": "test-job",
+                "input_gcs_path": "gs://bucket/input/",
+                "output_gcs_path": "gs://bucket/output/",
+            }
+        )
+
+        output = await backend.encode(input_config)
+
+        assert output.success is True
+        assert output.title_mov_path == "jobs/test/finals/Artist - Title (Title).mov"
+        assert output.end_mov_path == "jobs/test/finals/Artist - Title (End).mov"
+
 
 class TestGetEncodingBackend:
     """Test encoding backend factory function."""

--- a/backend/tests/test_gce_encoding_worker.py
+++ b/backend/tests/test_gce_encoding_worker.py
@@ -508,3 +508,50 @@ class TestWheelVersionSorting:
         wheels = ["/tmp/karaoke_gen-current.whl"]
         latest = self.select_latest_wheel(wheels)
         assert latest is None
+
+
+class TestScreenVideoStaging:
+    """Test that the standalone screen MOVs are copied into outputs/ for upload.
+
+    Mirrors the copy logic in run_encoding (kept self-contained, like the other
+    tests in this file). Regression: (Title).mov / (End).mov disappeared from the
+    Dropbox folder after #647/#650 moved screen generation into this encoder.
+    """
+
+    @staticmethod
+    def stage_screen_videos(title_video, end_video, output_dir: Path, base_name: str):
+        """Replicates run_encoding's screen-video staging step."""
+        import shutil
+        for screen_video, suffix in ((title_video, "Title"), (end_video, "End")):
+            if screen_video and Path(screen_video).is_file():
+                dest = output_dir / f"{base_name} ({suffix}).mov"
+                shutil.copy2(screen_video, dest)
+
+    def test_copies_title_and_end_with_canonical_names(self, tmp_path):
+        screens = tmp_path / "screens"
+        screens.mkdir()
+        title = screens / "title.mov"
+        end = screens / "end.mov"
+        title.write_bytes(b"title-mov-bytes")
+        end.write_bytes(b"end-mov-bytes")
+        outputs = tmp_path / "outputs"
+        outputs.mkdir()
+
+        self.stage_screen_videos(title, end, outputs, "Artist - Title")
+
+        assert (outputs / "Artist - Title (Title).mov").read_bytes() == b"title-mov-bytes"
+        assert (outputs / "Artist - Title (End).mov").read_bytes() == b"end-mov-bytes"
+
+    def test_skips_missing_end_video(self, tmp_path):
+        screens = tmp_path / "screens"
+        screens.mkdir()
+        title = screens / "title.mov"
+        title.write_bytes(b"title-mov-bytes")
+        outputs = tmp_path / "outputs"
+        outputs.mkdir()
+
+        # end_video is None (no end screen) — must not raise
+        self.stage_screen_videos(title, None, outputs, "Artist - Title")
+
+        assert (outputs / "Artist - Title (Title).mov").is_file()
+        assert not (outputs / "Artist - Title (End).mov").exists()

--- a/backend/tests/test_original_audio.py
+++ b/backend/tests/test_original_audio.py
@@ -1,0 +1,78 @@
+"""Tests for original-audio naming/location helpers (backend/services/original_audio.py).
+
+These back the regression fix that restores the original input audio
+(e.g. '<artist> - <title> (flacfetch).flac') to the Dropbox track folder.
+"""
+
+from types import SimpleNamespace
+
+from backend.services.original_audio import (
+    original_audio_source_tag,
+    original_audio_gcs_path,
+    original_audio_output_filename,
+)
+
+
+def _job(**kwargs):
+    base = dict(
+        audio_source_type=None,
+        url=None,
+        filename=None,
+        input_media_gcs_path=None,
+        file_urls={},
+    )
+    base.update(kwargs)
+    return SimpleNamespace(**base)
+
+
+class TestSourceTag:
+    def test_file_upload_maps_to_uploaded(self):
+        assert original_audio_source_tag(_job(audio_source_type="file_upload")) == "uploaded"
+
+    def test_youtube_url_maps_to_youtube(self):
+        assert original_audio_source_tag(_job(audio_source_type="youtube_url")) == "YouTube"
+
+    def test_audio_search_maps_to_flacfetch(self):
+        assert original_audio_source_tag(_job(audio_source_type="audio_search")) == "flacfetch"
+
+    def test_legacy_url_job_without_source_type(self):
+        assert original_audio_source_tag(_job(url="https://youtu.be/x")) == "YouTube"
+
+    def test_legacy_upload_without_source_type(self):
+        assert original_audio_source_tag(_job(filename="song.mp3")) == "uploaded"
+
+    def test_unknown_falls_back_to_input(self):
+        assert original_audio_source_tag(_job()) == "input"
+
+
+class TestGcsPath:
+    def test_prefers_input_media_gcs_path(self):
+        job = _job(input_media_gcs_path="jobs/j1/input/song.mp3",
+                   file_urls={"input": "jobs/j1/other.flac"})
+        assert original_audio_gcs_path(job) == "jobs/j1/input/song.mp3"
+
+    def test_file_urls_input_as_string(self):
+        job = _job(file_urls={"input": "jobs/j1/input.flac"})
+        assert original_audio_gcs_path(job) == "jobs/j1/input.flac"
+
+    def test_file_urls_input_as_dict(self):
+        job = _job(file_urls={"input": {"audio": "jobs/j1/input/song.flac"}})
+        assert original_audio_gcs_path(job) == "jobs/j1/input/song.flac"
+
+    def test_none_when_no_source(self):
+        assert original_audio_gcs_path(_job()) is None
+
+
+class TestOutputFilename:
+    def test_flacfetch_flac(self):
+        job = _job(audio_source_type="audio_search",
+                   input_media_gcs_path="jobs/j1/input/track.flac")
+        assert original_audio_output_filename(job, "Artist - Title") == "Artist - Title (flacfetch).flac"
+
+    def test_uploaded_mp3(self):
+        job = _job(audio_source_type="file_upload",
+                   input_media_gcs_path="jobs/j1/input/My Song.mp3")
+        assert original_audio_output_filename(job, "Artist - Title") == "Artist - Title (uploaded).mp3"
+
+    def test_none_when_no_audio(self):
+        assert original_audio_output_filename(_job(), "Artist - Title") is None

--- a/backend/tests/test_upload_results_screen_movs.py
+++ b/backend/tests/test_upload_results_screen_movs.py
@@ -1,0 +1,72 @@
+"""Test that _upload_results registers the standalone screen MOVs in file_urls.
+
+This makes (Title).mov / (End).mov appear in the admin files manifest and verifiable
+by the daily E2E. Regression: the screen MOVs were absent from Dropbox track folders.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+from backend.workers.video_worker import _upload_results
+
+
+@pytest.mark.asyncio
+async def test_upload_results_registers_screen_movs():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create local files the orchestrator would have downloaded into output_dir
+        title_mov = os.path.join(temp_dir, "Artist - Title (Title).mov")
+        end_mov = os.path.join(temp_dir, "Artist - Title (End).mov")
+        lossless = os.path.join(temp_dir, "Artist - Title (Final Karaoke Lossless 4k).mp4")
+        for p in (title_mov, end_mov, lossless):
+            with open(p, "wb") as f:
+                f.write(b"x")
+
+        from unittest.mock import MagicMock
+        job_manager = MagicMock()
+        storage = MagicMock()
+        storage.upload_file.side_effect = lambda local, gcs: f"gs://bucket/{gcs}"
+
+        result = {
+            "final_video": lossless,
+            "title_mov": title_mov,
+            "end_mov": end_mov,
+        }
+
+        await _upload_results("job-1", job_manager, storage, temp_dir, result)
+
+        # The screen MOVs are uploaded under finals/ and recorded in file_urls
+        registered = {
+            (c.args[1], c.args[2]) for c in job_manager.update_file_url.call_args_list
+        }
+        assert ("finals", "title_mov") in registered
+        assert ("finals", "end_mov") in registered
+
+        uploaded_gcs = {c.args[1] for c in storage.upload_file.call_args_list}
+        assert "jobs/job-1/finals/title_mov.mov" in uploaded_gcs
+        assert "jobs/job-1/finals/end_mov.mov" in uploaded_gcs
+
+
+@pytest.mark.asyncio
+async def test_upload_results_skips_missing_screen_movs():
+    """Jobs without screen MOVs (legacy/None) must not error or register them."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        lossless = os.path.join(temp_dir, "Artist - Title (Final Karaoke Lossless 4k).mp4")
+        with open(lossless, "wb") as f:
+            f.write(b"x")
+
+        from unittest.mock import MagicMock
+        job_manager = MagicMock()
+        storage = MagicMock()
+        storage.upload_file.side_effect = lambda local, gcs: f"gs://bucket/{gcs}"
+
+        result = {"final_video": lossless, "title_mov": None}  # end_mov absent entirely
+
+        await _upload_results("job-1", job_manager, storage, temp_dir, result)
+
+        registered = {
+            (c.args[1], c.args[2]) for c in job_manager.update_file_url.call_args_list
+        }
+        assert ("finals", "title_mov") not in registered
+        assert ("finals", "end_mov") not in registered

--- a/backend/tests/test_video_worker_orchestrator.py
+++ b/backend/tests/test_video_worker_orchestrator.py
@@ -1058,6 +1058,52 @@ class TestVideoWorkerOrchestratorEncoding:
             with pytest.raises(RuntimeError, match="stale"):
                 await orchestrator._download_gce_encoded_files(output)
 
+    @pytest.mark.asyncio
+    async def test_download_gce_includes_screen_movs(self):
+        """Screen MOVs returned by the encoder are downloaded into output_dir.
+
+        Regression: the standalone (Title).mov / (End).mov stopped reaching the
+        Dropbox folder after #647/#650. They must be pulled back like other finals.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config = OrchestratorConfig(
+                job_id="test-job",
+                artist="Test Artist",
+                title="Test Title",
+                title_video_path=os.path.join(temp_dir, "title.png"),
+                karaoke_video_path=os.path.join(temp_dir, "karaoke.mkv"),
+                instrumental_audio_path=os.path.join(temp_dir, "audio.flac"),
+                output_dir=temp_dir,
+            )
+
+            mock_storage = MagicMock()
+            mock_storage.download_file = MagicMock()
+
+            orchestrator = VideoWorkerOrchestrator(config, storage=mock_storage)
+
+            from backend.services.encoding_interface import EncodingOutput
+            output = EncodingOutput(
+                success=True,
+                lossless_4k_mp4_path="jobs/test-job/finals/Test Artist - Test Title (Final Karaoke Lossless 4k).mp4",
+                title_mov_path="jobs/test-job/finals/Test Artist - Test Title (Title).mov",
+                end_mov_path="jobs/test-job/finals/Test Artist - Test Title (End).mov",
+                encoding_time_seconds=0.0,
+                encoding_backend="gce",
+            )
+
+            await orchestrator._download_gce_encoded_files(output)
+
+            downloaded = {os.path.basename(c.args[0]) for c in mock_storage.download_file.call_args_list}
+            assert "Test Artist - Test Title (Title).mov" in downloaded
+            assert "Test Artist - Test Title (End).mov" in downloaded
+            # Result points the screen MOVs at their local copies in output_dir
+            assert orchestrator.result.title_mov == os.path.join(
+                temp_dir, "Test Artist - Test Title (Title).mov"
+            )
+            assert orchestrator.result.end_mov == os.path.join(
+                temp_dir, "Test Artist - Test Title (End).mov"
+            )
+
 
 class TestVideoWorkerOrchestratorOrganization:
     """Test organization stage."""
@@ -1404,6 +1450,36 @@ class TestCreateOrchestratorConfigFromJob:
         )
 
         assert config.instrumental_audio_path == "/tmp/test/Test Artist - Test Title (Instrumental User).mp3"
+
+    def test_create_config_includes_original_audio(self):
+        """Config carries the original input audio so it can be staged into the
+        Dropbox folder. Regression: source audio stopped reaching organised outputs.
+        """
+        job = MagicMock()
+        job.job_id = "test-123"
+        job.artist = "Test Artist"
+        job.title = "Test Title"
+        job.state_data = {"instrumental_selection": "clean"}
+        job.enable_cdg = False
+        job.enable_txt = False
+        job.enable_youtube_upload = False
+        job.is_private = False
+        job.brand_prefix = "NOMAD"
+        job.discord_webhook_url = None
+        job.youtube_description_template = None
+        job.dropbox_path = "/Karaoke"
+        job.gdrive_folder_id = None
+        job.keep_brand_code = None
+        job.existing_instrumental_gcs_path = None
+        job.file_urls = {'screens': {'title_png': 'screens/title.png', 'end_png': 'screens/end.png'}}
+        # flacfetch (audio_search) download
+        job.audio_source_type = "audio_search"
+        job.input_media_gcs_path = "jobs/test-123/input/track.flac"
+
+        config = create_orchestrator_config_from_job(job=job, temp_dir="/tmp/test")
+
+        assert config.original_audio_gcs_path == "jobs/test-123/input/track.flac"
+        assert config.original_audio_filename == "Test Artist - Test Title (flacfetch).flac"
 
     def test_create_config_passes_instrumental_selection(self):
         """Test that instrumental_selection is passed through to OrchestratorConfig.
@@ -1903,3 +1979,73 @@ class TestLrcHasLyricsContent:
         lrc_file.write_text("[ti:Song Title]\n[ar:Artist Name]\n[re:MidiCo]\n")
         orchestrator = self._make_orchestrator(lrc_file_path=str(lrc_file))
         assert orchestrator._lrc_has_lyrics_content() is False
+
+
+class TestStageOriginalAudio:
+    """Original input audio is staged into output_dir before folder uploads.
+
+    Regression: the source audio ((flacfetch).flac / (uploaded).mp3) stopped
+    appearing in the Dropbox track folder after the move to the distributed
+    pipeline. It must be fetched from GCS into output_dir before upload.
+    """
+
+    def _make(self, temp_dir, **overrides):
+        cfg = dict(
+            job_id="job-1",
+            artist="Test Artist",
+            title="Test Title",
+            title_video_path=os.path.join(temp_dir, "title.png"),
+            karaoke_video_path=os.path.join(temp_dir, "karaoke.mkv"),
+            instrumental_audio_path=os.path.join(temp_dir, "audio.flac"),
+            output_dir=temp_dir,
+        )
+        cfg.update(overrides)
+        config = OrchestratorConfig(**cfg)
+        storage = MagicMock()
+        return VideoWorkerOrchestrator(config, storage=storage), storage
+
+    def test_downloads_original_audio_into_output_dir(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            orch, storage = self._make(
+                temp_dir,
+                original_audio_gcs_path="jobs/job-1/input/track.flac",
+                original_audio_filename="Test Artist - Test Title (flacfetch).flac",
+            )
+            orch._stage_original_audio_for_upload()
+
+            storage.download_file.assert_called_once()
+            args = storage.download_file.call_args.args
+            assert args[0] == "jobs/job-1/input/track.flac"
+            assert args[1] == os.path.join(temp_dir, "Test Artist - Test Title (flacfetch).flac")
+
+    def test_noop_when_no_original_audio_configured(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            orch, storage = self._make(temp_dir)
+            orch._stage_original_audio_for_upload()
+            storage.download_file.assert_not_called()
+
+    def test_skips_when_already_present(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fname = "Test Artist - Test Title (uploaded).mp3"
+            # File already in output_dir (e.g. legacy/local run)
+            with open(os.path.join(temp_dir, fname), "wb") as f:
+                f.write(b"existing")
+            orch, storage = self._make(
+                temp_dir,
+                original_audio_gcs_path="jobs/job-1/input/song.mp3",
+                original_audio_filename=fname,
+            )
+            orch._stage_original_audio_for_upload()
+            storage.download_file.assert_not_called()
+
+    def test_download_failure_is_non_fatal(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            orch, storage = self._make(
+                temp_dir,
+                original_audio_gcs_path="jobs/job-1/input/track.flac",
+                original_audio_filename="Test Artist - Test Title (flacfetch).flac",
+            )
+            storage.download_file.side_effect = Exception("gcs boom")
+            # Must not raise
+            orch._stage_original_audio_for_upload()
+            assert any("Original audio" in w for w in orch.result.distribution_warnings)

--- a/backend/workers/audio_download_worker.py
+++ b/backend/workers/audio_download_worker.py
@@ -232,6 +232,10 @@ async def process_audio_download(job_id: str) -> bool:
             'input_media_gcs_path': audio_gcs_path,
             'filename': filename,
         })
+        # Record the original input audio in file_urls too (the upload path does this
+        # in audio_worker), so it appears in the admin files manifest consistently
+        # across all source types and can be staged into the output folder.
+        job_manager.update_file_url(job_id, 'input', 'audio', audio_gcs_path)
 
         # Download succeeded — clear any stale retry-pending marker and
         # previous error so the UI stops showing a resolved failure.

--- a/backend/workers/video_worker.py
+++ b/backend/workers/video_worker.py
@@ -359,6 +359,8 @@ async def generate_video_orchestrated(job_id: str) -> bool:
                     'final_with_vocals_mp4': result.final_with_vocals_mp4,
                     'final_karaoke_cdg_zip': result.final_karaoke_cdg_zip,
                     'final_karaoke_txt_zip': result.final_karaoke_txt_zip,
+                    'title_mov': result.title_mov,
+                    'end_mov': result.end_mov,
                 })
 
             # Store result metadata in job BEFORE transitioning to COMPLETE
@@ -1604,6 +1606,10 @@ async def _upload_results(
         ('final_with_vocals_mp4', 'finals', 'with_vocals_mp4'),
         ('final_karaoke_cdg_zip', 'packages', 'cdg_zip'),
         ('final_karaoke_txt_zip', 'packages', 'txt_zip'),
+        # Standalone screen videos — recorded so they appear in the admin files
+        # manifest and are verifiable (regression: missing from Dropbox folders)
+        ('title_mov', 'finals', 'title_mov'),
+        ('end_mov', 'finals', 'end_mov'),
     ]
     
     for result_key, category, file_key in file_mappings:

--- a/backend/workers/video_worker_orchestrator.py
+++ b/backend/workers/video_worker_orchestrator.py
@@ -28,6 +28,10 @@ from backend.models.job import JobStatus
 from backend.services.job_manager import JobManager
 from backend.services.storage_service import StorageService
 from backend.services.tracing import job_span, add_span_event
+from backend.services.original_audio import (
+    original_audio_gcs_path,
+    original_audio_output_filename,
+)
 from karaoke_gen.utils import sanitize_filename
 
 logger = logging.getLogger(__name__)
@@ -66,6 +70,11 @@ class OrchestratorConfig:
     # Dropbox/GDrive configuration
     dropbox_path: Optional[str] = None
     gdrive_folder_id: Optional[str] = None
+
+    # Original input audio to include in the uploaded folder (the archival master,
+    # e.g. "<artist> - <title> (flacfetch).flac"). GCS blob path + target filename.
+    original_audio_gcs_path: Optional[str] = None
+    original_audio_filename: Optional[str] = None
 
     # Keep existing brand code (for re-processing)
     keep_brand_code: Optional[str] = None
@@ -111,6 +120,11 @@ class OrchestratorResult:
     final_with_vocals_mp4: Optional[str] = None  # With Vocals MP4 (encoded from raw MKV)
     final_karaoke_cdg_zip: Optional[str] = None
     final_karaoke_txt_zip: Optional[str] = None
+
+    # Standalone 5-second screen videos (downloaded from GCE finals so they land in
+    # the Dropbox folder). Not used downstream — kept for archival/upload only.
+    title_mov: Optional[str] = None
+    end_mov: Optional[str] = None
 
     # Organization
     brand_code: Optional[str] = None
@@ -553,6 +567,9 @@ class VideoWorkerOrchestrator:
             ('lossy_4k_mp4_path', 'final_video_lossy'),
             ('lossy_720p_mp4_path', 'final_video_720p'),
             ('with_vocals_mp4_path', 'final_with_vocals_mp4'),
+            # Standalone screen videos — pulled back so they reach the Dropbox folder
+            ('title_mov_path', 'title_mov'),
+            ('end_mov_path', 'end_mov'),
         ]
 
         downloaded_count = 0
@@ -622,6 +639,16 @@ class VideoWorkerOrchestrator:
         """Run the distribution stage (YouTube, Dropbox, GDrive uploads)."""
         self.job_log.info("Starting distribution stage")
         self._update_progress(JobStatus.PACKAGING, 90, "Uploading files")
+
+        # Stage the original input audio into output_dir before any folder upload
+        # (Dropbox/GDrive upload the whole directory). Only worth the GCS fetch when
+        # such an upload will actually happen.
+        will_upload_folder = (
+            (self.config.dropbox_path and self.config.brand_prefix)
+            or self.config.gdrive_folder_id
+        )
+        if will_upload_folder:
+            self._stage_original_audio_for_upload()
 
         # YouTube upload
         if self.config.enable_youtube_upload and self.config.youtube_credentials:
@@ -758,6 +785,32 @@ class VideoWorkerOrchestrator:
             self.result.distribution_warnings.append(
                 f"YouTube upload skipped (quota exceeded) and failed to queue: {e}"
             )
+
+    def _stage_original_audio_for_upload(self):
+        """Copy the original input audio into output_dir so uploads include it.
+
+        The source audio (e.g. "<artist> - <title> (flacfetch).flac" /
+        "(uploaded).mp3") is the archival master used for separation/transcription.
+        The distributed pipeline otherwise leaves it in GCS only, so it stopped
+        appearing in the Dropbox track folder. Best-effort: never fail the pipeline.
+        """
+        gcs_path = self.config.original_audio_gcs_path
+        filename = self.config.original_audio_filename
+        if not gcs_path or not filename:
+            return
+
+        dest = os.path.join(self.config.output_dir, filename)
+        if os.path.exists(dest):
+            self.job_log.info(f"Original audio already present, skipping: {filename}")
+            return
+
+        try:
+            self.job_log.info(f"Staging original audio for upload: {filename}")
+            self.storage.download_file(gcs_path, dest)
+            self.job_log.info(f"Staged original audio: {dest}")
+        except Exception as e:
+            self.job_log.warning(f"Failed to stage original audio ({filename}): {e}")
+            self.result.distribution_warnings.append(f"Original audio not included: {e}")
 
     async def _upload_to_dropbox(self):
         """Upload files to Dropbox."""
@@ -994,6 +1047,10 @@ def create_orchestrator_config_from_job(
         # Dropbox/GDrive (overridden for private tracks)
         dropbox_path=dist.dropbox_path,
         gdrive_folder_id=dist.gdrive_folder_id,
+
+        # Original input audio to include in the uploaded folder (archival master)
+        original_audio_gcs_path=original_audio_gcs_path(job),
+        original_audio_filename=original_audio_output_filename(job, base_name),
 
         # Keep existing brand code
         keep_brand_code=getattr(job, 'keep_brand_code', None),

--- a/docs/archive/2026-06-17-dropbox-missing-files-plan.md
+++ b/docs/archive/2026-06-17-dropbox-missing-files-plan.md
@@ -1,0 +1,175 @@
+# Plan: Restore missing files in Dropbox track output folders
+
+**Date:** 2026-06-17
+**Branch:** `feat/sess-20260617-1501-dropbox-missing-files`
+**Status:** Implemented (v0.186.0) — Parts A/B/C done + a bundled CLI ffmpeg-hang fix (see end).
+
+## Problem
+
+Track output folders uploaded to Dropbox (e.g. `NOMAD-1184 - Eddie Money - I'll Get By`)
+are missing two file types that used to be present (last good folder ~Feb 2026):
+
+1. **Screen videos** — the 5-second `.mov` clips generated from the title/end screen
+   images: `<artist> - <title> (Title).mov` and `<artist> - <title> (End).mov`.
+   The folder still has the `(Title).png`/`.jpg`/`(End).png` images, just not the `.mov`s.
+2. **Original input audio** — the source file used for separation/transcription/with-vocals,
+   e.g. `<artist> - <title> (flacfetch).flac` or `<artist> - <title> (uploaded).mp3`.
+
+## Root cause
+
+The Dropbox upload (`VideoWorkerOrchestrator._upload_to_dropbox`,
+`backend/workers/video_worker_orchestrator.py`) uploads **the entire `output_dir`** wholesale
+via `dropbox.upload_folder(...)`. There is no curated file list — whatever is in `output_dir`
+gets uploaded. So both files are missing simply because they are **no longer in `output_dir`**
+by the time distribution runs. The pipeline migrated from a monolith (one working dir held
+everything) to distributed GCE workers, narrowing what lands in `output_dir`:
+
+### `.mov` screen videos — broke with PRs #647/#650 (2026-03-31)
+- Old: `screens_worker` generated `(Title).mov`/`(End).mov` locally; `video_worker` pulled
+  them into `output_dir`.
+- Now: to fit Cloud Run's 2 GiB cap (#640), `screens_worker` emits **PNG only**
+  (`intro_video_duration=0`), and `video_worker`/orchestrator download the **PNG**.
+- The GCE encoder (`backend/services/gce_encoding/main.py`, `generate_mov_from_png`)
+  **still generates** `title.mov`/`end.mov` from the PNGs — but as throwaway intermediates in
+  a `screens/` temp dir with generic names. Only the `outputs/` dir is uploaded to GCS
+  `finals/`, and the orchestrator's `_download_gce_encoded_files` only maps back 5 named
+  finals (`lossless_4k`, `lossy_4k`, `mkv`, `720p`, `with_vocals`). The standalone `.mov`s
+  are never returned.
+
+### Original input audio — never copied into `output_dir` in the distributed pipeline
+- Audio is downloaded by `audio_worker` early and stored in GCS:
+  - Uploaded files → persisted to `jobs/{job_id}/input/{filename}` (because `uploads/` has a
+    7-day lifecycle; `jobs/` is permanent).
+  - URL/flacfetch jobs → `input_media_gcs_path` / `file_urls['input']`.
+- The old monolith left this file in the working dir → it ended up in the Dropbox folder.
+- The new orchestrator never copies it into `output_dir`.
+
+## Decisions (from user, 2026-06-17)
+- **Scope:** Forward fix for all future jobs **+ backfill original audio** for past jobs where
+  it still exists in GCS. **No `.mov` backfill** (can't regenerate without re-encoding).
+- **Audio in Dropbox:** Include the full original audio file (it's the archival master), always.
+
+## Fix design
+
+Both fixes converge on "ensure the file is in `output_dir` before `_upload_to_dropbox`."
+
+### Part A — Restore `.mov` screen videos (forward only)
+
+Extend the existing GCE-finals mechanism so the standalone `.mov`s come back like any other final.
+
+1. **GCE worker** (`backend/services/gce_encoding/main.py`, `run_encoding`):
+   After the title/end `.mov`s are generated (they already are, for concat), copy them into the
+   `outputs/` dir with proper names `{base_name} (Title).mov` / `{base_name} (End).mov` before
+   `output_files` is collected. They then upload to GCS `finals/` automatically via
+   `output_dir.glob("*")`.
+2. **`EncodingOutput`** (`backend/services/encoding_interface.py`): add `title_mov_path`,
+   `end_mov_path`.
+3. **`GCEEncodingBackend.encode`** (same file): in the filename→key mapping, match
+   `(title).mov` / `(end).mov` → new keys (`title_mov`, `end_mov`); populate the new
+   `EncodingOutput` fields.
+4. **Orchestrator** (`_download_gce_encoded_files`): add `('title_mov_path', ...)`,
+   `('end_mov_path', ...)` to `file_mappings` so they download into `output_dir`. Failure to
+   download is non-fatal (consistent with existing per-file handling).
+5. **Local encoding path** (`LocalEncodingService` / `LocalEncodingBackend`): verify during
+   implementation whether the local fallback already leaves the `.mov`s in `output_dir`; if not,
+   mirror the behavior. Production is GCE, so this is secondary.
+
+### Part B — Restore original input audio (forward)
+
+In the orchestrator's distribution stage, **before** `_upload_to_dropbox`, fetch the original
+source audio from GCS into `output_dir` with the historical source-tagged name.
+
+- New helper (e.g. `_stage_original_audio_for_upload`) that:
+  - Resolves the GCS source: `job.input_media_gcs_path` (uploads persisted to `jobs/`), else
+    `file_urls['input']`/`['input']['audio']`.
+  - Derives the source suffix from `job.audio_source_type`:
+    - `file_upload` → `(uploaded)`
+    - `audio_search` → `(flacfetch)`
+    - `youtube_url` → `(YouTube)`
+    - (matches the historical monolith convention: `{artist_title} (flacfetch)` etc.)
+  - Downloads to `output_dir/{base_name} ({suffix}){ext}`, preserving the real extension
+    (`.flac`/`.mp3`/`.webm`/...).
+  - Non-fatal on failure (warn, continue) — Dropbox is already best-effort.
+
+### Part C — Backfill original audio for past jobs (audio only)
+
+One-off script (`backend/scripts/` or `scripts/`) — dry-run by default:
+- Query completed jobs since the cutoff (~Mar 2026) that have a `dropbox_link`/`brand_code`.
+- For each: locate original audio in GCS (skip if gone). Locate the Dropbox folder via
+  `{dropbox_path}/{brand_code} - {artist} - {title}`. Upload the audio with the source-tagged
+  name **only if not already present**.
+- Log a summary (restored / skipped-missing-audio / skipped-already-present / errors).
+
+## Test plan
+- **Unit:** `GCEEncodingBackend.encode` maps `.mov` filenames → new `EncodingOutput` fields;
+  source-suffix derivation for each `audio_source_type`; helper builds correct GCS source path
+  and output filename per source type.
+- **Orchestrator:** `_download_gce_encoded_files` downloads the two new `.mov` mappings;
+  `_stage_original_audio_for_upload` places the file in `output_dir` before upload (assert the
+  whole-folder upload then includes it). Mock storage/Dropbox.
+- **GCE worker:** `run_encoding` copies `.mov`s into `outputs/` with proper names (assert
+  collected `output_files` includes them).
+- **Manual:** run one real job end-to-end, confirm the Dropbox folder now contains
+  `(Title).mov`, `(End).mov`, and `(flacfetch).flac`/`(uploaded).mp3`. Backfill dry-run on a
+  small batch, then live on a couple of known folders.
+
+## Files to touch
+- `backend/services/gce_encoding/main.py` (A1)
+- `backend/services/encoding_interface.py` (A2, A3)
+- `backend/workers/video_worker_orchestrator.py` (A4, B)
+- `backend/services/local_encoding_service.py` (A5, verify)
+- new backfill script (C)
+- tests under `backend/tests/`
+
+## Bundled fix: ffmpeg interactive-prompt hang in `--finalise-only` (CLI)
+
+Found while regenerating the missing `.mov`s locally. `karaoke_finalise.py` only added
+`-y` to `ffmpeg_base_command` when `non_interactive=True`. In interactive mode, a
+pre-existing output (e.g. a prior `(With Vocals).mp4`) made ffmpeg emit
+`... already exists. Overwrite? [y/N]` to captured stderr and block on stdin until the
+600s subprocess timeout — silently aborting finalisation at step 2/6 (only CDG/TXT zips
+produced; no Final video files). The output's mtime never changed, proving no encode ran.
+
+Fix (in `karaoke_gen/karaoke_finalise/karaoke_finalise.py`):
+1. `-y` is now **unconditional** (re-runs overwrite intermediates idempotently).
+2. All ffmpeg `subprocess.run` calls pass `stdin=subprocess.DEVNULL` (defense-in-depth so
+   ffmpeg can never block on a prompt — `execute_command` + both branches of
+   `execute_command_with_fallback`).
+
+Tests: `tests/unit/test_karaoke_finalise_ffmpeg_prompt.py`; updated two existing tests that
+asserted the old conditional-`-y` / no-stdin behaviour.
+
+## Daily E2E verification (added per request)
+
+So the daily GHA E2E catches this class of regression automatically:
+- `audio_download_worker` now records the original audio in `file_urls['input']['audio']`
+  (URL/search jobs previously only set `input_media_gcs_path`), matching the upload path —
+  so original audio shows consistently in the admin files manifest.
+- `_upload_results` (video_worker) registers `title_mov`/`end_mov` under `file_urls['finals']`
+  (uploaded to `jobs/{id}/finals/title_mov.mov` etc.), so the screen MOVs are queryable +
+  downloadable in the admin UI.
+- `happy-path-real-user.spec.ts` (daily E2E Stage 2) gained **STEP 10.5**: after completion it
+  calls `GET /api/admin/jobs/{id}/files` and asserts the manifest contains
+  `finals/title_mov`, `finals/end_mov`, `input/audio`, and `finals/lossless_4k_mp4` — failing
+  loudly if any expected output is missing (vs. the old check that only opened one download).
+
+Tests: `test_upload_results_screen_movs.py` (mov registration + skip-when-missing),
+extended `test_audio_download_worker.py` (input/audio recorded).
+
+## Implementation notes (as built)
+- Part A files: `gce_encoding/main.py` (copy MOVs into `outputs/`), `encoding_interface.py`
+  (`title_mov_path`/`end_mov_path` + list→dict mapping), `video_worker_orchestrator.py`
+  (`OrchestratorResult.title_mov/end_mov` + download mappings).
+- Part B: `backend/services/original_audio.py` (new helper), orchestrator
+  `_stage_original_audio_for_upload` + two `OrchestratorConfig` fields wired in
+  `create_orchestrator_config_from_job`. Staged only when a folder upload will occur.
+- Part C: `backend/scripts/backfill_original_audio.py` (dry-run default; `--live`),
+  `DropboxService.file_exists`.
+- Local encoding backend leaves `title_mov_path`/`end_mov_path` as None (production is GCE;
+  the local CLI/monolith already writes `.mov`s into the track dir itself).
+
+## Risks / notes
+- Dropbox storage grows (large FLACs re-included) — intended per decision.
+- `.mov` regeneration on GCE adds a couple of small copies, negligible cost.
+- Backfill depends on original audio still existing in GCS; older jobs may have none → skipped.
+- Keep all new steps non-fatal so distribution never fails for an archival-file hiccup.

--- a/frontend/e2e/production/happy-path-real-user.spec.ts
+++ b/frontend/e2e/production/happy-path-real-user.spec.ts
@@ -986,6 +986,52 @@ test.describe('E2E Happy Path - Real User with Full UI Interactions', () => {
       console.log('STEP 10 COMPLETE: Downloads verified');
 
       // =========================================================================
+      // STEP 10.5: Verify Output File Completeness
+      // =========================================================================
+      // Guards against regressions where files silently stop being produced/
+      // distributed (e.g. the screen .mov videos and the original input audio
+      // disappearing from the organised Dropbox folders). Asserts the job's file
+      // manifest contains every expected output, not just that one download works.
+      console.log('\n========================================');
+      console.log('STEP 10.5: Verify Output File Completeness');
+      console.log('========================================');
+
+      const manifestToken = process.env.E2E_ADMIN_TOKEN;
+      if (manifestToken && jobId) {
+        const filesResponse = await page.request.get(
+          `${API_URL}/api/admin/jobs/${jobId}/files`,
+          { headers: { 'Authorization': `Bearer ${manifestToken}` } }
+        );
+        expect(filesResponse.ok()).toBe(true);
+        const manifest = await filesResponse.json();
+        const files: Array<{ category?: string; file_key?: string; name?: string }> =
+          manifest.files || [];
+        const keys = new Set(files.map((f) => `${f.category || ''}/${f.file_key || ''}`));
+        console.log(`  Manifest has ${files.length} files:`);
+        for (const f of files) {
+          console.log(`    - ${f.category}/${f.file_key}: ${f.name}`);
+        }
+
+        // The two regressions this guards against:
+        const required: Array<[string, string]> = [
+          ['finals/title_mov', 'Title screen video (.mov)'],
+          ['finals/end_mov', 'End screen video (.mov)'],
+          ['input/audio', 'Original input audio'],
+          // Core deliverable sanity check
+          ['finals/lossless_4k_mp4', 'Final lossless 4K video'],
+        ];
+        const missing = required.filter(([key]) => !keys.has(key));
+        if (missing.length > 0) {
+          console.log('  MISSING expected output files:');
+          for (const [key, desc] of missing) console.log(`    ✗ ${key} (${desc})`);
+        }
+        expect(missing, `Missing expected output files: ${missing.map(([k]) => k).join(', ')}`).toEqual([]);
+        console.log('STEP 10.5 COMPLETE: All expected output files present');
+      } else {
+        console.log('  Skipping - E2E_ADMIN_TOKEN not set or no job ID');
+      }
+
+      // =========================================================================
       // STEP 11: Verify Distribution (if enabled)
       // =========================================================================
       console.log('\n========================================');

--- a/karaoke_gen/karaoke_finalise/karaoke_finalise.py
+++ b/karaoke_gen/karaoke_finalise/karaoke_finalise.py
@@ -160,9 +160,13 @@ class KaraokeFinalise:
         # MP4 output flags for better compatibility and streaming
         self.mp4_flags = "-pix_fmt yuv420p -movflags +faststart+frag_keyframe+empty_moov"
 
-        # Update ffmpeg base command to include -y if non-interactive
-        if self.non_interactive:
-            self.ffmpeg_base_command += " -y"
+        # Always overwrite outputs. Without -y, ffmpeg prompts "... already exists.
+        # Overwrite? [y/N]" on stdin when an output file already exists; because we run
+        # ffmpeg with captured output and no stdin, that prompt is invisible and blocks
+        # until the subprocess timeout (e.g. a pre-existing (With Vocals).mp4 silently
+        # aborting --finalise-only at step 2/6). Re-running finalisation should always
+        # regenerate its intermediates, so unconditional -y is correct.
+        self.ffmpeg_base_command += " -y"
 
         # Detect and configure hardware acceleration
         # TODO: Re-enable this once we figure out why the resulting MP4s are 10x larger than when encoded with x264...
@@ -816,8 +820,10 @@ class KaraokeFinalise:
             return
         
         try:
-            result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=600)
-            
+            # stdin=DEVNULL so the subprocess can never block on an interactive prompt
+            # (e.g. ffmpeg's "Overwrite? [y/N]") — it reads EOF and proceeds/fails fast.
+            result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=600, stdin=subprocess.DEVNULL)
+
             # Log command output for debugging
             if result.stdout and result.stdout.strip():
                 self.logger.debug(f"Command STDOUT: {result.stdout.strip()}")
@@ -1815,8 +1821,8 @@ class KaraokeFinalise:
         if self.nvenc_available and gpu_command != cpu_command:
             self.logger.debug(f"Attempting hardware-accelerated encoding: {gpu_command}")
             try:
-                result = subprocess.run(gpu_command, shell=True, capture_output=True, text=True, timeout=300)
-                
+                result = subprocess.run(gpu_command, shell=True, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL)
+
                 if result.returncode == 0:
                     self.logger.info(f"✓ Hardware acceleration successful")
                     return
@@ -1829,7 +1835,7 @@ class KaraokeFinalise:
                         self.logger.warning("Empty error output detected, retrying with verbose logging...")
                         verbose_gpu_command = gpu_command.replace("-loglevel fatal", "-loglevel error")
                         try:
-                            verbose_result = subprocess.run(verbose_gpu_command, shell=True, capture_output=True, text=True, timeout=300)
+                            verbose_result = subprocess.run(verbose_gpu_command, shell=True, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL)
                             self.logger.warning(f"Verbose GPU Command: {verbose_gpu_command}")
                             if verbose_result.stderr:
                                 self.logger.warning(f"FFmpeg STDERR (verbose): {verbose_result.stderr}")
@@ -1856,7 +1862,7 @@ class KaraokeFinalise:
         # Use CPU command (either as fallback or primary method)
         self.logger.debug(f"Running software encoding: {cpu_command}")
         try:
-            result = subprocess.run(cpu_command, shell=True, capture_output=True, text=True, timeout=600)
+            result = subprocess.run(cpu_command, shell=True, capture_output=True, text=True, timeout=600, stdin=subprocess.DEVNULL)
             
             if result.returncode != 0:
                 error_msg = f"Software encoding failed with exit code {result.returncode}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.185.0"
+version = "0.186.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"

--- a/tests/unit/test_karaoke_finalise/test_ffmpeg_commands.py
+++ b/tests/unit/test_karaoke_finalise/test_ffmpeg_commands.py
@@ -71,7 +71,7 @@ def test_execute_command_runs_command(mock_subprocess_run, finaliser_with_aac):
     description = "Running test command"
     finaliser_with_aac.execute_command(command, description)
     
-    mock_subprocess_run.assert_called_once_with(command, shell=True, capture_output=True, text=True, timeout=600)
+    mock_subprocess_run.assert_called_once_with(command, shell=True, capture_output=True, text=True, timeout=600, stdin=subprocess.DEVNULL)
     finaliser_with_aac.logger.info.assert_any_call(description)
     finaliser_with_aac.logger.debug.assert_any_call(f"Executing command: {command}")
     finaliser_with_aac.logger.info.assert_any_call("✓ Command completed successfully")

--- a/tests/unit/test_karaoke_finalise/test_initialization.py
+++ b/tests/unit/test_karaoke_finalise/test_initialization.py
@@ -132,12 +132,16 @@ def test_init_non_interactive_ffmpeg(mock_logger):
     assert finaliser.ffmpeg_base_command.strip().endswith(" -y")
 
 def test_init_interactive_ffmpeg(mock_logger):
-    """Test ffmpeg command does not include -y when non_interactive is False."""
+    """Test ffmpeg command includes -y even when non_interactive is False.
+
+    -y is now unconditional: without it, a pre-existing output file makes ffmpeg
+    block on an invisible "Overwrite? [y/N]" prompt until the subprocess timeout.
+    """
     config = MINIMAL_CONFIG.copy()
     config["non_interactive"] = False
     with patch.object(KaraokeFinalise, 'detect_best_aac_codec', return_value='aac'):
         finaliser = KaraokeFinalise(logger=mock_logger, **config)
-    assert not finaliser.ffmpeg_base_command.strip().endswith(" -y")
+    assert finaliser.ffmpeg_base_command.strip().endswith(" -y")
 
 
 # --- AAC Codec Detection Tests ---

--- a/tests/unit/test_karaoke_finalise_ffmpeg_prompt.py
+++ b/tests/unit/test_karaoke_finalise_ffmpeg_prompt.py
@@ -1,0 +1,70 @@
+"""Regression tests for the ffmpeg interactive-prompt hang in finalisation.
+
+Bug: ``karaoke-gen --finalise-only`` (interactive) ran ffmpeg without ``-y`` and
+without a closed stdin. When an output file already existed (e.g. a pre-existing
+``(With Vocals).mp4`` from a prior run), ffmpeg printed ``... already exists.
+Overwrite? [y/N]`` to the captured stderr and blocked reading stdin until the
+600s timeout, silently aborting finalisation at step 2/6.
+
+Fixes:
+  1. ``-y`` is always part of ffmpeg_base_command (not only in non-interactive mode),
+     so re-runs overwrite intermediate outputs idempotently.
+  2. ffmpeg subprocess calls pass ``stdin=subprocess.DEVNULL`` so ffmpeg can never
+     block waiting on a prompt (defense-in-depth).
+"""
+
+import logging
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from karaoke_gen.karaoke_finalise.karaoke_finalise import KaraokeFinalise
+
+
+@pytest.fixture
+def kwargs():
+    return {
+        "logger": MagicMock(spec=logging.Logger),
+        "enable_cdg": False,
+        "enable_txt": False,
+        "no_video": False,
+        "dry_run": True,  # safe init; individual tests flip dry_run off as needed
+    }
+
+
+class TestFfmpegPromptHang:
+    def test_base_command_has_y_in_interactive_mode(self, kwargs):
+        kwargs["non_interactive"] = False
+        kf = KaraokeFinalise(**kwargs)
+        assert " -y" in kf.ffmpeg_base_command
+
+    def test_base_command_has_y_in_non_interactive_mode(self, kwargs):
+        kwargs["non_interactive"] = True
+        kf = KaraokeFinalise(**kwargs)
+        assert " -y" in kf.ffmpeg_base_command
+
+    def test_execute_command_closes_stdin(self, kwargs):
+        kwargs["non_interactive"] = True
+        kf = KaraokeFinalise(**kwargs)
+        kf.dry_run = False
+        with patch(
+            "karaoke_gen.karaoke_finalise.karaoke_finalise.subprocess.run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            kf.execute_command("ffmpeg -i in.mov out.mp4", "convert")
+        assert mock_run.call_args.kwargs.get("stdin") is subprocess.DEVNULL
+
+    def test_execute_command_with_fallback_cpu_closes_stdin(self, kwargs):
+        kwargs["non_interactive"] = True
+        kf = KaraokeFinalise(**kwargs)
+        kf.dry_run = False
+        kf.nvenc_available = False  # force the CPU path
+        with patch(
+            "karaoke_gen.karaoke_finalise.karaoke_finalise.subprocess.run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            kf.execute_command_with_fallback(
+                "ffmpeg gpu", "ffmpeg cpu", "encode"
+            )
+        assert mock_run.call_args.kwargs.get("stdin") is subprocess.DEVNULL


### PR DESCRIPTION
## Summary
- Organised Dropbox track folders stopped containing the 5-second screen videos (`(Title).mov`/`(End).mov`) and the original input audio (`(flacfetch).flac` / `(uploaded).mp3`). Root cause: `_upload_to_dropbox` uploads the whole `output_dir`, and the monolith→distributed-GCE migration quietly narrowed what lands there.
- Restores both file types for new jobs, adds an audio-only backfill for past jobs, and adds a daily-E2E guard so this regression class is caught automatically.
- Bundles a CLI fix for an ffmpeg interactive-prompt hang in `--finalise-only` (found while regenerating the missing files locally).

## Changes
**Screen `.mov`s (forward):** GCE encoder copies its generated `title/end.mov` into `outputs/` with canonical names → plumbed via `EncodingOutput.title_mov_path`/`end_mov_path`, the `GCEEncodingBackend` filename mapping, and `_download_gce_encoded_files` back into `output_dir`.

**Original audio (forward):** new `backend/services/original_audio.py` (source tag `(uploaded)`/`(flacfetch)`/`(YouTube)` + GCS path + filename); orchestrator `_stage_original_audio_for_upload()` fetches it into `output_dir` before folder uploads (non-fatal, only when a folder upload will occur).

**Backfill (audio only):** `backend/scripts/backfill_original_audio.py` — dry-run by default, `--live` to upload, skips when audio is gone from GCS or already present. `.mov` can't be backfilled (needs re-encode). Adds `DropboxService.file_exists` (re-raises non-not-found `ApiError`).

**Daily E2E guard:** `audio_download_worker` records original audio in `file_urls['input']['audio']`; `_upload_results` registers `title_mov`/`end_mov` under `file_urls['finals']`; `happy-path-real-user.spec.ts` STEP 10.5 asserts the admin files manifest contains `finals/title_mov`, `finals/end_mov`, `input/audio`, `finals/lossless_4k_mp4`.

**CLI ffmpeg-hang fix:** `karaoke_finalise` only added `-y` in non-interactive mode, so a pre-existing output made ffmpeg block on an invisible `Overwrite? [y/N]` prompt until the 600s timeout (silently aborting at step 2/6). `-y` is now unconditional + `stdin=subprocess.DEVNULL` on all ffmpeg `subprocess.run` calls.

## Testing
- [x] 38 new/updated unit tests; all affected suites green (`encoding_interface`, `video_worker_orchestrator`, `gce_encoding_worker`, `original_audio`, `backfill_original_audio`, `dropbox_service`, `upload_results_screen_movs`, `audio_download_worker`, full `karaoke_finalise` suite)
- [x] Full backend suite: +38 passing vs main, 0 new failures (12 pre-existing `asyncio.get_event_loop()` ordering failures on main, unrelated)
- [x] Output-file completeness now verified by the daily GHA E2E (STEP 10.5)

## Review
- [x] Local CodeRabbit review completed (scoped to this branch) — 1 major finding fixed (`file_exists` masking non-not-found errors), re-review clean (0 findings)

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)