### PR TITLE
fix(bulk): diagnose + harden MusicBrainz lookups failing in prod

### DIFF
--- a/backend/api/routes/bulk.py
+++ b/backend/api/routes/bulk.py
@@ -113,7 +113,7 @@ async def album_artists(
     try:
         results = await get_musicbrainz_service().search_artists(q, limit=limit)
     except Exception as e:  # noqa: BLE001
-        logger.warning("MusicBrainz artist search failed: %s", e)
+        logger.warning("MusicBrainz artist search failed: %r", e, exc_info=True)
         raise HTTPException(status_code=502, detail="Artist lookup is temporarily unavailable")
     return results
 
@@ -130,7 +130,7 @@ async def album_albums(
     try:
         return await get_musicbrainz_service().get_albums(artist_mbid)
     except Exception as e:  # noqa: BLE001
-        logger.warning("MusicBrainz album list failed: %s", e)
+        logger.warning("MusicBrainz album list failed: %r", e, exc_info=True)
         raise HTTPException(status_code=502, detail="Album lookup is temporarily unavailable")
 
 
@@ -159,7 +159,7 @@ async def album_tracklist(
         else:
             tracklist = await mb.get_album_tracklist(release_group_mbid)
     except Exception as e:  # noqa: BLE001
-        logger.warning("MusicBrainz tracklist failed: %s", e)
+        logger.warning("MusicBrainz tracklist failed: %r", e, exc_info=True)
         raise HTTPException(status_code=502, detail="Tracklist lookup is temporarily unavailable")
 
     tracks = tracklist.get("tracks", [])

--- a/backend/services/musicbrainz_service.py
+++ b/backend/services/musicbrainz_service.py
@@ -38,6 +38,8 @@ USER_AGENT = "NomadKaraoke/1.0 (contact@nomadkaraoke.com)"
 _MIN_INTERVAL_S = 1.0  # MusicBrainz politeness: ~1 req/s
 _CACHE_TTL_S = 600  # 10 min — album metadata is effectively static
 _REQUEST_TIMEOUT_S = 15.0
+_MAX_RETRIES = 3  # MusicBrainz 503s / transient transport errors are common from cloud egress
+_RETRY_BACKOFF_S = 0.5
 
 # Country preference for canonical-release tie-breaks (worldwide / Europe / US / UK).
 _PREFERRED_COUNTRIES = ["XW", "XE", "US", "GB"]
@@ -109,16 +111,34 @@ class MusicBrainzService:
         cached = self._cache.get(cache_key)
         if cached and (time.monotonic() - cached[0]) < _CACHE_TTL_S:
             return cached[1]
-        await self._throttle()
         params = {**params, "fmt": "json"}
-        async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT_S) as client:
-            resp = await client.get(
-                f"{MB_BASE}/{path}", params=params, headers={"User-Agent": USER_AGENT}
-            )
-            resp.raise_for_status()
-            data = resp.json()
-        self._cache[cache_key] = (time.monotonic(), data)
-        return data
+        last_exc: Optional[Exception] = None
+        for attempt in range(_MAX_RETRIES):
+            await self._throttle()
+            try:
+                async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT_S) as client:
+                    resp = await client.get(
+                        f"{MB_BASE}/{path}", params=params, headers={"User-Agent": USER_AGENT}
+                    )
+                    # MusicBrainz returns 503 when rate-limited/throttled — retry those.
+                    if resp.status_code == 503 and attempt < _MAX_RETRIES - 1:
+                        last_exc = httpx.HTTPStatusError(
+                            "503 from MusicBrainz", request=resp.request, response=resp
+                        )
+                        await asyncio.sleep(_RETRY_BACKOFF_S * (attempt + 1))
+                        continue
+                    resp.raise_for_status()
+                    data = resp.json()
+                self._cache[cache_key] = (time.monotonic(), data)
+                return data
+            except (httpx.TransportError, httpx.TimeoutException) as e:
+                # Connection/timeout errors — retry with backoff.
+                last_exc = e
+                logger.warning("MusicBrainz %s attempt %d/%d failed: %r", path, attempt + 1, _MAX_RETRIES, e)
+                if attempt < _MAX_RETRIES - 1:
+                    await asyncio.sleep(_RETRY_BACKOFF_S * (attempt + 1))
+        # Exhausted retries.
+        raise last_exc if last_exc else RuntimeError(f"MusicBrainz request failed: {path}")
 
     # -- Public API --------------------------------------------------------
 

--- a/backend/tests/test_musicbrainz_service.py
+++ b/backend/tests/test_musicbrainz_service.py
@@ -129,3 +129,60 @@ class TestServiceCalls:
         assert result["tracks"][0]["is_extra"] is False
         assert result["tracks"][2]["is_extra"] is True  # the (Live) track
         assert len(result["editions"]) == 2
+
+
+import httpx as _httpx
+
+
+class _FakeResp:
+    def __init__(self, status, json_data=None):
+        self.status_code = status
+        self._json = json_data
+        self.request = _httpx.Request("GET", "https://musicbrainz.org/ws/2/artist")
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise _httpx.HTTPStatusError(
+                f"{self.status_code}", request=self.request, response=self
+            )
+
+    def json(self):
+        return self._json
+
+
+def _patch_http(monkeypatch, mbs, svc, responses):
+    """Make AsyncClient.get return queued _FakeResp objects; disable throttle/backoff."""
+    async def _noop():
+        return None
+    monkeypatch.setattr(svc, "_throttle", _noop)
+    monkeypatch.setattr(mbs, "_RETRY_BACKOFF_S", 0)
+    calls = {"n": 0}
+
+    async def fake_get(self, url, **kwargs):
+        r = responses[min(calls["n"], len(responses) - 1)]
+        calls["n"] += 1
+        return r
+
+    monkeypatch.setattr(_httpx.AsyncClient, "get", fake_get)
+    return calls
+
+
+@pytest.mark.asyncio
+class TestRetry:
+    async def test_retries_503_then_succeeds(self, monkeypatch):
+        from backend.services import musicbrainz_service as mbs
+        svc = mbs.MusicBrainzService()
+        calls = _patch_http(monkeypatch, mbs, svc, [
+            _FakeResp(503),
+            _FakeResp(200, {"artists": [{"id": "x", "name": "Queen"}]}),
+        ])
+        out = await svc.search_artists("Queen")
+        assert out[0]["mbid"] == "x"
+        assert calls["n"] == 2  # one 503 retry, then success
+
+    async def test_exhausts_retries_raises(self, monkeypatch):
+        from backend.services import musicbrainz_service as mbs
+        svc = mbs.MusicBrainzService()
+        _patch_http(monkeypatch, mbs, svc, [_FakeResp(503)])
+        with pytest.raises(_httpx.HTTPStatusError):
+            await svc.search_artists("Queen")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.187.0"
+version = "0.187.1"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
Album-mode MusicBrainz lookups return 502 from Cloud Run (they work locally + in unit tests). Prod logs show an empty exception message, so this PR:

- Adds `%r` + `exc_info=True` to the 3 MB route handlers to capture the real exception type + traceback in prod.
- Adds retry-with-backoff (3×) to `musicbrainz_service._get` for MB 503s (rate-limiting) and transient transport/timeout errors — the most common cloud-egress failure mode.

Text mode + the credit gate are already verified working in prod; album lookup degrades gracefully to a 502 + frontend fallback. Once deployed, the logs will reveal the true cause and we can apply the targeted fix (e.g. route MB through flacfetch if it's a hard IP block).

Tests: 2 new retry unit tests (503→retry→success; exhaust→raise). Full MB suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@coderabbitai ignore