### PR TITLE
fix(e2e): click 'Complete Sign-In' gate in magic-link auth tests

### DIFF
--- a/frontend/e2e/helpers/auth.ts
+++ b/frontend/e2e/helpers/auth.ts
@@ -6,6 +6,52 @@ import { Page, APIRequestContext } from '@playwright/test';
 import { STORAGE_KEYS, URLS, TIMEOUTS } from './constants';
 
 /**
+ * Click through the "Complete Sign-In" gate on the magic-link verify page.
+ *
+ * As of #870 (fix(auth): gate magic-link verify behind explicit click), the
+ * `/auth/verify` page no longer auto-consumes the single-use token on mount.
+ * Instead it runs a read-only status probe and, for a valid link, shows a
+ * "Complete Sign-In" confirm gate. The token is only spent when this button
+ * is clicked — this protects the link from email scanners / security proxies
+ * that render the page (and run its JS) but never click.
+ *
+ * E2E tests navigate directly to the magic link, so they must click this gate
+ * themselves. Call this AFTER `page.goto(magicLink)` and BEFORE waiting for
+ * the post-sign-in states (success / credit interstitial).
+ *
+ * If the verify page shows the failure UI instead of the gate (e.g. the link
+ * was genuinely already used or expired), this throws with the on-page detail
+ * so the failure is diagnosable rather than a bare 30s timeout.
+ */
+export async function clickCompleteSignInGate(page: Page): Promise<void> {
+  const confirmButton = page.getByRole('button', { name: /complete sign-?in/i });
+  const failureHeading = page.getByText(/sign-in failed/i);
+
+  const outcome = await Promise.race([
+    confirmButton
+      .waitFor({ state: 'visible', timeout: 30000 })
+      .then(() => 'gate' as const),
+    failureHeading
+      .waitFor({ state: 'visible', timeout: 30000 })
+      .then(() => 'failure' as const),
+  ]);
+
+  if (outcome === 'failure') {
+    const detail = await page
+      .locator('.text-muted-foreground')
+      .first()
+      .textContent()
+      .catch(() => null);
+    throw new Error(
+      `Magic-link verify page showed the failure UI instead of the "Complete Sign-In" gate` +
+        ` (link already used / expired?): ${detail?.trim() ?? 'no detail'}`
+    );
+  }
+
+  await confirmButton.click();
+}
+
+/**
  * Set the auth token in localStorage before page navigation.
  * Must be called BEFORE navigating to the page.
  */

--- a/frontend/e2e/production/credit-purchase-real.spec.ts
+++ b/frontend/e2e/production/credit-purchase-real.spec.ts
@@ -2,7 +2,7 @@
 import { test, expect } from '@playwright/test';
 import { createEmailHelper, isEmailTestingAvailable } from '../helpers/email-testing';
 import { completeStripeCheckout } from '../helpers/stripe-checkout';
-import { getPageAuthToken } from '../helpers/auth';
+import { getPageAuthToken, clickCompleteSignInGate } from '../helpers/auth';
 import { URLS, TIMEOUTS } from '../helpers/constants';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -82,6 +82,11 @@ test.describe('Real Credit Purchase Flow', () => {
 
       // Navigate to magic link
       await page.goto(magicLink);
+
+      // Click the "Complete Sign-In" gate (verify page no longer auto-consumes
+      // the token on mount — see #870). This spends the single-use token.
+      await clickCompleteSignInGate(page);
+      console.log('  Clicked "Complete Sign-In" gate');
 
       // Handle verification result (new user interstitial or direct success)
       const verifyResult = await Promise.race([

--- a/frontend/e2e/production/full-user-journey.spec.ts
+++ b/frontend/e2e/production/full-user-journey.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, Page, APIRequestContext } from '@playwright/test';
 import { createEmailHelper, isEmailTestingAvailable } from '../helpers/email-testing';
+import { clickCompleteSignInGate } from '../helpers/auth';
 
 /**
  * Production E2E Test - Full User Journey
@@ -234,6 +235,10 @@ test.describe('Production E2E - Full User Journey', () => {
           throw new Error('Could not extract magic link from email');
         }
         await page.goto(magicLinkUrl);
+
+        // Click the "Complete Sign-In" gate (verify page no longer auto-consumes
+        // the token on mount — see #870). This spends the single-use token.
+        await clickCompleteSignInGate(page);
 
         // Wait for successful verification and redirect
         await expect(

--- a/frontend/e2e/production/happy-path-real-user.spec.ts
+++ b/frontend/e2e/production/happy-path-real-user.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, Page, BrowserContext } from '@playwright/test';
 import { createEmailHelper, isEmailTestingAvailable } from '../helpers/email-testing';
+import { clickCompleteSignInGate } from '../helpers/auth';
 
 /**
  * E2E Happy Path Test - Real User Journey with Full UI Interactions
@@ -334,6 +335,11 @@ test.describe('E2E Happy Path - Real User with Full UI Interactions', () => {
         // Navigate to the magic link URL to verify and authenticate
         await page.goto(magicLinkUrl);
         console.log('  Navigated to magic link verification page');
+
+        // Click the "Complete Sign-In" gate (verify page no longer auto-consumes
+        // the token on mount — see #870). This spends the single-use token.
+        await clickCompleteSignInGate(page);
+        console.log('  Clicked "Complete Sign-In" gate');
 
         // Wait for verification to complete — new users see a credit interstitial
         // (credits_granted, credits_denied, or credits_pending), returning users

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.190.2"
+version = "0.190.3"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Problem

The daily E2E (`e2e-daily.yml`) **Stage 1 (Credit Purchase) failed** (Run #87), with **Stage 2 (Happy Path) skipped** only because its `if` requires Stage 1 success.

Root cause: yesterday's `fix(auth): gate magic-link verify behind explicit click` (#870). The `/auth/verify` page no longer auto-consumes the token on mount — it now shows a **"Complete Sign-In"** confirm gate, and the token is only spent when that button is clicked (protects the link from email scanners).

The three magic-link E2E specs navigate to the link then *immediately* wait for the post-sign-in text ("Successfully signed in!" / "Welcome to Nomad Karaoke!"). That text now only appears **after** clicking the gate → 30s timeout → failure. All three were affected (Stage 2 has the same bug; it just never ran).

## Fix

New shared helper `clickCompleteSignInGate(page)` in `frontend/e2e/helpers/auth.ts`:
- waits for the gate button (`getByRole('button', { name: /complete sign-?in/i })`)
- races it against the `/sign-in failed/i` UI so a genuinely dead link throws a diagnostic error instead of a bare timeout
- clicks the gate

Called after `page.goto(magicLink)` in:
- `credit-purchase-real.spec.ts` (Stage 1)
- `happy-path-real-user.spec.ts` (Stage 2)
- `full-user-journey.spec.ts`

## Verification

- `playwright test --list` compiles all three specs; ESLint clean; CodeRabbit 0 findings.
- **Live against prod v0.190.2:** minted a real magic-link token via `POST /api/users/auth/magic-link`, drove it in an isolated browser → gate **"Complete Sign-In"** renders → click → **"Welcome to Nomad Karaoke!"** interstitial → **"Start Creating Karaoke"** → `/app`. Every selector in the fix and downstream test logic confirmed.

Test-only change (+ version bump 0.190.2 → 0.190.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@coderabbitai ignore