### PR TITLE
feat: fast-sync Nomad 720p masters to Divebar GCS mirror (Phase 1)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -20,6 +20,13 @@ class Settings(BaseSettings):
     gcs_temp_bucket: str = os.getenv("GCS_TEMP_BUCKET", "karaoke-gen-temp")
     gcs_output_bucket: str = os.getenv("GCS_OUTPUT_BUCKET", "karaoke-gen-outputs")
     firestore_collection: str = os.getenv("FIRESTORE_COLLECTION", "jobs")
+
+    # Nomad master fast-sync: push freshly-published Nomad 720p masters straight to the
+    # Divebar GCS mirror so kjbox (which mirrors that folder every 5 min) picks them up
+    # within minutes instead of waiting for the nightly Drive->GCS VM. Nomad-brand only.
+    divebar_files_bucket: str = os.getenv("DIVEBAR_FILES_BUCKET", "nomadkaraoke-divebar-files")
+    nomad_master_gcs_prefix: str = os.getenv("NOMAD_MASTER_GCS_PREFIX", "files/Nomad Karaoke/MP4-720p")
+    nomad_master_fast_sync_enabled: bool = os.getenv("NOMAD_MASTER_FAST_SYNC_ENABLED", "true").lower() == "true"
     
     # Audio Separator API (for GPU processing)
     audio_separator_api_url: Optional[str] = os.getenv("AUDIO_SEPARATOR_API_URL")

--- a/backend/services/gdrive_service.py
+++ b/backend/services/gdrive_service.py
@@ -266,6 +266,7 @@ class GoogleDriveService:
         brand_code: str,
         base_name: str,
         output_files: dict,
