### PR TITLE
feat: colorize word pills when a song has no reference lyrics

### DIFF
--- a/frontend/components/lyrics-review/TranscriptionView.tsx
+++ b/frontend/components/lyrics-review/TranscriptionView.tsx
@@ -49,6 +49,12 @@ export default function TranscriptionView({
   const { ready: audioReady } = useAudioReady()
   const [selectedSegmentIndex, setSelectedSegmentIndex] = useState<number | null>(null)
 
+  // With no reference lyrics, nothing classifies words as anchor/gap/corrected,
+  // so every pill would render uncoloured and the line loses the colour-scanning
+  // we rely on. Fall back to the gap-orange highlight for plain words in that
+  // case (applies to both Simple and Advanced via HighlightedText).
+  const hasReferenceLyrics = Object.keys(data.reference_lyrics ?? {}).length > 0
+
   // Timing warnings (shown in both Simple and Advanced): any word longer than
   // 2s, and any gap longer than 2s between consecutive words in a segment.
   // These are the issues the old Timeline view existed to surface.
@@ -262,6 +268,7 @@ export default function TranscriptionView({
                       timelineLayout={advancedMode}
                       timelineGrowByWordId={advancedMode ? timelineGrowByWordId : undefined}
                       timelineGapByWordId={advancedMode ? timelineGapByWordId : undefined}
+                      noReferenceFallback={!hasReferenceLyrics}
                     />
                   </div>
                 </div>

--- a/frontend/components/lyrics-review/shared/HighlightedText.tsx
+++ b/frontend/components/lyrics-review/shared/HighlightedText.tsx
@@ -72,6 +72,10 @@ export interface HighlightedTextProps {
   timelineGrowByWordId?: Map<string, number>
   // Advanced mode: gap (seconds) before a word → a proportional flex spacer
   timelineGapByWordId?: Map<string, number>
+  // No reference lyrics → no anchors/gaps classify any word, so plain pills
+  // render uncoloured. When true, plain words fall back to the gap-orange
+  // highlight so the line stays colour-scannable (both Simple and Advanced).
+  noReferenceFallback?: boolean
 }
 
 export function HighlightedText({
@@ -109,6 +113,7 @@ export function HighlightedText({
   timelineLayout = false,
   timelineGrowByWordId,
   timelineGapByWordId,
+  noReferenceFallback = false,
 }: HighlightedTextProps) {
   const tTiming = useTranslations('lyricsReview.transcription')
   const { handleWordClick } = useWordClick({
@@ -357,6 +362,7 @@ export function HighlightedText({
               aiTimingEstimated={aiEstimatedWordIds?.has(wordPos.word.id)}
               longWordSeconds={longWordByWordId?.get(wordPos.word.id)}
               timelineGrow={wordGrow}
+              fallbackGapColor={noReferenceFallback}
               id={`word-${wordPos.word.id}`}
               onClick={() =>
                 handleWordClick(
@@ -476,6 +482,7 @@ export function HighlightedText({
                     aiOriginalText={aiOriginalTextByWordId?.get(word.id)}
                     aiTimingEstimated={aiEstimatedWordIds?.has(word.id)}
                     longWordSeconds={longWordByWordId?.get(word.id)}
+                    fallbackGapColor={noReferenceFallback}
                     id={`word-${word.id}`}
                     onClick={() => handleWordClick(word.text, word.id, anchor, sequence)}
                     correction={correctionInfo}

--- a/frontend/components/lyrics-review/shared/Word.tsx
+++ b/frontend/components/lyrics-review/shared/Word.tsx
@@ -22,6 +22,7 @@ export const WordComponent = React.memo(function Word({
   aiTimingEstimated,
   longWordSeconds,
   timelineGrow,
+  fallbackGapColor,
   padding = 'px-[3px] py-[1px]',
   onClick,
   id,
@@ -47,7 +48,9 @@ export const WordComponent = React.memo(function Word({
             ? HIGHLIGHT_CLASSES.corrected
             : isUncorrectedGap
               ? HIGHLIGHT_CLASSES.uncorrectedGap
-              : ''
+              : fallbackGapColor
+                ? HIGHLIGHT_CLASSES.uncorrectedGap
+                : ''
 
   // Estimated-timing AI words (a word split into several, or an inserted word)
   // almost always need a timing nudge — flag them with a dashed amber underline

--- a/frontend/components/lyrics-review/shared/__tests__/Word.test.tsx
+++ b/frontend/components/lyrics-review/shared/__tests__/Word.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import enMessages from '@/messages/en.json'
+import { WordComponent } from '../Word'
+import { HIGHLIGHT_CLASSES } from '@/lib/lyrics-review/constants'
+
+const ORANGE = HIGHLIGHT_CLASSES.uncorrectedGap // 'bg-orange-500/25'
+
+function renderWord(props: any) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <WordComponent word="hello" shouldFlash={false} {...props} />
+    </NextIntlClientProvider>,
+  )
+}
+
+describe('WordComponent gap-orange fallback (no reference lyrics)', () => {
+  it('renders a plain word with NO background colour by default', () => {
+    renderWord({})
+    expect(screen.getByText('hello').className).not.toContain(ORANGE)
+  })
+
+  it('applies the gap-orange colour to a plain word when fallbackGapColor is set', () => {
+    renderWord({ fallbackGapColor: true })
+    expect(screen.getByText('hello').className).toContain(ORANGE)
+  })
+
+  it('does not override an anchor word (real classification wins)', () => {
+    renderWord({ fallbackGapColor: true, isAnchor: true })
+    const cls = screen.getByText('hello').className
+    expect(cls).toContain(HIGHLIGHT_CLASSES.anchor)
+    expect(cls).not.toContain(ORANGE)
+  })
+
+  it('does not override a currently-playing word (blue wins)', () => {
+    renderWord({ fallbackGapColor: true, isCurrentlyPlaying: true })
+    const cls = screen.getByText('hello').className
+    expect(cls).toContain('bg-blue-500')
+    expect(cls).not.toContain(ORANGE)
+  })
+
+  it('does not override a user-edited word', () => {
+    renderWord({ fallbackGapColor: true, isUserEdited: true })
+    const cls = screen.getByText('hello').className
+    expect(cls).toContain(HIGHLIGHT_CLASSES.userEdited)
+    expect(cls).not.toContain(ORANGE)
+  })
+})

--- a/frontend/lib/lyrics-review/types.ts
+++ b/frontend/lib/lyrics-review/types.ts
@@ -372,6 +372,11 @@ export interface WordProps {
   /** Advanced mode: flex-grow weight (= duration) so the word pill takes a
    *  share of the segment's full width proportional to how long it lasts. */
   timelineGrow?: number
+  /** No reference lyrics for this song → no anchors/gaps/corrections classify
+   *  any word, so plain pills would render uncoloured. When true, a plain word
+   *  falls back to the gap-orange highlight so the line stays colour-scannable.
+   *  Lowest precedence — any real classification colour still wins. */
+  fallbackGapColor?: boolean
   padding?: string
   onClick?: () => void
   id?: string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.187.3"
+version = "0.187.4"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- When a song has **no reference lyrics**, nothing classifies words as anchor/gap/corrected, so every word pill rendered uncoloured — losing the colour-scanning the review UI is built around (see attached screenshot: every line plain grey).
- Adds a lowest-precedence **gap-orange** fallback for plain word pills, gated on "no reference lyrics" (the same `Object.keys(reference_lyrics).length === 0` signal `GuidancePanel` uses for its "No reference lyrics found" panel).
- Works in **both Simple and Advanced** modes — threaded through the single `wordPositions` render path both modes share.

## Changes
- `lib/lyrics-review/types.ts` — new `fallbackGapColor?: boolean` on `WordProps`.
- `components/lyrics-review/shared/Word.tsx` — appends the fallback to the end of the colour chain, so any real classification colour (playing/AI/anchor/user-edited/corrected/gap) still wins.
- `components/lyrics-review/shared/HighlightedText.tsx` — new `noReferenceFallback` prop, passed down as `fallbackGapColor` to both `WordComponent` render paths.
- `components/lyrics-review/TranscriptionView.tsx` — computes `hasReferenceLyrics` and passes `noReferenceFallback={!hasReferenceLyrics}`.
- `components/lyrics-review/shared/__tests__/Word.test.tsx` — new focused test (5 cases) verifying the orange appears only with the fallback flag and never overrides a real classification colour.
- No new user-facing strings → no i18n changes.

## Testing
- [x] Frontend unit suite: 79 suites / 1049 tests pass (incl. new `Word.test.tsx`)
- [x] Typecheck clean on all touched files
- [x] CodeRabbit CLI review: 0 findings

## Review
- [x] Local CodeRabbit review completed
- [x] No issues to address

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8pq3aMDRkcPdrsmd1PqHH