### PR TITLE
docs: Cloudflare edge security (WAF + origin lock) — persistent-doc coverage

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -2,6 +2,13 @@
 
 Base URL: `https://api.nomadkaraoke.com` (production) or `http://localhost:8000` (local)
 
+> **Edge:** production traffic must go through `https://api.nomadkaraoke.com`
+> (proxied by Cloudflare — WAF + rate limiting). The Cloud Run origin is
+> **origin-locked**: requests hitting the raw `*.run.app` URL directly are
+> rejected with `403` unless they carry the Cloudflare-injected `X-Edge-Auth`
+> header (`/` and `/api/health*` are exempt for probes). See
+> [ARCHITECTURE.md § Edge Security](ARCHITECTURE.md#edge-security-cloudflare).
+
 ## Authentication
 
 All endpoints except `/health` and `/api/themes` require authentication.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,9 +11,17 @@
                             │ HTTPS
                             ▼
 ┌─────────────────────────────────────────────────────────────────┐
+│  Cloudflare edge  (api.nomadkaraoke.com proxied — orange-cloud) │
+│  WAF (exploit-path block) + rate limit + injects X-Edge-Auth    │
+│  header. See § Edge Security (Cloudflare).                      │
+└───────────────────────────┬─────────────────────────────────────┘
+                            │ HTTPS (SSL "full")
+                            ▼
+┌─────────────────────────────────────────────────────────────────┐
 │  Backend API (Cloud Run)                                        │
 │  FastAPI + Python 3.12                                          │
-│  https://api.nomadkaraoke.com                                   │
+│  https://api.nomadkaraoke.com  (origin lock: rejects direct-    │
+│  to-origin requests lacking X-Edge-Auth, health/root exempt)    │
 │                                                                 │
 │  Workers:                                                       │
 │  • Audio Worker    - Stem separation via Cloud Run GPU (L4)              │
@@ -60,6 +68,37 @@ collection with `service="frontend"` so they flow through the existing
 Discord-alerting pipeline. `ChunkLoadError` after deploy triggers an automatic
 hard reload; the `CrashReport` card also checks `/version.json` and shows an
 "Update now" CTA when the running bundle is stale.
+
+## Edge Security (Cloudflare)
+
+`api.nomadkaraoke.com` is proxied through Cloudflare (orange-cloud) — the same
+zone that already fronts the marketing site, `gen`, `decide`, and the tenant
+portals. Cut over 2026-07-20 after a vuln-scanner hammered the previously
+directly-exposed Cloud Run origin. Managed as IaC in
+`infrastructure/modules/edge_security.py` (`pulumi_cloudflare`).
+
+**Request path:** client → Cloudflare edge → Cloud Run. At the edge:
+- **WAF** (`http_request_firewall_custom`) blocks exploit/secret-exposure paths
+  (`/.env`, `/.git/`, `/.ssh/`, `wp-config`, `/etc/passwd`, …) — uses the
+  `contains` operator (regex `matches` needs a Business plan; zone is Free).
+- **Rate limiting** (`http_ratelimit`) — per-IP flood control (Free-plan limits:
+  `period=10s`, characteristics must include `cf.colo.id`). Excludes
+  `/api/internal/*` (scheduler/Cloud-Tasks cron).
+- **Origin lock** — a Transform Rule injects a secret `X-Edge-Auth` header
+  (`http_request_late_transform`); the backend's `EdgeAuthMiddleware`
+  (`backend/middleware/edge_auth.py`, `EDGE_AUTH_MODE=enforce`) rejects public
+  requests lacking it, so hitting the raw `*.run.app` origin directly is blocked
+  (health/root exempt for Cloud Run probes). Internal callers reach the backend
+  via `api.nomadkaraoke.com` (Cloud Tasks use `CLOUD_RUN_SERVICE_URL`), so they
+  traverse the edge and carry the header.
+
+**SSL:** zone TLS mode is **"full"** (not strict). The Cloud Run domain-mapping
+managed cert cannot provision behind Cloudflare (ACME challenge not visible), but
+"full" mode doesn't validate the origin cert, so the edge works and is
+**renewal-safe** — no run.app Origin Rule or load balancer needed. **Never switch
+the zone to "full (strict)".** Full rationale + cutover runbook:
+`docs/archive/2026-07-20-edge-security-hardening-plan.md` and
+`docs/archive/2026-07-20-edge-security-cutover-runbook.md`.
 
 ## Processing Pipeline
 

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -6,6 +6,44 @@ Key insights for future AI agents working on this codebase.
 
 ---
 
