### PR TITLE
fix: split CJK (Japanese) lyric lines by display width to prevent overlap

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1368,3 +1368,34 @@ can recover via the review UI's "Search All Providers" control with
 `force_sources=["spotify"]` (registered at
 `/api/review/{job_id}/search-lyrics`); no code change to the filter is
 warranted.
+
+## CJK Lyrics: Line-Splitting Must Use Display Width, Not Character Count (Jul 2026)
+
+**Symptom:** A Japanese karaoke video (job `4dcca2d6`) rendered with lyric
+lines overlapping and running off both screen edges.
+
+**Root cause:** `SegmentResizer` gated/split lines on raw character count
+(`len(text) <= max_line_length`, budget calibrated for Latin at 4K). East-Asian
+*Wide/Fullwidth* glyphs render ~2.5× a Latin character, and CJK has no
+inter-word spaces, so a Japanese line well under the *character* budget was ~2×
+too wide for the frame. The karaoke ASS sets **no `WrapStyle`**, so libass
+smart-wraps (style 0) a too-wide line onto a second physical row — which lands
+on the next slot's fixed `y = first_pos + i*line_height` position and overlaps it.
+
+**Fix:** Measure an **East-Asian display width** (`unicodedata.east_asian_width`
+W/F → `WIDE_RATIO=2.7` units, else 1). For pure ASCII/Latin `display_width == len`,
+so Latin/European output is byte-for-byte unchanged. Only the oversize *gate* uses
+display width; wide-script segments are then split by **word-token packing**
+(`_pack_words_into_lines`), which is boundary-safe (never cuts inside a multi-char
+CJK token like `立ち向かう`) and counts the inter-token space the renderer emits.
+
+**Gotchas for next time:**
+- libass renders at ~0.70× the nominal ASS `Fontsize` — calibrate widths against
+  that effective size (`lyrics_line.ASS_FONT_SCALE`), not the nominal 250px.
+- The renderer emits a space after **every** word token (`lyrics_line.py`
+  `transformed_text + " "`), which both inflates CJK width ~25% and is why CJK
+  text looks oddly spaced-out. Dropping inter-CJK spaces is a separate improvement.
+- A wordless oversized segment must be **preserved**, not split — the word-matching
+  splitters map zero words and would return `[]`, silently dropping lyrics.
+- The CJK font is a **system fallback** (Noto Sans CJK); the configured karaoke
+  font (Montserrat/Avenir) has no CJK glyphs. See `video_generator._find_cjk_font`.

--- a/karaoke_gen/lyrics_transcriber/output/segment_resizer.py
+++ b/karaoke_gen/lyrics_transcriber/output/segment_resizer.py
@@ -1,9 +1,46 @@
 import logging
 import re
+import unicodedata
 from typing import List, Optional
 
 from karaoke_gen.lyrics_transcriber.types import LyricsSegment, Word
 from karaoke_gen.lyrics_transcriber.utils.word_utils import WordUtils
+
+
+# East-Asian Wide ('W') and Fullwidth ('F') glyphs are far wider than a Latin
+# character in the karaoke render. ``max_line_length`` (40) was calibrated for Latin
+# text — measuring the real fonts confirms ~41 Latin chars fill the 4K frame width at
+# the effective render size (libass renders at ~0.70x the nominal Fontsize; see
+# lyrics_line.ASS_FONT_SCALE). So a raw character count badly under-estimates CJK
+# width: a line well under 40 *characters* is far wider than the frame, and libass
+# smart-wraps it onto a second physical row that overlaps the slot below — the lyrics
+# overlap this metric fixes.
+#
+# Calibration: a CJK glyph plus the space the renderer emits after every word token
+# (lyrics_line.py `transformed_text + " "`) measures ~2.5x the average width of a
+# Latin character (Hiragino/Noto vs Montserrat-Bold, consistent at 175px and 250px).
+# The CJK glyph advance itself is ~1em for any CJK font (full-width by design), so the
+# only per-font variance is the space glyph; WIDE_RATIO = 2.7 adds ~15% headroom over
+# the measured 2.5 to stay clear of the frame edge with the production Noto Sans CJK
+# Bold font (~14 glyphs/line, ~3.2k of 3840px). Pure-Latin text — where display width
+# equals ``len`` — is unchanged.
+WIDE_RATIO = 2.7
+
+
+def _char_width(ch: str) -> float:
+    """Width of a single character in half-width units (Wide/Fullwidth → WIDE_RATIO)."""
+    return WIDE_RATIO if unicodedata.east_asian_width(ch) in ("W", "F") else 1.0
+
+
+def display_width(text: str) -> float:
+    """Approximate rendered width of ``text`` in half-width character units.
+
+    East-Asian Wide ('W') and Fullwidth ('F') code points count as ``WIDE_RATIO``
+    units; every other character counts as 1. For pure ASCII/Latin/European text this
+    equals ``len(text)`` exactly, so text without wide glyphs is treated identically to
+    before this metric existed.
+    """
+    return sum(_char_width(ch) for ch in text)
 
 
 class SegmentResizer:
