### PR TITLE
feat(runner-manager): Windows GPU ephemeral runner family (gpu-windows)

### DIFF
--- a/.github/workflows/build-runner-images.yml
+++ b/.github/workflows/build-runner-images.yml
@@ -1,12 +1,16 @@
 name: Build GHA Runner Images
 
-# Produces three custom GCE images used by the ephemeral GitHub Actions runner
-# dispatcher: gha-runner-general, gha-runner-build, gha-runner-gpu.
+# Produces the custom GCE images used by the ephemeral GitHub Actions runner
+# dispatcher: gha-runner-general, gha-runner-build, gha-runner-gpu,
+# gha-runner-gpu-windows.
 #
 # Flow per variant:
-#   1. Create a temporary build VM from debian-cloud/debian-12 with
-#      infrastructure/scripts/runner-image-provision.sh as metadata-startup-script.
-#   2. Poll for /opt/runner-image-ready via gcloud ssh (survives kernel-upgrade reboots).
+#   1. Create a temporary build VM from the variant's base image with the
+#      variant's provisioning script as its startup script:
+#        - Linux variants:  debian-12 + runner-image-provision.sh (startup-script)
+#        - gpu-windows:     windows-server-2022-dc + runner-image-provision.ps1
+#                           (windows-startup-script-ps1)
+#   2. Poll the serial console for the READY/FAILED marker (survives reboots).
 #   3. Stop the VM, snapshot its boot disk to a new image in the `gha-runner-<variant>`
 #      image family with name gha-runner-<variant>-<timestamp>.
 #   4. Delete the build VM (boot disk auto-deletes).
@@ -16,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       variants:
-        description: 'Comma-separated variants to build (general,build,gpu) or "all"'
+        description: 'Comma-separated variants to build (general,build,gpu,gpu-windows) or "all"'
         required: false
         default: 'all'
       skip_prune:
@@ -50,7 +54,7 @@ jobs:
         run: |
           requested='${{ github.event.inputs.variants || 'all' }}'
           if [[ "$requested" == "all" || -z "$requested" ]]; then
-            echo 'variants=["general","build","gpu"]' >> "$GITHUB_OUTPUT"
+            echo 'variants=["general","build","gpu","gpu-windows"]' >> "$GITHUB_OUTPUT"
           else
             json="$(echo "$requested" | tr ',' '\n' | jq -R . | jq -sc .)"
             echo "variants=$json" >> "$GITHUB_OUTPUT"
@@ -88,6 +92,11 @@ jobs:
           family="gha-runner-${variant}"
           vm="gha-image-build-${variant}-${ts}"
 
+          # Per-variant base image + startup-script metadata key: Windows
+          # VMs only execute scripts under windows-startup-script-ps1.
+          image_flag="--image=${{ env.BASE_IMAGE }}"
+          metadata_file="startup-script=infrastructure/scripts/runner-image-provision.sh"
+
           case "$variant" in
             general|build)
               machine="n2-standard-8"
@@ -100,6 +109,16 @@ jobs:
               machine="n1-standard-4"
               disk_size="200"
               accel="--maintenance-policy=TERMINATE --accelerator=type=nvidia-tesla-t4,count=1"
+              ;;
+            gpu-windows)
+              # T4 attached so the GRID driver install can validate WDDM mode
+              # (required for DirectML). Keep disk in sync with the
+              # gpu-windows FamilySpec in runner_manager/ephemeral.py.
+              machine="n1-standard-4"
+              disk_size="100"
+              accel="--maintenance-policy=TERMINATE --accelerator=type=nvidia-tesla-t4,count=1"
+              image_flag="--image-family=windows-server-2022-dc --image-project=windows-cloud"
+              metadata_file="windows-startup-script-ps1=infrastructure/scripts/runner-image-provision.ps1"
               ;;
             *)
               echo "Unknown variant: $variant" >&2
@@ -114,6 +133,8 @@ jobs:
             echo "machine=$machine"
             echo "disk_size=$disk_size"
             echo "accel=$accel"
+            echo "image_flag=$image_flag"
+            echo "metadata_file=$metadata_file"
           } >> "$GITHUB_OUTPUT"
 
       - name: Create build VM
@@ -123,14 +144,14 @@ jobs:
             --project='${{ env.GCP_PROJECT }}' \
             --zone='${{ env.BUILD_ZONE }}' \
             --machine-type='${{ steps.params.outputs.machine }}' \
-            --image='${{ env.BASE_IMAGE }}' \
+            ${{ steps.params.outputs.image_flag }} \
             --boot-disk-size='${{ steps.params.outputs.disk_size }}GB' \
             --boot-disk-type=pd-balanced \
             --boot-disk-auto-delete \
             --service-account="${{ secrets.GCP_SERVICE_ACCOUNT }}" \
             --scopes=https://www.googleapis.com/auth/cloud-platform \
             --metadata=enable-oslogin=TRUE,image-variant='${{ matrix.variant }}' \
