### PR TITLE
fix(bulk): detect community versions for overlong song titles

### DIFF
--- a/backend/services/karaokenerds_service.py
+++ b/backend/services/karaokenerds_service.py
@@ -15,11 +15,21 @@ from urllib.parse import urlencode
 import httpx
 from bs4 import BeautifulSoup
 
+from backend.services.match_judge.classifier import normalize_for_match
+
 logger = logging.getLogger(__name__)
 
 SEARCH_URL = "https://karaokenerds.com/Search"
 REQUEST_TIMEOUT = 8
 USER_AGENT = "NomadKaraokeGen/1.0"
+
+# karaokenerds.com's search silently returns zero results once a query exceeds
+# ~10 whitespace-separated terms (observed: 10 terms match, 11 return nothing).
+# Long/repetitive titles like "I Do, I Do, I Do, I Do, I Do" combined with the
+# artist blow past this, so the song is falsely reported as having no community
+# version. When that happens we retry with the title alone (the highest-signal
+# term) and keep only results whose artist matches.
+MAX_RELIABLE_QUERY_TERMS = 10
 
 # In-memory TTL cache: { cache_key: (expiry_timestamp, data) }
 _cache: dict[str, tuple[float, Any]] = {}
@@ -146,6 +156,45 @@ def parse_results(html: str) -> list[dict]:
     return songs
 
 
