### PR TITLE
fix(divebar): mirror sync % reaches 100% (green) when fully caught up

### DIFF
--- a/infrastructure/functions/divebar_lookup/main.py
+++ b/infrastructure/functions/divebar_lookup/main.py
@@ -323,19 +323,21 @@ def _get_full_stats() -> dict:
             SELECT
                 COUNT(*) as total_files,
                 COUNT(DISTINCT brand) as total_brands,
-                COUNTIF(gcs_path IS NOT NULL) as gcs_synced,
+                COUNTIF(gcs_path LIKE 'gs://%') as gcs_synced,
                 COUNTIF(gcs_path IS NULL) as gcs_pending,
+                COUNTIF(gcs_path IS NOT NULL AND gcs_path NOT LIKE 'gs://%') as gcs_unavailable,
                 COUNTIF(artist IS NOT NULL AND title IS NOT NULL) as with_metadata,
                 ROUND(SUM(file_size) / 1024/1024/1024, 1) as total_gb,
-                ROUND(SUM(CASE WHEN gcs_path IS NOT NULL THEN file_size ELSE 0 END) / 1024/1024/1024, 1) as gcs_synced_gb,
+                ROUND(SUM(CASE WHEN gcs_path LIKE 'gs://%' THEN file_size ELSE 0 END) / 1024/1024/1024, 1) as gcs_synced_gb,
                 ROUND(SUM(CASE WHEN gcs_path IS NULL THEN file_size ELSE 0 END) / 1024/1024/1024, 1) as gcs_pending_gb,
+                ROUND(SUM(CASE WHEN gcs_path IS NOT NULL AND gcs_path NOT LIKE 'gs://%' THEN file_size ELSE 0 END) / 1024/1024/1024, 1) as gcs_unavailable_gb,
                 MAX(synced_at) as last_index_sync
             FROM `{GCP_PROJECT_ID}.{DATASET}.divebar_catalog`
         ),
         format_stats AS (
             SELECT format, COUNT(*) as count,
                 ROUND(SUM(file_size) / 1024/1024/1024, 1) as gb,
-                COUNTIF(gcs_path IS NOT NULL) as in_gcs
+                COUNTIF(gcs_path LIKE 'gs://%') as in_gcs
             FROM `{GCP_PROJECT_ID}.{DATASET}.divebar_catalog`
             GROUP BY format
             ORDER BY count DESC
@@ -365,7 +367,7 @@ def _get_full_stats() -> dict:
     fmt_sql = f"""
         SELECT format, COUNT(*) as count,
             ROUND(SUM(file_size) / 1024/1024/1024, 1) as gb,
-            COUNTIF(gcs_path IS NOT NULL) as in_gcs
+            COUNTIF(gcs_path LIKE 'gs://%') as in_gcs
         FROM `{GCP_PROJECT_ID}.{DATASET}.divebar_catalog`
         GROUP BY format ORDER BY count DESC
     """
@@ -376,6 +378,9 @@ def _get_full_stats() -> dict:
             "gb": fmt_row.gb,
             "in_gcs": fmt_row.in_gcs,
         }