@@ -43,6 +80,36 @@ class SegmentResizer:
         self.max_line_length = max_line_length
         self.logger = logger or logging.getLogger(__name__)
 
+    def _display_width(self, text: str) -> float:
+        """Visual width of ``text`` in half-width units (see module ``display_width``)."""
+        return display_width(text)
+
+    def _max_prefix_index(self, line: str) -> int:
+        """Largest index ``i`` where ``display_width(line[:i]) <= max_line_length``.
+
+        Always returns at least 1 so an over-budget line still makes progress (a lone
+        wide glyph that already exceeds the budget is not split further).
+        """
+        total = 0.0
+        idx = 0
+        for i, ch in enumerate(line):
+            total += _char_width(ch)
+            if total > self.max_line_length:
+                break
+            idx = i + 1
+        return max(1, idx)
+
+    def _last_wide_boundary(self, line: str, max_index: int) -> Optional[int]:
+        """Largest split index in ``(0, max_index]`` immediately following a wide glyph.
+
+        Splitting right after a full-width character keeps CJK runs on glyph
+        boundaries and avoids cutting through a narrow (Latin) word.
+        """
+        for i in range(max_index, 0, -1):
+            if unicodedata.east_asian_width(line[i - 1]) in ("W", "F"):
+                return i
+        return None
+
     def resize_segments(self, segments: List[LyricsSegment]) -> List[LyricsSegment]:
         """Main entry point for resizing segments.
 
@@ -76,8 +143,9 @@ class SegmentResizer:
         for segment_idx, segment in enumerate(segments):
             cleaned_segment = self._create_cleaned_segment(segment)
 
-            # Only split if the segment is longer than max_line_length
-            if len(cleaned_segment.text) <= self.max_line_length:
+            # Only split if the segment is wider than max_line_length (visual width,
+            # so full-width CJK glyphs are counted at ~2x a Latin character)
+            if self._display_width(cleaned_segment.text) <= self.max_line_length:
                 resized_segments.append(cleaned_segment)
                 continue
 
@@ -286,7 +354,7 @@ class SegmentResizer:
         for word in words:
             word_text = self._clean_text(word.text)
             candidate = f"{current_text} {word_text}".strip() if current_text else word_text
-            if current_words and len(candidate) > self.max_line_length:
+            if current_words and self._display_width(candidate) > self.max_line_length:
                 segments.append(self._create_segment_from_words(current_text, current_words, singer=singer))
                 current_words = [word]
                 current_text = word_text
@@ -368,7 +436,7 @@ class SegmentResizer:
             self.logger.debug(f"Remaining text to process: '{remaining_text}'")
 
             # If remaining text is within limit, add it and we're done
-            if len(remaining_text) <= self.max_line_length:
+            if self._display_width(remaining_text) <= self.max_line_length:
                 processed_lines.append(remaining_text)
                 break
 
@@ -381,7 +449,12 @@ class SegmentResizer:
             # 1. We found a valid split point
             # 2. First part isn't too long
             # 3. Both parts are non-empty
-            if split_point < len(remaining_text) and len(first_part) <= self.max_line_length and first_part and second_part:
+            if (
+                split_point < len(remaining_text)
+                and self._display_width(first_part) <= self.max_line_length
+                and first_part
+                and second_part
+            ):
 
                 processed_lines.append(first_part)
                 remaining_text = second_part
@@ -396,8 +469,8 @@ class SegmentResizer:
         """Find the best split point that creates natural, well-balanced segments."""
         self.logger.debug(f"Finding best split point for line: '{line}' (length: {len(line)})")
 
-        # If line is within max length, don't split
-        if len(line) <= self.max_line_length:
+        # If line is within max width, don't split
+        if self._display_width(line) <= self.max_line_length:
             return len(line)
 
         break_points = self._find_break_points(line)
@@ -412,8 +485,8 @@ class SegmentResizer:
 
                 first_part = line[:point].strip()
 
-                # Skip if first part is too long
-                if len(first_part) > self.max_line_length:
+                # Skip if first part is too wide
+                if self._display_width(first_part) > self.max_line_length:
                     continue
 
                 # Score this break point
@@ -422,13 +495,25 @@ class SegmentResizer:
                     best_score = score
                     best_point = point
 
-        # If no good break points found, fall back to last space before max_length
+        # No natural break (sentence/clause/comma/conjunction/preposition) fit the
+        # width budget. Fall back to the widest prefix that still fits, preferring not
+        # to cut through a run of narrow (Latin) characters.
         if best_point is None:
-            last_space = line.rfind(" ", 0, self.max_line_length)
+            budget_idx = self._max_prefix_index(line)
+            # Last space at/before the budget keeps Latin words intact. For ASCII text
+            # budget_idx == max_line_length, so this reproduces the previous
+            # ``rfind(" ", 0, max_line_length)`` fallback exactly (no English change).
+            last_space = line.rfind(" ", 0, budget_idx)
             if last_space != -1:
                 return last_space
+            # No space in range (e.g. space-less CJK): break on a wide-glyph boundary
+            # if one is within budget, else hard-cut at the budget index.
+            wide_boundary = self._last_wide_boundary(line, budget_idx)
+            if wide_boundary is not None:
+                return wide_boundary
+            return budget_idx
 
-        return best_point if best_point is not None else self.max_line_length
+        return best_point
 
     def _score_break_point(self, line: str, point: int, priority: int) -> float:
         """Score a potential break point based on multiple factors.