+## Cloudflare edge in front of Cloud Run — the SSL "dragon" (Jul 2026)
+
+Putting `api.nomadkaraoke.com` behind Cloudflare (WAF/rate-limit/origin-lock)
+surfaced several non-obvious gotchas. See `infrastructure/modules/edge_security.py`
+and `docs/archive/2026-07-20-edge-security-*.md`.
+
+- **Cloud Run domain-mapping managed certs cannot provision behind Cloudflare.**
+  Even with a correct grey-cloud CNAME → `ghs.googlehosted.com` (right DNS,
+  propagated, no CAA), Google's ACME challenge is "not visible through the public
+  internet" and the cert stays `pending` forever. Recreating the mapping doesn't
+  help. **This does not matter** because the zone SSL mode is **"full" (not
+  strict)**: Cloudflare encrypts to the origin but doesn't validate its cert, so
+  the edge works regardless and is **renewal-safe** (a never-provisioning /
+  never-renewing cert can't cause a 525 when the cert isn't checked). **Rule:
+  keep the zone on "full", never "full (strict)".** The much-feared run.app
+  SNI-override Origin Rule and a GCP load balancer are both unnecessary — and the
+  Origin Rule is blocked anyway by the zone's singleton `http_request_origin`
+  entrypoint (already holds a flacfetch prod rule).
+- **A proxied (orange) record blocks cert issuance** (DNS points at Cloudflare,
+  not `ghs`) — so if you ever DO need the managed cert, create grey → provision →
+  flip orange. For the prod cutover this was moot: `api`'s cert already existed
+  and "full" mode tolerates it, so the cutover was just the grey→orange flip.
+- **Cloudflare Free-plan WAF/rate-limit constraints (fail at apply time):** the
+  regex `matches` operator needs Business+ (use `contains`); rate-limit `period`
+  must be `10`s and `characteristics` MUST include `cf.colo.id` (per-colo
+  counting); managed OWASP ruleset is Pro+ only.
+- **Origin lock without breaking internal callers:** all internal traffic (Cloud
+  Tasks via `CLOUD_RUN_SERVICE_URL`, schedulers, frontend) reaches the backend
+  through `api.nomadkaraoke.com`, so it traverses Cloudflare and carries the
+  injected `X-Edge-Auth` header. Validated by running the prod E2E in `warn` mode
+  first and confirming **zero** missing-header warnings before flipping to
+  `enforce`. Health/root paths are exempt (Cloud Run probes hit the origin
+  directly).
+- **Applying from a worktree:** the prod Pulumi stack shows benign cross-worktree
+  Cloud Function source-archive drift (last applied from a different worktree) —
+  apply edge changes with `pulumi up --target <urn>` to avoid touching it. CI
+  does NOT auto-run `pulumi up` (apply locally before merge).
+
 ## Magic-link auth vs. email link-scanners (Jul 2026)
 
 - **Never auto-consume a single-use token on page render.** `/auth/verify` used to

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@
 | **i18n / Multilingual (frontend)** | Working (next-intl, en/es/de, 1062 strings, [locale] routing) |
 | **Referral system** | Working (referral links with configurable discounts, 20% cash kickback via Stripe Connect, auto-payout at $20) |
 | **Error monitor** | New (Cloud Run Job every 15 min — log collection, normalization, LLM dedup/grouping, Discord alerts, auto-resolution, daily digest) |
