### PR TITLE
fix(divebar): make 'Refresh catalog' reliably sync just-published tracks (Phase 4)

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -484,6 +484,19 @@ kn_data_sync_resources = kn_data_sync.create_kn_data_sync_resources(all_secrets)
 
 divebar_lookup_resources = divebar_lookup.create_divebar_lookup_resources(all_secrets)
 
+# The index function (divebar_mirror) chains the index-dependent scheduler jobs
+# (file-sync VM + xref rebuild) on completion, so its SA needs run permission on
+# those jobs — same least-privilege custom role the lookup SA uses for on-demand
+# refresh. Fixes the "Refresh catalog" race (sync VM ran before the index finished).
+gcp.projects.IAMMember(
+    "divebar-mirror-scheduler-runner",
+    project=PROJECT_ID,
+    role=divebar_lookup_resources["scheduler_runner_role"].id,
+    member=divebar_mirror_resources["service_account"].email.apply(
+        lambda email: f"serviceAccount:{email}"
+    ),
+)
+
 # ==================== Divebar File Sync VM ====================
 # Divebar File Sync VM (downloads karaoke files from Drive to GCS)
 divebar_sync_instance = divebar_sync_vm.create_divebar_sync_vm(

--- a/infrastructure/functions/divebar_lookup/main.py
+++ b/infrastructure/functions/divebar_lookup/main.py
@@ -48,12 +48,14 @@ GCP_REGION = os.environ.get("GCP_REGION", "us-central1")
 DATASET = "karaoke_decide"
 REFRESH_SECRET_ID = os.environ.get("DIVEBAR_REFRESH_SECRET_ID", "divebar-refresh-token")
 
-# Cloud Scheduler jobs the `refresh` action force-runs, in pipeline order.
-# Each carries its own OIDC identity/target, so we only need run permission.
+# The `refresh` action force-runs ONLY the index job. The index function chains the
+# index-dependent jobs (file-sync VM + xref rebuild) itself, on completion — see
+# divebar_mirror._trigger_downstream_jobs. Firing all three here concurrently used to
+# race: the sync VM finished before the index had the newly-published rows, so a
+# just-published track was indexed but not byte-synced to GCS until the next nightly
+# run. Chaining from the index's actual completion removes that race.
 REFRESH_SCHEDULER_JOBS = [
-    "divebar-mirror-daily",        # Drive -> BigQuery index (track first appears)
-    "divebar-sync-vm-daily",       # Drive -> GCS file sync (upgrades to fast URL)
-    "divebar-xref-rebuild-daily",  # KN <-> Divebar cross-reference rebuild
+    "divebar-mirror-daily",  # Drive -> BigQuery index; chains sync-VM + xref when done
 ]
 
 

--- a/infrastructure/functions/divebar_lookup/main.py
+++ b/infrastructure/functions/divebar_lookup/main.py
@@ -55,7 +55,11 @@ REFRESH_SECRET_ID = os.environ.get("DIVEBAR_REFRESH_SECRET_ID", "divebar-refresh
 # just-published track was indexed but not byte-synced to GCS until the next nightly
 # run. Chaining from the index's actual completion removes that race.
 REFRESH_SCHEDULER_JOBS = [
-    "divebar-mirror-daily",  # Drive -> BigQuery index; chains sync-VM + xref when done
+    # Refresh-only mirror trigger: its request body sets chain_downstream, so the
+    # index chains the sync-VM + xref itself on completion. (divebar-mirror-daily,
+    # the nightly cron, omits the flag and leaves the standalone nightly sync/xref
+    # schedules alone — so refreshing never double-runs the nightly pipeline.)
+    "divebar-mirror-refresh",
 ]
 
 

--- a/infrastructure/functions/divebar_lookup/test_main.py
+++ b/infrastructure/functions/divebar_lookup/test_main.py
@@ -107,20 +107,24 @@ class TestRefreshTriggers:
         assert len(result["failed"]) == 1
         assert result["failed"][0]["job"] == main.REFRESH_SCHEDULER_JOBS[0]
 
-    def test_refresh_triggers_only_the_index_not_sync_or_xref(self, _reset_scheduler):
+    def test_refresh_triggers_only_the_refresh_mirror_not_sync_or_xref(self, _reset_scheduler):
         # Regression: the file-sync VM and xref rebuild are chained by the index
-        # function on completion (see divebar_mirror._trigger_downstream_jobs).
-        # Triggering them here concurrently raced the sync VM ahead of the index,
-        # so a just-published track was indexed but never byte-synced to GCS until
-        # the next nightly run. Refresh must fire ONLY the index.
-        assert main.REFRESH_SCHEDULER_JOBS == ["divebar-mirror-daily"]
+        # function on completion (see divebar_mirror._trigger_downstream_jobs), NOT
+        # fired here. Firing them here concurrently raced the sync VM ahead of the
+        # index, so a just-published track was indexed but never byte-synced to GCS
+        # until the next nightly run. Refresh must fire ONLY the flag-carrying mirror
+        # trigger, which chains the rest.
+        assert main.REFRESH_SCHEDULER_JOBS == ["divebar-mirror-refresh"]
         assert "divebar-sync-vm-daily" not in main.REFRESH_SCHEDULER_JOBS
         assert "divebar-xref-rebuild-daily" not in main.REFRESH_SCHEDULER_JOBS
+        # Must NOT use the nightly cron job (which omits the chain flag).
+        assert "divebar-mirror-daily" not in main.REFRESH_SCHEDULER_JOBS
 
         main._refresh(TOKEN)
         called_paths = [c.kwargs["name"] for c in _reset_scheduler.run_job.call_args_list]
         assert all("divebar-sync-vm-daily" not in p for p in called_paths)
         assert all("divebar-xref-rebuild-daily" not in p for p in called_paths)
+        assert any("divebar-mirror-refresh" in p for p in called_paths)
 
 
 # ---------------------------------------------------------------------------

--- a/infrastructure/functions/divebar_lookup/test_main.py
+++ b/infrastructure/functions/divebar_lookup/test_main.py
@@ -107,6 +107,21 @@ class TestRefreshTriggers:
         assert len(result["failed"]) == 1
         assert result["failed"][0]["job"] == main.REFRESH_SCHEDULER_JOBS[0]
 
+    def test_refresh_triggers_only_the_index_not_sync_or_xref(self, _reset_scheduler):
+        # Regression: the file-sync VM and xref rebuild are chained by the index
+        # function on completion (see divebar_mirror._trigger_downstream_jobs).
+        # Triggering them here concurrently raced the sync VM ahead of the index,
+        # so a just-published track was indexed but never byte-synced to GCS until
+        # the next nightly run. Refresh must fire ONLY the index.
+        assert main.REFRESH_SCHEDULER_JOBS == ["divebar-mirror-daily"]
+        assert "divebar-sync-vm-daily" not in main.REFRESH_SCHEDULER_JOBS
+        assert "divebar-xref-rebuild-daily" not in main.REFRESH_SCHEDULER_JOBS
+
+        main._refresh(TOKEN)
+        called_paths = [c.kwargs["name"] for c in _reset_scheduler.run_job.call_args_list]
+        assert all("divebar-sync-vm-daily" not in p for p in called_paths)
+        assert all("divebar-xref-rebuild-daily" not in p for p in called_paths)
+
 
 # ---------------------------------------------------------------------------
 # _norm_sql — symmetric normalization for the xref join

--- a/infrastructure/functions/divebar_mirror/main.py
+++ b/infrastructure/functions/divebar_mirror/main.py
@@ -46,10 +46,29 @@ DOWNSTREAM_SCHEDULER_JOBS = [
 ]
 
 
+def _wants_downstream_chain(request) -> bool:
+    """True only when the caller explicitly asked to chain the index-dependent jobs.
+
+    The manual "Refresh catalog" path triggers a dedicated scheduler job whose body
+    sets ``chain_downstream``. The nightly mirror cron does NOT set it, so the nightly
+    pipeline keeps its own staggered sync/xref schedules and we never double-run them.
+    """
+    try:
+        body = request.get_json(silent=True) or {}
+        if isinstance(body, dict) and body.get("chain_downstream"):
+            return True
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        return str(request.args.get("chain_downstream", "")).lower() in ("1", "true", "yes")
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def _trigger_downstream_jobs():
-    """Force-run the index-dependent scheduler jobs. Best-effort: a failure here is
-    logged and reported but never fails the index build itself (the nightly
-    schedulers remain a backstop)."""
+    """Force-run the index-dependent scheduler jobs (file-sync VM + xref rebuild).
+    Best-effort: a failure here is logged and reported but never fails the index
+    build itself."""
     from google.cloud import scheduler_v1
 
     client = scheduler_v1.CloudSchedulerClient()
@@ -127,11 +146,14 @@ def sync_divebar_index(request):
             "total_duration_s": round(total_duration, 1),
         }
 
-        # Chain the index-dependent jobs now that the fresh catalog is loaded. This
-        # runs at the index's actual completion (which can outlast the caller's HTTP
-        # timeout), so a manual "Refresh catalog" reliably syncs just-published files
-        # instead of racing the file-sync VM ahead of the index.
-        result["downstream"] = _trigger_downstream_jobs()
+        # Chain the index-dependent jobs (file-sync VM + xref) ONLY when the caller
+        # asked for it — the manual "Refresh catalog" path. Firing here, at the index's
+        # actual completion (which outlasts the caller's HTTP timeout), is what makes a
+        # refresh reliably sync just-published files instead of racing the sync VM ahead
+        # of the index. The nightly mirror cron doesn't set the flag, so it leaves the
+        # standalone nightly sync/xref schedules to run once — no double-run.
+        if _wants_downstream_chain(request):
+            result["downstream"] = _trigger_downstream_jobs()
 
         logger.info("Sync complete: %s", json.dumps(result))
         return _json_response(result)

--- a/infrastructure/functions/divebar_mirror/main.py
+++ b/infrastructure/functions/divebar_mirror/main.py
@@ -32,6 +32,37 @@ DIVEBAR_FOLDER_ID = os.environ.get(
     "DIVEBAR_FOLDER_ID", "1zxnSZcE03gzy0YVGOdnTrEIi8It_3Wu8"
 )
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "nomadkaraoke")
+GCP_REGION = os.environ.get("GCP_REGION", "us-central1")
+
+# Jobs that depend on a fresh index. Triggered here, at the index build's ACTUAL
+# completion, rather than concurrently by the caller — this fixes the race where the
+# file-sync VM ran before the index had the newly-published rows (so a manual
+# "Refresh catalog" click reliably syncs just-published tracks). Order within the
+# list is not significant: xref reads the catalog (now fresh), the sync VM reads the
+# catalog for pending files (now fresh); neither depends on the other.
+DOWNSTREAM_SCHEDULER_JOBS = [
+    "divebar-sync-vm-daily",       # Drive -> GCS file byte-sync
+    "divebar-xref-rebuild-daily",  # KN <-> Divebar cross-reference rebuild
+]
+
+
+def _trigger_downstream_jobs():
+    """Force-run the index-dependent scheduler jobs. Best-effort: a failure here is
+    logged and reported but never fails the index build itself (the nightly
+    schedulers remain a backstop)."""
+    from google.cloud import scheduler_v1
+
+    client = scheduler_v1.CloudSchedulerClient()
+    triggered, failed = [], []
+    for job in DOWNSTREAM_SCHEDULER_JOBS:
+        job_path = f"projects/{GCP_PROJECT_ID}/locations/{GCP_REGION}/jobs/{job}"
+        try:
+            client.run_job(name=job_path)
+            triggered.append(job)
+        except Exception as e:  # noqa: BLE001 - never fail the index on this
+            logger.warning("Failed to trigger downstream job %s: %s", job, e)
+            failed.append({"job": job, "error": str(e)})
+    return {"triggered": triggered, "failed": failed}
 
 
 def _json_response(data: dict, status: int = 200):
