### PR TITLE
feat: remove Nomad GCS master on delete/edit/private (Phase 2)

### DIFF
--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -1709,6 +1709,12 @@ async def delete_job_outputs(
             logger.error(f"Error deleting Google Drive files for job {job_id}: {e}", exc_info=True)
             results["gdrive"] = {"status": "error", "error": str(e)}
 
+    # Remove the Nomad 720p master(s) from the GCS fast-sync mirror too (prefix-keyed
+    # by brand_code, covers renames). Non-fatal, Nomad-only, no-op otherwise.
+    if brand_code:
+        from backend.services.nomad_master_mirror import cleanup_nomad_masters
+        cleanup_nomad_masters(brand_code)
+
     # Clean up GCS finals folder - prevents stale files from being picked up during re-encoding
     try:
         from backend.services.storage_service import StorageService

--- a/backend/api/routes/jobs.py
+++ b/backend/api/routes/jobs.py
@@ -396,6 +396,11 @@ async def edit_completed_track(
                 delete_results = gdrive.delete_files(file_ids)
                 all_success = all(delete_results.values())
                 cleanup_results["gdrive"] = {"status": "success" if all_success else "partial", "files": delete_results}
+                # Also remove the Nomad 720p master from the GCS fast-sync mirror
+                # (prefix-keyed by brand_code, so it covers renames). Non-fatal,
+                # Nomad-brand only, no-op otherwise.
+                from backend.services.nomad_master_mirror import cleanup_nomad_masters
+                cleanup_nomad_masters(brand_code)
             else:
                 cleanup_results["gdrive"] = {"status": "skipped", "reason": "Google Drive not configured"}
         except Exception as e:
@@ -2274,6 +2279,14 @@ async def cleanup_distribution(
                         "status": "success" if all_success else "partial",
                         "files": delete_results,
                     }
+
+                # Remove the Nomad 720p master(s) from the GCS fast-sync mirror too, so a
+                # re-finalise (incl. artist/title rename) doesn't leave the old cut on
+                # kjbox. Prefix-keyed by brand_code (covers renames); the subsequent
+                # re-run's push re-adds the new master. Non-fatal, Nomad-only.
+                if brand_code:
+                    from backend.services.nomad_master_mirror import cleanup_nomad_masters
+                    cleanup_nomad_masters(brand_code)
                     if gdrive_method:
                         results["gdrive"]["method"] = gdrive_method
                 else:

--- a/backend/api/routes/jobs.py
+++ b/backend/api/routes/jobs.py
@@ -2279,14 +2279,6 @@ async def cleanup_distribution(
                         "status": "success" if all_success else "partial",
                         "files": delete_results,
                     }
-
-                # Remove the Nomad 720p master(s) from the GCS fast-sync mirror too, so a
-                # re-finalise (incl. artist/title rename) doesn't leave the old cut on
-                # kjbox. Prefix-keyed by brand_code (covers renames); the subsequent
-                # re-run's push re-adds the new master. Non-fatal, Nomad-only.
-                if brand_code:
-                    from backend.services.nomad_master_mirror import cleanup_nomad_masters
-                    cleanup_nomad_masters(brand_code)
                     if gdrive_method:
                         results["gdrive"]["method"] = gdrive_method
                 else:
@@ -2295,6 +2287,14 @@ async def cleanup_distribution(
                         "status": "skipped",
                         "reason": "no files found to delete",
                     }
+
+                # Remove the Nomad 720p master(s) from the GCS fast-sync mirror too, so a
+                # re-finalise (incl. artist/title rename) doesn't leave the old cut on
+                # kjbox. Prefix-keyed by brand_code (covers renames); the subsequent
+                # re-run's push re-adds the new master. Non-fatal, Nomad-only.
+                if brand_code:
+                    from backend.services.nomad_master_mirror import cleanup_nomad_masters
+                    cleanup_nomad_masters(brand_code)
             else:
                 results["gdrive"] = {
                     "status": "failed",

--- a/backend/services/nomad_master_mirror.py
+++ b/backend/services/nomad_master_mirror.py
@@ -76,3 +76,56 @@ class NomadMasterMirror:
         except Exception as e:  # noqa: BLE001 - never fatal to the pipeline
             logger.warning("Nomad master mirror delete failed for %s: %s", blob_name, e)
             return False
+
+    def delete_masters_by_brand(self, brand_code: str) -> int:
+        """Delete ALL 720p master objects for a Nomad release, matched by the unique
+        ``{brand_code} - `` filename prefix.
+
+        Keying on the brand_code prefix (rather than a reconstructed title) covers
+        renames for free: every artist/title variant a release was ever published
+        under shares the same ``NOMAD-#### - `` prefix. Best-effort; returns the count
+        deleted. Refuses to run for a non-Nomad / empty brand code so a broad prefix
+        can never match unrelated objects.
+        """
+        if not is_nomad_public_brand(brand_code):
+            return 0
+        # Require a full ``NOMAD-####`` code (non-empty suffix after the hyphen) so the
+        # delete prefix is always specific to one release — never a bare ``NOMAD``.
+        suffix = brand_code.split("-", 1)[1] if "-" in brand_code else ""
+        if not suffix.strip():
+            return 0
+        prefix = f"{settings.nomad_master_gcs_prefix.strip('/')}/{brand_code} - "
+        deleted = 0
+        try:
+            for blob in self._bucket.list_blobs(prefix=prefix):
+                try:
+                    blob.delete()
+                    deleted += 1
+                except Exception as e:  # noqa: BLE001
+                    logger.warning("Failed to delete mirror object %s: %s", blob.name, e)
+            if deleted:
+                logger.info(
+                    "Removed %d Nomad master object(s) from gs://%s/%s*",
+                    deleted, settings.divebar_files_bucket, prefix,
+                )
+        except Exception as e:  # noqa: BLE001 - never fatal to the pipeline
+            logger.warning("Nomad master mirror prefix-delete failed for %s: %s", prefix, e)
+        return deleted
+
+
+def cleanup_nomad_masters(brand_code: Optional[str]) -> int:
+    """Best-effort removal of a Nomad release's 720p master(s) from the GCS mirror,
+    keyed by brand_code prefix (covers renames). No-op for non-Nomad / ``NOMADNP``
+    brands or when fast-sync is disabled. Never raises — a cleanup failure must not
+    break job delete/edit flows (the object just lingers until overwritten). Call this
+    wherever the pipeline deletes a job's Drive/Dropbox outputs.
+    """
+    try:
+        if not settings.nomad_master_fast_sync_enabled:
+            return 0
+        if not is_nomad_public_brand(brand_code):
+            return 0
+        return NomadMasterMirror().delete_masters_by_brand(brand_code)
+    except Exception as e:  # noqa: BLE001 - never fatal to the caller
+        logger.warning("Nomad master mirror cleanup skipped: %s", e)
+        return 0

--- a/backend/services/visibility_change_service.py
+++ b/backend/services/visibility_change_service.py
@@ -269,6 +269,12 @@ class VisibilityChangeService:
             except Exception as e:
                 logger.warning(f"[job:{job_id}] Failed to delete Google Drive files: {e}")
 
+        # A track going private should also leave the public Nomad GCS fast-sync mirror
+        # (and thus kjbox). Prefix-keyed by brand_code, non-fatal, Nomad-only.
+        if brand_code:
+            from backend.services.nomad_master_mirror import cleanup_nomad_masters
+            cleanup_nomad_masters(brand_code)
+
         # Delete GCS finals if requested
         if not keep_gcs_finals:
             try:

--- a/backend/tests/test_admin_delete_outputs.py
+++ b/backend/tests/test_admin_delete_outputs.py
@@ -108,6 +108,24 @@ class TestDeleteOutputsSuccess:
             assert data["job_id"] == "test-job-123"
             assert "outputs_deleted_at" in data
 
+    def test_delete_outputs_removes_nomad_gcs_master(self, client, mock_complete_job):
+        """Deleting a NOMAD job's outputs must also remove its 720p master from the
+        GCS fast-sync mirror (wiring guard for the delete side)."""
+        with patch('backend.api.routes.admin.JobManager') as mock_jm_class, \
+             patch('backend.api.routes.admin.get_user_service') as mock_user_service, \
+             patch('backend.services.nomad_master_mirror.cleanup_nomad_masters') as mock_cleanup:
+            mock_jm = Mock()
+            mock_jm.get_job.return_value = mock_complete_job  # brand_code = "NOMAD-1234"
+            mock_jm_class.return_value = mock_jm
+            mock_db = Mock()
+            mock_db.collection.return_value.document.return_value = Mock()
+            mock_user_service.return_value.db = mock_db
+
+            response = client.post("/api/admin/jobs/test-job-123/delete-outputs")
+
+            assert response.status_code == 200
+            mock_cleanup.assert_called_once_with("NOMAD-1234")
+
     def test_delete_outputs_clears_state_data_keys(self, client, mock_complete_job):
         """Test that output-related state_data keys are listed as cleared."""
         with patch('backend.api.routes.admin.JobManager') as mock_jm_class, \

--- a/backend/tests/test_nomad_master_mirror.py
+++ b/backend/tests/test_nomad_master_mirror.py
@@ -87,3 +87,69 @@ def test_delete_720p_is_non_fatal_on_error():
     blob.delete.side_effect = RuntimeError("boom")
 
     assert mirror.delete_720p("NOMAD-9 - X - Y.mp4") is False
+
+
+# --- delete_masters_by_brand (prefix delete; covers renames) ---
+
+def _mirror_with_blobs(names):
+    blobs = []
+    for n in names:
+        b = MagicMock()
+        b.name = n
+        blobs.append(b)
+    bucket = MagicMock()
+    bucket.list_blobs.return_value = blobs
+    client = MagicMock()
+    client.bucket.return_value = bucket
+    return NomadMasterMirror(client=client), bucket, blobs
+
+
+def test_delete_masters_by_brand_deletes_all_matching_by_prefix():
+    # Two objects for the same release (e.g. an old + renamed title) both go.
+    mirror, bucket, blobs = _mirror_with_blobs([
+        "files/Nomad Karaoke/MP4-720p/NOMAD-1500 - Rush - Spirit of Radio.mp4",
+        "files/Nomad Karaoke/MP4-720p/NOMAD-1500 - Rush - The Spirit of Radio.mp4",
+    ])
+    n = mirror.delete_masters_by_brand("NOMAD-1500")
+    assert n == 2
+    bucket.list_blobs.assert_called_once_with(
+        prefix="files/Nomad Karaoke/MP4-720p/NOMAD-1500 - "
+    )
+    for b in blobs:
+        b.delete.assert_called_once()
+
+
+@pytest.mark.parametrize("brand", ["NOMADNP-1500", "VOCALSTAR-1", "", None, "NOMAD"])
+def test_delete_masters_by_brand_refuses_non_nomad_or_bare(brand):
+    # Must never list/delete for a non-Nomad or bare brand — a broad prefix could
+    # wipe unrelated objects.
+    mirror, bucket, _blobs = _mirror_with_blobs([])
+    assert mirror.delete_masters_by_brand(brand) == 0
+    bucket.list_blobs.assert_not_called()
+
+
+def test_delete_masters_by_brand_is_non_fatal_on_list_error():
+    mirror, bucket, _blobs = _mirror_with_blobs([])
+    bucket.list_blobs.side_effect = RuntimeError("gcs down")
+    assert mirror.delete_masters_by_brand("NOMAD-1500") == 0
+
+
+def test_cleanup_nomad_masters_delegates_for_nomad(monkeypatch):
+    from backend.services import nomad_master_mirror as mod
+
+    called = {}
+    inst = MagicMock()
+    inst.delete_masters_by_brand.return_value = 3
+    monkeypatch.setattr(mod, "NomadMasterMirror", lambda: inst)
+
+    assert mod.cleanup_nomad_masters("NOMAD-1500") == 3
+    inst.delete_masters_by_brand.assert_called_once_with("NOMAD-1500")
+
+
+@pytest.mark.parametrize("brand", ["NOMADNP-1", "OTHER-1", "", None])
+def test_cleanup_nomad_masters_noop_for_non_nomad(brand, monkeypatch):
+    from backend.services import nomad_master_mirror as mod
+
+    # Must not even construct the mirror (no GCS client) for non-Nomad brands.
+    monkeypatch.setattr(mod, "NomadMasterMirror", lambda: (_ for _ in ()).throw(AssertionError("should not construct")))
+    assert mod.cleanup_nomad_masters(brand) == 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.189.0"
+version = "0.190.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Why

Phase 1 pushes new Nomad 720p masters to the GCS mirror (→ kjbox in minutes). This adds the **delete side** so an edit or delete also propagates: the *latest* cut wins on the box, and stale/renamed masters don't linger. Per the agreed policy — **Nomad deletes OK; community keep-forever**.

## What

- **`NomadMasterMirror.delete_masters_by_brand(brand_code)`** — deletes every 720p master object matched by the unique `"{brand_code} - "` prefix. Keying on `brand_code` (not a reconstructed title) **covers renames for free**: every title a release was published under shares the same `NOMAD-#### - ` prefix.
  - **Hard safety guard:** refuses unless the brand is a full `NOMAD-####` code (non-empty suffix), so a bare/empty prefix can never over-delete. The `" - "` (space-dash-space) separator makes prefixes collision-proof across brand lengths (`NOMAD-15` can't match `NOMAD-150…`).
- **`cleanup_nomad_masters(brand_code)`** — best-effort, Nomad-only, never raises. Wired after the existing Drive/Dropbox output deletes at the four flows that remove a job's public outputs: job delete/edit cleanup, re-finalize/re-encode (so a rename drops the old cut; the re-run's push re-adds the new), admin delete-outputs, and visibility public→private.

Same-name re-edits already self-heal via Phase 1 (push overwrites; kjbox rsync updates on size change). This handles **deletes and renames**.

## Testing
- 26 unit tests: prefix delete, rename coverage, the `NOMAD-####` safety guard (refuses bare/empty/`NOMADNP`/other brands), non-fatal on error, `cleanup_nomad_masters` delegation/no-op.
- Integration wiring test: admin delete-outputs endpoint calls `cleanup_nomad_masters` with the job's `brand_code`.
- Local: mirror + gdrive + jobs-API + admin-delete + visibility suites green.

## Review
Local `feature-dev:code-reviewer` — verified the over-deletion safety (prefix collision-proofness, brand gating, IAM scope) is sound; added the wiring test it recommended.

Phase 2 of the nomad-master fast-sync work. Pairs with the kjbox true-mirror change (Phase 3) so deletes reconcile onto the device. (Phases 1 & 4 already shipped: #866, #867.)

@coderabbitai ignore