### PR TITLE
fix: parse-titles auto-chunks large batches into concurrent Gemini calls (v0.189.1)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -132,6 +132,10 @@ class Settings(BaseSettings):
     parse_titles_model: str = os.getenv("PARSE_TITLES_MODEL", "gemini-3.5-flash")
     parse_titles_timeout_ms: int = int(os.getenv("PARSE_TITLES_TIMEOUT_MS", "20000"))
     parse_titles_max_items: int = int(os.getenv("PARSE_TITLES_MAX_ITEMS", "200"))
+    # Items per Gemini call: large client batches are split into concurrent
+    # chunks of this size so one call never outgrows parse_titles_timeout_ms
+    # (a 100-item single call did, blanking the whole batch).
+    parse_titles_chunk_size: int = int(os.getenv("PARSE_TITLES_CHUNK_SIZE", "10"))
 
     # Cloud Tasks (for scalable worker coordination)
     # When enabled, workers are triggered via Cloud Tasks for guaranteed delivery

--- a/backend/services/parse_titles/service.py
+++ b/backend/services/parse_titles/service.py
@@ -1,6 +1,7 @@
 """Batch orchestration + graceful degrade for karaoke-filename parsing."""
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from backend.services.parse_titles import ai
@@ -20,8 +21,13 @@ async def parse_titles(
 ) -> list[dict]:
     """Parse a batch of filenames → id-aligned {id, artist, title, confidence}.
 
+    Large batches are split into concurrent chunks of parse_titles_chunk_size
+    so a single Gemini call never outgrows parse_titles_timeout_ms (a 100-item
+    single call did, and the timeout blanked the whole batch).
+
     Never raises: a disabled kill-switch or any model failure yields blank
-    results so the (kjbox) caller keeps its deterministic guess.
+    results — per chunk, so one bad chunk doesn't blank its neighbours — and
+    the (kjbox) caller keeps its deterministic guess.
     """
     if not items:
         return []