+| **Edge security (Cloudflare)** | Working (api.nomadkaraoke.com proxied — WAF + rate limit + origin lock enforced; 2026-07-20) |
 
 ## Known Issues
 
@@ -53,6 +54,8 @@
 (No pending work items)
 
 ## Recent Changes
+
+- **Cloudflare Edge Security for the Backend API** (2026-07-20): `api.nomadkaraoke.com` is now proxied through Cloudflare (WAF + rate limiting + origin lock), after a vuln-scanner hammered the previously directly-exposed Cloud Run origin. WAF blocks exploit/secret-exposure paths (`contains` operator — regex needs a Business plan); per-IP rate limiting excludes `/api/internal/*`; a Transform Rule injects a secret `X-Edge-Auth` header that the backend's `EdgeAuthMiddleware` (`EDGE_AUTH_MODE=enforce`) requires, blocking direct-to-`*.run.app` bypass (health/root exempt). Key finding: the Cloud Run managed cert can't provision behind Cloudflare, but zone SSL mode "full" (not strict) doesn't validate the origin cert, so it works and is renewal-safe — **never switch the zone to "full (strict)".** Managed as IaC in `infrastructure/modules/edge_security.py`. Also retuned the "High Error Rate" alert to 5xx-only (scanner 404s no longer page). See [ARCHITECTURE.md § Edge Security](ARCHITECTURE.md#edge-security-cloudflare), [LESSONS-LEARNED.md](LESSONS-LEARNED.md#cloudflare-edge-in-front-of-cloud-run--the-ssl-dragon-jul-2026), and [archive/2026-07-20-edge-security-cutover-runbook.md](archive/2026-07-20-edge-security-cutover-runbook.md).
 
 - **AI Auto-Correct Suggestions** (2026-06-11): Opt-in AI correction suggestions in the lyrics review UI — the third attempt at lyrics auto-correction, redesigned around the failures that led to disabling it in PR #321 (Jan 2026). One whole-song LLM call (default Gemini 3.1 Pro via Vertex, `AUTO_CORRECT_MODEL` env) compares the working transcription against reference lyrics and returns word-id-keyed suggestions; nothing is applied until the reviewer accepts each one (or accept-all) in a dedicated panel with per-row undo. New `POST /api/review/{job_id}/auto-correct` endpoint + `backend/services/auto_correct/`; frontend `useAutoCorrect` hook, `AutoCorrectModal` (knobs: adlib removal, insertions, confidence filter), `AutoCorrectPanel`. Accept/reject decisions land in the EditLog (`ai_suggestion_*` ops) to measure real accept rates. 5-model offline eval over 30 real jobs with human ground truth picked the default (Fable 5 ≈ Gemini 3.1 Pro ≫ GPT-5.2, which made lyrics worse). See [archive/2026-06-10-lyrics-auto-correction-reeval-plan.md](archive/2026-06-10-lyrics-auto-correction-reeval-plan.md).
 


### PR DESCRIPTION
Documents the 2026-07-20 edge cutover (shipped in #886 + #888) in the persistent docs.

## Changes
- **ARCHITECTURE.md**: Cloudflare edge added to the System Overview request path + new **§ Edge Security (Cloudflare)** (WAF, rate limit, origin lock, SSL "full" rationale).
- **LESSONS-LEARNED.md**: the SSL "dragon" resolution (managed cert can't provision behind CF, but "full" mode makes it work + renewal-safe → never use "full (strict)") + Free-plan WAF/rate-limit constraints + origin-lock-without-breaking-internal-callers.
- **README.md**: Recent Changes entry + Current State row.
- **API.md**: origin-lock note (direct-to-`*.run.app` → 403 without `X-Edge-Auth`).

Docs-only; no version bump.

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)