-            --metadata-from-file=startup-script=infrastructure/scripts/runner-image-provision.sh \
+            --metadata-from-file='${{ steps.params.outputs.metadata_file }}' \
             --labels=purpose=gha-runner-image-builder,variant='${{ matrix.variant }}' \
             ${{ steps.params.outputs.accel }}
 

--- a/.github/workflows/build-runner-images.yml
+++ b/.github/workflows/build-runner-images.yml
@@ -8,7 +8,7 @@ name: Build GHA Runner Images
 #   1. Create a temporary build VM from the variant's base image with the
 #      variant's provisioning script as its startup script:
 #        - Linux variants:  debian-12 + runner-image-provision.sh (startup-script)
-#        - gpu-windows:     windows-server-2022-dc + runner-image-provision.ps1
+#        - gpu-windows:     windows-2022 + runner-image-provision.ps1
 #                           (windows-startup-script-ps1)
 #   2. Poll the serial console for the READY/FAILED marker (survives reboots).
 #   3. Stop the VM, snapshot its boot disk to a new image in the `gha-runner-<variant>`
@@ -117,7 +117,7 @@ jobs:
               machine="n1-standard-4"
               disk_size="100"
               accel="--maintenance-policy=TERMINATE --accelerator=type=nvidia-tesla-t4,count=1"
-              image_flag="--image-family=windows-server-2022-dc --image-project=windows-cloud"
+              image_flag="--image-family=windows-2022 --image-project=windows-cloud"
               metadata_file="windows-startup-script-ps1=infrastructure/scripts/runner-image-provision.ps1"
               ;;
             *)

--- a/docs/EPHEMERAL-GHA-RUNNERS.md
+++ b/docs/EPHEMERAL-GHA-RUNNERS.md
@@ -216,7 +216,7 @@ re-deploy).
 
 ## Image families
 
-Three GCE image families are maintained by
+Four GCE image families are maintained by
 [`.github/workflows/build-runner-images.yml`](../.github/workflows/build-runner-images.yml):
 
 | Family | Base | Bakes | Built on |
@@ -224,6 +224,19 @@ Three GCE image families are maintained by
 | `gha-runner-general` | Debian 12 | Docker, gcloud, runner v2.332, Python 3.13 (pyenv), Node 20, Java 21, FFmpeg, Poetry | n2-standard-8, 50GB pd-balanced |
 | `gha-runner-build` | Debian 12 | Same as general + pre-pulled `karaoke-backend-base`/`:latest` + `fake-gcs-server` | n2-standard-8, 50GB pd-balanced |
 | `gha-runner-gpu` | Debian 12 | NVIDIA driver + CUDA 12.4, Python 3.13 (compiled), FFmpeg+libsamplerate, audio-separator models (~14GB at `/opt/audio-separator-models`) | n1-standard-4 + T4, 200GB pd-balanced |