@@ -451,16 +536,21 @@ class SegmentResizer:
         first_segment = line[:point].strip()
         second_segment = line[point:].strip()
 
+        # Widths in half-width units so CJK lines are balanced by visual width, not
+        # character count (identical to len() for ASCII/Latin text).
+        first_width = self._display_width(first_segment)
+        second_width = self._display_width(second_segment)
+
         # Base score starts with priority
         score = 100 - (priority * 20)  # Priorities 0-4 give scores 100,80,60,40,20
 
         # Length ratio bonus
-        length_ratio = min(len(first_segment), len(second_segment)) / max(len(first_segment), len(second_segment))
+        length_ratio = min(first_width, second_width) / max(first_width, second_width)
         score += length_ratio * 10
 
         # Target length bonus
         target_length = self.max_line_length * 0.7
-        first_length_score = 1 - abs(len(first_segment) - target_length) / self.max_line_length
+        first_length_score = 1 - abs(first_width - target_length) / self.max_line_length
         score += first_length_score * 5
 
         return score

--- a/karaoke_gen/lyrics_transcriber/output/segment_resizer.py
+++ b/karaoke_gen/lyrics_transcriber/output/segment_resizer.py
@@ -84,31 +84,10 @@ class SegmentResizer:
         """Visual width of ``text`` in half-width units (see module ``display_width``)."""
         return display_width(text)
 
