### PR TITLE
fix(encoding): scope worker warmup/heartbeat to review-auth, not admin

### DIFF
--- a/backend/api/routes/encoding_worker.py
+++ b/backend/api/routes/encoding_worker.py
@@ -2,13 +2,21 @@
 Encoding worker lifecycle endpoints.
 
 Provides warmup and heartbeat endpoints for the blue-green
-encoding worker VMs. Called by the frontend to ensure the
-primary VM is running before encoding requests.
+encoding worker VMs. Called by the lyrics-review frontend to ensure the
+primary VM is running before the reviewer previews a render.
+
+Auth: these are gated on ``require_review_auth`` (review access to a specific
+job), NOT ``require_admin``. The callers are ordinary customers on the
+lyrics-review page — gating on admin makes every non-admin caller 403, which
+silently defeats the JIT pre-warm. Scoping to the job being reviewed keeps the
+abuse posture identical to the rest of the review surface: you can only warm
+the shared encoding VM if you already have review access to a real job.
 """
 
 import logging
+from typing import Tuple
 from fastapi import APIRouter, Depends
-from backend.api.dependencies import require_admin
+from backend.api.dependencies import require_review_auth
 from backend.services.encoding_worker_manager import EncodingWorkerManager
 from backend.services.encoding_errors import EncodingWorkerStartError
 
@@ -36,12 +44,17 @@ def get_worker_manager():
     return _manager
 
 
-@router.post("/warmup")
+@router.post("/warmup/{job_id}")
 async def warmup_encoding_worker(
-    _admin=Depends(require_admin),
+    job_id: str,
+    _auth: Tuple[str, str] = Depends(require_review_auth),
     manager=Depends(get_worker_manager),
 ):
-    """Start the primary encoding worker VM if it's stopped."""
+    """Start the primary encoding worker VM if it's stopped.
+
+    Called on lyrics-review page load so the VM is warm by the time the
+    reviewer previews a render. ``job_id`` scopes auth to the job under review.
+    """
     try:
         result = manager.ensure_primary_running()
         if result["started"]:
