### PR TITLE
fix(custom-lyrics): don't 500 when a repair call returns an empty response

### DIFF
--- a/backend/services/custom_lyrics/result.py
+++ b/backend/services/custom_lyrics/result.py
@@ -15,6 +15,9 @@ class StopReason(str, Enum):
     MAX_ITERS_REACHED = "max_iters_reached"
     LINE_COUNT_MISMATCH = "line_count_mismatch"
     VERBATIM_SKIP = "verbatim_skip"
+    # A repair iteration failed (e.g. the model returned an empty/blocked
+    # response); we keep the best result found so far instead of failing.
+    REPAIR_FAILED = "repair_failed"
 
 
 @dataclass

--- a/backend/services/custom_lyrics/service.py
+++ b/backend/services/custom_lyrics/service.py
@@ -247,11 +247,20 @@ class CustomLyricsService:
                     settings=settings,
                 )
             except Exception:
-                logger.exception(
+                # Repair is a best-effort *improvement* step. If a repair call
+                # fails (e.g. the model returned an empty/blocked response, or a
+                # transient Vertex error), we must NOT throw away the successful
+                # initial result — that turned a working generation into a 500 and
+                # a browser "NetworkError". Keep the best candidate found so far.
+                # WARNING (not exception/ERROR): this is now a handled, non-fatal
+                # degradation, so it should not trip the production error monitor.
+                logger.warning(
                     "custom_lyrics_repair_call_failed",
+                    exc_info=True,
                     extra={"job_id": job_id, "iteration": iter_num, "stage": "repair"},
                 )
-                raise
+                stop_reason = StopReason.REPAIR_FAILED
+                break
             validations = self._validate_with_length_handling(
                 candidate_lines, target_lines, target_segments,
                 tolerance=params.tolerance, fixed=settings.fixed_line_count,
@@ -564,7 +573,40 @@ class CustomLyricsService:
                 },
             ),
         )
-        return self._parse_lines(response.text)
+        # The model can return no text (safety block, MAX_TOKENS with no content,
+        # empty candidate). `response.text` is then None and json.loads(None) would
+        # raise a raw TypeError -> uncaught 500 without CORS headers -> the browser
+        # reports a confusing "NetworkError". Surface a clean, diagnosable error.
+        text = response.text
+        if text is None:
+            raise CustomLyricsServiceError(
+                f"The AI returned an empty response ({self._describe_empty_response(response)}). "
+                f"Please try again.",
+                status_code=502,
+            )
+        return self._parse_lines(text)
+
+    @staticmethod
+    def _describe_empty_response(response: Any) -> str:
+        """Best-effort reason for an empty model response, for logs and messages."""
+        parts: list[str] = []
+        try:
+            block_reason = getattr(getattr(response, "prompt_feedback", None), "block_reason", None)
+            if block_reason:
+                parts.append(f"prompt_block={getattr(block_reason, 'name', block_reason)}")
+        except Exception:  # pragma: no cover - defensive
+            pass
+        try:
+            candidates = getattr(response, "candidates", None) or []
+            if candidates:
+                finish = getattr(candidates[0], "finish_reason", None)
+                if finish is not None:
+                    parts.append(f"finish_reason={getattr(finish, 'name', finish)}")
+            else:
+                parts.append("no_candidates")
+        except Exception:  # pragma: no cover - defensive
+            pass
+        return ", ".join(parts) if parts else "unknown"
 
     @staticmethod
     def _parse_lines(text: str) -> list[str]:

--- a/backend/tests/services/custom_lyrics/test_service.py
+++ b/backend/tests/services/custom_lyrics/test_service.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from backend.services.custom_lyrics.result import StopReason
-from backend.services.custom_lyrics.service import CustomLyricsService
+from backend.services.custom_lyrics.service import CustomLyricsService, CustomLyricsServiceError
 from backend.services.custom_lyrics.settings import GenerationSettings, StrictnessLevel
 
 
@@ -95,6 +95,67 @@ def test_repairs_one_line(service: CustomLyricsService) -> None:
     assert result.lines == ["xx", "yy"]
     assert result.iterations_used == 1
     assert result.stop_reason is StopReason.SUCCESS
