### PR TITLE
fix(dr): correct backup freshness monitor limit + scheduler deadline (weekly-S3 Firestore regressions)

### DIFF
--- a/.github/workflows/dr-backup-freshness.yml
+++ b/.github/workflows/dr-backup-freshness.yml
@@ -54,8 +54,14 @@ jobs:
 
           BUCKET = os.environ["BUCKET"]
           # (label, prefix, max_age_hours)
+          # NOTE: Firestore and BigQuery export to GCS staging nightly but are
+          # only uploaded to S3 *weekly* (Sundays) to cut cross-cloud egress —
+          # see backup_to_aws/main.py (firestore_to_s3_today). This monitor only
+          # sees the S3 (off-site) copy, so their limits must allow a full week
+          # plus slack (192h ≈ 8 days), NOT the 36h nightly cadence. GCS job
+          # files and secrets DO upload to S3 nightly, so they stay at 36h.
           TARGETS = [
-              ("Firestore",         "firestore/",              36),
+              ("Firestore",         "firestore/",              192),
               ("GCS job files",     "gcs/job-files/",          36),
               ("Encrypted secrets", "secrets/",                36),
               ("BigQuery weekly",   "bigquery/daily-refresh/", 192),

--- a/docs/DISASTER-RECOVERY.md
+++ b/docs/DISASTER-RECOVERY.md
@@ -1,6 +1,6 @@
 # Disaster Recovery Runbook
 
-**Last updated:** 2026-04-20
+**Last updated:** 2026-06-18
 **Design doc:** `docs/archive/2026-03-27-business-continuity-design.md`
 **Implementation plan:** `docs/archive/2026-03-29-business-continuity-plan.md`
 **External services reference:** `docs/archive/2026-03-29-external-services-config.md`
@@ -9,7 +9,7 @@
 
 | Data | Backup Location | Recovery Method | RPO |
 |------|----------------|-----------------|-----|
-| Firestore | S3 `firestore/YYYY-MM-DD/` | Import to new GCP project | 24h |
+| Firestore | S3 `firestore/YYYY-MM-DD/` | Import to new GCP project | 7 days off-site (S3); 24h local (GCS staging) |
 | BigQuery (weekly) | S3 `bigquery/daily-refresh/` | Load Parquet files | 7 days |
 | BigQuery (monthly) | S3 `bigquery/musicbrainz/` | Load Parquet files | 30 days |
 | BigQuery (Spotify) | S3 `bigquery/spotify/` | Load from Glacier Deep Archive | N/A (static) |
@@ -342,6 +342,15 @@ export AWS_DEFAULT_REGION=us-east-1
 ## Backup freshness monitor
 
 A GitHub Actions cron (`.github/workflows/dr-backup-freshness.yml`) runs daily at 14:00 UTC and checks that the most recent objects in `s3://nomadkaraoke-backup/firestore/`, `gcs/job-files/`, `secrets/`, and `bigquery/daily-refresh/` are no older than their per-prefix limit. Stale or missing backups → Discord alert + workflow failure.
+
+Per-prefix limits reflect each prefix's **S3 (off-site)** cadence, which is not the same as its GCS-staging cadence:
+
+| Prefix | S3 upload cadence | Monitor limit |
+|--------|-------------------|---------------|
+| `gcs/job-files/`, `secrets/` | nightly | 36h |
+| `firestore/`, `bigquery/daily-refresh/` | weekly (Sundays) | 192h (≈8 days) |
+
+Firestore exports to GCS staging nightly (24h local restore point) but only ships to S3 weekly to cut cross-cloud egress (see `backup_to_aws/main.py` → `firestore_to_s3_today`). The monitor only sees the S3 copy, so its Firestore limit must allow a full week — using the 36h nightly figure caused a false "DR backup is stale" alert every Tue–Sat (fixed 2026-06-18).
 
 This monitor runs in GitHub, not GCP, so it survives a complete GCP project loss.
 

--- a/infrastructure/modules/backup.py
+++ b/infrastructure/modules/backup.py
@@ -159,7 +159,11 @@ def create_backup_resources(all_secrets: dict) -> dict:
         service_config=cloudfunctionsv2.FunctionServiceConfigArgs(
             available_memory="2Gi",
             available_cpu="1",
-            timeout_seconds=3600,
+            # Kept in lockstep with the scheduler's attempt_deadline (1800s, the
+            # Cloud Scheduler max) below. If the function could run longer than
+            # the scheduler waits, runs in that gap would re-trigger the very
+            # timeout→retry→"Path already exists" collision this aligns to avoid.
+            timeout_seconds=1800,
             min_instance_count=0,
             max_instance_count=1,
             service_account_email=sa.email,
@@ -213,6 +217,14 @@ def create_backup_resources(all_secrets: dict) -> dict:
         region=REGION,
         schedule="0 1 * * *",
         time_zone="America/New_York",
+        # The backup pipeline (esp. the Firestore export) runs for several
+        # minutes. Without an explicit deadline, Cloud Scheduler defaults to
+        # 180s, times out the HTTP call, and retries — while the original
+        # invocation keeps running to success. The retry then collides on the
+        # already-created firestore/<date>/ export path ("400 Path already
+        # exists"), producing a spurious FAILED backup report every night.
+        # 1800s (30m, the Scheduler max) lets it wait for the real result.
+        attempt_deadline="1800s",
         http_target=cloudscheduler.JobHttpTargetArgs(
             uri=function.url,
             http_method="POST",


### PR DESCRIPTION
## Summary

Fixes two DR-backup alerting regressions introduced by PR #823 (Jun-14 cost reduction), which switched the Firestore S3 upload from **nightly → weekly (Sundays)** to cut cross-cloud egress. Both surfaced as Discord alerts on 2026-06-17/18; backups themselves were never actually broken.

### 1. False "🚨 DR backup is stale" alert (fires every Tue–Sat)
The off-platform freshness monitor (`dr-backup-freshness.yml`) checks the **S3** copy of `firestore/` against a **36h** limit — set back when Firestore uploaded to S3 nightly. Since #823, Firestore ships to S3 only weekly (like BigQuery, which correctly uses 192h), so the S3 copy is >36h old from Tuesday onward **by design**.

Monitor run history confirms: 06-14 Sun ✅ → 06-15 Mon ✅ (~34h) → 06-16 Tue ❌ → 06-17 Wed ❌, repeating weekly.

**Fix:** Firestore limit `36h → 192h` (≈8 days), matching its actual weekly off-site cadence. The nightly GCS-staging export (1-day local restore point) is unaffected.

### 2. Spurious "Path already exists" FAILED backup report
Cloud Scheduler had no `attempt_deadline` (default **180s**), but the Firestore export runs for minutes. Scheduler timed out the HTTP call and retried (`retry_count=2`) while the original invocation kept running to success; the retry then collided on the already-created `firestore/<date>/` export path → `400 Path already exists`.

**Fix:** set `attempt_deadline="1800s"` (Cloud Scheduler max) and align the Cloud **Function** `timeout_seconds` 3600 → 1800, so the function can't outrun the scheduler's wait and reopen the same collision window (per CodeRabbit).

Also refreshes `docs/DISASTER-RECOVERY.md`: Firestore off-site RPO is 7 days (S3) / 24h local (GCS), and the freshness-monitor section now documents the per-prefix S3 cadence so this can't regress again.

## Changes
- `.github/workflows/dr-backup-freshness.yml` — Firestore freshness limit 36h → 192h + explanatory comment
- `infrastructure/modules/backup.py` — scheduler `attempt_deadline="1800s"`; function `timeout_seconds` 3600 → 1800
- `docs/DISASTER-RECOVERY.md` — RPO table + freshness-monitor cadence docs

## Testing
- Backup function unit tests: 13 passed (no function code changed)
- YAML + embedded-Python + Pulumi module all validate/compile
- CodeRabbit: 0 findings (1 major fixed: function/scheduler timeout mismatch)
- **`pulumi up` applied to prod** (clean diff: 2 updated, 265 unchanged). Verified live: scheduler `attemptDeadline=1800s`, function `timeoutSeconds=1800`. Merging keeps IaC in sync (CI re-applies as no-op).

Infra/CI + docs only; no application code (no version bump).

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)