### PR TITLE
fix(runner-manager): reap TERMINATED ephemeral VMs immediately (frees GPU quota)

### DIFF
--- a/infrastructure/functions/runner_manager/ephemeral.py
+++ b/infrastructure/functions/runner_manager/ephemeral.py
@@ -571,8 +571,20 @@ def cleanup_orphans(pat: str) -> dict:
     for zone, instance in vms:
         age = _vm_age_minutes(instance)
         registered = instance.name in runner_by_name
+        status = getattr(instance, "status", "")
 
-        if age >= MAX_VM_LIFETIME_MINUTES:
+        if status == "TERMINATED":
+            # Ephemeral runners self-shutdown after their single job — a
+            # stopped VM will never work again, but its attached GPU still
+            # counts against NVIDIA_T4_GPUS quota until the VM is DELETED.
+            # Leaving corpses for the age-based rules below meant back-to-back
+            # CI waves exhausted quota and the (fire-and-forget) dispatcher
+            # silently stranded queued jobs. Reap immediately.
+            print(f"{instance.name}: TERMINATED — deleting immediately to release GPU quota")
+            if not registered:
+                _log_serial_tail(zone, instance.name)
+            to_delete.append((zone, instance.name))
+        elif age >= MAX_VM_LIFETIME_MINUTES:
             print(f"{instance.name}: age={age:.1f}min > max, deleting")
             to_delete.append((zone, instance.name))
         elif not registered and age >= ORPHAN_GRACE_MINUTES:

--- a/infrastructure/functions/runner_manager/test_ephemeral.py
+++ b/infrastructure/functions/runner_manager/test_ephemeral.py
@@ -307,9 +307,10 @@ class TestSecureBootPerFamily:
         assert kwargs["enable_integrity_monitoring"] is True
 
 
-def _make_instance(name, age_minutes, zone="us-central1-a"):
+def _make_instance(name, age_minutes, zone="us-central1-a", status="RUNNING"):
     inst = MagicMock()
     inst.name = name
+    inst.status = status
     created = datetime.now(timezone.utc) - timedelta(minutes=age_minutes)
     inst.creation_timestamp = created.isoformat().replace("+00:00", "Z")
     return inst
@@ -405,6 +406,39 @@ class TestCleanupOrphans:
 
         dereg.assert_called_once_with("ghp_test", 99)
         assert result["deregistered_runners"] == ["gha-general-zombie"]
+
+    def test_terminated_vm_deleted_immediately_even_when_young_and_registered(self):
+        # A self-shutdown ephemeral VM still holds GPU quota until deleted;
+        # it must be reaped on the next pass regardless of age/registration.
+        ep = _fresh_module()
+        vms = [("us-central1-a", _make_instance("gha-gpu-done", age_minutes=3, status="TERMINATED"))]
+        runners = [{"name": "gha-gpu-done", "id": 12, "status": "offline"}]
+
+        with self._patch_listing(ep, vms), patch.object(
+            ep, "list_org_runners", return_value=runners
+        ), patch.object(
+            ep, "_delete_vm", return_value=("gha-gpu-done", "deleted")
+        ), patch.object(ep, "_log_serial_tail") as serial_mock:
+            result = ep.cleanup_orphans("ghp_test")
+
+        assert "gha-gpu-done" in result["deleted_vms"]
+        # Registered VM ran its job normally — no serial dump needed.
+        serial_mock.assert_not_called()
+
+    def test_terminated_unregistered_vm_dumps_serial_before_delete(self):
+        ep = _fresh_module()
+        vms = [("us-central1-a", _make_instance("gha-gpu-neverran", age_minutes=5, status="TERMINATED"))]
+        runners = []
+
+        with self._patch_listing(ep, vms), patch.object(
+            ep, "list_org_runners", return_value=runners
+        ), patch.object(
+            ep, "_delete_vm", return_value=("gha-gpu-neverran", "deleted")
+        ), patch.object(ep, "_log_serial_tail") as serial_mock:
+            result = ep.cleanup_orphans("ghp_test")
+
+        assert "gha-gpu-neverran" in result["deleted_vms"]
+        serial_mock.assert_called_once_with("us-central1-a", "gha-gpu-neverran")
 
     def test_delete_failure_is_recorded(self):
         ep = _fresh_module()


### PR DESCRIPTION
Stopped VMs with GPUs attached still count against `NVIDIA_T4_GPUS` quota until deleted. Self-shutdown ephemeral runners sat as TERMINATED corpses for up to ~45 min, so back-to-back CI waves exhausted quota and the fire-and-forget dispatcher silently stranded queued jobs — the async `QUOTA_EXCEEDED` operation failure is invisible (observed repeatedly today, at quota 4 and after the bump to 8; e.g. operations from run 29770005437's dispatch at 18:58Z).

A TERMINATED single-use VM can never work again → delete on the next cleanup pass regardless of age/registration, with a serial-console dump first when it never registered.

43/43 tests pass (2 new). Will `pulumi up` before merge.

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)