@@ -95,6 +126,12 @@ def sync_divebar_index(request):
             "list_duration_s": round(list_duration, 1),
             "total_duration_s": round(total_duration, 1),
         }
+
+        # Chain the index-dependent jobs now that the fresh catalog is loaded. This
+        # runs at the index's actual completion (which can outlast the caller's HTTP
+        # timeout), so a manual "Refresh catalog" reliably syncs just-published files
+        # instead of racing the file-sync VM ahead of the index.
+        result["downstream"] = _trigger_downstream_jobs()
 
         logger.info("Sync complete: %s", json.dumps(result))
         return _json_response(result)

--- a/infrastructure/functions/divebar_mirror/requirements.txt
+++ b/infrastructure/functions/divebar_mirror/requirements.txt
@@ -5,5 +5,8 @@ google-auth>=2.23.0
 # BigQuery
 google-cloud-bigquery>=3.13.0
 
+# Cloud Scheduler (chain index-dependent jobs on completion)
+google-cloud-scheduler>=2.13.0
+
 # Cloud Functions framework
 functions-framework>=3.0.0

--- a/infrastructure/functions/divebar_mirror/test_main.py
+++ b/infrastructure/functions/divebar_mirror/test_main.py
@@ -80,3 +80,30 @@ def test_index_dependent_jobs_are_the_ones_removed_from_refresh():
         "divebar-sync-vm-daily",
         "divebar-xref-rebuild-daily",
     ]