+async def _search_songs(query: str) -> list[dict] | None:
+    """Run a single karaokenerds search and parse the results.
+
+    Returns the parsed song list, or ``None`` if the HTTP request failed (so the
+    caller can distinguish "search errored" from "search returned nothing").
+    """
+    params = urlencode({"query": query, "webFilter": "OnlyWeb"})
+    url = f"{SEARCH_URL}?{params}"
+    try:
+        async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+            resp = await client.get(
+                url,
+                headers={"User-Agent": USER_AGENT},
+                follow_redirects=True,
+            )
+            resp.raise_for_status()
+    except Exception as e:
+        logger.warning(f"KaraokeNerds search failed for '{query}': {e}")
+        return None
+    return parse_results(resp.text)
+
+
+def _extract_community_songs(songs: list[dict]) -> tuple[list[dict], str | None]:
+    """Filter parsed songs to those with community tracks; return (songs, best_url)."""
+    community_songs: list[dict] = []
+    best_youtube_url: str | None = None
+    for song in songs:
+        community_tracks = [t for t in song["tracks"] if t["is_community"]]
+        if community_tracks:
+            community_songs.append({
+                "title": song["title"],
+                "artist": song["artist"],
+                "community_tracks": community_tracks,
+            })
+            if best_youtube_url is None:
+                best_youtube_url = community_tracks[0]["youtube_url"]
+    return community_songs, best_youtube_url
+
+
 async def check_community_versions(artist: str, title: str) -> dict:
     """
     Check if a song has community-approved karaoke versions on karaokenerds.
@@ -161,39 +210,32 @@ async def check_community_versions(artist: str, title: str) -> dict:
     if cached is not None:
         return cached
 
-    params = urlencode({"query": query, "webFilter": "OnlyWeb"})
-    url = f"{SEARCH_URL}?{params}"
-
-    try:
-        async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
-            resp = await client.get(
-                url,
-                headers={"User-Agent": USER_AGENT},
-                follow_redirects=True,
-            )
-            resp.raise_for_status()
-    except Exception as e:
-        logger.warning(f"KaraokeNerds search failed for '{query}': {e}")
+    songs = await _search_songs(query)
+    if songs is None:
+        # Hard failure (network/HTTP) — cache a negative so we don't hammer the
+        # site, matching prior behaviour.
         result = {"has_community": False, "songs": [], "best_youtube_url": None}
         _cache_set(cache_key, result)
         return result
 
-    songs = parse_results(resp.text)
+    # karaokenerds chokes on overlong queries and returns nothing. If the
+    # combined "artist title" query was too long AND came back empty, retry with
+    # the title alone, then keep only results whose artist matches (title-only is
+    # broader, so this guards against same-titled songs by other artists).
+    if (
+        not songs
+        and title.strip()
+        and len(query.split()) > MAX_RELIABLE_QUERY_TERMS
+    ):
+        fallback = await _search_songs(title)
+        if fallback:
+            key_artist = normalize_for_match(artist)
+            songs = [
+                s for s in fallback
+                if normalize_for_match(s.get("artist") or "") == key_artist
+            ]
 
-    # Filter to only songs that have community tracks with YouTube URLs
-    community_songs = []
-    best_youtube_url = None
-
-    for song in songs:
-        community_tracks = [t for t in song["tracks"] if t["is_community"]]
-        if community_tracks:
-            community_songs.append({
-                "title": song["title"],
-                "artist": song["artist"],
-                "community_tracks": community_tracks,
-            })
-            if best_youtube_url is None:
-                best_youtube_url = community_tracks[0]["youtube_url"]
+    community_songs, best_youtube_url = _extract_community_songs(songs)
 
     result = {
         "has_community": len(community_songs) > 0,

--- a/backend/tests/test_karaokenerds_service.py
+++ b/backend/tests/test_karaokenerds_service.py
@@ -9,6 +9,7 @@ from backend.services.karaokenerds_service import (
     parse_results,
     _clean_youtube_url,
     _parse_single_track,
+    check_community_versions,
     check_community_versions_batch,
 )
 from bs4 import BeautifulSoup
@@ -264,3 +265,112 @@ async def test_batch_empty_song_has_empty_versions():
     results = await check_community_versions_batch([{"artist": "", "title": ""}])
     assert results[0]["available"] is False
     assert results[0]["versions"] == []
+
+
+# --- check_community_versions: overlong-query fallback (KaraokeNerds term cap) ---
+
+
+def _community_song(title, artist, brand="Nomad Karaoke", url="https://youtu.be/x"):
+    return {
+        "title": title,
+        "artist": artist,
+        "tracks": [
+            {"brand_name": brand, "brand_code": "NK", "youtube_url": url, "is_community": True}
+        ],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _clear_community_cache():
+    """check_community_versions caches in-process; isolate each test."""
+    from backend.services import karaokenerds_service as svc
+    svc._cache.clear()
+    yield
+    svc._cache.clear()
+
+
+@pytest.mark.asyncio
+async def test_overlong_query_falls_back_to_title_only(monkeypatch):
+    """An overlong "artist title" query that returns nothing retries title-only
+    and matches by artist (the ABBA 'I Do, I Do, I Do, I Do, I Do' bug)."""
+    title = "I Do, I Do, I Do, I Do, I Do"
+    calls = []
+
+    async def fake_search(query):
+        calls.append(query)
+        if query == f"ABBA {title}":
+            return []  # combined query is too long -> KaraokeNerds returns nothing
+        if query == title:
+            return [_community_song("I Do I Do I Do I Do I Do", "ABBA")]
+        return []
+
+    monkeypatch.setattr(
+        "backend.services.karaokenerds_service._search_songs", fake_search
+    )
+
+    result = await check_community_versions("ABBA", title)
+
+    assert result["has_community"] is True
+    assert result["songs"][0]["artist"] == "ABBA"
+    assert calls == [f"ABBA {title}", title]  # combined first, then title-only fallback
+
+
+@pytest.mark.asyncio
+async def test_fallback_filters_out_wrong_artist(monkeypatch):
+    """Title-only fallback is broader, so same-titled songs by other artists
+    must be discarded — no false positive."""
+    title = "I Do, I Do, I Do, I Do, I Do"
+
+    async def fake_search(query):
+        if query == title:
+            return [_community_song("I Do I Do I Do I Do I Do", "Some Other Band")]
+        return []
+
+    monkeypatch.setattr(
+        "backend.services.karaokenerds_service._search_songs", fake_search
+    )
+
+    result = await check_community_versions("ABBA", title)
+
+    assert result["has_community"] is False
+    assert result["songs"] == []
+
+
+@pytest.mark.asyncio
+async def test_short_empty_query_does_not_fall_back(monkeypatch):
+    """A short query that legitimately returns nothing must NOT trigger a second
+    request (avoids doubling load for songs with no community version)."""
+    calls = []
+
+    async def fake_search(query):
+        calls.append(query)
+        return []
+
+    monkeypatch.setattr(
+        "backend.services.karaokenerds_service._search_songs", fake_search
+    )
+
+    result = await check_community_versions("ABBA", "Dancing Queen")
+
+    assert result["has_community"] is False
+    assert calls == ["ABBA Dancing Queen"]  # no fallback request
+
+
+@pytest.mark.asyncio
+async def test_nonempty_combined_result_skips_fallback(monkeypatch):
+    """If the combined query returns results, never fall back even when long."""
+    title = "I Do, I Do, I Do, I Do, I Do"
+    calls = []
+
+    async def fake_search(query):
+        calls.append(query)
+        return [_community_song("I Do I Do I Do I Do I Do", "ABBA")]
+
+    monkeypatch.setattr(
+        "backend.services.karaokenerds_service._search_songs", fake_search
+    )
+
+    result = await check_community_versions("ABBA", title)
+
+    assert result["has_community"] is True
+    assert calls == [f"ABBA {title}"]  # only the combined query ran

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.188.0"
+version = "0.188.1"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Problem

In Bulk Mode (By album), ABBA's **"I Do, I Do, I Do, I Do, I Do"** showed **no community versions** even though two exist on KaraokeNerds (Nomad Karaoke + RUE ABBA Karaoke). Tracks with no detected community version are **ticked by default**, so the user would have generated a **duplicate of an existing community karaoke video**.

## Root cause

Not the commas, and not our title-matching — it's a limit in **karaokenerds.com's own search**: it silently returns **zero results once a query exceeds ~10 whitespace-separated terms** (verified against the live site: 10 terms match, 11 return nothing, regardless of word order).

`check_community_versions` searches `"{artist} {title}"`. For this track that's 11 terms → 0 results → falsely reported as "no community version".

| Query | Terms | Live result |
|---|---|---|
| `ABBA I Do I Do I Do I Do` | 9 | ✅ 2 songs |
| `I Do I Do I Do I Do I Do` (title alone) | 10 | ✅ 2 songs |
| `ABBA I Do, I Do, I Do, I Do, I Do` (what bulk sends) | 11 | ❌ 0 songs |

## Fix

In `backend/services/karaokenerds_service.py`:
- Extracted `_search_songs(query)` and `_extract_community_songs(songs)` helpers.
- When the combined `"{artist} {title}"` query **exceeds `MAX_RELIABLE_QUERY_TERMS` (10)** *and* returns nothing, retry with **title-only** (the highest-signal term), then keep only results whose artist matches via `normalize_for_match` (reused from `match_judge.classifier`) — guarding against same-titled songs by other artists.
- **Gated on query length**, so short songs and genuine no-community songs incur **zero extra requests** (KaraokeNerds rate-limiting matters in bulk).

Verified through the real code path: the ABBA track now returns `has_community: True` with both brands; short songs are unchanged.

**Known residual limit:** a title that *alone* exceeds 10 words still chokes — inherent to KaraokeNerds' search, not handled here.

## Tests

4 regression tests (mock `_search_songs`): overlong→title-only fallback, wrong-artist false-positive guard, short-query-no-fallback, non-empty-skips-fallback. 48 passed across `test_karaokenerds_service`, `test_bulk_album_lookup`, `test_bulk_search_worker`, `test_bulk_submit`, `test_catalog_routes`, `test_match_judge_routes`. CodeRabbit: 0 findings.

@coderabbitai ignore