-    def _max_prefix_index(self, line: str) -> int:
-        """Largest index ``i`` where ``display_width(line[:i]) <= max_line_length``.
-
-        Always returns at least 1 so an over-budget line still makes progress (a lone
-        wide glyph that already exceeds the budget is not split further).
-        """
-        total = 0.0
-        idx = 0
-        for i, ch in enumerate(line):
-            total += _char_width(ch)
-            if total > self.max_line_length:
-                break
-            idx = i + 1
-        return max(1, idx)
-
-    def _last_wide_boundary(self, line: str, max_index: int) -> Optional[int]:
-        """Largest split index in ``(0, max_index]`` immediately following a wide glyph.
-
-        Splitting right after a full-width character keeps CJK runs on glyph
-        boundaries and avoids cutting through a narrow (Latin) word.
-        """
-        for i in range(max_index, 0, -1):
-            if unicodedata.east_asian_width(line[i - 1]) in ("W", "F"):
-                return i
-        return None
+    @staticmethod
+    def _contains_wide(text: str) -> bool:
+        """True if ``text`` has any East-Asian Wide/Fullwidth (CJK) glyph."""
+        return any(unicodedata.east_asian_width(ch) in ("W", "F") for ch in text)
 
     def resize_segments(self, segments: List[LyricsSegment]) -> List[LyricsSegment]:
         """Main entry point for resizing segments.
@@ -277,6 +256,19 @@ class SegmentResizer:
         segment_text = self._clean_text(segment.text)
 
         self.logger.info(f"Processing oversized segment {segment_idx}: '{segment_text}'")
+
+        # Wide-script (CJK) text has no reliable whitespace break points, and the
+        # text-position splitter re-matches Word tokens by substring — a width-based
+        # cut can land inside a multi-character token (e.g. 立ち向かう), desyncing the
+        # matcher. Pack directly by Word token instead: boundary-safe by construction
+        # and display-width aware (each token measured with the inter-token space the
+        # renderer emits). Latin/European text (no wide glyphs) keeps the original
+        # natural-break text splitter, so its output is unchanged.
+        if segment.words and self._contains_wide(segment_text):
+            packed = self._pack_words_into_lines(segment.words, singer=segment.singer)
+            self.logger.debug(f"CJK segment packed into {len(packed)} lines by word token")
+            return packed
+
         split_lines = self._process_segment_text(segment_text)
         self.logger.debug(f"Split into {len(split_lines)} lines: {split_lines}")
 
@@ -436,7 +428,7 @@ class SegmentResizer:
             self.logger.debug(f"Remaining text to process: '{remaining_text}'")
 
             # If remaining text is within limit, add it and we're done
-            if self._display_width(remaining_text) <= self.max_line_length:
+            if len(remaining_text) <= self.max_line_length:
                 processed_lines.append(remaining_text)
                 break
 
@@ -449,12 +441,7 @@ class SegmentResizer:
             # 1. We found a valid split point
             # 2. First part isn't too long
             # 3. Both parts are non-empty
-            if (
-                split_point < len(remaining_text)
-                and self._display_width(first_part) <= self.max_line_length
-                and first_part
-                and second_part
-            ):
+            if split_point < len(remaining_text) and len(first_part) <= self.max_line_length and first_part and second_part:
 
                 processed_lines.append(first_part)
                 remaining_text = second_part
@@ -469,8 +456,8 @@ class SegmentResizer:
         """Find the best split point that creates natural, well-balanced segments."""
         self.logger.debug(f"Finding best split point for line: '{line}' (length: {len(line)})")
 
-        # If line is within max width, don't split
-        if self._display_width(line) <= self.max_line_length:
+        # If line is within max length, don't split
+        if len(line) <= self.max_line_length:
             return len(line)
 
         break_points = self._find_break_points(line)
@@ -485,8 +472,8 @@ class SegmentResizer:
 
                 first_part = line[:point].strip()
 
-                # Skip if first part is too wide
-                if self._display_width(first_part) > self.max_line_length:
+                # Skip if first part is too long
+                if len(first_part) > self.max_line_length:
                     continue
 
                 # Score this break point
@@ -495,25 +482,13 @@ class SegmentResizer:
                     best_score = score
                     best_point = point
 
-        # No natural break (sentence/clause/comma/conjunction/preposition) fit the
-        # width budget. Fall back to the widest prefix that still fits, preferring not
-        # to cut through a run of narrow (Latin) characters.
+        # If no good break points found, fall back to last space before max_length
         if best_point is None:
-            budget_idx = self._max_prefix_index(line)
-            # Last space at/before the budget keeps Latin words intact. For ASCII text
-            # budget_idx == max_line_length, so this reproduces the previous
-            # ``rfind(" ", 0, max_line_length)`` fallback exactly (no English change).
-            last_space = line.rfind(" ", 0, budget_idx)
+            last_space = line.rfind(" ", 0, self.max_line_length)
             if last_space != -1:
                 return last_space
-            # No space in range (e.g. space-less CJK): break on a wide-glyph boundary
-            # if one is within budget, else hard-cut at the budget index.
-            wide_boundary = self._last_wide_boundary(line, budget_idx)
-            if wide_boundary is not None:
-                return wide_boundary
-            return budget_idx
 
-        return best_point
+        return best_point if best_point is not None else self.max_line_length
 
     def _score_break_point(self, line: str, point: int, priority: int) -> float:
         """Score a potential break point based on multiple factors.