+
+
+def test_repair_failure_falls_back_to_best(service: CustomLyricsService) -> None:
+    """A failed repair call must keep the successful initial result, not 500.
+
+    Regression for job dc60ebf4: the initial generation succeeded but the repair
+    Gemini call returned response.text=None -> json.loads(None) TypeError ->
+    uncaught 500 (no CORS headers) -> browser "NetworkError". The whole good
+    generation was thrown away by a best-effort improvement step.
+    """
+    target_segments = [_segment(0.0, 1.0, "aa"), _segment(1.0, 2.0, "bb")]
+    target_lines = ["aa", "bb"]
+    calls = {"n": 0}
+
+    def _fake_call(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return ["xx yy zz qq", "yy"]  # initial: 1 violation → triggers a repair
+        raise RuntimeError("Gemini returned an empty response")  # repair blows up
+
+    with patch.object(CustomLyricsService, "_call_gemini", side_effect=_fake_call):
+        result = service.generate(
+            job_id="j1",
+            target_lines=target_lines,
+            target_segments=target_segments,
+            artist=None, title=None, custom_text="c",
+            file_bytes=None, file_mime=None, file_name=None,
+            notes=None,
+            settings=GenerationSettings(strictness=StrictnessLevel.BALANCED),
+        )
+
+    assert result.stop_reason is StopReason.REPAIR_FAILED
+    assert result.lines == ["xx yy zz qq", "yy"]  # fell back to the initial (best)
+    assert calls["n"] == 2  # initial + exactly one failed repair, then stop
+
+
+def test_empty_gemini_response_raises_clean_error(service: CustomLyricsService) -> None:
+    """response.text=None -> CustomLyricsServiceError(502), never a raw TypeError.
+
+    The endpoint maps CustomLyricsServiceError to a proper HTTP error (with CORS);
+    a raw TypeError escapes to a 500 with no CORS headers, which the browser shows
+    as an opaque "NetworkError".
+    """
+    fake_response = MagicMock()
+    fake_response.text = None
+    fake_response.candidates = []
+    fake_response.prompt_feedback = None
+    fake_client = MagicMock()
+    fake_client.models.generate_content.return_value = fake_response
+
+    with patch("backend.services.custom_lyrics.service.genai.Client", return_value=fake_client):
+        with pytest.raises(CustomLyricsServiceError) as exc:
+            service._call_gemini(
+                system_prompt="s",
+                user_prompt="u",
+                pdf_bytes=None,
+                settings=GenerationSettings(),
+            )
+
+    assert exc.value.status_code == 502
+    assert "empty response" in str(exc.value).lower()
 
 
 def test_plateau_detection(service: CustomLyricsService) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.188.6"
+version = "0.188.7"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Fixes the custom-lyrics **"NetworkError when attempting to fetch resource"** failure (job `dc60ebf4`) and the recurring **`custom_lyrics_repair_call_failed`** production alert (Count 2).

## Root cause
From prod logs, the flow for `dc60ebf4`:
1. Initial Gemini generation **succeeds** and validates (~2 min).
2. A **repair** iteration's response comes back with `response.text = None` (safety block / MAX_TOKENS / empty candidate).
3. `_parse_lines(None)` → `TypeError: the JSON object must be str, bytes or bytearray, not NoneType`.

That `TypeError`:
- was **re-raised by the repair loop** — throwing away the *successful initial result*, and
- escaped as an **uncaught 500 with no CORS headers**, so the browser (Firefox) showed an opaque `NetworkError` instead of any real message.

`api.nomadkaraoke.com` is direct Cloud Run (`server: Google Frontend`, no Cloudflare, 1800s timeout), so this was **not** a proxy/latency cutoff — the 500 itself was the failure.

## Fixes
- **`_call_gemini`**: treat `response.text = None` as a clean `CustomLyricsServiceError(502)` with a diagnosable reason (`prompt_block` / `finish_reason`). The endpoint already maps that to a proper HTTP error **with CORS** — never a raw `TypeError`.
- **Repair loop**: a failed repair is best-effort → fall back to the best candidate so far (new `StopReason.REPAIR_FAILED`) instead of re-raising. The user gets their successful initial generation instead of losing everything.
- **Log severity**: `custom_lyrics_repair_call_failed` downgraded from `logger.exception` (ERROR) to `logger.warning` — now that it's handled/non-fatal it shouldn't trip the error monitor; traceback breadcrumb kept for diagnosing Gemini empties.

## Testing
- `test_repair_failure_falls_back_to_best` — initial succeeds, repair raises → result is the initial lines, `stop_reason == REPAIR_FAILED`, no exception.
- `test_empty_gemini_response_raises_clean_error` — `response.text=None` → `CustomLyricsServiceError(502)`, not `TypeError`.
- Full custom_lyrics suite green (60). CodeRabbit: 0 findings.

## Follow-up (not in this PR)
The initial Gemini call took ~2 min for this job — the end-to-end latency (and the spinner UX during it) is a separate concern worth optimizing (fewer repair iterations, faster model, or an async/polling endpoint).

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)
