### PR TITLE
ci: publish wheel-only to PyPI (fix 10 GB storage cap)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,7 +516,10 @@ jobs:
           virtualenvs-in-project: true
 
       - name: Build package
-        run: poetry build
+        # Wheel-only: we ship a universal py3-none-any wheel. The sdist bundles
+        # the 33-locale Next.js static export (~50 MB) as dead weight and pushed
+        # the PyPI project over its 10 GB cap. pip always installs from the wheel.
+        run: poetry build --format wheel
 
       - name: Test package installation
         run: |
@@ -831,7 +834,12 @@ jobs:
             venv-package-${{ runner.os }}-py3.13-
 
       - name: Build package
-        run: poetry build
+        # Wheel-only: we publish a universal py3-none-any wheel to PyPI. The
+        # sdist bundled the 33-locale Next.js static export (~50 MB/release) as
+        # dead weight and pushed the project over PyPI's 10 GB storage cap.
+        # pip always installs from the wheel; nothing builds karaoke-gen from
+        # source (the GCE encoding worker pulls the wheel from GCS).
+        run: poetry build --format wheel
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -925,7 +933,6 @@ jobs:
           prerelease: false
           files: |
             dist/*.whl
-            dist/*.tar.gz
 
   deploy-frontend:
     name: "Deploy - Frontend (Cloudflare Pages)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.187.4"
+version = "0.187.5"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Problem

Every `poetry publish` on merge to `main` was failing with:

```
HTTP Error 400: Project size too large. Limit project 'karaoke-gen' total size 10 GB.
```

The PyPI project had grown to **10.711 GB across 444 releases**, over the 10 GB cap.

## Root cause

Since the i18n initiative (**v0.172.1, 2026-04-23**), `next build` pre-renders the app into **33 locale directories** (~112 MB uncompressed), and both the wheel **and** the sdist bundle this static export. Per-release cost jumped from ~18 MB to ~104 MB (53.7 MB wheel + 50.2 MB sdist). 57 fat releases = >5.8 GB of the 10.7 GB total.

## Fix (this PR): publish wheel-only

The sdist is dead weight — we ship a universal `py3-none-any` wheel, pip always installs from it, and nothing builds karaoke-gen from source (the GCE encoding worker pulls the wheel from GCS, not PyPI).

- `poetry build --format wheel` in both the package-test and package-publish jobs (no sdist built)
- drop `dist/*.tar.gz` from the GitHub release attachments
- bump `0.187.4 → 0.187.5`

**Per-release PyPI cost: 104 MB → 54 MB.** The wheel is unchanged — it still bundles the frontend the CLI local-review server reads at runtime (verified: built wheel contains all 3575 `out/` entries + entry points).

## Companion one-time cleanup (already done, not in this diff)

Deleted **42 old fat releases** (`0.172.1`–`0.182.2`, ~4.35 GB) via the PyPI web UI, keeping the 15 most recent fat releases (`0.183.0`–`0.187.2`) and all 387 small historical releases (`≤0.171.x`). Project is now **~6.36 GB** (3.64 GB headroom). Nothing internal pins old PyPI versions, so blast radius was zero.

## Testing

- `poetry build --format wheel` → `dist/` contains only the 53.7 MB wheel (no tar.gz), wheel has all `out/` assets + 3 console entry points.
- `ci.yml` validated (parses, no remaining sdist/tar.gz dependencies).
- No application code changed; full suite runs in CI on this PR.
- The merge itself is the live verification that `poetry publish` succeeds (publishes 0.187.5 wheel-only).

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)