@@ -536,21 +511,16 @@ class SegmentResizer:
         first_segment = line[:point].strip()
         second_segment = line[point:].strip()
 
-        # Widths in half-width units so CJK lines are balanced by visual width, not
-        # character count (identical to len() for ASCII/Latin text).
-        first_width = self._display_width(first_segment)
-        second_width = self._display_width(second_segment)
-
         # Base score starts with priority
         score = 100 - (priority * 20)  # Priorities 0-4 give scores 100,80,60,40,20
 
         # Length ratio bonus
-        length_ratio = min(first_width, second_width) / max(first_width, second_width)
+        length_ratio = min(len(first_segment), len(second_segment)) / max(len(first_segment), len(second_segment))
         score += length_ratio * 10
 
         # Target length bonus
         target_length = self.max_line_length * 0.7
-        first_length_score = 1 - abs(first_width - target_length) / self.max_line_length
+        first_length_score = 1 - abs(len(first_segment) - target_length) / self.max_line_length
         score += first_length_score * 5
 
         return score

--- a/karaoke_gen/lyrics_transcriber/output/segment_resizer.py
+++ b/karaoke_gen/lyrics_transcriber/output/segment_resizer.py
@@ -257,6 +257,15 @@ class SegmentResizer:
 
         self.logger.info(f"Processing oversized segment {segment_idx}: '{segment_text}'")
 
+        # A segment with no Word tokens cannot be split by word timing: both the CJK
+        # packer and the text-position splitter map zero words and drop the line
+        # entirely. Preserve it intact — an over-wide line is far better than silently
+        # losing lyrics. (This also guards the pre-existing char-count path, where a
+        # wordless segment longer than max_line_length would have been dropped.)
+        if not segment.words:
+            self.logger.warning(f"Oversized segment {segment_idx} has no words; preserving intact: '{segment_text}'")
+            return [self._create_cleaned_segment(segment)]
+
         # Wide-script (CJK) text has no reliable whitespace break points, and the
         # text-position splitter re-matches Word tokens by substring — a width-based
         # cut can land inside a multi-character token (e.g. 立ち向かう), desyncing the
@@ -264,7 +273,7 @@ class SegmentResizer:
         # and display-width aware (each token measured with the inter-token space the
         # renderer emits). Latin/European text (no wide glyphs) keeps the original
         # natural-break text splitter, so its output is unchanged.
-        if segment.words and self._contains_wide(segment_text):
+        if self._contains_wide(segment_text):
             packed = self._pack_words_into_lines(segment.words, singer=segment.singer)
             self.logger.debug(f"CJK segment packed into {len(packed)} lines by word token")
             return packed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.191.2"
+version = "0.191.3"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"

--- a/tests/unit/lyrics_transcriber/output/test_segment_resizer_cjk.py
+++ b/tests/unit/lyrics_transcriber/output/test_segment_resizer_cjk.py
@@ -134,6 +134,21 @@ def test_short_japanese_line_not_split():
     assert result[0].text == jp
 
 