+
+
+class _Req:
+    """Minimal stand-in for a functions_framework request."""
+
+    def __init__(self, json=None, args=None):
+        self._json = json
+        self.args = args or {}
+
+    def get_json(self, silent=False):
+        return self._json
+
+
+def test_wants_chain_true_from_json_body():
+    assert main._wants_downstream_chain(_Req(json={"chain_downstream": True})) is True
+
+
+def test_wants_chain_from_query_param():
+    assert main._wants_downstream_chain(_Req(args={"chain_downstream": "true"})) is True
+
+
+def test_does_not_chain_when_flag_absent():
+    # The nightly mirror cron sends no flag -> must NOT chain (else it double-runs the
+    # standalone nightly sync/xref schedules).
+    assert main._wants_downstream_chain(_Req(json={})) is False
+    assert main._wants_downstream_chain(_Req(json=None)) is False
+    assert main._wants_downstream_chain(_Req(json={"chain_downstream": False})) is False

--- a/infrastructure/functions/divebar_mirror/test_main.py
+++ b/infrastructure/functions/divebar_mirror/test_main.py
@@ -1,0 +1,82 @@
+"""
+Tests for divebar_mirror/main.py — focused on the downstream-job chaining that
+fixes the "Refresh catalog" race.
+
+The index build, on completion, force-runs the index-dependent scheduler jobs
+(file-sync VM + xref rebuild). Firing them here — at the index's actual
+completion — rather than concurrently from the caller ensures a just-published
+track is byte-synced to GCS on the same refresh instead of racing the sync VM
+ahead of the index.
+"""
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Stub Cloud Function deps not installed in the test env. functions_framework.http
+# must be an identity decorator so the real entry point stays callable. The local
+# helper modules (drive/index/parser) pull heavy Google client libs at import; stub
+# them since these tests only exercise _trigger_downstream_jobs.
+_functions_framework = MagicMock()
+_functions_framework.http = lambda fn: fn
+_scheduler_mod = MagicMock()
+for name, mod in (
+    ("functions_framework", _functions_framework),
+    ("google.cloud.bigquery", MagicMock()),
+    ("google.cloud.scheduler_v1", _scheduler_mod),
+    ("drive_client", MagicMock()),
+    ("filename_parser", MagicMock()),
+    ("index_builder", MagicMock()),
+):
+    sys.modules.setdefault(name, mod)
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import main  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_scheduler():
+    """Fresh scheduler client mock for each test."""
+    client = MagicMock()
+    _scheduler_mod.CloudSchedulerClient = MagicMock(return_value=client)
+    yield client
+
+
+def test_triggers_both_index_dependent_jobs():
+    # autouse _reset_scheduler fixture patches CloudSchedulerClient (returns success)
+    result = main._trigger_downstream_jobs()
+
+    assert result["triggered"] == [
+        "divebar-sync-vm-daily",
+        "divebar-xref-rebuild-daily",
+    ]
+    assert result["failed"] == []
+
+
+def test_downstream_job_paths_are_fully_qualified(_reset_scheduler):
+    main._trigger_downstream_jobs()
+    called = [c.kwargs["name"] for c in _reset_scheduler.run_job.call_args_list]
+    assert called == [
+        f"projects/{main.GCP_PROJECT_ID}/locations/{main.GCP_REGION}/jobs/divebar-sync-vm-daily",
+        f"projects/{main.GCP_PROJECT_ID}/locations/{main.GCP_REGION}/jobs/divebar-xref-rebuild-daily",
+    ]
+
+
+def test_one_downstream_failure_does_not_block_the_other(_reset_scheduler):
+    _reset_scheduler.run_job.side_effect = [RuntimeError("already running"), None]
+
+    result = main._trigger_downstream_jobs()
+
+    assert result["triggered"] == ["divebar-xref-rebuild-daily"]
+    assert len(result["failed"]) == 1
+    assert result["failed"][0]["job"] == "divebar-sync-vm-daily"
+
+
+def test_index_dependent_jobs_are_the_ones_removed_from_refresh():
+    # These must be chained here, NOT triggered concurrently by the lookup refresh.
+    assert main.DOWNSTREAM_SCHEDULER_JOBS == [
+        "divebar-sync-vm-daily",
+        "divebar-xref-rebuild-daily",
+    ]