+| `gha-runner-gpu-windows` | Windows Server 2022 | NVIDIA **GRID** driver (WDDM — required for DirectML; datacenter driver = TCC = no DirectX), Python 3.12, Git, FFmpeg, Poetry, runner (win-x64), DirectML test models at `C:\audio-separator-models` | n1-standard-4 + T4, 100GB pd-balanced |
+
+The Windows variant is provisioned by
+[`runner-image-provision.ps1`](../infrastructure/scripts/runner-image-provision.ps1)
+delivered via the `windows-startup-script-ps1` metadata key (Windows ignores
+`startup-script`). It exists for python-audio-separator's `windows-directml`
+integration tests (RoFormer-on-Windows, issue #292 there).
+
+**Label routing**: runners advertise `self-hosted, <os>, x64, gcp[, gpu]`.
+The dispatcher resolves families with precedence windows → gpu → build →
+general, so jobs MUST include an OS label in `runs-on`
+(`[self-hosted, linux, gpu]` / `[self-hosted, windows, gpu]`) — GitHub
+schedules onto any runner whose labels are a superset of the job's.
 
 Each image is tagged `gha-runner-<variant>-<YYYYMMDD-HHMMSS>` and joined to the
 matching image family. The dispatcher always selects from the family, so the
@@ -235,7 +248,7 @@ Build cadence: monthly cron (`0 2 1 * *` UTC) + `workflow_dispatch`. Manual:
 ```bash
 gh workflow run build-runner-images.yml -f variants=general,build
 gh workflow run build-runner-images.yml -f variants=gpu
-gh workflow run build-runner-images.yml          # all three
+gh workflow run build-runner-images.yml          # all variants
 ```
 
 Pulumi does **not** manage images — they're produced by the GHA workflow. The

--- a/docs/EPHEMERAL-GHA-RUNNERS.md
+++ b/docs/EPHEMERAL-GHA-RUNNERS.md
@@ -232,11 +232,12 @@ delivered via the `windows-startup-script-ps1` metadata key (Windows ignores
 `startup-script`). It exists for python-audio-separator's `windows-directml`
 integration tests (RoFormer-on-Windows, issue #292 there).
 
-**Label routing**: runners advertise `self-hosted, <os>, x64, gcp[, gpu]`.
-The dispatcher resolves families with precedence windows → gpu → build →
-general, so jobs MUST include an OS label in `runs-on`
-(`[self-hosted, linux, gpu]` / `[self-hosted, windows, gpu]`) — GitHub
-schedules onto any runner whose labels are a superset of the job's.
+**Label routing**: every runner advertises `self-hosted, <os>, x64, gcp`.
+Families additionally advertise `large-disk` (general/build), `docker-build`
+(build), or `gpu` (GPU families). The dispatcher resolves families with
+precedence windows → gpu → build → general, so jobs MUST include an OS label
+in `runs-on` (`[self-hosted, linux, gpu]` / `[self-hosted, windows, gpu]`) —
+GitHub schedules onto any runner whose labels are a superset of the job's.
 
 Each image is tagged `gha-runner-<variant>-<YYYYMMDD-HHMMSS>` and joined to the
 matching image family. The dispatcher always selects from the family, so the

--- a/infrastructure/functions/runner_manager/ephemeral.py
+++ b/infrastructure/functions/runner_manager/ephemeral.py
@@ -53,6 +53,10 @@ class FamilySpec:
     extra_runner_labels: tuple[str, ...]
     has_gpu: bool
     needs_external_ip_in_fallback_zone: bool
+    # Advertised OS label; also selects the startup-script metadata key —
+    # Windows VMs only execute scripts under `windows-startup-script-ps1`
+    # and silently ignore `startup-script`.
+    os_label: str = "linux"
 
 
 FAMILIES: dict[str, FamilySpec] = {
@@ -87,6 +91,18 @@ FAMILIES: dict[str, FamilySpec] = {
         # rare fallback case rather than provisioning region-wide NAT.
         needs_external_ip_in_fallback_zone=True,
     ),
+    "gpu-windows": FamilySpec(
+        name="gpu-windows",
+        machine_type="n1-standard-4",
+        # Windows Server base image is 50GB; the bake uses a 100GB disk
+        # (models + drivers), so the disk we create here must be >= 100GB.
+        disk_size_gb=100,
+        image_family="gha-runner-gpu-windows",
+        extra_runner_labels=("x64", "gcp", "gpu"),
+        has_gpu=True,
+        needs_external_ip_in_fallback_zone=True,
+        os_label="windows",
+    ),
 }
 
 
@@ -107,6 +123,24 @@ fi
 cd /home/runner/actions-runner
 # --jitconfig implies --ephemeral: runs one job, deregisters, exits.
 sudo -u runner ./run.sh --jitconfig "$JIT"
+"""
+
+
+# Windows equivalent, delivered via the `windows-startup-script-ps1` metadata
+# key. Runs as SYSTEM on every boot — fine for a single-use VM. The finally
+# block guarantees shutdown even if the runner crashes, so the orphan-cleanup
+# pass can delete the stopped VM.
+WINDOWS_STARTUP_SCRIPT_PS1 = r"""$ErrorActionPreference = "Stop"
+try {
+    $jit = Invoke-RestMethod -Headers @{ "Metadata-Flavor" = "Google" } `
+        -Uri "http://metadata.google.internal/computeMetadata/v1/instance/attributes/jit-config"
+    if (-not $jit) { throw "jit-config metadata missing" }
+    Set-Location "C:\actions-runner"
+    # --jitconfig implies --ephemeral: runs one job, deregisters, exits.
+    & .\run.cmd --jitconfig "$jit"
+} finally {
+    shutdown /s /t 30
+}
 """
 
 
@@ -132,11 +166,16 @@ def get_compute_client() -> compute_v1.InstancesClient:
 def resolve_family(labels: Iterable[str]) -> FamilySpec:
     """Pick the right image family for a queued job's labels.
 
-    Precedence: gpu → build → general. A job that asks for both ``gpu`` and
-    ``docker-build`` shouldn't exist today; if it ever does we'd want a separate
-    image, not a coin-flip.
+    Precedence: windows → gpu → build → general. A job that asks for both
+    ``gpu`` and ``docker-build`` shouldn't exist today; if it ever does we'd
+    want a separate image, not a coin-flip.
+
+    Any ``windows`` job routes to the (only) Windows family — gpu-windows —
+    even without a ``gpu`` label, so it runs rather than queueing forever.
     """
     label_set = {label.lower() for label in labels}
+    if "windows" in label_set:
+        return FAMILIES["gpu-windows"]
     if "gpu" in label_set:
         return FAMILIES["gpu"]
     if "docker-build" in label_set:
@@ -146,7 +185,7 @@ def resolve_family(labels: Iterable[str]) -> FamilySpec:
 
 def runner_labels_for(family: FamilySpec) -> list[str]:
     """Compose the labels advertised to GitHub by this runner."""
-    return ["self-hosted", "linux", *family.extra_runner_labels]
+    return ["self-hosted", family.os_label, *family.extra_runner_labels]
 
 
 # ---------------------------------------------------------------------------
@@ -277,10 +316,17 @@ def _build_instance(
             compute_v1.AccessConfig(name="External NAT", type_="ONE_TO_ONE_NAT"),
         ]
 
+    if family.os_label == "windows":
+        startup_item = compute_v1.Items(
+            key="windows-startup-script-ps1", value=WINDOWS_STARTUP_SCRIPT_PS1
+        )
+    else:
+        startup_item = compute_v1.Items(key="startup-script", value=STARTUP_SCRIPT)
+
     metadata = compute_v1.Metadata(
         items=[
             compute_v1.Items(key="jit-config", value=jit_config),
-            compute_v1.Items(key="startup-script", value=STARTUP_SCRIPT),
+            startup_item,
             compute_v1.Items(key="enable-oslogin", value="TRUE"),
         ]
     )

--- a/infrastructure/functions/runner_manager/ephemeral.py
+++ b/infrastructure/functions/runner_manager/ephemeral.py
@@ -516,8 +516,12 @@ def _log_serial_tail(zone: str, name: str) -> None:
     requiring an Ops Agent on the image.
     """
     try:
+        # No port kwarg: the deployed google-cloud-compute client rejects it
+        # (TypeError: unexpected keyword argument 'port', seen 2026-07-20 in
+        # prod logs — it silently disabled ALL serial capture). Port 1 is the
+        # API default anyway.
         out = get_compute_client().get_serial_port_output(
-            project=PROJECT_ID, zone=zone, instance=name, port=1
+            project=PROJECT_ID, zone=zone, instance=name
         )
         contents = out.contents or ""
         tail = contents[-_SERIAL_TAIL_BYTES:]

--- a/infrastructure/functions/runner_manager/test_ephemeral.py
+++ b/infrastructure/functions/runner_manager/test_ephemeral.py
@@ -94,6 +94,23 @@ class TestResolveFamily:
         fam = ep.resolve_family(["Self-Hosted", "Linux", "GPU"])
         assert fam.name == "gpu"
 
+    def test_windows_gpu_routes_to_windows_family(self):
+        ep = _fresh_module()
+        fam = ep.resolve_family(["self-hosted", "windows", "gpu"])
+        assert fam.name == "gpu-windows"
+
+    def test_windows_without_gpu_still_routes_to_windows_family(self):
+        # Only one Windows family exists; better to run the job on it than
+        # let a [self-hosted, windows] job queue forever.
+        ep = _fresh_module()
+        fam = ep.resolve_family(["self-hosted", "windows"])
+        assert fam.name == "gpu-windows"
+
+    def test_linux_gpu_does_not_route_to_windows(self):
+        ep = _fresh_module()
+        fam = ep.resolve_family(["self-hosted", "linux", "gpu"])
+        assert fam.name == "gpu"
+
 
 class TestRunnerLabelsFor:
     def test_general_labels_include_existing_set(self):
@@ -115,6 +132,14 @@ class TestRunnerLabelsFor:
     def test_gpu_labels_include_gpu(self):
         ep = _fresh_module()
         labels = ep.runner_labels_for(ep.FAMILIES["gpu"])
+        assert "gpu" in labels
+        assert "linux" in labels
+
+    def test_windows_labels_advertise_windows_not_linux(self):
+        ep = _fresh_module()
+        labels = ep.runner_labels_for(ep.FAMILIES["gpu-windows"])
+        assert "windows" in labels
+        assert "linux" not in labels
         assert "gpu" in labels
 
 
@@ -238,6 +263,10 @@ class TestSchedulingPerFamily:
 
     def test_gpu_keeps_terminate(self):
         kwargs = self._build_for("gpu")
+        assert kwargs.get("on_host_maintenance") == "TERMINATE"
+
+    def test_gpu_windows_keeps_terminate(self):
+        kwargs = self._build_for("gpu-windows")
         assert kwargs.get("on_host_maintenance") == "TERMINATE"
 
 
@@ -435,6 +464,52 @@ class TestStartupScript:
         assert "config.sh" not in ep.STARTUP_SCRIPT
         # Should pull the JIT config from instance metadata
         assert "metadata.google.internal" in ep.STARTUP_SCRIPT
+
+    def test_windows_startup_script_uses_jitconfig_and_shuts_down(self):
+        ep = _fresh_module()
+        ps1 = ep.WINDOWS_STARTUP_SCRIPT_PS1
+        assert "--jitconfig" in ps1
+        assert "run.cmd" in ps1
+        assert "shutdown /s" in ps1
+        assert "metadata.google.internal" in ps1
+        # finally-block shutdown must survive a runner crash
+        assert "finally" in ps1
+
+
+class TestStartupMetadataKeyPerFamily:
+    """Windows VMs only execute `windows-startup-script-ps1`; Linux VMs only
+    execute `startup-script`. Passing the wrong key silently does nothing and
+    the VM never registers."""
+
+    def _metadata_keys_for(self, family_name):
+        ep = _fresh_module()
+        _compute_stub.Items.reset_mock()
+        ep._build_instance(
+            name=f"gha-{family_name}-test",
+            family=ep.FAMILIES[family_name],
+            zone="us-central1-a",
+            jit_config="JIT",
+            image_self_link="projects/p/global/images/family/x",
+            use_external_ip=False,
+        )
+        return {c.kwargs.get("key"): c.kwargs.get("value") for c in _compute_stub.Items.call_args_list}
+
+    def test_linux_families_use_startup_script(self):
+        for fam in ("general", "build", "gpu"):
+            keys = self._metadata_keys_for(fam)
+            assert "startup-script" in keys, fam
+            assert "windows-startup-script-ps1" not in keys, fam
+
+    def test_windows_family_uses_ps1_key(self):
+        keys = self._metadata_keys_for("gpu-windows")
+        assert "windows-startup-script-ps1" in keys
+        assert "startup-script" not in keys
+        assert "run.cmd" in keys["windows-startup-script-ps1"]
+
+    def test_jit_config_present_for_all_families(self):
+        for fam in ("general", "build", "gpu", "gpu-windows"):
+            keys = self._metadata_keys_for(fam)
+            assert keys.get("jit-config") == "JIT", fam
 
 
 class TestSchedulerAuthGate:

--- a/infrastructure/scripts/runner-image-provision.ps1
+++ b/infrastructure/scripts/runner-image-provision.ps1
@@ -45,10 +45,14 @@ function Phase-Done([string]$name) { Test-Path "$MARKER_DIR\$name" }
 function Mark-Phase([string]$name) { New-Item -ItemType File -Force -Path "$MARKER_DIR\$name" | Out-Null }
 
 function Download([string]$url, [string]$dest) {
-    if ((Test-Path $dest) -and ((Get-Item $dest).Length -gt 0)) { return }
+    # Completed downloads are renamed from .part, so an existing $dest is
+    # always complete (a reboot mid-download leaves only the .part file).
+    if (Test-Path $dest) { return }
     Write-Output "  -> $(Split-Path -Leaf $dest)"
-    & curl.exe -fSL --retry 3 --connect-timeout 30 -o $dest $url
+    $tmp = "$dest.part"
+    & curl.exe -fSL --retry 3 --connect-timeout 30 -o $tmp $url
     if ($LASTEXITCODE -ne 0) { throw "download failed: $url" }
+    Move-Item -Force $tmp $dest
 }
 
 function Add-MachinePath([string]$dir) {
@@ -122,6 +126,11 @@ try {
             throw "GRID driver installer exited with $($p.ExitCode)"
         }
         Mark-Phase "grid-driver"
+        if ($p.ExitCode -eq 1) {
+            Write-Output "GRID installer requests a reboot; rebooting before WDDM check"
+            Restart-Computer -Force
+            exit 0   # provisioning resumes on next boot
+        }
     }
 
     # ================= Verify WDDM mode (DirectML requirement) ============
@@ -135,9 +144,12 @@ try {
         $model = & $smi --query-gpu=driver_model.current --format=csv,noheader
         Write-Output "Driver model: $model"
         if ($model -notmatch "WDDM") {
-            Write-Output "GPU is in TCC mode; switching to WDDM and rebooting"
+            $attemptsFile = "$MARKER_DIR\wddm-attempts"
+            $attempts = if (Test-Path $attemptsFile) { [int](Get-Content $attemptsFile) } else { 0 }
+            if ($attempts -ge 3) { throw "WDDM switch did not take effect after $attempts reboot attempts" }
+            Set-Content -Path $attemptsFile -Value ($attempts + 1)
+            Write-Output "GPU is in TCC mode; switching to WDDM and rebooting (attempt $($attempts + 1)/3)"
             & $smi -fdm 0
-            Mark-Phase "wddm-pending-reboot"
             Restart-Computer -Force
             exit 0   # provisioning resumes on next boot
         }

--- a/infrastructure/scripts/runner-image-provision.ps1
+++ b/infrastructure/scripts/runner-image-provision.ps1
@@ -1,0 +1,246 @@
+# Image-time provisioning for the gpu-windows ephemeral GHA runner image.
+#
+# Runs as `windows-startup-script-ps1` on a fresh Windows Server 2022 VM with
+# an NVIDIA T4 attached (created by .github/workflows/build-runner-images.yml).
+#
+# Installs:
+#   - NVIDIA GRID driver (WDDM mode — REQUIRED for DirectML; the datacenter
+#     driver runs the T4 in TCC mode which has no DirectX support)
+#   - Python 3.12 (torch-directml has no 3.13 wheels), Git, FFmpeg, Poetry
+#   - GitHub Actions runner (win-x64) at C:\actions-runner
+#   - audio-separator DirectML test models at C:\audio-separator-models
+#
+# Conventions shared with runner-image-provision.sh (Linux):
+#   - All output reaches the GCE serial console (the guest agent echoes
+#     windows-startup-script-ps1 output to COM1), which the bake workflow
+#     polls — no SSH/WinRM dependency.
+#   - Success marker line:  "### runner-image: READY: ..."
+#   - Failure marker line:  "### runner-image-provision FAILED"
+#
+# Idempotent: windows-startup-script-ps1 runs on EVERY boot, and the GRID
+# driver step may need a reboot (TCC→WDDM switch). Completed phases are
+# skipped via marker files under C:\provision-markers.
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$VARIANT = "gpu-windows"
+$PYTHON_VERSION = "3.12.10"
+$GIT_VERSION = "2.45.2"
+$RUNNER_VERSION = "2.334.0"   # keep in sync with runner-image-provision.sh
+
+$MARKER_DIR = "C:\provision-markers"
+$READY_FILE = "C:\runner-image-ready"
+$WORK = "C:\provision-work"
+
+function Ck([string]$msg) {
+    Write-Output ""
+    Write-Output "================================================================"
+    Write-Output "### runner-image: $msg  ($(Get-Date -Format o))"
+    Write-Output "================================================================"
+}
+
+function Phase-Done([string]$name) { Test-Path "$MARKER_DIR\$name" }
+function Mark-Phase([string]$name) { New-Item -ItemType File -Force -Path "$MARKER_DIR\$name" | Out-Null }
+
+function Download([string]$url, [string]$dest) {
+    if ((Test-Path $dest) -and ((Get-Item $dest).Length -gt 0)) { return }
+    Write-Output "  -> $(Split-Path -Leaf $dest)"
+    & curl.exe -fSL --retry 3 --connect-timeout 30 -o $dest $url
+    if ($LASTEXITCODE -ne 0) { throw "download failed: $url" }
+}
+
+function Add-MachinePath([string]$dir) {
+    $current = [Environment]::GetEnvironmentVariable("Path", "Machine")
+    if ($current -notlike "*$dir*") {
+        [Environment]::SetEnvironmentVariable("Path", "$current;$dir", "Machine")
+    }
+    $env:Path = "$env:Path;$dir"
+}
+
+# Already fully provisioned (post-reboot re-run after completion, or manual
+# re-run): re-emit the READY marker for the serial-console poller and stop.
+if (Test-Path $READY_FILE) {
+    Ck "READY: variant=$VARIANT (already provisioned)"
+    exit 0
+}
+
+New-Item -ItemType Directory -Force -Path $MARKER_DIR, $WORK | Out-Null
+
+try {
+    Ck "starting variant=$VARIANT"
+
+    # ================= Windows Update off (bake determinism) ==============
+    if (-not (Phase-Done "wu-off")) {
+        Ck "phase: disable windows update"
+        Stop-Service wuauserv -ErrorAction SilentlyContinue
+        Set-Service wuauserv -StartupType Disabled -ErrorAction SilentlyContinue
+        Mark-Phase "wu-off"
+    }
+
+    # ================= Defender exclusions (I/O speed) ====================
+    if (-not (Phase-Done "defender")) {
+        Ck "phase: defender exclusions"
+        foreach ($p in @("C:\actions-runner", "C:\audio-separator-models", $WORK)) {
+            Add-MpPreference -ExclusionPath $p -ErrorAction SilentlyContinue
+        }
+        Mark-Phase "defender"
+    }
+
+    # ================= NVIDIA GRID driver (WDDM for DirectML) =============
+    if (-not (Phase-Done "grid-driver")) {
+        Ck "phase: nvidia grid driver"
+        # GCP hosts GRID installers in the public nvidia-drivers-us-public
+        # bucket. Enumerate GRID*/ dirs newest-first and take the first one
+        # containing a Windows Server 2022 installer.
+        $api = "https://storage.googleapis.com/storage/v1/b/nvidia-drivers-us-public/o"
+        $dirs = (& curl.exe -fsSL "$api`?prefix=GRID/&delimiter=/" | ConvertFrom-Json).prefixes
+        if (-not $dirs) { throw "could not list GRID driver directories" }
+        # Sort by the leading numeric version (e.g. "GRID/GRID18.1/" -> 18.1);
+        # tolerate any dir naming by falling back to 0 for non-numeric.
+        $dirs = $dirs | Sort-Object {
+            $m = [regex]::Match($_, '(\d+(\.\d+)?)')
+            if ($m.Success) { [double]$m.Groups[1].Value } else { 0.0 }
+        } -Descending
+        $installerUrl = $null
+        foreach ($d in $dirs) {
+            $objs = (& curl.exe -fsSL "$api`?prefix=$d" | ConvertFrom-Json).items
+            $match = $objs | Where-Object { $_.name -like "*server2022*.exe" } | Select-Object -First 1
+            if ($match) {
+                $installerUrl = "https://storage.googleapis.com/nvidia-drivers-us-public/$($match.name)"
+                break
+            }
+        }
+        if (-not $installerUrl) { throw "no server2022 GRID installer found in nvidia-drivers-us-public" }
+        Write-Output "GRID installer: $installerUrl"
+        $installer = "$WORK\grid-driver.exe"
+        Download $installerUrl $installer
+        # -s: silent, -noreboot: we control reboots via the WDDM check below
+        $p = Start-Process -FilePath $installer -ArgumentList "-s", "-noreboot" -Wait -PassThru
+        if ($p.ExitCode -ne 0 -and $p.ExitCode -ne 1) {  # 1 = success-needs-reboot
+            throw "GRID driver installer exited with $($p.ExitCode)"
+        }
+        Mark-Phase "grid-driver"
+    }
+
+    # ================= Verify WDDM mode (DirectML requirement) ============
+    if (-not (Phase-Done "wddm")) {
+        Ck "phase: verify WDDM driver model"
+        $smi = @(
+            "C:\Windows\System32\nvidia-smi.exe",
+            "C:\Program Files\NVIDIA Corporation\NVSMI\nvidia-smi.exe"
+        ) | Where-Object { Test-Path $_ } | Select-Object -First 1
+        if (-not $smi) { throw "nvidia-smi not found after driver install" }
+        $model = & $smi --query-gpu=driver_model.current --format=csv,noheader
+        Write-Output "Driver model: $model"
+        if ($model -notmatch "WDDM") {
+            Write-Output "GPU is in TCC mode; switching to WDDM and rebooting"
+            & $smi -fdm 0
+            Mark-Phase "wddm-pending-reboot"
+            Restart-Computer -Force
+            exit 0   # provisioning resumes on next boot
+        }
+        Mark-Phase "wddm"
+    }
+
+    # ================= Python 3.12 =======================================
+    if (-not (Phase-Done "python")) {
+        Ck "phase: python $PYTHON_VERSION"
+        $exe = "$WORK\python-installer.exe"
+        Download "https://www.python.org/ftp/python/$PYTHON_VERSION/python-$PYTHON_VERSION-amd64.exe" $exe
+        $p = Start-Process -FilePath $exe -ArgumentList "/quiet", "InstallAllUsers=1", "PrependPath=1", "Include_launcher=1" -Wait -PassThru
+        if ($p.ExitCode -ne 0) { throw "python installer exited with $($p.ExitCode)" }
+        Mark-Phase "python"
+    }
+    $py = "C:\Program Files\Python312\python.exe"
+    if (-not (Test-Path $py)) { throw "python not found at $py" }
+
+    # ================= Git ===============================================
+    if (-not (Phase-Done "git")) {
+        Ck "phase: git $GIT_VERSION"
+        $exe = "$WORK\git-installer.exe"
+        Download "https://github.com/git-for-windows/git/releases/download/v$GIT_VERSION.windows.1/Git-$GIT_VERSION-64-bit.exe" $exe
+        $p = Start-Process -FilePath $exe -ArgumentList "/VERYSILENT", "/NORESTART" -Wait -PassThru
+        if ($p.ExitCode -ne 0) { throw "git installer exited with $($p.ExitCode)" }
+        Mark-Phase "git"
+    }
+
+    # ================= FFmpeg ============================================
+    if (-not (Phase-Done "ffmpeg")) {
+        Ck "phase: ffmpeg"
+        $zip = "$WORK\ffmpeg.zip"
+        Download "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip" $zip
+        Expand-Archive -Path $zip -DestinationPath $WORK\ffmpeg-extract -Force
+        $bin = Get-ChildItem "$WORK\ffmpeg-extract" -Recurse -Filter ffmpeg.exe | Select-Object -First 1
+        if (-not $bin) { throw "ffmpeg.exe not found in archive" }
+        New-Item -ItemType Directory -Force -Path "C:\ffmpeg\bin" | Out-Null
+        Copy-Item "$($bin.DirectoryName)\*" "C:\ffmpeg\bin" -Force
+        Add-MachinePath "C:\ffmpeg\bin"
+        Mark-Phase "ffmpeg"
+    }
+
+    # ================= Poetry (system-wide, SYSTEM-user friendly) =========
+    if (-not (Phase-Done "poetry")) {
+        Ck "phase: poetry"
+        # pip install into the all-users Python — its Scripts dir is already
+        # on the machine PATH, and works for jobs running as any user
+        # (pipx would land in the SYSTEM profile and break for others).
+        & $py -m pip install --no-input --quiet poetry
+        if ($LASTEXITCODE -ne 0) { throw "pip install poetry failed" }
+        Mark-Phase "poetry"
+    }
+
+    # ================= GitHub Actions runner ==============================
+    if (-not (Phase-Done "runner")) {
+        Ck "phase: actions runner v$RUNNER_VERSION"
+        $zip = "$WORK\actions-runner.zip"
+        Download "https://github.com/actions/runner/releases/download/v$RUNNER_VERSION/actions-runner-win-x64-$RUNNER_VERSION.zip" $zip
+        New-Item -ItemType Directory -Force -Path "C:\actions-runner" | Out-Null
+        Expand-Archive -Path $zip -DestinationPath "C:\actions-runner" -Force
+        if (-not (Test-Path "C:\actions-runner\run.cmd")) { throw "runner extract failed" }
+        Mark-Phase "runner"
+    }
+
+    # ================= audio-separator DirectML test models ===============
+    # Lean set: only what the windows-directml integration job uses (the
+    # Linux GPU image bakes the full ~14GB suite; Windows doesn't run the
+    # ensemble/demucs tests).
+    if (-not (Phase-Done "models")) {
+        Ck "phase: audio-separator models (DirectML test set)"
+        $modelDir = "C:\audio-separator-models"
+        New-Item -ItemType Directory -Force -Path $modelDir | Out-Null
+        $BASE = "https://github.com/TRvlvr/model_repo/releases/download/all_public_uvr_models"
+        $CONF = "https://raw.githubusercontent.com/TRvlvr/application_data/main/mdx_model_data/mdx_c_configs"
+        $META = "https://raw.githubusercontent.com/TRvlvr/application_data/main"
+        $FALLBACK = "https://github.com/nomadkaraoke/python-audio-separator/releases/download/model-configs"
+
+        # Metadata (same filenames as the Linux image)
+        Download "$META/filelists/download_checks.json" "$modelDir\download_checks.json"
+        Download "$META/vr_model_data/model_data_new.json" "$modelDir\vr_model_data.json"
+        Download "$META/mdx_model_data/model_data_new.json" "$modelDir\mdx_model_data.json"
+
+        # RoFormer (the point of this image) + MDX + VR regression guards
+        Download "$BASE/mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956.ckpt" "$modelDir\mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956.ckpt"
+        Download "$FALLBACK/mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956_config.yaml" "$modelDir\mel_band_roformer_karaoke_aufr33_viperx_sdr_10.1956_config.yaml"
+        Download "$BASE/model_bs_roformer_ep_317_sdr_12.9755.ckpt" "$modelDir\model_bs_roformer_ep_317_sdr_12.9755.ckpt"
+        Download "$CONF/model_bs_roformer_ep_317_sdr_12.9755.yaml" "$modelDir\model_bs_roformer_ep_317_sdr_12.9755.yaml"
+        Download "$BASE/UVR-MDX-NET-Inst_HQ_4.onnx" "$modelDir\UVR-MDX-NET-Inst_HQ_4.onnx"
+        Download "$BASE/2_HP-UVR.pth" "$modelDir\2_HP-UVR.pth"
+        Mark-Phase "models"
+    }
+
+    # ================= Done ==============================================
+    New-Item -ItemType File -Force -Path $READY_FILE | Out-Null
+    Ck "READY: variant=$VARIANT  ts=$(Get-Date -Format o)"
+}
+catch {
+    Write-Output ""
+    Write-Output "########################################################################"
+    Write-Output "### runner-image-provision FAILED"
+    Write-Output "###   error=$($_.Exception.Message)"
+    Write-Output "###   at=$($_.InvocationInfo.PositionMessage)"
+    Write-Output "###   variant=$VARIANT  ts=$(Get-Date -Format o)"
+    Write-Output "########################################################################"
+    exit 1
+}


### PR DESCRIPTION
## Summary

Adds a Windows Server + T4 family to the ephemeral GHA runner fleet, following the existing pattern exactly (JIT-config single-use VMs from pre-baked image families). Built for python-audio-separator's upcoming `windows-directml` integration tests — part 2 of the RoFormer-on-Windows plan (nomadkaraoke/python-audio-separator#292; see plan in nomadkaraoke/python-audio-separator#294).

### Dispatcher (`ephemeral.py`)
- `FamilySpec.os_label` (default `linux`) replaces the hardcoded `linux` advertised label
- New `gpu-windows` family: n1-standard-4 + T4, `gha-runner-gpu-windows` image family, 100GB disk
- `resolve_family` precedence: windows → gpu → build → general
- Windows VMs get the JIT startup script via the `windows-startup-script-ps1` metadata key (`run.cmd --jitconfig` + guaranteed shutdown in `finally`); Linux families unchanged
- +8 unit tests (41 pass): family routing, advertised labels, per-family startup metadata key, TERMINATE scheduling

### Image bake
- `runner-image-provision.ps1`: NVIDIA **GRID** driver (WDDM mode — the datacenter driver runs T4 in TCC mode with no DirectX, which breaks DirectML), with TCC→WDDM switch + bounded reboot retries; Python 3.12 (torch-directml has no 3.13 wheels); Git, FFmpeg, system-wide Poetry, actions-runner win-x64; lean DirectML model set at `C:\audio-separator-models`. Idempotent via phase markers (startup scripts re-run every boot); emits the same READY/FAILED serial-console markers as the Linux provisioner so the existing wait step works unchanged.
- `build-runner-images.yml`: `gpu-windows` variant (windows-cloud/`windows-2022` base, per-variant image + startup-metadata flags), included in monthly "all" builds
- `docs/EPHEMERAL-GHA-RUNNERS.md`: fourth image family + label-routing rules

## Deploy sequence (operator)

1. **Before merge: `pulumi up` locally** (runner-manager function redeploys with the new family — my ADC is read-only so I could not run it)
2. Merge, then bake the first image: `gh workflow run build-runner-images.yml -f variants=gpu-windows`
3. First consumer job (`windows-directml`, `runs-on: [self-hosted, windows, gpu]`) lands in python-audio-separator next — it doubles as the verification job

The companion label fix (`runs-on: [self-hosted, linux, gpu]` on existing jobs, so Windows runners can't steal Linux jobs) is already in nomadkaraoke/python-audio-separator#294.

## Testing

- `test_ephemeral.py`: 41/41 pass
- Workflow YAML validated; CodeRabbit local review run, findings applied (windows-2022 family name, bounded WDDM retry, reboot on installer exit 1, atomic downloads)
- Real-world validation happens at first bake + first `windows-directml` job (next PR)

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)