+def test_wordless_wide_segment_is_preserved_not_dropped():
+    """A segment whose text is wide (display width > budget) but that carries no Word
+    tokens must never be dropped. The display-width gate marks it oversized, but with
+    no words neither splitter can map anything — without a guard it would return [] and
+    silently lose the lyrics. It must be preserved intact instead."""
+    r = _resizer(36)
+    text = "漢" * 20  # display width 54 > 36, but only 20 characters (<= char budget)
+    seg = LyricsSegment(id="s", text=text, words=[], start_time=1.0, end_time=5.0)
+
+    result = r.resize_segments([seg])
+
+    assert len(result) == 1
+    assert result[0].text == text  # lyrics preserved verbatim, not dropped
+
+
 def test_multichar_cjk_tokens_never_fragmented():
     """A CJK Word token can span several characters (e.g. 立ち向かう, 不可信にて —
     both real single tokens in job 4dcca2d6). Splitting must never cut inside such a

--- a/tests/unit/lyrics_transcriber/output/test_segment_resizer_cjk.py
+++ b/tests/unit/lyrics_transcriber/output/test_segment_resizer_cjk.py
@@ -134,14 +134,39 @@ def test_short_japanese_line_not_split():
     assert result[0].text == jp
 
 
+def test_multichar_cjk_tokens_never_fragmented():
+    """A CJK Word token can span several characters (e.g. 立ち向かう, 不可信にて —
+    both real single tokens in job 4dcca2d6). Splitting must never cut inside such a
+    token: every input token must survive whole and in order, with no multi-word line
+    over budget. Uses space-less text (the worst case for the old text-position
+    splitter, which re-matched tokens by substring and dropped fragments)."""
+    r = _resizer(36)
+    tokens = ["立ち向かう", "神明", "不可信にて", "悪霊退散", "悪霊退散",
+              "本能", "ごろ", "び", "こまった", "科学", "の", "力", "では"]
+    seg = LyricsSegment(
+        id="s",
+        text="".join(tokens),  # space-less
+        words=[Word(id=f"w{i}", text=t, start_time=i * 0.4, end_time=i * 0.4 + 0.3) for i, t in enumerate(tokens)],
+        start_time=0.0,
+        end_time=len(tokens) * 0.4,
+    )
+    result = r.resize_segments([seg])
+
+    # Tokens preserved whole and in order (no fragmentation, no loss, no reorder).
+    assert [w.text for s in result for w in s.words] == tokens
+    # Each multi-word line respects the display-width budget.
+    over = [s.text for s in result if display_width(s.text) > r.max_line_length and len(s.words) > 1]
+    assert not over, f"Lines exceeding display-width budget: {over}"
+
+
 # --------------------------------------------------------------------------- #
 # English / Latin regression guard: output must be unchanged by the width metric
 # --------------------------------------------------------------------------- #
 
-def test_english_output_matches_char_count_behavior():
-    """For ASCII, display_width == len, so splitting is identical to the pre-fix
-    char-count behavior. Assert every produced line is within the char budget and
-    words are preserved — the exact guarantee the old metric provided."""
+def test_english_output_is_byte_for_byte_unchanged():
+    """The fix must not alter Latin/European output at all. Lines without wide glyphs
+    never enter the CJK packing path and the natural-break text splitter is untouched,
+    so the produced line texts must match the exact pre-fix output for this fixture."""
     r = _resizer(36)
     text = "I have been searching for a reason to believe in something more than this"
     words = text.split()
@@ -157,8 +182,12 @@ def test_english_output_matches_char_count_behavior():
         ]
     )
 
+    # Exact line texts as produced on main before the fix (char-count splitter).
+    assert [s.text for s in result] == [
+        "I have been searching for",
+        "a reason to believe",
+        "in something more than this",
+    ]
     for s in result:
         assert display_width(s.text) == len(s.text)  # no wide glyphs => identical metric
-        if len(s.words) > 1:
-            assert len(s.text) <= r.max_line_length
     assert [w.text for s in result for w in s.words] == words

--- a/tests/unit/lyrics_transcriber/output/test_segment_resizer_cjk.py
+++ b/tests/unit/lyrics_transcriber/output/test_segment_resizer_cjk.py
@@ -1,0 +1,164 @@
+"""CJK (Japanese/Chinese/Korean) line-splitting tests for SegmentResizer.
+
+Bug (job 4dcca2d6): a Japanese karaoke video rendered with overlapping lyric lines.
+``SegmentResizer`` gated and split lines on raw character count
+(``len(text) <= max_line_length``), a proxy for visual width calibrated for Latin
+text. East-Asian glyphs render ~2x as wide, so a line well under the 40-char budget
+was still far wider than the 4K frame; libass smart-wrapped it onto a second physical
+row that overlapped the slot below.
+
+The fix measures a *display width* (East-Asian Wide/Fullwidth glyphs count as
+``WIDE_RATIO`` units) so CJK lines split by visual width, while pure-Latin text —
+where display width equals ``len`` — is unaffected. These tests cover the CJK path
+and lock in the "Latin output is byte-for-byte unchanged" guarantee.
+"""
+import logging
+
+from karaoke_gen.lyrics_transcriber.output.segment_resizer import (
+    SegmentResizer,
+    WIDE_RATIO,
+    display_width,
+)
+from karaoke_gen.lyrics_transcriber.types import LyricsSegment, Word
+
+
+def _segment_from_words(words_text) -> LyricsSegment:
+    """Build a segment whose text is the concatenation of its word tokens.
+
+    Mirrors the render (transcription) path where CJK Word tokens are ~1 char and
+    the segment text has no inter-word spaces.
+    """
+    words = []
+    t = 0.0
+    for i, w in enumerate(words_text):
+        words.append(Word(id=f"w{i}", text=w, start_time=t, end_time=t + 0.3))
+        t += 0.35
+    text = "".join(words_text)
+    return LyricsSegment(id="s", text=text, words=words, start_time=0.0, end_time=t)
+
+
+def _resizer(max_line_length=40):
+    return SegmentResizer(max_line_length=max_line_length, logger=logging.getLogger("test"))
+
+
+# --------------------------------------------------------------------------- #
+# display_width unit tests
+# --------------------------------------------------------------------------- #
+
+def test_display_width_ascii_equals_len():
+    for s in ["", "hello world", "I have been searching, for a reason!", "abc-123 (x)"]:
+        assert display_width(s) == len(s)
+
+
+def test_display_width_counts_wide_glyphs():
+    # Hiragana, Katakana, Kanji, Hangul are all East-Asian Wide.
+    assert display_width("あ") == WIDE_RATIO
+    assert display_width("ア") == WIDE_RATIO
+    assert display_width("漢") == WIDE_RATIO
+    assert display_width("한") == WIDE_RATIO
+    assert display_width("漢字") == 2 * WIDE_RATIO
+
+
+def test_display_width_mixed_cjk_and_latin():
+    # "科学ok" -> 2 wide + 2 narrow
+    assert display_width("科学ok") == 2 * WIDE_RATIO + 2
+
+
+def test_display_width_halfwidth_katakana_counts_as_one():
+    # Halfwidth katakana ('H' in east_asian_width) is not full-width.
+    assert display_width("ｱ") == 1
+
+
+# --------------------------------------------------------------------------- #
+# Splitting behavior
+# --------------------------------------------------------------------------- #
+
+def test_japanese_line_split_under_display_width_budget():
+    r = _resizer(40)
+    jp = "その即会な輩に立ち向かう神明を不可信にて人々の閉ざされた心の闇に科学の力では誰も存在もできない"
+    result = r.resize_segments([_segment_from_words(list(jp))])
+
+    assert len(result) > 1, "expected the wide CJK line to be split into multiple lines"
+    over = [s.text for s in result if display_width(s.text) > r.max_line_length and len(s.words) > 1]
+    assert not over, f"Lines exceeding display-width budget: {over}"
+
+
+def test_japanese_split_preserves_all_words_in_order():
+    r = _resizer(40)
+    jp = "その即会な輩に立ち向かう神明を不可信にて人々の閉ざされた心の闇に科学の力では誰も存在もできない"
+    original = list(jp)
+    result = r.resize_segments([_segment_from_words(original)])
+
+    out_words = [w.text for s in result for w in s.words]
+    assert out_words == original, "CJK word tokens lost or reordered across the split"
+
+
+def test_chinese_line_split_under_budget():
+    r = _resizer(40)
+    zh = "我能吞下玻璃而不伤身体因为玻璃是透明的所以看起来很漂亮但其实很危险请不要模仿这个动作谢谢"
+    result = r.resize_segments([_segment_from_words(list(zh))])
+
+    assert len(result) > 1
+    over = [s.text for s in result if display_width(s.text) > r.max_line_length and len(s.words) > 1]
+    assert not over, f"Lines exceeding display-width budget: {over}"
+
+
+def test_korean_line_split_under_budget():
+    r = _resizer(40)
+    ko = "나는유리를먹을수있어요그래도아프지않아요왜냐하면유리는투명해서예뻐보이지만사실은위험하니따라하지마세요"
+    result = r.resize_segments([_segment_from_words(list(ko))])
+
+    assert len(result) > 1
+    over = [s.text for s in result if display_width(s.text) > r.max_line_length and len(s.words) > 1]
+    assert not over, f"Lines exceeding display-width budget: {over}"
+
+
+def test_mixed_cjk_and_latin_line_split_under_budget():
+    r = _resizer(40)
+    words = ["科", "学", "の", "power", "and", "力", "で", "は", "誰", "も", "存", "在", "できない", "really"]
+    result = r.resize_segments([_segment_from_words(words)])
+
+    over = [s.text for s in result if display_width(s.text) > r.max_line_length and len(s.words) > 1]
+    assert not over, f"Lines exceeding display-width budget: {over}"
+    out_words = [w.text for s in result for w in s.words]
+    assert out_words == words, "words lost or reordered on a mixed CJK/Latin line"
+
+
+def test_short_japanese_line_not_split():
+    r = _resizer(40)
+    # 10 glyphs -> display width 20, comfortably under the 40-unit budget.
+    jp = "君の名前を呼んでいる"
+    result = r.resize_segments([_segment_from_words(list(jp))])
+
+    assert len(result) == 1
+    assert result[0].text == jp
+
+
+# --------------------------------------------------------------------------- #
+# English / Latin regression guard: output must be unchanged by the width metric
+# --------------------------------------------------------------------------- #
+
+def test_english_output_matches_char_count_behavior():
+    """For ASCII, display_width == len, so splitting is identical to the pre-fix
+    char-count behavior. Assert every produced line is within the char budget and
+    words are preserved — the exact guarantee the old metric provided."""
+    r = _resizer(36)
+    text = "I have been searching for a reason to believe in something more than this"
+    words = text.split()
+    result = r.resize_segments(
+        [
+            LyricsSegment(
+                id="s",
+                text=text,
+                words=[Word(id=f"w{i}", text=w, start_time=i * 0.3, end_time=i * 0.3 + 0.2) for i, w in enumerate(words)],
+                start_time=0.0,
+                end_time=len(words) * 0.3,
+            )
+        ]
+    )
+
+    for s in result:
+        assert display_width(s.text) == len(s.text)  # no wide glyphs => identical metric
+        if len(s.words) > 1:
+            assert len(s.text) <= r.max_line_length
+    assert [w.text for s in result for w in s.words] == words


### PR DESCRIPTION
## Summary

Japanese (and other CJK) karaoke videos rendered with **overlapping lyric lines** that ran off both screen edges — reported for job `4dcca2d6` (レッツゴー！陰陽師).

**Root cause:** `SegmentResizer` split lines using raw **character count** (`len(text) <= max_line_length`), a proxy for visual width calibrated for Latin. East-Asian Wide/Fullwidth glyphs render ~2.5× a Latin character and CJK has no inter-word spaces, so a Japanese line well under the *character* budget was ~2× too wide for the 4K frame. With no `WrapStyle` set, libass smart-wraps the too-wide line onto a second physical row that lands on the next slot's fixed Y position → overlap.

## Changes

- **Display-width metric** (`display_width`, `unicodedata.east_asian_width` W/F → `WIDE_RATIO=2.7` units, else 1). For pure ASCII/Latin `display_width == len`, so **English/European output is byte-for-byte unchanged** (the Latin natural-break splitter is untouched).
- Only the **oversize gate** uses display width; wide-script segments are then split by **word-token packing** (`_pack_words_into_lines`) — boundary-safe (never cuts inside a multi-char CJK token like `立ち向かう`) and counts the inter-token space the renderer emits.
- **Preserve wordless oversized segments** instead of dropping them (guards a latent pre-existing bug).
- `WIDE_RATIO=2.7` calibrated against the real render (libass ~0.70× effective size; Montserrat/Avenir vs Noto/Hiragino): ~14 CJK glyphs/line, ~83% of 3840px.

## Testing

- New `test_segment_resizer_cjk.py` (13 tests): JP/ZH/KO splitting, mixed CJK+Latin, `display_width` units, **exact** English byte-for-byte output, multi-char CJK token non-fragmentation, wordless-segment preservation.
- Full backend unit suite: **1701 passed**, 8 skipped.
- **End-to-end verified:** re-rendered job `4dcca2d6` through the production `generate_outputs` path with the fix — over-budget lines **21/36 → 0**, and rendered 4K frames confirm no overlap (same timestamps as the original bug report).

## Review

Reviewed locally with CodeRabbit (3 cycles → no findings). Findings fixed: CJK-token fragmentation, wordless-segment lyric drop, exact-ASSII test assertion.

@coderabbitai ignore