--- a/infrastructure/modules/divebar_mirror.py
+++ b/infrastructure/modules/divebar_mirror.py
@@ -174,6 +174,9 @@ def create_divebar_mirror_resources(all_secrets: dict) -> dict:
             environment_variables={
                 "DIVEBAR_FOLDER_ID": DIVEBAR_FOLDER_ID,
                 "GCP_PROJECT_ID": PROJECT_ID,
+                # Region the divebar scheduler jobs live in — the index function
+                # chains the sync-VM + xref jobs (via run_job) on completion.
+                "GCP_REGION": REGION,
             },
         ),
     )

--- a/infrastructure/modules/divebar_mirror.py
+++ b/infrastructure/modules/divebar_mirror.py
@@ -10,6 +10,7 @@ Creates:
 - BigQuery table for the Divebar catalog index
 """
 
+import base64
 from pathlib import Path
 
 import pulumi
@@ -226,5 +227,36 @@ def create_divebar_mirror_resources(all_secrets: dict) -> dict:
         ),
     )
     resources["scheduler"] = scheduler
+
+    # Refresh-only trigger. The manual "Refresh catalog" action force-runs THIS job
+    # (via run_job) instead of divebar-mirror-daily. Its body sets chain_downstream,
+    # so the index — on completion — chains the file-sync VM + xref rebuild, fixing
+    # the race where those ran before the fresh index existed. The nightly mirror cron
+    # omits the flag, so it leaves the standalone nightly sync/xref schedules to run
+    # once (no double-run). The cron below is a parked placeholder (Cloud Scheduler
+    # requires a schedule); this job is driven by run_job, not the clock.
+    refresh_scheduler = cloudscheduler.Job(
+        "divebar-mirror-refresh-scheduler",
+        name="divebar-mirror-refresh",
+        description="On-demand Divebar index refresh that chains the sync VM + xref (run via forceRun)",
+        region=REGION,
+        schedule="0 4 1 1 *",  # parked (Jan 1); driven by run_job, not the clock
+        time_zone="America/New_York",
+        http_target=cloudscheduler.JobHttpTargetArgs(
+            uri=function.url,
+            http_method="POST",
+            headers={"Content-Type": "application/json"},
+            body=base64.b64encode(b'{"chain_downstream": true}').decode("utf-8"),
+            oidc_token=cloudscheduler.JobHttpTargetOidcTokenArgs(
+                service_account_email=sa.email,
+            ),
+        ),
+        retry_config=cloudscheduler.JobRetryConfigArgs(
+            retry_count=2,
+            min_backoff_duration="60s",
+            max_backoff_duration="300s",
+        ),
+    )
+    resources["refresh_scheduler"] = refresh_scheduler
 
     return resources


### PR DESCRIPTION
## Why

Clicking "Refresh catalog" (or the nightly-equivalent on demand) advertised "trigger the GCS file sync now", but a just-published track was indexed (searchable) yet **not byte-synced to GCS** until the next nightly run. Verified 2026-07-02: the refresh fired all 3 divebar scheduler jobs **concurrently**, but the file-sync VM only copies files already in the BigQuery index — and it finished (~3 min) before the slow index rebuild added the new rows. So the sync raced ahead of the index and missed the new files.

## What

**Chain-on-completion, gated to the refresh path:**
- The index function (`divebar_mirror`) now, on a successful build, triggers the index-dependent jobs itself — the file-sync VM + xref rebuild — via `scheduler_v1.run_job`. This fires at the index's **actual completion** (which outlasts the caller's HTTP timeout), so ordering is guaranteed.
- The chain only fires when the request sets `chain_downstream`. A new **refresh-only** scheduler job (`divebar-mirror-refresh`) carries that flag in its body; the `refresh` action force-runs it instead of `divebar-mirror-daily`.
- **The nightly pipeline is 100% untouched** — `divebar-mirror-daily` (2 AM) omits the flag, so it does not chain, and the standalone nightly `divebar-sync-vm-daily` (3 AM) + `divebar-xref-rebuild-daily` (6 AM) run once as before. No double-run; the nightly sync's safety net is preserved.

## Files
- `functions/divebar_mirror/main.py`: `_wants_downstream_chain` + `_trigger_downstream_jobs`, gated call, `GCP_REGION`.
- `functions/divebar_mirror/requirements.txt`: `google-cloud-scheduler`.
- `modules/divebar_mirror.py`: `GCP_REGION` env + new `divebar-mirror-refresh` scheduler job (flag body, parked cron, run via forceRun).
- `functions/divebar_lookup/main.py`: `refresh` triggers only `divebar-mirror-refresh`.
- `__main__.py`: grant the mirror SA the existing `divebarSchedulerRunner` role.

## Review
Local `feature-dev:code-reviewer`. It flagged (confidence 82) that an earlier unconditional-chain version would double-run the nightly sync/xref — fixed via the refresh-only flag+job above so the nightly path is untouched.

## Testing
- `divebar_mirror/test_main.py`: downstream-trigger job paths, partial-failure isolation, flag parsing (chains on flag, NOT on absent/false).
- `divebar_lookup/test_main.py`: regression guard that refresh triggers only `divebar-mirror-refresh` (never sync/xref/mirror-daily).

## Deploy
Infra-only. **Already applied to prod** via `pulumi up` (mirror+lookup functions redeployed, `divebar-mirror-refresh` job created, mirror-SA scheduler-runner grant). Verified the deployed job POSTs `{"chain_downstream": true}` to the mirror function.

Phase 4 of the nomad-master fast-sync work. (Phase 1 shipped in #866.)

@coderabbitai ignore