### PR TITLE
fix(divebar): repair nightly Drive→GCS sync scheduler (doubled URL + wrong token type)

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -485,12 +485,25 @@ divebar_sync_scheduler = cloudscheduler.Job(
     schedule="0 3 * * *",  # 3:00 AM ET (after index refresh at 2 AM)
     time_zone="America/New_York",
     http_target=cloudscheduler.JobHttpTargetArgs(
-        uri=divebar_sync_instance.self_link.apply(
-            lambda link: f"https://compute.googleapis.com/compute/v1/{link}/start"
+        # Build the compute.instances.start endpoint from the instance name.
+        # NOTE: instance.self_link already resolves to a FULL URL
+        # (https://www.googleapis.com/compute/v1/projects/.../instances/divebar-sync),
+        # so prepending another host produced a doubled URL that 404'd (NOT_FOUND),
+        # silently stopping the nightly Drive->GCS byte sync. Construct the URL
+        # explicitly from project/zone/name to avoid depending on self_link's format.
+        uri=divebar_sync_instance.name.apply(
+            lambda name: (
+                f"https://compute.googleapis.com/compute/v1/"
+                f"projects/{PROJECT_ID}/zones/{ZONE}/instances/{name}/start"
+            )
         ),
         http_method="POST",
-        oidc_token=cloudscheduler.JobHttpTargetOidcTokenArgs(
+        # compute.googleapis.com is a native Google API, so it requires an OAuth 2.0
+        # access token (cloud-platform scope) — NOT an OIDC identity token. Using
+        # oidc_token here caused HTTP 401 UNAUTHENTICATED once the URL was correct.
+        oauth_token=cloudscheduler.JobHttpTargetOauthTokenArgs(
             service_account_email=divebar_mirror_resources["service_account"].email,
+            scope="https://www.googleapis.com/auth/cloud-platform",
         ),
     ),
     retry_config=cloudscheduler.JobRetryConfigArgs(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.188.4"
+version = "0.188.5"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

The `divebar-sync-vm-daily` Cloud Scheduler job — which starts the `divebar-sync` GCE VM that copies community karaoke files **Drive → GCS mirror** nightly — has never successfully started the VM. As a result the byte sync silently stalled: the BigQuery index (`divebar_catalog`) kept refreshing nightly, but **no new file bytes reached `gs://nomadkaraoke-divebar-files`** since ~2026-05-16 (VM `lastStartTimestamp` and newest GCS objects both 2026-05-16, ~6 weeks stale).

Downstream impact: kjbox showed recent community/Nomad tracks as "available from mirror" (index is fresh) but **fell back to YouTube on download** because the bytes weren't in GCS. In the Nomad 720p folder alone, 98 of 1,496 indexed releases (NOMAD-1406→1497) were missing from GCS.

## Root cause — two bugs in the scheduler's `http_target`

1. **Doubled URL → HTTP 404 NOT_FOUND.** `instance.self_link` already resolves to a full URL (`https://www.googleapis.com/compute/v1/...`); the code prepended another compute host on top, producing `.../compute/v1/https://www.googleapis.com/compute/v1/...`. Now the `compute.instances.start` endpoint is built explicitly from `PROJECT_ID`/`ZONE`/`name`.
2. **Wrong token type → HTTP 401 UNAUTHENTICATED** (masked by the 404 until #1 was fixed). `compute.googleapis.com` is a native Google API and requires an **OAuth 2.0 access token** with `cloud-platform` scope, not an OIDC identity token. Swapped `oidc_token` → `oauth_token`.

## Testing / deployment

Deployed to prod via **targeted** `pulumi up` (scheduler job resource only — the other diffs in a full preview were non-reproducible `FileArchive` re-hashes of unchanged function source, deliberately excluded):

- Before: manual trigger → HTTP 404 (code 5), then HTTP 401 (code 2) after the URL fix.
- After: manual trigger → **HTTP 200**, VM transitions to **RUNNING**, startup script logs `=== Divebar file sync starting ===` and runs the catch-up sync, then self-shuts-down.

No behavior change to any other resource; provider pin (`pulumi-gcp==9.22.0`) held (269 unchanged).

@coderabbitai ignore