### PR TITLE
feat(auth): show already-used/expired message upfront on verify page

### DIFF
--- a/backend/api/routes/users.py
+++ b/backend/api/routes/users.py
@@ -481,6 +481,32 @@ async def verify_magic_link(
     )
 
 
+class MagicLinkStatusResponse(BaseModel):
+    status: str  # "valid" | "used" | "expired" | "invalid"
+
+
+@router.get("/auth/link-status", response_model=MagicLinkStatusResponse)
+async def magic_link_status(
+    token: str,
+    user_service: UserService = Depends(get_user_service),
+):
+    """
+    Read-only status of a magic link — does NOT consume it.
+
+    The verify page calls this on load so it can show the correct UI upfront:
+    the "Complete Sign-In" gate for a valid link, or an "already used / expired"
+    message for a dead one — without making the user click only to then fail.
+
+    This endpoint is intentionally non-mutating so that an email link-scanner
+    which renders the verify page (and triggers this read) cannot burn a still-
+    valid token before the real user clicks. Token consumption happens only in
+    the separate GET /auth/verify, which requires an explicit user click.
+    """
+    if not token or not token.strip():
+        return MagicLinkStatusResponse(status="invalid")
+    return MagicLinkStatusResponse(status=user_service.get_magic_link_status(token))
+
+
 @router.post("/auth/resend-from-token", response_model=ResendFromTokenResponse)
 async def resend_magic_link_from_token(
     request: ResendFromTokenRequest,

--- a/backend/services/user_service.py
+++ b/backend/services/user_service.py
@@ -373,6 +373,36 @@ class UserService:
             logger.exception("Error verifying magic link")
             return False, None, "An error occurred during verification"
 
+    def get_magic_link_status(self, token: str) -> str:
+        """
+        Read-only check of a magic link's status WITHOUT consuming it.
+
+        Used by the verify page on load to decide whether to show the
+        "Complete Sign-In" gate (valid) or a dead-link message (used/expired).
+        Crucially this must never mutate the token: an email link-scanner that
+        renders the verify page triggers this read, but must not burn a still-
+        valid link before the real user clicks.
+
+        Returns one of: "valid", "used", "expired", "invalid".
+        """
+        try:
+            if not token or not token.strip():
+                return "invalid"
+
+            doc = self.db.collection(MAGIC_LINKS_COLLECTION).document(token).get()
+            if not doc.exists:
+                return "invalid"
+
+            magic_link = MagicLinkToken(**doc.to_dict())
+            if magic_link.used:
+                return "used"
+            if datetime.utcnow() > magic_link.expires_at:
+                return "expired"
+            return "valid"
+        except Exception:
+            logger.exception("Error checking magic link status")
+            return "invalid"
+
     def grant_welcome_credits_if_eligible(
         self,
         email: str,

--- a/backend/tests/test_magic_link_status.py
+++ b/backend/tests/test_magic_link_status.py
@@ -1,0 +1,132 @@
+"""
+Unit tests for UserService.get_magic_link_status.
+
+This is a READ-ONLY status check used by the verify page to decide, on load,
+whether to show the "Complete Sign-In" gate (valid link) or an "already used /
+expired" message (dead link). It must NEVER consume the token — otherwise an
+email link-scanner that renders the verify page would burn a valid link before
+the real user clicks, which is exactly the bug this whole feature prevents.
+"""
+import sys
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mock Firestore before importing modules that use it.
+sys.modules.setdefault('google.cloud.firestore', MagicMock())
+sys.modules.setdefault('google.cloud.firestore_v1', MagicMock())
+
+from fastapi.testclient import TestClient
+
+
+def _service_with_doc(mock_fs, mock_settings, doc_dict, exists=True):
+    mock_settings.return_value = MagicMock(google_cloud_project='test')
+    mock_db = MagicMock()
+    mock_fs.Client.return_value = mock_db
+    mock_doc = MagicMock()
+    mock_doc.exists = exists
+    mock_doc.to_dict.return_value = doc_dict
+    mock_db.collection.return_value.document.return_value.get.return_value = mock_doc
+    from backend.services.user_service import UserService
+    return UserService(), mock_db
+
+
+def _link_dict(**overrides):
+    d = {
+        'token': 'tok123',
+        'email': 'user@example.com',
+        'created_at': datetime.utcnow(),
+        'expires_at': datetime.utcnow() + timedelta(hours=1),
+        'used': False,
+        'used_at': None,
+    }
+    d.update(overrides)
+    return d
+
+
+class TestGetMagicLinkStatus:
+    @patch('backend.services.user_service.get_settings')
+    @patch('backend.services.user_service.firestore')
+    def test_valid_link_returns_valid(self, mock_fs, mock_settings):
+        service, _ = _service_with_doc(mock_fs, mock_settings, _link_dict())
+        assert service.get_magic_link_status('tok123') == 'valid'
+
+    @patch('backend.services.user_service.get_settings')
+    @patch('backend.services.user_service.firestore')
+    def test_valid_link_is_not_consumed(self, mock_fs, mock_settings):
+        """The scanner-safety guarantee: a status check must not mutate the token."""
+        service, mock_db = _service_with_doc(mock_fs, mock_settings, _link_dict())
+        service.get_magic_link_status('tok123')
+        doc_ref = mock_db.collection.return_value.document.return_value
+        doc_ref.update.assert_not_called()
+        doc_ref.set.assert_not_called()
+
+    @patch('backend.services.user_service.get_settings')
+    @patch('backend.services.user_service.firestore')
+    def test_used_link_returns_used(self, mock_fs, mock_settings):
+        service, _ = _service_with_doc(
+            mock_fs, mock_settings, _link_dict(used=True, used_at=datetime.utcnow())
+        )
+        assert service.get_magic_link_status('tok123') == 'used'
+
+    @patch('backend.services.user_service.get_settings')
+    @patch('backend.services.user_service.firestore')
+    def test_expired_link_returns_expired(self, mock_fs, mock_settings):
+        service, _ = _service_with_doc(
+            mock_fs, mock_settings, _link_dict(expires_at=datetime.utcnow() - timedelta(minutes=1))
+        )
+        assert service.get_magic_link_status('tok123') == 'expired'
+
+    @patch('backend.services.user_service.get_settings')
+    @patch('backend.services.user_service.firestore')
+    def test_missing_link_returns_invalid(self, mock_fs, mock_settings):
+        service, _ = _service_with_doc(mock_fs, mock_settings, {}, exists=False)
+        assert service.get_magic_link_status('missing') == 'invalid'
+
+    @patch('backend.services.user_service.get_settings')
+    @patch('backend.services.user_service.firestore')
+    def test_empty_token_returns_invalid(self, mock_fs, mock_settings):
+        service, _ = _service_with_doc(mock_fs, mock_settings, _link_dict())
+        assert service.get_magic_link_status('   ') == 'invalid'
+
+
+class TestLinkStatusEndpoint:
+    """GET /api/users/auth/link-status — thin, read-only wrapper over the service."""
+
+    def _client(self, status_value):
+        from backend.main import app
+        from backend.services.user_service import get_user_service
+        svc = MagicMock()
+        svc.get_magic_link_status.return_value = status_value
+        app.dependency_overrides[get_user_service] = lambda: svc
+        return TestClient(app), app, svc
+
+    def test_endpoint_returns_status_for_valid(self):
+        client, app, svc = self._client("valid")
+        try:
+            r = client.get("/api/users/auth/link-status", params={"token": "tok123"})
+            assert r.status_code == 200
+            assert r.json()["status"] == "valid"
+            svc.get_magic_link_status.assert_called_once_with("tok123")
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_endpoint_returns_used(self):
+        client, app, svc = self._client("used")
+        try:
+            r = client.get("/api/users/auth/link-status", params={"token": "burned"})
+            assert r.status_code == 200
+            assert r.json()["status"] == "used"
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_endpoint_returns_invalid_for_empty_token_without_touching_firestore(self):
+        client, app, svc = self._client("valid")  # service would say valid, but route must short-circuit
+        try:
+            r = client.get("/api/users/auth/link-status", params={"token": "   "})
+            assert r.status_code == 200
+            assert r.json()["status"] == "invalid"
+            svc.get_magic_link_status.assert_not_called()
+        finally:
+            app.dependency_overrides.clear()

--- a/frontend/__tests__/verify-page-resend.test.tsx
+++ b/frontend/__tests__/verify-page-resend.test.tsx
@@ -37,10 +37,13 @@ jest.mock('@/lib/auth', () => {
 // Referral helper is incidental.
 jest.mock('@/lib/referral', () => ({ setReferralCode: jest.fn() }))
 
-// API client — only the resend method matters here.
+// API client. getMagicLinkStatus decides the initial UI (gate vs. dead-link);
+// resendMagicLinkFromToken drives the recovery flow.
 const resendMock = jest.fn()
+const getStatusMock = jest.fn()
 jest.mock('@/lib/api', () => ({
   api: {
+    getMagicLinkStatus: (token: string) => getStatusMock(token),
     resendMagicLinkFromToken: (token: string) => resendMock(token),
   },
 }))
@@ -70,22 +73,25 @@ async function clickConfirmToVerify() {
   })
 }
 
-describe('VerifyMagicLinkPage — scanner-safety gate', () => {
+describe('VerifyMagicLinkPage — scanner-safety gate (valid link)', () => {
   beforeEach(() => {
     pushMock.mockClear()
     resendMock.mockReset()
     verifyMagicLinkMock.mockClear()
+    getStatusMock.mockReset()
+    getStatusMock.mockResolvedValue({ status: 'valid' })
   })
 
   it('does NOT verify the token on mount (link-scanners must not burn it)', async () => {
     render(wrap(<VerifyMagicLinkPage />))
 
-    // The confirm prompt is shown...
+    // The confirm prompt is shown for a valid link...
     expect(
       await screen.findByRole('button', { name: /Complete Sign-?In/i }),
     ).toBeInTheDocument()
 
-    // ...and crucially, no verification happened without a user gesture.
+    // ...the status check is read-only, and no verification happened.
+    expect(getStatusMock).toHaveBeenCalledWith(tokenParam)
     expect(verifyMagicLinkMock).not.toHaveBeenCalled()
   })
 
@@ -100,11 +106,51 @@ describe('VerifyMagicLinkPage — scanner-safety gate', () => {
   })
 })
 
+describe('VerifyMagicLinkPage — already-used / expired link', () => {
+  beforeEach(() => {
+    pushMock.mockClear()
+    resendMock.mockReset()
+    verifyMagicLinkMock.mockClear()
+    getStatusMock.mockReset()
+  })
+
+  it('shows the failure UI upfront (no gate, no verify) when the link is already used', async () => {
+    getStatusMock.mockResolvedValue({ status: 'used' })
+
+    render(wrap(<VerifyMagicLinkPage />))
+
+    // Failure UI + one-click resend appear without the user clicking anything.
+    expect(await screen.findByText('Sign-in failed')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /Email me a new link/i }),
+    ).toBeInTheDocument()
+
+    // No "Complete Sign-In" gate, and the token was never sent to verify.
+    expect(
+      screen.queryByRole('button', { name: /Complete Sign-?In/i }),
+    ).not.toBeInTheDocument()
+    expect(verifyMagicLinkMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the gate if the status check itself errors (never block a valid user)', async () => {
+    getStatusMock.mockRejectedValue(new Error('status endpoint down'))
+
+    render(wrap(<VerifyMagicLinkPage />))
+
+    expect(
+      await screen.findByRole('button', { name: /Complete Sign-?In/i }),
+    ).toBeInTheDocument()
+    expect(verifyMagicLinkMock).not.toHaveBeenCalled()
+  })
+})
+
 describe('VerifyMagicLinkPage — resend recovery flow', () => {
   beforeEach(() => {
     pushMock.mockClear()
     resendMock.mockReset()
     verifyMagicLinkMock.mockClear()
+    getStatusMock.mockReset()
+    getStatusMock.mockResolvedValue({ status: 'valid' })
   })
 
   it('shows "Email me a new link" button after verification fails', async () => {

--- a/frontend/app/[locale]/auth/verify/page.tsx
+++ b/frontend/app/[locale]/auth/verify/page.tsx
@@ -10,19 +10,21 @@ import { setReferralCode } from "@/lib/referral"
 import { api } from "@/lib/api"
 import { useTranslations } from "next-intl"
 
-type VerifyState = "confirm" | "verifying" | "preparing" | "credits_granted" | "credits_denied" | "credits_pending" | "success" | "error"
+type VerifyState = "checking" | "confirm" | "verifying" | "preparing" | "credits_granted" | "credits_denied" | "credits_pending" | "success" | "error"
 type ResendState = "idle" | "sending" | "sent" | "no_token" | "failed"
 
 function VerifyMagicLinkContent() {
   const t = useTranslations('auth')
   const router = useRouter()
   const searchParams = useSearchParams()
-  // Start in a "confirm" gate that requires an explicit click before we spend
-  // the single-use token. Automated email link-scanners (Gmail/Safe-Browsing,
-  // corporate security proxies) render this page and run its JS, but they do
-  // NOT click buttons — so gating verification behind a user gesture stops them
-  // from burning the token before the real user can use it.
-  const [state, setState] = useState<VerifyState>("confirm")
+  // Start in "checking": a read-only status probe runs on mount to decide the
+  // initial UI. A VALID link shows the "Complete Sign-In" gate — an explicit
+  // click is required before we spend the single-use token, so automated email
+  // link-scanners (Gmail/Safe-Browsing, corporate security proxies) that render
+  // this page and run its JS can't burn the token (they don't click). A DEAD
+  // link (already used / expired) shows the failure UI upfront, so the user
+  // isn't offered a button that will only fail when clicked.
+  const [state, setState] = useState<VerifyState>("checking")
   const [errorMessage, setErrorMessage] = useState("")
   const [creditsGranted, setCreditsGranted] = useState(0)
   const [creditStatus, setCreditStatus] = useState<string>("not_applicable")
@@ -34,9 +36,11 @@ function VerifyMagicLinkContent() {
 
   const { verifyMagicLink, user, error } = useAuth()
 
-  // Mount-time setup only — deliberately does NOT verify the token. Storing the
-  // referral code and remembering the token are side-effect-free reads; the
-  // token is spent only when the user clicks "Complete Sign-In".
+  // Mount-time setup — deliberately does NOT verify (consume) the token. It
+  // stores the referral code, remembers the token, and runs a READ-ONLY status
+  // probe to pick the initial UI. The status check does not mutate the token,
+  // so a scanner rendering this page can't burn a valid link; consumption still
+  // happens only when the user clicks "Complete Sign-In".
   useEffect(() => {
     if (hasSetup.current) return
     hasSetup.current = true
@@ -58,6 +62,20 @@ function VerifyMagicLinkContent() {
     // Remember the original token so both the confirm action and the failure
     // UI's one-click resend can use it without re-entering an email.
     setOriginalToken(token)
+
+    // Read-only probe: show the gate for a valid link, or the failure UI upfront
+    // for an already-used/expired one. If the probe itself fails, fall back to
+    // the gate so a transient error never blocks a user with a valid link.
+    api.getMagicLinkStatus(token)
+      .then(({ status }) => {
+        if (status === "valid") {
+          setState("confirm")
+        } else {
+          setState("error")
+          setErrorMessage(t('linkExpiredOrUsed'))
+        }
+      })
+      .catch(() => setState("confirm"))
   }, [searchParams, t])
 
   const handleConfirm = async () => {
@@ -141,6 +159,19 @@ function VerifyMagicLinkContent() {
 
   return (
     <div className="max-w-md w-full bg-card border border-border rounded-xl p-8 text-center">
+      {/* Checking link status (read-only probe, does not consume the token) */}
+      {state === "checking" && (
+        <>
+          <Loader2 className="w-12 h-12 text-primary animate-spin mx-auto mb-4" />
+          <h1 className="text-xl font-semibold text-foreground mb-2">
+            {t('pleaseWait')}
+          </h1>
+          <p className="text-muted-foreground">
+            {t('verifyingWait')}
+          </p>
+        </>
+      )}
+
       {/* Confirm gate — an explicit click is required before we spend the
           single-use token, so automated email link-scanners that render this
           page (but never click) can't burn the link before the real user. */}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1542,6 +1542,19 @@ export const api = {
   /**
    * Verify a magic link token and get a session
    */
+  /**
+   * Read-only status check for a magic link — does NOT consume the token.
+   * Used by the verify page on load to show the correct UI upfront (the
+   * "Complete Sign-In" gate for a valid link, or an already-used/expired
+   * message for a dead one) without making the user click only to then fail.
+   */
+  async getMagicLinkStatus(token: string): Promise<{ status: 'valid' | 'used' | 'expired' | 'invalid' }> {
+    const response = await fetch(`${API_BASE_URL}/api/users/auth/link-status?token=${encodeURIComponent(token)}`, {
+      method: 'GET',
+    })
+    return handleResponse(response)
+  },
+
   async verifyMagicLink(token: string, referralCode?: string | null): Promise<VerifyMagicLinkResponse> {
     const headers: HeadersInit = {};
     if (referralCode) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.190.1"
+version = "0.190.2"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
@coderabbitai ignore

Follow-up to #870. That PR added the "Complete Sign-In" gate so email link-scanners can't burn a magic link before the user clicks. This PR improves the case where the link is **genuinely already used or expired**: instead of showing a "Complete Sign-In" button that only fails when clicked, the verify page now shows the "link expired or already used" message (with one-click resend) **upfront**.

### How it stays scanner-safe

The decision uses a **read-only** status probe that does **not** consume the token:

- New `GET /api/users/auth/link-status` + `UserService.get_magic_link_status()` return `valid` / `used` / `expired` / `invalid` without mutating the doc (verified by a unit test asserting `update`/`set` are never called).
- The verify page calls it on mount:
  - `valid` → show the **Complete Sign-In** gate (token still spent only on the explicit click).
  - `used`/`expired`/`invalid` → show the failure UI + resend immediately.
  - probe **errors** → fall back to the gate, so a transient status-endpoint failure never blocks a user holding a valid link.

Because the probe is non-mutating, a scanner rendering the page still can't burn a valid token — consumption remains gated behind the click, exactly as in #870.

### Notes

- Reuses existing i18n strings (`pleaseWait`, `verifyingWait`, `linkExpiredOrUsed`) — no new translation keys.
- The status endpoint is an unauthenticated read, same trust model as `/auth/verify` (the 256-bit token is the only credential); it reveals only valid/used/expired for a token the caller already holds.

### Testing

- **Backend (9):** service returns correct status for valid/used/expired/missing/empty **and does not consume** a valid token; endpoint returns the status and short-circuits empty tokens without hitting Firestore.
- **Frontend (8):** valid → gate, no verify on mount; dead link → failure UI upfront with no gate and no verify call; probe-error → gate fallback; resend recovery intact.
- Full frontend suite green (1072); backend auth suite green (75); `tsc` + `eslint` clean; CodeRabbit local: 0 findings.
- Version `0.190.1 → 0.190.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