@@ -64,12 +77,17 @@ async def warmup_encoding_worker(
         return {"started": False, "error": str(e)}
 
 
-@router.post("/heartbeat")
+@router.post("/heartbeat/{job_id}")
 async def heartbeat_encoding_worker(
-    _admin=Depends(require_admin),
+    job_id: str,
+    _auth: Tuple[str, str] = Depends(require_review_auth),
     manager=Depends(get_worker_manager),
 ):
-    """Update activity timestamp to prevent idle shutdown."""
+    """Update activity timestamp to prevent idle shutdown.
+
+    Called periodically while the reviewer works. ``job_id`` scopes auth to the
+    job under review.
+    """
     try:
         manager.update_activity()
         return {"status": "ok"}

--- a/backend/tests/test_encoding_worker_routes.py
+++ b/backend/tests/test_encoding_worker_routes.py
@@ -2,6 +2,12 @@
 Unit tests for encoding worker lifecycle endpoints.
 
 Tests the warmup and heartbeat API endpoints.
+
+These endpoints are called from the customer-facing lyrics-review page to
+pre-warm the encoding VM. They are therefore gated on ``require_review_auth``
+(review access to a specific job), NOT ``require_admin`` — otherwise every
+non-admin customer 403s and the pre-warm silently never happens (the bug this
+suite guards against).
 """
 import logging
 
@@ -10,16 +16,24 @@ from unittest.mock import MagicMock
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from backend.api.routes.encoding_worker import router, get_worker_manager
-from backend.api.dependencies import require_admin
+from backend.api.dependencies import require_admin, require_review_auth
 from backend.services.encoding_errors import (
     EncodingWorkerCapacityError,
     EncodingWorkerStartError,
 )
 
+JOB_ID = "test-job-123"
+WARMUP_URL = f"/api/internal/encoding-worker/warmup/{JOB_ID}"
+HEARTBEAT_URL = f"/api/internal/encoding-worker/heartbeat/{JOB_ID}"
 
-def get_mock_admin():
-    """Override for require_admin dependency."""
-    return ("admin-token", "admin", 0)
+
+async def fake_review_auth():
+    """Override for require_review_auth — stands in for a review user.
+
+    Deliberately returns a *non-admin* auth result (auth_type="full") so the
+    tests exercise the review-scoped path, not admin access.
+    """
+    return (JOB_ID, "full")
 
 
 class TestWarmupEndpoint:
@@ -27,7 +41,7 @@ class TestWarmupEndpoint:
         self.mock_manager = MagicMock()
         self.app = FastAPI()
         self.app.include_router(router, prefix="/api")
-        self.app.dependency_overrides[require_admin] = get_mock_admin
+        self.app.dependency_overrides[require_review_auth] = fake_review_auth
         self.app.dependency_overrides[get_worker_manager] = lambda: self.mock_manager
         self.client = TestClient(self.app)
 
@@ -37,7 +51,7 @@ class TestWarmupEndpoint:
             "vm_name": "encoding-worker-a",
             "primary_url": "http://34.1.2.3:8080",
         }
-        response = self.client.post("/api/internal/encoding-worker/warmup")
+        response = self.client.post(WARMUP_URL)
         assert response.status_code == 200
         data = response.json()
         assert data["started"] is True
@@ -49,7 +63,7 @@ class TestWarmupEndpoint:
             "vm_name": "encoding-worker-a",
             "primary_url": "http://34.1.2.3:8080",
         }
-        response = self.client.post("/api/internal/encoding-worker/warmup")
+        response = self.client.post(WARMUP_URL)
         assert response.status_code == 200
         assert response.json()["started"] is False
 
@@ -57,7 +71,7 @@ class TestWarmupEndpoint:
         self.mock_manager.ensure_primary_running.side_effect = RuntimeError(
             "VM not found"
         )
-        response = self.client.post("/api/internal/encoding-worker/warmup")
+        response = self.client.post(WARMUP_URL)
         assert response.status_code == 200
         assert response.json()["started"] is False
         assert "error" in response.json()
@@ -78,7 +92,7 @@ class TestWarmupEndpoint:
             )
         )
         with caplog.at_level(logging.WARNING):
-            response = self.client.post("/api/internal/encoding-worker/warmup")
+            response = self.client.post(WARMUP_URL)
         assert response.status_code == 200
         assert response.json()["started"] is False
         warmup_records = [
@@ -106,7 +120,7 @@ class TestWarmupEndpoint:
             )
         )
         with caplog.at_level(logging.WARNING):
-            response = self.client.post("/api/internal/encoding-worker/warmup")
+            response = self.client.post(WARMUP_URL)
         assert response.status_code == 200
         assert not [
             r
@@ -121,7 +135,7 @@ class TestWarmupEndpoint:
             "misconfigured service account"
         )
         with caplog.at_level(logging.WARNING):
-            response = self.client.post("/api/internal/encoding-worker/warmup")
+            response = self.client.post(WARMUP_URL)
         assert response.status_code == 200
         error_records = [
             r
@@ -137,12 +151,12 @@ class TestHeartbeatEndpoint:
         self.mock_manager = MagicMock()
         self.app = FastAPI()
         self.app.include_router(router, prefix="/api")
-        self.app.dependency_overrides[require_admin] = get_mock_admin
+        self.app.dependency_overrides[require_review_auth] = fake_review_auth
         self.app.dependency_overrides[get_worker_manager] = lambda: self.mock_manager
         self.client = TestClient(self.app)
 
     def test_heartbeat_updates_activity(self):
-        response = self.client.post("/api/internal/encoding-worker/heartbeat")
+        response = self.client.post(HEARTBEAT_URL)
         assert response.status_code == 200
         assert response.json()["status"] == "ok"
         self.mock_manager.update_activity.assert_called_once()
@@ -151,6 +165,55 @@ class TestHeartbeatEndpoint:
         self.mock_manager.update_activity.side_effect = RuntimeError(
             "Firestore error"
         )
-        response = self.client.post("/api/internal/encoding-worker/heartbeat")
+        response = self.client.post(HEARTBEAT_URL)
         assert response.status_code == 200
         assert response.json()["status"] == "error"
+
+
+class TestReviewAuthGating:
+    """Regression guard: these endpoints must be review-auth gated, not admin.
+
+    Before this fix they used ``require_admin``, so every non-admin customer on
+    the lyrics-review page got a 403 and the JIT pre-warm never happened.
+    """
+
+    def test_routes_depend_on_review_auth_not_admin(self):
+        """The route dependencies reference require_review_auth, never require_admin."""
+        deps = set()
+        for route in router.routes:
+            dependant = getattr(route, "dependant", None)
+            if dependant is None:
+                continue
+            # Flatten the whole dependency tree for the route.
+            stack = list(dependant.dependencies)
+            while stack:
+                d = stack.pop()
+                deps.add(d.call)
+                stack.extend(d.dependencies)
+        assert require_review_auth in deps, (
+            "warmup/heartbeat must be gated on require_review_auth"
+        )
+        assert require_admin not in deps, (
+            "warmup/heartbeat must NOT require admin (regresses pre-warm for "
+            "all non-admin customers)"
+        )
+
+    def test_unauthenticated_request_is_rejected(self):
+        """With real auth (no override, no token), warmup is rejected — not 200/500."""
+        app = FastAPI()
+        app.include_router(router, prefix="/api")
+        app.dependency_overrides[get_worker_manager] = lambda: MagicMock()
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post(WARMUP_URL)
+        # require_review_auth with no credentials raises 401.
+        assert response.status_code == 401
+
+    def test_job_id_is_required_in_path(self):
+        """The old job-less path no longer exists (404), forcing job scoping."""
+        app = FastAPI()
+        app.include_router(router, prefix="/api")
+        app.dependency_overrides[require_review_auth] = fake_review_auth
+        app.dependency_overrides[get_worker_manager] = lambda: MagicMock()
+        client = TestClient(app)
+        response = client.post("/api/internal/encoding-worker/warmup")
+        assert response.status_code == 404

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -230,7 +230,9 @@ done
 
 **Configuration knobs:** `MAX_PER_TICK = 1` and `MAX_WAIT_SECONDS = 24*3600` constants in `backend/api/routes/internal.py::retry_pending_render_jobs`.
 
-**Not an incident:** a *primary* warmup hitting `503 SERVICE_UNAVAILABLE` / capacity exhaustion is self-healing — the encoding flow's `ensure_any_running()` falls back to an alternate-zone worker and the job completes. As of 0.174.12 the `/internal/encoding-worker/warmup` endpoint logs this at **WARNING** (`"Primary encoding worker warmup failed (...); encoding will fall back..."`), specifically so it stays below the error monitor's `severity>=ERROR` filter and does **not** page Discord. Only a genuine, unexpected warmup failure (non-`EncodingWorkerStartError`) logs at ERROR. If you see the WARNING in logs with a job that still completed, no action is needed.
+**Not an incident:** a *primary* warmup hitting `503 SERVICE_UNAVAILABLE` / capacity exhaustion is self-healing — the encoding flow's `ensure_any_running()` falls back to an alternate-zone worker and the job completes. As of 0.174.12 the `/internal/encoding-worker/warmup/{job_id}` endpoint logs this at **WARNING** (`"Primary encoding worker warmup failed (...); encoding will fall back..."`), specifically so it stays below the error monitor's `severity>=ERROR` filter and does **not** page Discord. Only a genuine, unexpected warmup failure (non-`EncodingWorkerStartError`) logs at ERROR. If you see the WARNING in logs with a job that still completed, no action is needed.
+
+**403 on `/internal/encoding-worker/warmup` or `/heartbeat`:** as of 0.188.9 these endpoints are `{job_id}`-scoped and gated on `require_review_auth` (not `require_admin`). The lyrics-review page calls them on load / while editing so the encoding VM is warm by the time the reviewer previews a render. If you see 403s in the browser console, the caller lacks review access to that job — before 0.188.9 they required admin, so **every non-admin customer 403'd and the JIT pre-warm never fired** (renders paid the full cold-boot latency).
 
 ---
 

--- a/frontend/components/lyrics-review/LyricsAnalyzer.tsx
+++ b/frontend/components/lyrics-review/LyricsAnalyzer.tsx
@@ -387,22 +387,25 @@ export default function LyricsAnalyzer({
     setSessionRestoreOpen(true)
   }, [sessionClient])
 
-  // Warm up encoding worker VM when lyrics review page loads
+  // Warm up encoding worker VM when lyrics review page loads.
+  // Only in cloud mode (jobId present) — the endpoint is review-auth scoped to
+  // the job, and there's no cloud encoding VM to warm in local mode.
   useEffect(() => {
-    if (!isReadOnly) {
-      warmupEncodingWorker()
+    if (!isReadOnly && jobId) {
+      warmupEncodingWorker(jobId)
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Debounced heartbeat — keeps VM alive during active editing
   const lastHeartbeat = useRef(0)
   const sendHeartbeat = useCallback(() => {
+    if (!jobId) return
     const now = Date.now()
     if (now - lastHeartbeat.current > 60_000) {
       lastHeartbeat.current = now
-      heartbeatEncodingWorker()
+      heartbeatEncodingWorker(jobId)
     }
-  }, [])
+  }, [jobId])
 
   // Heartbeat the encoding worker as the reviewer works. Crash recovery /
   // restore now flows entirely through review sessions (server in cloud mode,

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -3507,10 +3507,16 @@ export const lyricsReviewApi = {
 /**
  * Signal the backend to start the encoding worker VM.
  * Fire-and-forget — doesn't wait for the VM to boot.
+ *
+ * Scoped to the job being reviewed: the endpoint authorizes via the same
+ * review access as the rest of the lyrics-review page (require_review_auth),
+ * so getAuthHeaders() supplies the reviewer's token. Passing an admin-only
+ * token was the previous behaviour and 403'd for every non-admin customer.
  */
-export async function warmupEncodingWorker(): Promise<void> {
+export async function warmupEncodingWorker(jobId: string): Promise<void> {
+  if (!jobId) return
   try {
-    await fetch(`${API_BASE_URL}/api/internal/encoding-worker/warmup`, {
+    await fetch(`${API_BASE_URL}/api/internal/encoding-worker/warmup/${encodeURIComponent(jobId)}`, {
       method: 'POST',
       headers: getAuthHeaders(),
     })
@@ -3521,10 +3527,12 @@ export async function warmupEncodingWorker(): Promise<void> {
 
 /**
  * Send heartbeat to keep encoding worker alive during active session.
+ * Scoped to the job being reviewed (see warmupEncodingWorker).
  */
-export async function heartbeatEncodingWorker(): Promise<void> {
+export async function heartbeatEncodingWorker(jobId: string): Promise<void> {
+  if (!jobId) return
   try {
-    await fetch(`${API_BASE_URL}/api/internal/encoding-worker/heartbeat`, {
+    await fetch(`${API_BASE_URL}/api/internal/encoding-worker/heartbeat/${encodeURIComponent(jobId)}`, {
       method: 'POST',
       headers: getAuthHeaders(),
     })

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.188.8"
+version = "0.188.9"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

The lyrics-review page pre-warms the encoding VM on load (and heartbeats while the reviewer edits) so it's booted by the time they preview a render. Both endpoints — `POST /api/internal/encoding-worker/warmup` and `/heartbeat` — required `require_admin` since they were introduced (Mar 25 2026, #595). So **every non-admin customer got a 403 and the JIT pre-warm silently never fired**. Renders still completed (the encoding flow's own `ensure_any_running()` boots the VM on demand), but customers paid the full cold-boot latency the pre-warm was meant to hide. Reported via 403s in the review-screen devtools console.

## Root cause

`require_admin` is an admin-only gate; the callers are ordinary customers on a customer-facing page. Admin was the wrong altitude — the rest of the review surface (`submitCorrections`, `handlers`, annotations, audio-edit…) uses `require_review_auth`, which the review page's token already satisfies.

## Fix

Re-scope both endpoints to `require_review_auth` with a `{job_id}` path param:

- **Backend** (`encoding_worker.py`): `POST /warmup/{job_id}` and `/heartbeat/{job_id}`, gated on `require_review_auth`. Warming the shared VM now authorizes exactly like the review page's other calls, so warmup/heartbeat succeed **precisely when** the review page works — owners, admins (bypass), and `review_token` users included. Abuse posture is unchanged: you can only warm the VM if you already have review access to a real job.
- **Frontend** (`api.ts`, `LyricsAnalyzer.tsx`): thread `jobId` through `warmupEncodingWorker`/`heartbeatEncodingWorker`, only fire in cloud mode (`jobId` present — no cloud VM to warm in local mode).

## Changes

- `backend/api/routes/encoding_worker.py` — review-auth + `{job_id}` path
- `frontend/lib/api.ts` — job-scoped URLs, `jobId` param + guard
- `frontend/components/lyrics-review/LyricsAnalyzer.tsx` — pass `jobId`, gate on it
- `backend/tests/test_encoding_worker_routes.py` — review-auth contract + regression guard that these routes are **not** admin-gated
- `docs/TROUBLESHOOTING.md` — note the auth change and 403 diagnosis
- `pyproject.toml` — 0.188.8 → 0.188.9

## Testing

- Backend: `test_encoding_worker_routes.py` (11) + manager/persistence/system-status/retry (67 total) + `test_api_routes.py` (17) — all green. New regression test asserts the routes depend on `require_review_auth` and **never** `require_admin`, plus 401-on-no-auth and 404-on-jobless-path.
- Frontend: `jest` lyrics-review + api (319) green; `tsc` clean on both changed files.
- Prod verification to follow after deploy: open a review page as a non-admin customer and confirm warmup/heartbeat return 200 (not 403).

@coderabbitai ignore