@@ -29,22 +35,34 @@ async def parse_titles(
         from backend.config import settings
         enabled = getattr(settings, "parse_titles_enabled", True)
         max_items = int(getattr(settings, "parse_titles_max_items", 200))
+        chunk_size = max(1, int(getattr(settings, "parse_titles_chunk_size", 10)))
     except Exception:  # pragma: no cover
         # Fail closed: if config can't load, don't reach for the external AI.
         logger.warning("parse_titles settings unavailable; disabling parser")
-        enabled, max_items = False, 200
+        enabled, max_items, chunk_size = False, 200, 10
     if not enabled:
         return _blanks(items)
 
     head, tail = items[:max_items], items[max_items:]
+    chunks = [head[i:i + chunk_size] for i in range(0, len(head), chunk_size)]
+    parsed = await asyncio.gather(
+        *(_parse_chunk(chunk, model=model, generate=generate) for chunk in chunks)
+    )
+    return [r for chunk_results in parsed for r in chunk_results] + _blanks(tail)
+
+
+async def _parse_chunk(chunk: list[dict], *, model, generate) -> list[dict]:
+    """One Gemini call; any failure degrades to blanks for this chunk only."""
     try:
-        results = await ai.ai_parse(head, model=model, generate=generate)
+        results = await ai.ai_parse(chunk, model=model, generate=generate)
     except Exception as exc:
-        logger.warning("parse_titles degraded (%s); returning blanks", exc)
-        return _blanks(items)
+        logger.warning(
+            "parse_titles chunk degraded (%s); blanks for %d items", exc, len(chunk))
+        return _blanks(chunk)
     # ai_parse is id-aligned by construction; guard the contract defensively so a
     # future refactor can't silently return a mis-aligned/short batch.
-    if len(results) != len(head):
-        logger.warning("parse_titles length mismatch; returning blanks")
-        return _blanks(items)
-    return results + _blanks(tail)
+    if len(results) != len(chunk):
+        logger.warning(
+            "parse_titles chunk length mismatch; blanks for %d items", len(chunk))
+        return _blanks(chunk)
+    return results

--- a/backend/tests/test_parse_titles.py
+++ b/backend/tests/test_parse_titles.py
@@ -86,3 +86,89 @@ def test_parse_titles_happy_path(monkeypatch):
 
 def test_parse_titles_empty_returns_empty():
     assert asyncio.run(service.parse_titles([])) == []
+
+
+# --- auto-chunking: large batches must not ride one >20s Gemini call ---
+
+def _items(n):
+    return [{"id": str(i), "filename": f"file {i}.mp4"} for i in range(n)]
+
+
+def _ok_results(model, system, user):
+    """Echo one parsed result per '- id=' line in the user prompt."""
+    ids = [line.split("id='", 1)[1].split("'", 1)[0]
+           for line in user.splitlines() if line.startswith("- id=")]
+    return {"results": [{"id": i, "artist": f"A{i}", "title": f"T{i}",
+                         "confidence": 0.9} for i in ids]}
+
+
+def test_settings_parse_titles_chunk_size_default():
+    from backend.config import Settings
+    assert Settings().parse_titles_chunk_size == 10
+
+
+def test_parse_titles_chunks_large_batches(monkeypatch):
+    from backend.config import settings
+    monkeypatch.setattr(settings, "parse_titles_enabled", True)
+    calls = []
+
+    async def gen(model, system, user):
+        n = sum(1 for line in user.splitlines() if line.startswith("- id="))
+        calls.append(n)
+        return _ok_results(model, system, user)
+
+    out = asyncio.run(service.parse_titles(_items(25), generate=gen))
+    assert sorted(calls, reverse=True) == [10, 10, 5]   # 25 items -> 3 Gemini calls
+    assert [r["id"] for r in out] == [str(i) for i in range(25)]  # id-aligned
+    assert all(r["artist"] == f'A{r["id"]}' for r in out)
+
+
+def test_parse_titles_chunk_failure_degrades_only_that_chunk(monkeypatch):
+    from backend.config import settings
+    monkeypatch.setattr(settings, "parse_titles_enabled", True)
+
+    async def gen(model, system, user):
+        if "id='10'" in user:  # the middle chunk (items 10-19)
+            raise RuntimeError("vertex timeout")
+        return _ok_results(model, system, user)
+
+    out = asyncio.run(service.parse_titles(_items(25), generate=gen))
+    assert out[0]["artist"] == "A0" and out[24]["artist"] == "A24"
+    assert all(out[i]["artist"] == "" and out[i]["confidence"] == 0.0
+               for i in range(10, 20))                   # only that chunk blank
+    assert [r["id"] for r in out] == [str(i) for i in range(25)]
+
+
+def test_parse_titles_chunks_run_concurrently(monkeypatch):
+    """The chunks must be issued in parallel — a 100-item batch shouldn't pay
+    10 sequential Gemini round-trips."""
+    from backend.config import settings
+    monkeypatch.setattr(settings, "parse_titles_enabled", True)
+    started = 0
+    all_started = asyncio.Event()
+
+    async def gen(model, system, user):
+        nonlocal started
+        started += 1
+        if started == 3:
+            all_started.set()
+        # Sequential execution would deadlock here on the first chunk.
+        await asyncio.wait_for(all_started.wait(), timeout=5)
+        return _ok_results(model, system, user)
+
+    out = asyncio.run(service.parse_titles(_items(25), generate=gen))
+    assert len(out) == 25 and out[0]["artist"] == "A0"
+
+
+def test_parse_titles_respects_configured_chunk_size(monkeypatch):
+    from backend.config import settings
+    monkeypatch.setattr(settings, "parse_titles_enabled", True)
+    monkeypatch.setattr(settings, "parse_titles_chunk_size", 4, raising=False)
+    calls = []
+
+    async def gen(model, system, user):
+        calls.append(sum(1 for line in user.splitlines() if line.startswith("- id=")))
+        return _ok_results(model, system, user)
+
+    asyncio.run(service.parse_titles(_items(10), generate=gen))
+    assert sorted(calls, reverse=True) == [4, 4, 2]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.189.0"
+version = "0.189.1"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
Fixes the last loose end from the download-naming handoff: a 100-item `POST /api/parse-karaoke-titles` batch rode a **single** Gemini call that exceeded the 20s `parse_titles_timeout_ms`, blanking the whole batch — forcing kjbox's `refine_titles.py` to run `--batch-size 10`. The service now auto-chunks internally, so clients can send up to `parse_titles_max_items` (200) in one request.

## Changes
- `service.parse_titles` splits any batch into **concurrent** chunks of `parse_titles_chunk_size` (new setting, default 10, env `PARSE_TITLES_CHUNK_SIZE`) via `asyncio.gather` — no single Gemini call can outgrow the timeout, and a 100-item batch costs ~1 round-trip of latency, not 10.
- Graceful degrade is now **per chunk**: a failed/mis-sized chunk blanks only its own items instead of the whole batch. Kill-switch, `max_items` tail-blanking, and id-alignment unchanged.

## Testing (TDD — all watched fail first)
- 25 items → exactly 3 calls of 10/10/5, id-aligned results
- Middle-chunk failure blanks only items 10–19
- Concurrency proven with a 3-way barrier (sequential execution would deadlock)
- Configured chunk size respected (4/4/2)
- Full backend suite: 3663 passed, 139 env skips

## Review
- [x] CodeRabbit CLI: 0 findings

## After deploy
kjbox `refine_titles.py` can drop the `--batch-size 10` workaround (default batch works).

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)