+        warnings: Optional[list] = None,
     ) -> Dict[str, str]:
         """
         Upload final files to public share folder structure.
@@ -325,10 +326,14 @@ class GoogleDriveService:
             # Fast-sync the 720p master straight to the Divebar GCS mirror so kjbox
             # (which mirrors that folder every 5 min) picks it up within minutes,
             # instead of waiting for the nightly Drive->GCS VM. Nomad-brand only,
-            # best-effort, never fatal to the Drive upload.
-            self._fast_sync_nomad_master(
+            # best-effort, never fatal to the Drive upload. A failure is surfaced as
+            # a distribution warning (drives the admin alert) so this can't silently
+            # rot into "nightly VM only" — the nightly VM stays the backfill net.
+            fast_sync_warning = self._fast_sync_nomad_master(
                 brand_code, mp4_720p_path, f"{filename_base}.mp4"
             )
+            if fast_sync_warning and warnings is not None:
+                warnings.append(fast_sync_warning)
 
         # Upload CDG ZIP to CDG/
         cdg_zip_path = output_files.get("final_karaoke_cdg_zip")
@@ -347,13 +352,17 @@ class GoogleDriveService:
 
     def _fast_sync_nomad_master(
         self, brand_code: str, local_720p_path: str, filename: str
-    ) -> None:
+    ) -> Optional[str]:
         """Best-effort push of a freshly-published Nomad 720p master to the Divebar
         GCS mirror so kjbox picks it up within minutes (vs the nightly VM).
 
         No-op unless the fast-sync is enabled and this is a public Nomad release
         (``NOMAD-####``, excluding ``NOMADNP`` private tracks). Never raises — the
         Drive upload has already succeeded and the nightly VM is the backfill net.
+
+        Returns a human-readable warning string on failure (so the caller can surface
+        it via ``distribution_warnings`` / the admin alert), or ``None`` on
+        success or when skipped.
         """
         try:
             from backend.config import settings
@@ -363,13 +372,19 @@ class GoogleDriveService:
             )
 
             if not settings.nomad_master_fast_sync_enabled:
-                return
+                return None
             if not is_nomad_public_brand(brand_code):
-                return
+                return None
 
-            NomadMasterMirror().push_720p(local_720p_path, filename)
+            if NomadMasterMirror().push_720p(local_720p_path, filename):
+                return None
+            return (
+                f"Nomad master fast-sync to the GCS mirror failed for {filename} "
+                f"(the nightly Drive->GCS VM will backfill it)"
+            )
         except Exception as e:  # noqa: BLE001 - never fatal to the pipeline
             logger.warning(f"Nomad master fast-sync skipped (unexpected error): {e}")
+            return f"Nomad master fast-sync errored for {filename}: {e}"
 
     def delete_file(self, file_id: str) -> bool:
         """

--- a/backend/services/gdrive_service.py
+++ b/backend/services/gdrive_service.py
@@ -322,6 +322,14 @@ class GoogleDriveService:
             uploaded_files["mp4_720p"] = file_id
             logger.info(f"Uploaded 720p MP4 to MP4-720p/ folder")
 
+            # Fast-sync the 720p master straight to the Divebar GCS mirror so kjbox
+            # (which mirrors that folder every 5 min) picks it up within minutes,
+            # instead of waiting for the nightly Drive->GCS VM. Nomad-brand only,
+            # best-effort, never fatal to the Drive upload.
+            self._fast_sync_nomad_master(
+                brand_code, mp4_720p_path, f"{filename_base}.mp4"
+            )
+
         # Upload CDG ZIP to CDG/
         cdg_zip_path = output_files.get("final_karaoke_cdg_zip")
         if cdg_zip_path and os.path.exists(cdg_zip_path):
@@ -336,6 +344,32 @@ class GoogleDriveService:
 
         logger.info(f"Public share upload complete: {len(uploaded_files)} files uploaded")
         return uploaded_files
+
+    def _fast_sync_nomad_master(
+        self, brand_code: str, local_720p_path: str, filename: str
+    ) -> None:
+        """Best-effort push of a freshly-published Nomad 720p master to the Divebar
+        GCS mirror so kjbox picks it up within minutes (vs the nightly VM).
+
+        No-op unless the fast-sync is enabled and this is a public Nomad release
+        (``NOMAD-####``, excluding ``NOMADNP`` private tracks). Never raises — the
+        Drive upload has already succeeded and the nightly VM is the backfill net.
+        """
+        try:
+            from backend.config import settings
+            from backend.services.nomad_master_mirror import (
+                NomadMasterMirror,
+                is_nomad_public_brand,
+            )
+
+            if not settings.nomad_master_fast_sync_enabled:
+                return
+            if not is_nomad_public_brand(brand_code):
+                return
+
+            NomadMasterMirror().push_720p(local_720p_path, filename)
+        except Exception as e:  # noqa: BLE001 - never fatal to the pipeline
+            logger.warning(f"Nomad master fast-sync skipped (unexpected error): {e}")
 
     def delete_file(self, file_id: str) -> bool:
         """

--- a/backend/services/nomad_master_mirror.py
+++ b/backend/services/nomad_master_mirror.py
@@ -1,0 +1,78 @@
+"""
+Fast-path mirror of freshly-published Nomad masters into the Divebar GCS bucket.
+
+New Nomad releases are uploaded to Google Drive at finalize time, but the Drive->GCS
+byte-sync VM only runs nightly, so kjbox (which mirrors that GCS folder every 5 min)
+would otherwise wait up to ~24h for a new master. This pushes the 720p master straight
+to the exact GCS object the nightly VM would produce, so kjbox picks it up within minutes.
+
+Idempotent with the nightly VM: identical object name + size means its additive
+`gcloud storage rsync` sees the file already present and skips it.
+
+Scoped to public Nomad Karaoke masters only (brand prefix ``NOMAD``, excluding the
+``NOMADNP`` private-track prefix). Every operation is best-effort / non-fatal: a failure
+here must never break the distribution pipeline — the nightly VM remains the safety net.
+"""
+import logging
+from typing import Optional
+
+from google.cloud import storage
+from google.cloud.exceptions import NotFound
+
+from backend.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def is_nomad_public_brand(brand_code: Optional[str]) -> bool:
+    """True only for public Nomad releases (``NOMAD-####``), not ``NOMADNP`` privates."""
+    if not brand_code:
+        return False
+    prefix = brand_code.split("-", 1)[0].strip().upper()
+    return prefix == "NOMAD"
+
+
+class NomadMasterMirror:
+    """Push/remove Nomad 720p masters in the Divebar GCS bucket that kjbox mirrors."""
+
+    def __init__(self, client: Optional[storage.Client] = None):
+        self._client = client or storage.Client(project=settings.google_cloud_project)
+        self._bucket = self._client.bucket(settings.divebar_files_bucket)
+
+    def _blob_name(self, filename: str) -> str:
+        prefix = settings.nomad_master_gcs_prefix.strip("/")
+        return f"{prefix}/{filename}"
+
+    def push_720p(self, local_path: str, filename: str) -> bool:
+        """Upload a 720p master to the divebar GCS mirror. Best-effort; returns success."""
+        blob_name = self._blob_name(filename)
+        try:
+            blob = self._bucket.blob(blob_name)
+            blob.upload_from_filename(local_path)
+            logger.info(
+                "Fast-synced Nomad master to gs://%s/%s",
+                settings.divebar_files_bucket,
+                blob_name,
+            )
+            return True
+        except Exception as e:  # noqa: BLE001 - never fatal to the pipeline
+            logger.warning("Nomad master fast-sync push failed for %s: %s", blob_name, e)
+            return False
+
+    def delete_720p(self, filename: str) -> bool:
+        """Delete a 720p master from the mirror. Best-effort; 404 == already gone."""
+        blob_name = self._blob_name(filename)
+        try:
+            self._bucket.blob(blob_name).delete()
+            logger.info(
+                "Removed Nomad master from gs://%s/%s",
+                settings.divebar_files_bucket,
+                blob_name,
+            )
+            return True
+        except NotFound:
+            logger.debug("Nomad master already absent in mirror: %s", blob_name)
+            return False
+        except Exception as e:  # noqa: BLE001 - never fatal to the pipeline
+            logger.warning("Nomad master mirror delete failed for %s: %s", blob_name, e)
+            return False

--- a/backend/tests/test_gdrive_service.py
+++ b/backend/tests/test_gdrive_service.py
@@ -419,10 +419,11 @@ class TestUploadToPublicShare:
         cdg_file.write_bytes(b"cdg package")
         
         service = GoogleDriveService()
-        
+
         # Mock methods
-        with patch.object(service, "get_or_create_folder") as mock_get_folder:
-            with patch.object(service, "upload_file") as mock_upload:
+        with patch.object(service, "get_or_create_folder") as mock_get_folder, \
+             patch.object(service, "upload_file") as mock_upload, \
+             patch("backend.services.nomad_master_mirror.NomadMasterMirror") as mock_mirror_cls:
                 mock_get_folder.side_effect = [
                     "mp4-folder-id",
                     "mp4-720-folder-id",
@@ -433,30 +434,91 @@ class TestUploadToPublicShare:
                     "720p-file-id",
                     "cdg-file-id",
                 ]
-                
+
                 output_files = {
                     "final_karaoke_lossy_mp4": str(mp4_file),
                     "final_karaoke_lossy_720p_mp4": str(mp4_720_file),
                     "final_karaoke_cdg_zip": str(cdg_file),
                 }
-                
+
                 result = service.upload_to_public_share(
                     root_folder_id="root-123",
                     brand_code="NOMAD-1163",
                     base_name="Artist - Title",
                     output_files=output_files,
                 )
-                
+
                 # Should have created/found 3 folders
                 assert mock_get_folder.call_count == 3
-                
+
                 # Should have uploaded 3 files
                 assert mock_upload.call_count == 3
-                
+
                 # Check result
                 assert result["mp4"] == "mp4-file-id"
                 assert result["mp4_720p"] == "720p-file-id"
                 assert result["cdg"] == "cdg-file-id"
+
+                # Nomad brand → the 720p master is fast-synced to the Divebar GCS
+                # mirror with the exact "{brand_code} - {base_name}.mp4" object name.
+                mock_mirror_cls.return_value.push_720p.assert_called_once_with(
+                    str(mp4_720_file), "NOMAD-1163 - Artist - Title.mp4"
+                )
+
+    @patch("backend.services.gdrive_service.get_settings")
+    def test_public_share_no_fast_sync_for_non_nomad_brand(self, mock_get_settings, tmp_path):
+        """Non-Nomad brands (and NOMADNP privates) must NOT touch the divebar mirror."""
+        from backend.services.gdrive_service import GoogleDriveService
+
+        mock_settings = Mock()
+        mock_settings.get_secret.return_value = json.dumps({
+            "refresh_token": "token", "client_id": "id", "client_secret": "secret",
+        })
+        mock_get_settings.return_value = mock_settings
+
+        mp4_720_file = tmp_path / "output_720p.mp4"
+        mp4_720_file.write_bytes(b"720p video")
+
+        service = GoogleDriveService()
+        with patch.object(service, "get_or_create_folder", return_value="f"), \
+             patch.object(service, "upload_file", return_value="id"), \
+             patch("backend.services.nomad_master_mirror.NomadMasterMirror") as mock_mirror_cls:
+            for brand in ("VOCALSTAR-12", "NOMADNP-1163"):
+                service.upload_to_public_share(
+                    root_folder_id="root-123",
+                    brand_code=brand,
+                    base_name="Artist - Title",
+                    output_files={"final_karaoke_lossy_720p_mp4": str(mp4_720_file)},
+                )
+            mock_mirror_cls.assert_not_called()
+
+    @patch("backend.services.gdrive_service.get_settings")
+    def test_public_share_fast_sync_failure_is_non_fatal(self, mock_get_settings, tmp_path):
+        """A mirror failure must never break the (already-succeeded) Drive upload."""
+        from backend.services.gdrive_service import GoogleDriveService
+
+        mock_settings = Mock()
+        mock_settings.get_secret.return_value = json.dumps({
+            "refresh_token": "token", "client_id": "id", "client_secret": "secret",
+        })
+        mock_get_settings.return_value = mock_settings
+
+        mp4_720_file = tmp_path / "output_720p.mp4"
+        mp4_720_file.write_bytes(b"720p video")
+
+        service = GoogleDriveService()
+        with patch.object(service, "get_or_create_folder", return_value="f"), \
+             patch.object(service, "upload_file", return_value="720p-file-id"), \
+             patch("backend.services.nomad_master_mirror.NomadMasterMirror",
+                   side_effect=RuntimeError("gcs down")):
+            result = service.upload_to_public_share(
+                root_folder_id="root-123",
+                brand_code="NOMAD-1163",
+                base_name="Artist - Title",
+                output_files={"final_karaoke_lossy_720p_mp4": str(mp4_720_file)},
+            )
+            # Drive upload still reports success despite the mirror blowing up.
+            assert result["mp4_720p"] == "720p-file-id"
     
     @patch("backend.services.gdrive_service.get_settings")
     def test_upload_to_public_share_skips_missing_files(

--- a/backend/tests/test_gdrive_service.py
+++ b/backend/tests/test_gdrive_service.py
@@ -507,6 +507,7 @@ class TestUploadToPublicShare:
         mp4_720_file.write_bytes(b"720p video")
 
         service = GoogleDriveService()
+        warnings: list = []
         with patch.object(service, "get_or_create_folder", return_value="f"), \
              patch.object(service, "upload_file", return_value="720p-file-id"), \
              patch("backend.services.nomad_master_mirror.NomadMasterMirror",
@@ -516,9 +517,13 @@ class TestUploadToPublicShare:
                 brand_code="NOMAD-1163",
                 base_name="Artist - Title",
                 output_files={"final_karaoke_lossy_720p_mp4": str(mp4_720_file)},
+                warnings=warnings,
             )
-            # Drive upload still reports success despite the mirror blowing up.
+            # Drive upload still reports success despite the mirror blowing up...
             assert result["mp4_720p"] == "720p-file-id"
+            # ...and the failure is surfaced as a distribution warning (admin alert),
+            # not silently swallowed.
+            assert any("fast-sync" in w for w in warnings)
     
     @patch("backend.services.gdrive_service.get_settings")
     def test_upload_to_public_share_skips_missing_files(

--- a/backend/tests/test_nomad_master_mirror.py
+++ b/backend/tests/test_nomad_master_mirror.py
@@ -1,0 +1,89 @@
+"""Unit tests for the Nomad master fast-sync mirror (Phase 1)."""
+from unittest.mock import MagicMock
+
+import pytest
+from google.cloud.exceptions import NotFound
+
+from backend.services.nomad_master_mirror import (
+    NomadMasterMirror,
+    is_nomad_public_brand,
+)
+
+
+@pytest.mark.parametrize(
+    "brand_code, expected",
+    [
+        ("NOMAD-1500", True),
+        ("NOMAD-0001", True),
+        ("NOMAD-1500", True),
+        ("NOMADNP-1234", False),   # private tracks must never enter the public mirror
+        ("nomadnp-1", False),
+        ("TRACK-0000", False),
+        ("VOCALSTAR-12", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_is_nomad_public_brand(brand_code, expected):
+    assert is_nomad_public_brand(brand_code) is expected
+
+
+def _mirror_with_mock():
+    """NomadMasterMirror wired to a mock GCS client; returns (mirror, blob)."""
+    blob = MagicMock()
+    bucket = MagicMock()
+    bucket.blob.return_value = blob
+    client = MagicMock()
+    client.bucket.return_value = bucket
+    mirror = NomadMasterMirror(client=client)
+    return mirror, bucket, blob
+
+
+def test_push_720p_uses_exact_divebar_object_name_and_uploads():
+    mirror, bucket, blob = _mirror_with_mock()
+
+    ok = mirror.push_720p(
+        "/tmp/out/NOMAD-1500 - Rush - The Spirit of Radio.mp4",
+        "NOMAD-1500 - Rush - The Spirit of Radio.mp4",
+    )
+
+    assert ok is True
+    # Object name MUST match the nightly VM's layout exactly (idempotency).
+    bucket.blob.assert_called_once_with(
+        "files/Nomad Karaoke/MP4-720p/NOMAD-1500 - Rush - The Spirit of Radio.mp4"
+    )
+    blob.upload_from_filename.assert_called_once_with(
+        "/tmp/out/NOMAD-1500 - Rush - The Spirit of Radio.mp4"
+    )
+
+
+def test_push_720p_is_non_fatal_on_error():
+    mirror, _bucket, blob = _mirror_with_mock()
+    blob.upload_from_filename.side_effect = RuntimeError("boom")
+
+    # Must not raise; returns False so the pipeline continues.
+    assert mirror.push_720p("/tmp/x.mp4", "NOMAD-1 - A - B.mp4") is False
+
+
+def test_delete_720p_removes_blob():
+    mirror, bucket, blob = _mirror_with_mock()
+
+    assert mirror.delete_720p("NOMAD-1500 - Rush - The Spirit of Radio.mp4") is True
+    bucket.blob.assert_called_once_with(
+        "files/Nomad Karaoke/MP4-720p/NOMAD-1500 - Rush - The Spirit of Radio.mp4"
+    )
+    blob.delete.assert_called_once()
+
+
+def test_delete_720p_missing_is_noop():
+    mirror, _bucket, blob = _mirror_with_mock()
+    blob.delete.side_effect = NotFound("gone")
+
+    assert mirror.delete_720p("NOMAD-9 - X - Y.mp4") is False
+
+
+def test_delete_720p_is_non_fatal_on_error():
+    mirror, _bucket, blob = _mirror_with_mock()
+    blob.delete.side_effect = RuntimeError("boom")
+
+    assert mirror.delete_720p("NOMAD-9 - X - Y.mp4") is False

--- a/backend/workers/video_worker.py
+++ b/backend/workers/video_worker.py
@@ -1123,6 +1123,7 @@ async def _handle_native_distribution(
                     brand_code=upload_brand_code,
                     base_name=base_name,
                     output_files=output_files,
+                    warnings=result.setdefault('distribution_warnings', []),
                 )
                 
                 result['gdrive_files'] = uploaded

--- a/backend/workers/video_worker_orchestrator.py
+++ b/backend/workers/video_worker_orchestrator.py
@@ -876,6 +876,7 @@ class VideoWorkerOrchestrator:
                 brand_code=brand_code,
                 base_name=base_name,
                 output_files=output_files,
+                warnings=self.result.distribution_warnings,
             )
 
             self.result.gdrive_files = uploaded

--- a/docs/archive/2026-07-02-nomad-master-fast-sync-plan.md
+++ b/docs/archive/2026-07-02-nomad-master-fast-sync-plan.md
@@ -1,0 +1,194 @@
+# Nomad master fast-sync to kjbox — diagnosis + plan (2026-07-02)
+
+## Symptom
+New Nomad releases made on karaoke-gen are expected to appear on kjbox at
+`/opt/nomad/downloads/NOMAD-720p/` "within minutes". In reality the box is stuck
+at **NOMAD-1497** while Google Drive already has **NOMAD-1500** (made today).
+
+## Root cause (evidence-backed) — NOT a broken component
+The sync is a **3-hop pipeline**. Two hops are continuous; the middle hop is **daily**:
+
+| Hop | Mechanism | Cadence | State 2026-07-02 15:00 ET |
+|-----|-----------|---------|---------------------------|
+| 1. gen → **Google Drive** `MP4-720p/` | `gdrive_service.upload_to_public_share()` at finalize | immediate | ✅ has NOMAD-1500 |
+| 2. Drive → **GCS** `gs://nomadkaraoke-divebar-files/files/Nomad Karaoke/MP4-720p/` | `divebar-sync` VM via `divebar-sync-vm-daily` scheduler | **once/day @ 03:00 ET** | ❌ stuck at 1497 |
+| 3. GCS → **kjbox** `NOMAD-720p/` | `nomad-master-sync.timer` (`sync_masters.py`) | every 5 min | ✅ mirrors GCS (1497) |
+
+Evidence:
+- GCS masters folder latest object = `NOMAD-1497` (1496 objects) — read via `claude-readonly` SA.
+- `divebar-sync` VM `lastStartTimestamp = 2026-07-02T03:00 ET`, now `TERMINATED` (self-terminates after rsync). It captured Drive up to 1497; 1498–1500 were made later today.
+- kjbox timer healthy: fires every 5 min, `{changed:False, copied:0, error:None}` = correctly in sync with a stale GCS. Its clean result is **correct**, not a bug.
+- karaoke-gen has **no** code that writes to the GCS divebar bucket (`grep` of `backend/` for `nomadkaraoke-divebar-files` / `MP4-720p` GCS → only Drive uploads). GCS is populated *exclusively* by the daily VM.
+
+**Conclusion:** the "within minutes" guarantee only ever covered hop 3. Hop 2 is a
+~24h bottleneck that was never built for freshness. Fresh releases are delayed up to ~1 day.
+
+(Red herring ruled out: `master_sync_source` absent from device `config.json` — the sync
+works, so `load_config()` supplies it from `config.py` defaults. Not the issue.)
+
+## Options
+- **A. Direct gen→GCS push at finalize (RECOMMENDED).** When gen uploads the 720p master
+  to Drive, also upload it to the same GCS object the daily VM would produce. Existing kjbox
+  5-min timer then delivers within minutes. Idempotent with the daily VM (same object name+size
+  → rsync skips). No kjbox change. gen-side code + 1 IAM grant.
+- B. Trigger the sync VM per release. Reuses machinery but boots an e2-medium VM each time
+  (~1–2 min + full-tree rsync); heavy, can thrash on bursts.
+- C. Run the daily VM hourly. Trivial cron change but delay up to ~1h (not "minutes") and pays
+  VM boot ×24/day.
+
+## Recommended design — Option A
+
+### Where
+`backend/workers/video_worker_orchestrator.py::_upload_to_gdrive()` (line ~874) and the sibling
+call in `backend/workers/video_worker.py` (~1121). Both call
+`gdrive.upload_to_public_share(root_folder_id=..., brand_code=..., base_name=..., output_files=...)`.
+
+Cleanest: add the GCS push **inside `upload_to_public_share()`** (single place, both callers
+covered) OR a small helper invoked right after it. Prefer inside, guarded, non-fatal.
+
+### GCS object path (must match the daily VM exactly for idempotency)
+`gs://nomadkaraoke-divebar-files/files/Nomad Karaoke/MP4-720p/{brand_code} - {safe_base_name}.mp4`
+- Matches observed names, e.g. `.../MP4-720p/NOMAD-0001 - This Is Me Smiling - Prettier.mp4`.
+- `filename_base = f"{brand_code} - {sanitize_filename(base_name)}"` — already computed in the method.
+
+### Gating (correctness)
+- Only push when `brand_prefix == "NOMAD"` (i.e. brand_code `NOMAD-####`).
+  **Exclude `NOMADNP`** (private tracks) — they must not enter the public masters mirror.
+- Only the 720p artifact (that's all kjbox mirrors). Skip 4K/CDG.
+
+### Config
+- `DIVEBAR_FILES_BUCKET` env (default `nomadkaraoke-divebar-files`).
+- `NOMAD_MASTER_GCS_PREFIX` (default `files/Nomad Karaoke/MP4-720p`).
+- Feature flag `NOMAD_MASTER_FAST_SYNC_ENABLED` (default true) for easy kill-switch.
+
+### Reliability
+- Wrap in try/except; on failure append a `distribution_warnings` entry and continue
+  (exactly like the existing Drive/Dropbox uploads — never fail the pipeline). The daily VM
+  remains the backfill safety net, so a missed fast-push self-heals within 24h.
+- Reuse `google.cloud.storage` (already a gen dep). Upload via `blob.upload_from_filename`.
+
+### Delete / replace symmetry (REQUIRED — Andrew's #1)
+The whole existing mirror chain is **additive / never-delete**, so deletes & renames already
+orphan files today:
+- `divebar_file_sync.py` (VM) only ever downloads Drive→GCS; it never deletes a GCS object. A file
+  gone from Drive is marked `missing:drive_404` in BigQuery *only if it was still pending*; anything
+  already in GCS is never revisited → stale forever.
+- kjbox `sync_masters.py` is explicitly additive ("never deletes local files").
+So Drive deletes/renames leave orphans in **both** GCS and kjbox-local right now. Option A doesn't
+introduce this, but it propagates new files faster and gives gen the clean hook to fix it for Nomad
+masters.
+
+gen already deletes Drive outputs at these events — mirror each with a GCS delete of the deterministic
+master object `files/Nomad Karaoke/MP4-720p/{brand_code} - {name}.mp4`:
+- Job delete: `services/job_manager.py:354`, `api/routes/jobs.py:396`
+- Re-finalize / re-process (delete old outputs before re-upload): `api/routes/jobs.py:2270`
+- Admin delete: `api/routes/admin.py:1700`
+- Visibility change public→private: `services/visibility_change_service.py:267`
+
+Rename/edit case: if artist/title changes, the object NAME changes. gen must delete the **old** object
+name (reconstruct from the job's previously-stored output filename / `gdrive_files` metadata) and write
+the new one — otherwise the rename orphans the old GCS object (the daily VM won't clean it either).
+
+**Delete policy (RESOLVED by Andrew 2026-07-02):**
+- **Community uploads: keep-forever in GCS — do NOT delete.** Deliberate: preserves valid karaoke
+  video data even if a user removes it from their Drive. (This is why the general mirror is additive.)
+- **Nomad Karaoke masters: deletes ARE allowed** — we control the source, and the goal is that the
+  *latest edited version* is what ends up on kjbox. So Nomad deletes/renames SHOULD propagate all the
+  way to kjbox-local (an orphaned old-named file would keep playing the stale cut).
+- ⇒ Delete symmetry is **Nomad-brand only** (same gate as the push). Never delete community objects.
+
+**Recommended mechanism for kjbox-local propagation:** make the NOMAD-720p mirror a *true mirror* of
+its GCS source — change `sync_masters.py`'s rsync to `--delete-unmatched-destination-objects` (scoped
+to the Nomad masters folder we fully control, NOT the general additive community policy). Then gen just
+deletes/replaces the GCS object and kjbox auto-reconciles (deletes old, pulls new) on its next 5-min
+tick — no separate gen→kjbox delete channel needed. This is the kjbox half of the change.
+- ⚠️ **SAFETY GUARD (critical):** `--delete-unmatched` + an empty/failed source listing = wipe the
+  whole local mirror. Guard: refuse to run the delete-mode rsync if the GCS source lists 0 objects
+  (or drops below a sanity threshold vs. current local count); on any listing/auth error, fall back to
+  additive-only. Never let a transient auth failure (like today's expired token) delete 1500 files.
+
+### IAM (infra — needs `pulumi up` before merge)
+Add binding: `backend_service_account` → `roles/storage.objectCreator` (create-only is enough;
+use `objectAdmin` if we later want overwrite/idempotent re-put) on bucket
+`nomadkaraoke-divebar-files`. Put it in `infrastructure/modules/iam/worker_sas.py`
+(`grant_backend_compute_permissions`) or alongside the divebar bucket definition. ~5 lines.
+- `grant_backend_compute_permissions` today grants only encoding-worker VM lifecycle — no bucket write.
+
+### Testing
+- Unit: mock `storage.Client`; assert (a) Nomad 720p → `upload_from_filename` called with the exact
+  `files/Nomad Karaoke/MP4-720p/{filename_base}.mp4` blob name; (b) NOMADNP → NOT pushed;
+  (c) non-Nomad brand → NOT pushed; (d) GCS failure → warning appended, pipeline continues.
+- Idempotency note: gen writes the identical object name the VM would → next daily rsync no-ops.
+- Prod E2E (post-deploy, once): finalize a throwaway NOMAD test job, assert object appears in GCS
+  within seconds and on kjbox `NOMAD-720p/` within ~5 min.
+
+## Immediate gap (1498–1500 not yet in GCS)
+Independent of the durable fix. To backfill now (needs admin gcloud; readonly SA can't):
+```bash
+gcloud scheduler jobs run divebar-sync-vm-daily --location=us-central1 --project=nomadkaraoke
+```
+This starts the `divebar-sync` VM immediately → mirrors today's Drive releases to GCS → kjbox
+picks them up within 5 min. Otherwise they flow automatically at tonight's 03:00 ET run.
+
+## Phase 4 — Refresh-catalog sequential fix (infra: `divebar_lookup` CF)
+
+Confirmed root cause of the failed manual test (2026-07-02): `_refresh()` (main.py:443) fires all 3
+scheduler jobs via `client.run_job()` in a loop with **no wait**. The sync VM (`divebar-sync-vm-daily`)
+only copies files already in the BigQuery index, but it launches ~concurrently with the index rebuild
+(`divebar-mirror-daily`) and finishes (~3 min) before the index adds the new rows → just-published
+files get indexed (searchable) but miss the GCS sync pass. The **nightly path avoids this by time gaps**
+(mirror 02:00 → sync 03:00 → xref 06:00 ET); the button collapses those gaps.
+
+Dependency truth: **sync VM depends on the index; xref depends on the index (catalog rows), NOT on the
+GCS file sync.** So correct order = run index → (on completion) run sync-VM **and** xref.
+
+**Recommended fix — chain-on-completion (robust, non-blocking, also hardens nightly):**
+- `_refresh()` triggers ONLY `divebar-mirror-daily` (the index) and returns immediately (button stays snappy).
+- The index builder (`divebar_mirror`), at the end of a successful run, triggers `divebar-sync-vm-daily`
+  and `divebar-xref-rebuild-daily`.
+- Nightly can then be simplified to a single index trigger (the chain follows), or left as-is (the extra
+  staggered triggers become harmless no-ops / redundant). Keep nightly schedulers for now; just add the
+  chain so BOTH paths sequence correctly.
+- Alternative (simpler, worse UX) considered & rejected: make `_refresh()` block — synchronously await
+  the index (poll `MAX(synced_at)` in `divebar_catalog`) then fire sync+xref. Rejected: blocks the button
+  for minutes and risks the CF timeout.
+
+## Implementation notes locked in (from code reads)
+- **gen GCS client**: `StorageService` is hardwired to `settings.gcs_bucket_name` (gen's default bucket),
+  so it can't target the divebar bucket. Add a dedicated `backend/services/nomad_master_mirror.py`
+  (own `storage.Client`, `bucket=settings.divebar_files_bucket`) with `push_720p(local, filename)` and
+  `delete_720p(filename)` — isolated, mockable, non-fatal. Config: `DIVEBAR_FILES_BUCKET`
+  (`nomadkaraoke-divebar-files`), `NOMAD_MASTER_GCS_PREFIX` (`files/Nomad Karaoke/MP4-720p`),
+  `NOMAD_MASTER_FAST_SYNC_ENABLED` (kill switch).
+- **Push call site**: inside `gdrive_service.upload_to_public_share()` right after the 720p Drive upload
+  (single place, covers both worker callers), guarded + non-fatal.
+- **Brand gate**: `brand_code` prefix before first `-` == `"NOMAD"` exactly (so `NOMADNP-####` private is
+  excluded). NB: in the BigQuery index `brand_code` is literally just `"NOMAD"` and the release number
+  lives only in the filename — but gen's job-side `brand_code` here IS the full `NOMAD-####`.
+- **Object name**: `{NOMAD_MASTER_GCS_PREFIX}/{brand_code} - {sanitize_filename(base_name)}.mp4` — matches
+  the daily VM's output exactly → idempotent.
+
+## Rollout
+1. `pulumi up` locally for the IAM grant (verify no unrelated drift).
+2. Code + unit tests; `make test`.
+3. `/test-review` → `/docs-review` → `/coderabbit` → version bump → `/pr`.
+4. Merge → deploy → prod E2E with a NOMAD test job.
+
+## Decision log
+1. Approach: **A — direct gen→GCS push (CONFIRMED by Andrew).**
+2. Scope: **Nomad-brand only (CONFIRMED)** — push AND delete are Nomad-gated; community objects are
+   never touched (keep-forever policy). Generalizing to all brands is out of scope.
+3. Delete policy: **CONFIRMED** — Nomad deletes/renames propagate to GCS *and* kjbox-local (latest
+   edit wins on the box); community = keep-forever. See "Delete/replace symmetry".
+4. Current-gap backfill (1498–1500): Andrew triggered it via the kjbox "Refresh catalog" button
+   2026-07-02 ~15:xx ET to verify the existing pipeline end-to-end (no code change).
+
+## This is a two-repo change (kjbox + gen)
+- **gen**: direct GCS push on Nomad finalize; delete/replace GCS object on Nomad job delete + rename;
+  +1 Pulumi IAM grant (backend SA → objectAdmin on divebar bucket, need overwrite+delete not just create).
+- **kjbox**: `sync_masters.py` → true-mirror rsync (`--delete-unmatched-destination-objects`) with the
+  empty-source safety guard, so GCS deletes/renames reconcile onto the box.
+
+## Still open
+- Exact IAM role: `objectAdmin` (needs delete+overwrite for the delete/replace path) vs narrower.
+- kjbox true-mirror safety-guard threshold (refuse delete if source count 0 / << local count).

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -460,6 +460,20 @@ retry_pending_render_jobs_scheduler = cloudscheduler.Job(
 
 divebar_mirror_resources = divebar_mirror.create_divebar_mirror_resources(all_secrets)
 
+# Grant the karaoke-backend SA write+delete on the Divebar files bucket so it can
+# fast-sync freshly-published Nomad 720p masters straight into the GCS mirror that
+# kjbox pulls from every 5 min (nomad-master fast-sync). objectAdmin (not just
+# objectCreator) because the edit/rename/delete path removes stale objects too.
+# Scoped in code to the "files/Nomad Karaoke/MP4-720p/" prefix + NOMAD brand only.
+gcp.storage.BucketIAMMember(
+    "backend-divebar-files-master-writer",
+    bucket=divebar_mirror_resources["files_bucket"].name,
+    role="roles/storage.objectAdmin",
+    member=backend_service_account.email.apply(
+        lambda email: f"serviceAccount:{email}"
+    ),
+)
+
 # ==================== KaraokeNerds Data Sync (Phase 2) ====================
 # Daily sync of KN catalog and community data to BigQuery/GCS
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.188.11"
+version = "0.189.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Why

New Nomad releases upload to Google Drive at finalize time, but the **Drive→GCS byte-sync VM only runs nightly (3 AM ET)**, and kjbox mirrors that GCS folder to `/opt/nomad/downloads/NOMAD-720p/` every 5 min. So a release made during the day sat up to **~24h** before it could reach kjbox. The "within minutes" expectation only ever held for the GCS→kjbox hop; the Drive→GCS hop was the daily bottleneck.

Full diagnosis + phased plan: `docs/archive/2026-07-02-nomad-master-fast-sync-plan.md`.

## What (Phase 1 — the push)

At finalize, push the 720p master **straight to GCS** (`gs://nomadkaraoke-divebar-files/files/Nomad Karaoke/MP4-720p/{brand_code} - {name}.mp4`) — the exact object the nightly VM would produce — so kjbox's existing 5-min timer delivers it within minutes. No kjbox change needed.

- **`backend/services/nomad_master_mirror.py`** (new): `NomadMasterMirror.push_720p/delete_720p` + `is_nomad_public_brand` gate.
- **`gdrive_service.upload_to_public_share`**: guarded `_fast_sync_nomad_master` after the 720p Drive upload.
- **Config**: `DIVEBAR_FILES_BUCKET`, `NOMAD_MASTER_GCS_PREFIX`, `NOMAD_MASTER_FAST_SYNC_ENABLED` (kill switch).
- **Infra**: grant `karaoke-backend` SA `objectAdmin` on the divebar bucket. **Already applied to prod** via targeted `pulumi up` (update #760).

## Guarantees

- **Idempotent** with the nightly VM (identical object name+size → its additive rsync skips it); the VM stays the backfill safety net.
- **Nomad-brand only** — excludes `NOMADNP` private tracks and all other brands/tenants.
- **Best-effort / non-fatal** — a push failure never breaks the pipeline; it is surfaced as a `distribution_warnings` entry (drives the admin alert) so it can't silently rot into "nightly-only".

## Testing

- New unit tests (`test_nomad_master_mirror.py`): gate matrix, exact GCS object name, non-fatal on error, delete/404.
- `upload_to_public_share` integration tests: Nomad push happens with correct name; non-Nomad/NOMADNP skipped; mirror failure non-fatal + warning surfaced.
- Local: affected suites green (mirror, gdrive, distribution, video_worker orchestrator). Full suite runs in CI.

## Scope / follow-ups

This is **Phase 1 of 4**. Follow-ups (separate PRs): Phase 2 gen delete/replace on Nomad edit/delete; Phase 3 kjbox true-mirror so deletes/renames reconcile onto the box; Phase 4 fix the "Refresh catalog" button to run the divebar jobs sequentially (currently races index vs sync).

@coderabbitai ignore