### PR TITLE
fix(lyrics-review): recompute segment times on Ctrl+click word delete

### DIFF
--- a/frontend/lib/lyrics-review/__tests__/segmentOperations.test.ts
+++ b/frontend/lib/lyrics-review/__tests__/segmentOperations.test.ts
@@ -3,6 +3,7 @@ import {
   mergeSegment,
   addSegmentBefore,
   deleteSegment,
+  deleteWord,
 } from '../utils/segmentOperations'
 import type { CorrectionData } from '../types'
 
@@ -96,5 +97,66 @@ describe('segmentOperations — singer inheritance', () => {
     const result = deleteSegment(data, 0)
     expect(result.corrected_segments[0].id).toBe('s2')
     expect(result.corrected_segments[0].singer).toBe(2)
+  })
+})
+
+describe('deleteWord — segment timing recompute', () => {
+  const threeWordSegment = () => baseData([{
+    id: 's1', text: 'hello world foo', start_time: 0, end_time: 3,
+    words: [
+      { id: 'w1', text: 'hello', start_time: 0, end_time: 1 },
+      { id: 'w2', text: 'world', start_time: 1, end_time: 2 },
+      { id: 'w3', text: 'foo', start_time: 2, end_time: 3 },
+    ],
+  }])
+
+  it('deleting the first word tightens segment start_time to the next word', () => {
+    const result = deleteWord(threeWordSegment(), 'w1')
+    const seg = result.corrected_segments[0]
+    expect(seg.words.map((w: any) => w.id)).toEqual(['w2', 'w3'])
+    expect(seg.start_time).toBe(1) // was 0 (w1's start); now w2's start
+    expect(seg.end_time).toBe(3)
+    expect(seg.text).toBe('world foo')
+  })
+
+  it('deleting the last word tightens segment end_time to the previous word', () => {
+    const result = deleteWord(threeWordSegment(), 'w3')
+    const seg = result.corrected_segments[0]
+    expect(seg.words.map((w: any) => w.id)).toEqual(['w1', 'w2'])
+    expect(seg.start_time).toBe(0)
+    expect(seg.end_time).toBe(2) // was 3 (w3's end); now w2's end
+    expect(seg.text).toBe('hello world')
+  })
+
+  it('deleting a middle word leaves segment bounds unchanged', () => {
+    const result = deleteWord(threeWordSegment(), 'w2')
+    const seg = result.corrected_segments[0]
+    expect(seg.start_time).toBe(0)
+    expect(seg.end_time).toBe(3)
+  })
+
+  it('deleting a word when all remaining words are untimed nulls the segment bounds', () => {
+    const data = baseData([{
+      id: 's1', text: 'hello world', start_time: 0, end_time: 1,
+      words: [
+        { id: 'w1', text: 'hello', start_time: 0, end_time: 1 },
+        { id: 'w2', text: 'world', start_time: null, end_time: null },
+      ],
+    }])
+    const result = deleteWord(data, 'w1')
+    const seg = result.corrected_segments[0]
+    expect(seg.start_time).toBeNull()
+    expect(seg.end_time).toBeNull()
+  })
+
+  it('deleting the only word removes the whole segment', () => {
+    const data = baseData([
+      { id: 's1', text: 'hello', start_time: 0, end_time: 1,
+        words: [{ id: 'w1', text: 'hello', start_time: 0, end_time: 1 }] },
+      { id: 's2', text: 'world', start_time: 1, end_time: 2,
+        words: [{ id: 'w2', text: 'world', start_time: 1, end_time: 2 }] },
+    ])
+    const result = deleteWord(data, 'w1')
+    expect(result.corrected_segments.map((s: any) => s.id)).toEqual(['s2'])
   })
 })

--- a/frontend/lib/lyrics-review/utils/segmentOperations.ts
+++ b/frontend/lib/lyrics-review/utils/segmentOperations.ts
@@ -363,11 +363,23 @@ export function deleteWord(data: CorrectionData, wordId: string): CorrectionData
   const updatedWords = segment.words.filter((_, index) => index !== wordIndex)
 
   if (updatedWords.length > 0) {
-    // Update the segment with the word removed
+    // Recompute the segment's boundary times from the remaining words so the
+    // segment no longer spans a deleted first/last word. This mirrors the
+    // Edit-segment modal's updateSegment behaviour (EditModal.tsx), keeping the
+    // Ctrl+click "delete word" path consistent with it.
+    const validStartTimes = updatedWords
+      .map((w) => w.start_time)
+      .filter((t): t is number => t !== null)
+    const validEndTimes = updatedWords
+      .map((w) => w.end_time)
+      .filter((t): t is number => t !== null)
+
     const updatedSegment = {
       ...segment,
       words: updatedWords,
       text: updatedWords.map((w) => w.text).join(' '),
+      start_time: validStartTimes.length > 0 ? Math.min(...validStartTimes) : null,
+      end_time: validEndTimes.length > 0 ? Math.max(...validEndTimes) : null,
     }
 
     // Update the data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.188.7"
+version = "0.188.8"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Ctrl+click "delete word" mode in the lyrics review Synchronizer removed the word but left the **segment's** `start_time`/`end_time` pointing at the deleted word — deleting the first word left the segment starting too early; the last word left it ending too late.
- This diverged from the Edit-segment modal, which recomputes the segment bounds on every word change. The two paths now behave identically.

## Root cause
`deleteWord()` in `frontend/lib/lyrics-review/utils/segmentOperations.ts` built the updated segment with `{ ...segment, words, text }`, spreading the stale `start_time`/`end_time` and never recomputing them from the remaining words. The correct path (`EditModal.updateSegment`) filters the remaining timed words and takes `Math.min`/`Math.max` (or `null` when none remain). `LyricsAnalyzer.tsx:667` is the sole caller of `deleteWord`.

## Changes
- `deleteWord` now recomputes `start_time`/`end_time` from the remaining words (null when no timed words remain), mirroring `EditModal.updateSegment`.
- Added 5 unit tests to `segmentOperations.test.ts`: first/last/middle-word deletion, all-untimed remainder → null bounds, and only-word deletion → whole segment removed.

## Testing
- [x] New `deleteWord` tests: red before fix, green after
- [x] Full `segmentOperations` suite: 11/11 pass
- [x] Full frontend jest suite: 82 suites / 1068 tests pass
- [x] `tsc --noEmit`: no new type errors in changed files

## Review
- [x] Local CodeRabbit review completed (0 findings)
- [x] Review feedback addressed

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)