### PR TITLE
fix(lyrics-review): pad long-word duration pill in Simple mode

### DIFF
--- a/frontend/components/lyrics-review/shared/Word.tsx
+++ b/frontend/components/lyrics-review/shared/Word.tsx
@@ -86,7 +86,7 @@ export const WordComponent = React.memo(function Word({
     <span
       id={id}
       className={cn(
-        hasDurationBadge ? 'inline-flex items-center' : 'inline-block',
+        hasDurationBadge ? 'inline-flex items-center gap-1' : 'inline-block',
         'transition-colors duration-200 cursor-pointer rounded-sm text-[0.85rem] leading-[1.2]',
         !isTimeline && 'mr-[0.25em]',
         padding,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.187.2"
+version = "0.187.3"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Adds a little breathing room between a word and its long-word duration pill in the Simple-mode lyrics review, so the amber `🕐 3.3s` badge isn't squashed up against the word text.

## The bug

The duration badge uses `ml-auto` to hug the right edge in Advanced/Timeline mode. But `ml-auto` only consumes free space — in Simple mode the pill is content-sized, so `ml-auto` resolved to `0` and the badge sat flush against the word. The badge's own `pl-1`/`px-1` only pad *inside* the amber border, not between the word and the pill.

## The fix

Add `gap-1` (4px) to the outer flex container, applied only to long-word pills (`hasDurationBadge`):

```diff
- hasDurationBadge ? 'inline-flex items-center' : 'inline-block',
+ hasDurationBadge ? 'inline-flex items-center gap-1' : 'inline-block',
```

- Plain words (no badge) are untouched — they use `inline-block`.
- Timeline/Advanced mode unaffected: `ml-auto` still hugs the badge to the right edge; the gap is just a minimum.

## Before / After

Before: `now🕐3.3s` (badge flush against "now")
After: `now 🕐3.3s` (4px gap)

## Testing

- All 142 lyrics-review unit tests pass (17 suites).
- No snapshots reference this component, so the class change breaks nothing.
- CodeRabbit: 0 findings.

@coderabbitai ignore
