### PR TITLE
fix: filter benign ResizeObserver-loop noise from client error monitor

### DIFF
--- a/frontend/lib/__tests__/crash-reporter.test.ts
+++ b/frontend/lib/__tests__/crash-reporter.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+import { isBenignError, reportClientError, __resetForTest } from '@/lib/crash-reporter'
+
+describe('isBenignError', () => {
+  it('treats ResizeObserver loop notices as benign (both phrasings)', () => {
+    expect(
+      isBenignError(new Error('ResizeObserver loop completed with undelivered notifications.'))
+    ).toBe(true)
+    expect(isBenignError(new Error('ResizeObserver loop limit exceeded'))).toBe(true)
+    // window.onerror sometimes hands us the bare string.
+    expect(isBenignError('ResizeObserver loop completed with undelivered notifications.')).toBe(
+      true
+    )
+  })
+
+  it('still treats media AbortError as benign', () => {
+    const abort = new Error('The play() request was interrupted')
+    abort.name = 'AbortError'
+    expect(isBenignError(abort)).toBe(true)
+  })
+
+  it('does not suppress real errors', () => {
+    expect(isBenignError(new Error('Cannot read properties of undefined'))).toBe(false)
+    expect(
+      isBenignError(new TypeError("Failed to set the 'currentTime' property"))
+    ).toBe(false)
+  })
+})
+
+describe('reportClientError', () => {
+  beforeEach(() => {
+    __resetForTest()
+    global.fetch = jest.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch
+  })
+  afterEach(() => jest.restoreAllMocks())
+
+  const ctx = {
+    href: 'https://gen.nomadkaraoke.com/en/app/jobs/',
+    userAgent: 'test',
+  }
+
+  it('never POSTs a benign ResizeObserver error to the monitor', async () => {
+    await reportClientError({
+      error: new Error('ResizeObserver loop completed with undelivered notifications.'),
+      source: 'window.onerror',
+      context: ctx,
+    })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('POSTs a genuine error', async () => {
+    await reportClientError({
+      error: new Error('boom'),
+      source: 'window.onerror',
+      context: ctx,
+    })
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/lib/__tests__/crash-reporter.test.ts
+++ b/frontend/lib/__tests__/crash-reporter.test.ts
@@ -30,11 +30,20 @@ describe('isBenignError', () => {
 })
 
 describe('reportClientError', () => {
+  // jsdom has no global fetch to spyOn, so assign directly — but save and
+  // restore the original so the mock never leaks into other suites.
+  let fetchSpy: jest.Mock
+  let originalFetch: typeof global.fetch
   beforeEach(() => {
     __resetForTest()
-    global.fetch = jest.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch
+    originalFetch = global.fetch
+    fetchSpy = jest.fn().mockResolvedValue({ ok: true } as Response)
+    global.fetch = fetchSpy as unknown as typeof fetch
   })
-  afterEach(() => jest.restoreAllMocks())
+  afterEach(() => {
+    global.fetch = originalFetch
+    jest.restoreAllMocks()
+  })
 
   const ctx = {
     href: 'https://gen.nomadkaraoke.com/en/app/jobs/',
@@ -47,7 +56,7 @@ describe('reportClientError', () => {
       source: 'window.onerror',
       context: ctx,
     })
-    expect(global.fetch).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
   })
 
   it('POSTs a genuine error', async () => {
@@ -56,6 +65,6 @@ describe('reportClientError', () => {
       source: 'window.onerror',
       context: ctx,
     })
-    expect(global.fetch).toHaveBeenCalledTimes(1)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/lib/crash-reporter.ts
+++ b/frontend/lib/crash-reporter.ts
@@ -92,17 +92,29 @@ function signatureFor(message: string, stack: string | null, source: string): st
 
 /**
  * Benign errors that are routinely produced by the browser during normal use
- * and carry no diagnostic value. The most common is a rejected
- * `HTMLMediaElement.play()` promise (DOMException "AbortError") that fires when
- * playback is interrupted by a pause / src change / unmount — e.g. clicking play
- * on the lyrics-review audio while it is still loading. These must never reach
- * the error monitor.
+ * and carry no diagnostic value. These must never reach the error monitor:
+ *
+ * - A rejected `HTMLMediaElement.play()` promise (DOMException "AbortError")
+ *   that fires when playback is interrupted by a pause / src change / unmount —
+ *   e.g. clicking play on the lyrics-review audio while it is still loading.
+ * - The "ResizeObserver loop …" notice: a spec-defined signal that an observer
+ *   callback nudged layout and the browser deferred the next batch a frame. It
+ *   is not a crash — Chrome hides it from its own console — and every page using
+ *   ResizeObserver (TimelineCanvas, FlyerPreview, the VNC toolbar, …) emits it.
  */
-function isBenignError(e: unknown): boolean {
+const BENIGN_MESSAGE_PATTERNS = [
+  // Both the current ("completed with undelivered notifications") and legacy
+  // ("loop limit exceeded") Chromium phrasings.
+  /resizeobserver loop/i,
+]
+
+export function isBenignError(e: unknown): boolean {
   if (e instanceof DOMException && e.name === 'AbortError') return true
   // Some browsers surface the same media abort as a plain Error.
   if (e instanceof Error && e.name === 'AbortError') return true
-  return false
+  const message =
+    e instanceof Error ? e.message : typeof e === 'string' ? e : ''
+  return BENIGN_MESSAGE_PATTERNS.some((re) => re.test(message))
 }
 
 /**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.191.0"
+version = "0.191.1"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
The error monitor fired a 🔴 New Error Pattern alert for \`ResizeObserver loop completed with undelivered notifications\` (on \`singa.\`, build ad3c0bff). This is a **benign, spec-defined browser signal** — not a crash. Chrome hides it from its own console; every page using ResizeObserver (TimelineCanvas, FlyerPreview, VNC toolbar) emits it occasionally. It reached the monitor because the global \`window.onerror\` handler reports everything with no benign-noise filter.

## Changes
- Extend the existing \`isBenignError\` filter in \`frontend/lib/crash-reporter.ts\` (which already drops media \`AbortError\`) to also skip both ResizeObserver-loop phrasings (\`completed with undelivered notifications\` + legacy \`loop limit exceeded\`).
- Add \`crash-reporter\` unit tests (benign detection + that a genuine error still POSTs).

## Testing
- [x] \`npx jest lib/__tests__/crash-reporter.test.ts\` — 5/5 pass
- [x] Verified real errors (e.g. the \`currentTime\` TypeError) are NOT suppressed

## Review
- [x] Local CodeRabbit review (1 minor finding — test fetch-mock leak — fixed)
- [x] Version bumped 0.191.0 → 0.191.1

## Context
Unrelated to the karaoke \`currentTime\` fix shipped in #877. Also confirmed the same-day E2E "Happy Path" alert was a landing-page \`page.goto\` timeout flake (site healthy), re-running to confirm.

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)