+
+    # Files that can actually be mirrored (exclude permanently-unavailable ones).
+    syncable = row.total_files - row.gcs_unavailable
 
     return {
         "catalog": {
@@ -388,9 +393,18 @@ def _get_full_stats() -> dict:
         "gcs_mirror": {
             "synced": row.gcs_synced,
             "pending": row.gcs_pending,
+            # Files that can never be mirrored: no longer on Drive (404/410) or
+            # too large to buffer. Marked with a sentinel gcs_path by the sync VM.
+            "unavailable": row.gcs_unavailable,
+            "syncable_total": syncable,
             "synced_gb": row.gcs_synced_gb,
             "pending_gb": row.gcs_pending_gb,
-            "percent": round(row.gcs_synced / row.total_files * 100, 1) if row.total_files else 0,
+            "unavailable_gb": row.gcs_unavailable_gb,
+            # Percent of *syncable* files mirrored. Reaches 100% once every file
+            # that can be synced is in GCS — unavailable files are excluded from
+            # the denominator so a healthy, fully-caught-up mirror reads 100%
+            # (green) instead of being pinned below by permanently-dead links.
+            "percent": round(row.gcs_synced / syncable * 100, 1) if syncable else 0,
         },
         "formats": formats,
         "cross_reference": {

--- a/infrastructure/functions/divebar_lookup/test_main.py
+++ b/infrastructure/functions/divebar_lookup/test_main.py
@@ -164,3 +164,56 @@ class TestRefreshDispatch:
         body, status, _ = main.divebar_lookup(MockRequest({"action": "refresh"}))
         assert status == 403
         _reset_scheduler.run_job.assert_not_called()
+
+
+def _stats_row(**overrides):
+    """A fake BigQuery result row for _get_full_stats (attribute access)."""
+    defaults = dict(
+        total_files=50249, total_brands=63, with_metadata=50072,
+        total_gb=876.4, gcs_synced=50031, gcs_pending=0, gcs_unavailable=218,
+        gcs_synced_gb=874.7, gcs_pending_gb=0.0, gcs_unavailable_gb=1.6,
+        last_index_sync=None, total_matches=38435, unique_kn_songs=1,
+        unique_divebar_files=1, last_xref_rebuild=None, kn_songs=1, kn_community=1,
+    )
+    defaults.update(overrides)
+    row = MagicMock()
+    for k, v in defaults.items():
+        setattr(row, k, v)
+    return row
+
+
+def _patch_bq(monkeypatch, row):
+    """Make main.bigquery.Client().query().result() yield [row] then [] (formats)."""
+    client = MagicMock()
+    client.query.return_value.result.side_effect = [[row], []]
+    monkeypatch.setattr(main.bigquery, "Client", lambda project=None: client)
+
+
+class TestFullStatsPercent:
+    def test_percent_100_when_no_pending(self, monkeypatch):
+        # All syncable files mirrored; the only non-synced rows are unavailable.
+        _patch_bq(monkeypatch, _stats_row(gcs_synced=50031, gcs_pending=0, gcs_unavailable=218))
+        g = main._get_full_stats()["gcs_mirror"]
+        assert g["pending"] == 0
+        assert g["unavailable"] == 218
+        assert g["syncable_total"] == 50031
+        assert g["percent"] == 100.0  # green
+
+    def test_pending_keeps_percent_below_100(self, monkeypatch):
+        # Real pending work (null gcs_path) legitimately holds it under 100.
+        _patch_bq(monkeypatch, _stats_row(gcs_synced=50031, gcs_pending=217, gcs_unavailable=1))
+        g = main._get_full_stats()["gcs_mirror"]
+        assert g["pending"] == 217
+        assert g["percent"] == 99.6
+
+    def test_unavailable_excluded_from_denominator(self, monkeypatch):
+        # 90 synced, 10 unavailable, 0 pending -> 100% (not 90%).
+        _patch_bq(monkeypatch, _stats_row(total_files=100, gcs_synced=90, gcs_pending=0, gcs_unavailable=10))
+        g = main._get_full_stats()["gcs_mirror"]
+        assert g["syncable_total"] == 90
+        assert g["percent"] == 100.0
+
+    def test_zero_syncable_is_zero_not_crash(self, monkeypatch):
+        _patch_bq(monkeypatch, _stats_row(total_files=5, gcs_synced=0, gcs_pending=0, gcs_unavailable=5))
+        g = main._get_full_stats()["gcs_mirror"]
+        assert g["percent"] == 0

--- a/infrastructure/scripts/divebar_file_sync.py
+++ b/infrastructure/scripts/divebar_file_sync.py
@@ -42,6 +42,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from google.auth import default
 from google.cloud import bigquery, storage
 from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaIoBaseDownload
 
 logging.basicConfig(
@@ -107,9 +108,10 @@ def get_sync_stats(bq_client):
     query = f"""
         SELECT
             COUNT(*) as total,
-            COUNTIF(gcs_path IS NOT NULL) as synced,
+            COUNTIF(gcs_path LIKE 'gs://%') as synced,
             COUNTIF(gcs_path IS NULL) as pending,
-            ROUND(SUM(CASE WHEN gcs_path IS NOT NULL THEN file_size ELSE 0 END) / 1024/1024/1024, 1) as synced_gb,
+            COUNTIF(gcs_path IS NOT NULL AND gcs_path NOT LIKE 'gs://%') as unavailable,
+            ROUND(SUM(CASE WHEN gcs_path LIKE 'gs://%' THEN file_size ELSE 0 END) / 1024/1024/1024, 1) as synced_gb,
             ROUND(SUM(CASE WHEN gcs_path IS NULL THEN file_size ELSE 0 END) / 1024/1024/1024, 1) as pending_gb
         FROM `{PROJECT_ID}.{DATASET}.{TABLE}`
     """
@@ -118,13 +120,21 @@ def get_sync_stats(bq_client):
         "total": row.total,
         "synced": row.synced,
         "pending": row.pending,
+        # Sentinel gcs_path values (missing:*/skipped:*) — non-null but not in GCS.
+        "unavailable": row.unavailable,
         "synced_gb": row.synced_gb,
         "pending_gb": row.pending_gb,
     }
 
 
 def download_and_upload(drive_service, gcs_bucket, file_id, gcs_path, expected_size=None):
-    """Download a file from Drive and upload to GCS. Returns True on success."""
+    """Download a file from Drive and upload to GCS.
+
+    Returns ``(ok, actual_size, gone)``. ``gone`` is True when Drive reports the
+    file no longer exists (HTTP 404/410) — a permanent failure the caller should
+    record so it stops counting as "pending" and isn't retried every run.
+    Any other error returns ``gone=False`` (transient — safe to retry).
+    """
     try:
         # Download from Drive
         request = drive_service.files().get_media(fileId=file_id)
@@ -142,11 +152,23 @@ def download_and_upload(drive_service, gcs_bucket, file_id, gcs_path, expected_s
         blob = gcs_bucket.blob(gcs_path)
         blob.upload_from_file(buffer, timeout=300)
 
-        return True, actual_size
+        return True, actual_size, False
+
+    except HttpError as e:
+        status = getattr(e, "status_code", None)
+        if status is None:
+            status = getattr(getattr(e, "resp", None), "status", None)
+        try:
+            status = int(status)
+        except (TypeError, ValueError):
+            status = None
+        gone = status in (404, 410)
+        logger.error("Failed %s: %s", gcs_path, e)
+        return False, 0, gone
 
     except Exception as e:
         logger.error("Failed %s: %s", gcs_path, e)
-        return False, 0
+        return False, 0, False
 
 
 def update_gcs_path(bq_client, file_id, gcs_path):
@@ -179,24 +201,25 @@ def sync_file(gcs_bucket, bq_client, row):
     file_size = row.file_size or 0
     size_mb = file_size / 1024 / 1024
 
-    # Skip files too large to buffer in memory (would OOM the VM)
+    # Skip files too large to buffer in memory (would OOM the VM). Marked
+    # unsyncable so they don't count as pending or get retried every run.
     if file_size > MAX_FILE_SIZE:
         update_gcs_path(bq_client, file_id, "skipped:too_large")
         logger.warning("  ⏭ %s skipped (%.0f MB > 3 GB limit)", drive_path, size_mb)
-        return True, 0
+        return True, 0, True
 
     # Check if file already exists in GCS (avoids re-downloading)
     blob = gcs_bucket.blob(gcs_path)
     if blob.exists():
         update_gcs_path(bq_client, file_id, full_gcs_path)
         logger.info("  ⏭ %s already in GCS, updated gcs_path", drive_path)
-        return True, 0
+        return True, 0, False
 
     logger.info("Downloading %s (%.1f MB)...", drive_path, size_mb)
     start = time.time()
 
     drive_service = get_drive_service()
-    ok, actual_size = download_and_upload(
+    ok, actual_size, gone = download_and_upload(
         drive_service, gcs_bucket, file_id, gcs_path, row.file_size
     )
 
@@ -208,9 +231,17 @@ def sync_file(gcs_bucket, bq_client, row):
             "  ✓ %s (%.1f MB in %.1fs, %.1f MB/s)",
             drive_path, actual_size / 1024 / 1024, duration, speed,
         )
-        return True, actual_size
+        return True, actual_size, False
+    elif gone:
+        # File no longer exists in Drive (deleted/moved since it was indexed).
+        # Mark unsyncable so it stops counting as pending and isn't retried
+        # every night; a genuinely new upload gets a fresh file_id + row.
+        update_gcs_path(bq_client, file_id, "missing:drive_404")
+        logger.warning("  ✗ %s unavailable on Drive (404/410) — marked unsyncable", drive_path)
+        return False, 0, True
     else:
-        return False, 0
+        # Transient failure (network, 5xx, timeout) — leave gcs_path NULL to retry.
+        return False, 0, False
 
 
 def main():
@@ -227,10 +258,10 @@ def main():
     # Show current progress
     stats = get_sync_stats(bq_client)
     logger.info(
-        "Sync status: %d/%d files synced (%.1f/%.1f GB), %d pending (%.1f GB)",
+        "Sync status: %d/%d files synced (%.1f/%.1f GB), %d pending (%.1f GB), %d unavailable",
         stats["synced"], stats["total"], stats["synced_gb"],
         stats["synced_gb"] + stats["pending_gb"],
-        stats["pending"], stats["pending_gb"],
+        stats["pending"], stats["pending_gb"], stats["unavailable"],
     )
 
     # Get unsynced files
@@ -261,12 +292,17 @@ def main():
     downloaded = 0
     recovered = 0
     failed = 0
+    unavailable = 0
     bytes_synced = 0
     overall_start = time.time()
 
-    def _tally(ok, size):
-        nonlocal downloaded, recovered, failed, bytes_synced
-        if ok:
+    def _tally(ok, size, is_unavailable=False):
+        nonlocal downloaded, recovered, failed, unavailable, bytes_synced
+        if is_unavailable:
+            # Permanently unsyncable (Drive 404/410 or too-large) — recorded in
+            # BigQuery via a sentinel gcs_path, so not a retry-worthy failure.
+            unavailable += 1
+        elif ok:
             if size > 0:
                 downloaded += 1
                 bytes_synced += size
@@ -278,8 +314,8 @@ def main():
     def _log_progress():
         elapsed = time.time() - overall_start
         logger.info(
-            "Progress: %d downloaded, %d recovered, %d failed (of %d), %.1f GB, %.0f s",
-            downloaded, recovered, failed, len(files),
+            "Progress: %d downloaded, %d recovered, %d unavailable, %d failed (of %d), %.1f GB, %.0f s",
+            downloaded, recovered, unavailable, failed, len(files),
             bytes_synced / 1024 / 1024 / 1024, elapsed,
         )
 
@@ -291,7 +327,7 @@ def main():
             }
             for future in as_completed(futures):
                 _tally(*future.result())
-                if (downloaded + recovered + failed) % 50 == 0:
+                if (downloaded + recovered + failed + unavailable) % 50 == 0:
                     _log_progress()
     else:
         for i, row in enumerate(files):
@@ -301,8 +337,8 @@ def main():
 
     elapsed = time.time() - overall_start
     logger.info(
-        "Done: %d downloaded, %d recovered from GCS, %d failed, %.1f GB in %.0f s",
-        downloaded, recovered, failed, bytes_synced / 1024 / 1024 / 1024, elapsed,
+        "Done: %d downloaded, %d recovered from GCS, %d unavailable (marked), %d failed, %.1f GB in %.0f s",
+        downloaded, recovered, unavailable, failed, bytes_synced / 1024 / 1024 / 1024, elapsed,
     )
 
 

--- a/infrastructure/scripts/test_divebar_file_sync.py
+++ b/infrastructure/scripts/test_divebar_file_sync.py
@@ -1,0 +1,128 @@
+"""Tests for divebar_file_sync.py — focused on how failed downloads are
+classified. Dead Drive links (404/410) must be marked with a sentinel gcs_path
+so they stop counting as "pending" and aren't retried every nightly run, while
+transient errors must stay NULL (retryable).
+
+Google client libs aren't installed in the test env, so they're stubbed before
+import. HttpError must be a *real* exception class (the module does
+``except HttpError``), so we provide a concrete stub.
+"""
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _HttpError(Exception):
+    def __init__(self, status):
+        self.status_code = status
+        self.resp = types.SimpleNamespace(status=status)
+        super().__init__(f"HTTP {status}")
+
+
+def _install_stubs():
+    sys.modules.setdefault("google", types.ModuleType("google"))
+    gauth = types.ModuleType("google.auth"); gauth.default = MagicMock()
+    sys.modules["google.auth"] = gauth
+    gcloud = types.ModuleType("google.cloud")
+    gcloud.bigquery = MagicMock(); gcloud.storage = MagicMock()
+    sys.modules["google.cloud"] = gcloud
+    sys.modules.setdefault("googleapiclient", types.ModuleType("googleapiclient"))
+    disc = types.ModuleType("googleapiclient.discovery"); disc.build = MagicMock()
+    sys.modules["googleapiclient.discovery"] = disc
+    errs = types.ModuleType("googleapiclient.errors"); errs.HttpError = _HttpError
+    sys.modules["googleapiclient.errors"] = errs
+    http = types.ModuleType("googleapiclient.http"); http.MediaIoBaseDownload = MagicMock()
+    sys.modules["googleapiclient.http"] = http
+
+
+_install_stubs()
+sys.path.insert(0, os.path.dirname(__file__))
+import divebar_file_sync as mod  # noqa: E402
+
+
+class _Row:
+    def __init__(self, file_id="fid", drive_path="Brand/Song.mp4", file_size=1000):
+        self.file_id = file_id
+        self.drive_path = drive_path
+        self.file_size = file_size
+        self.drive_md5 = "abc"
+
+
+# ---- download_and_upload: classify the failure ----
+
+def test_download_404_is_gone(monkeypatch):
+    inst = MagicMock(); inst.next_chunk.side_effect = _HttpError(404)
+    monkeypatch.setattr(mod, "MediaIoBaseDownload", MagicMock(return_value=inst))
+    ok, size, gone = mod.download_and_upload(MagicMock(), MagicMock(), "fid", "files/x")
+    assert (ok, size, gone) == (False, 0, True)
+
+
+def test_download_410_is_gone(monkeypatch):
+    inst = MagicMock(); inst.next_chunk.side_effect = _HttpError(410)
+    monkeypatch.setattr(mod, "MediaIoBaseDownload", MagicMock(return_value=inst))
+    _, _, gone = mod.download_and_upload(MagicMock(), MagicMock(), "fid", "files/x")
+    assert gone is True
+
+
+def test_download_500_is_not_gone(monkeypatch):
+    inst = MagicMock(); inst.next_chunk.side_effect = _HttpError(500)
+    monkeypatch.setattr(mod, "MediaIoBaseDownload", MagicMock(return_value=inst))
+    ok, size, gone = mod.download_and_upload(MagicMock(), MagicMock(), "fid", "files/x")
+    assert (ok, gone) == (False, False)  # transient — retry
+
+
+def test_download_generic_error_is_not_gone(monkeypatch):
+    inst = MagicMock(); inst.next_chunk.side_effect = RuntimeError("network blip")
+    monkeypatch.setattr(mod, "MediaIoBaseDownload", MagicMock(return_value=inst))
+    ok, size, gone = mod.download_and_upload(MagicMock(), MagicMock(), "fid", "files/x")
+    assert (ok, gone) == (False, False)
+
+
+# ---- sync_file: record the outcome in BigQuery ----
+
+def _bucket_blob_missing():
+    bucket = MagicMock()
+    bucket.blob.return_value.exists.return_value = False
+    return bucket
+
+
+def test_sync_file_marks_dead_link_unsyncable(monkeypatch):
+    monkeypatch.setattr(mod, "get_drive_service", MagicMock())
+    monkeypatch.setattr(mod, "download_and_upload", MagicMock(return_value=(False, 0, True)))
+    upd = MagicMock(); monkeypatch.setattr(mod, "update_gcs_path", upd)
+    bq = MagicMock()
+    ok, size, unavailable = mod.sync_file(_bucket_blob_missing(), bq, _Row())
+    assert (ok, size, unavailable) == (False, 0, True)
+    upd.assert_called_once_with(bq, "fid", "missing:drive_404")
+
+
+def test_sync_file_transient_stays_null(monkeypatch):
+    monkeypatch.setattr(mod, "get_drive_service", MagicMock())
+    monkeypatch.setattr(mod, "download_and_upload", MagicMock(return_value=(False, 0, False)))
+    upd = MagicMock(); monkeypatch.setattr(mod, "update_gcs_path", upd)
+    ok, size, unavailable = mod.sync_file(_bucket_blob_missing(), MagicMock(), _Row())
+    assert (ok, size, unavailable) == (False, 0, False)
+    upd.assert_not_called()  # left NULL to retry next run
+
+
+def test_sync_file_success_marks_gcs_path(monkeypatch):
+    monkeypatch.setattr(mod, "get_drive_service", MagicMock())
+    monkeypatch.setattr(mod, "download_and_upload", MagicMock(return_value=(True, 4242, False)))
+    upd = MagicMock(); monkeypatch.setattr(mod, "update_gcs_path", upd)
+    bq = MagicMock()
+    ok, size, unavailable = mod.sync_file(_bucket_blob_missing(), bq, _Row(file_id="ok1"))
+    assert (ok, size, unavailable) == (True, 4242, False)
+    args = upd.call_args[0]
+    assert args[0] is bq and args[1] == "ok1" and args[2].startswith("gs://")
+
+
+def test_sync_file_too_large_is_unavailable(monkeypatch):
+    upd = MagicMock(); monkeypatch.setattr(mod, "update_gcs_path", upd)
+    bq = MagicMock()
+    huge = _Row(file_id="big", file_size=mod.MAX_FILE_SIZE + 1)
+    ok, size, unavailable = mod.sync_file(MagicMock(), bq, huge)
+    assert (ok, size, unavailable) == (True, 0, True)
+    upd.assert_called_once_with(bq, "big", "skipped:too_large")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.188.9"
+version = "0.188.10"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

The KJ **Divebar Catalog Status** modal never reached a fully-green/complete state — the GCS-mirror figure was pinned at **99.6% synced** with a permanent "217 pending". Those 217 are Drive files that now **404** (deleted/renamed since indexing); they sat at `gcs_path IS NULL` forever, counted as "pending" *and* re-attempted every nightly sync.

kjbox needs **no change** — its display already renders `>=95%` green and `==100%` "Fully synced". The fix is entirely upstream in gen: make "synced" mean *"everything that can be mirrored is"*.

## Changes

**`infrastructure/scripts/divebar_file_sync.py`**
- Classify download failures: a **404/410** (file gone from Drive) now marks `gcs_path='missing:drive_404'` — a sentinel mirroring the existing `skipped:too_large` — so it drops out of the `WHERE gcs_path IS NULL` worklist (no more nightly re-attempts) and out of "pending". **Transient** errors (5xx/network) still leave `gcs_path` NULL to retry.
- New **"unavailable"** tally in the run summary; progress-log cadence and `get_sync_stats` updated to count only real `gs://` paths as synced.

**`infrastructure/functions/divebar_lookup/main.py` (`_get_full_stats`)**
- `synced` = `COUNTIF(gcs_path LIKE 'gs://%')`; split out an **`unavailable`** bucket (`missing:*`/`skipped:*`); `percent = synced / (total - unavailable)`.
- A fully-caught-up mirror now reports **100%**. Payload also exposes `unavailable`, `unavailable_gb`, `syncable_total` for transparent display.

## Testing
- New `infrastructure/scripts/test_divebar_file_sync.py` (8 tests): 404/410-gone vs transient/5xx classification; each `sync_file` sentinel path (dead-link, transient, success, too-large).
- +4 `_get_full_stats` percent cases in `divebar_lookup/test_main.py` (100% when no pending; pending holds <100%; unavailable excluded from denominator; zero-syncable guard). 23/23 pass.
- Stats SQL validated read-only against prod: `gcs_unavailable=1` today; `percent → 100` once the sync marks the 217 dead links.
- CodeRabbit: 2 cycles → 0 findings.

## Rollout
- `divebar-lookup` deploys via `pulumi up` (run locally before merge).
- `divebar_file_sync.py` deploys via the sync VM's `git pull origin main` on its next run; the first post-merge sync marks the 217 dead links, after which the modal shows **100% "Fully synced" (green)**.

@coderabbitai ignore