### PR TITLE
fix(frontend): correct timeline editor collision checks

### DIFF
--- a/frontend/components/lyrics-review/TimelineEditor.tsx
+++ b/frontend/components/lyrics-review/TimelineEditor.tsx
@@ -43,7 +43,7 @@ export default function TimelineEditor({
     isResize: boolean
   ): boolean => {
     if (isResize) {
-      if (currentIndex === words.length - 1) return false
+      if (currentIndex === words.length) return false
 
       const nextWord = words[currentIndex + 1]
       if (!nextWord || nextWord.start_time === null) return false

--- a/frontend/components/lyrics-review/TimelineEditor.tsx
+++ b/frontend/components/lyrics-review/TimelineEditor.tsx
@@ -46,8 +46,16 @@ export default function TimelineEditor({
       if (currentIndex === words.length) return false
 
       const nextWord = words[currentIndex + 1]
-      if (!nextWord || nextWord.start_time === null) return false
-      return proposedEnd > nextWord.start_time
+      if (nextWord && nextWord.start_time !== null && proposedEnd > nextWord.start_time) {
+        return true;
+      }
+
+      const previousWord = words[currentIndex - 1];
+      if (previousWord && previousWord.end_time !== null && proposedStart < previousWord.end_time) {
+        return true;
+      }
+
+      return false;
     }
 
     return words.some((word, index) => {

--- a/frontend/components/lyrics-review/TimelineEditor.tsx
+++ b/frontend/components/lyrics-review/TimelineEditor.tsx
@@ -43,19 +43,25 @@ export default function TimelineEditor({
     isResize: boolean
   ): boolean => {
     if (isResize) {
-      if (currentIndex === words.length) return false
-
-      const nextWord = words[currentIndex + 1]
+      // Compare against the nearest *timed* neighbours, not just array neighbours:
+      // unsynchronized words (null timestamps) aren't drawn on the timeline, so an
+      // adjacent null-timed word must be skipped to reach the real neighbour bar.
+      const nextWord = words
+        .slice(currentIndex + 1)
+        .find((word) => word.start_time !== null && word.end_time !== null)
       if (nextWord && nextWord.start_time !== null && proposedEnd > nextWord.start_time) {
-        return true;
+        return true
       }
 
-      const previousWord = words[currentIndex - 1];
+      const previousWord = words
+        .slice(0, currentIndex)
+        .reverse()
+        .find((word) => word.start_time !== null && word.end_time !== null)
       if (previousWord && previousWord.end_time !== null && proposedStart < previousWord.end_time) {
-        return true;
+        return true
       }
 
-      return false;
+      return false
     }
 
     return words.some((word, index) => {


### PR DESCRIPTION
`checkCollision()` only checked if the new time collided with the start time of the word right after, but never if the new time collided with *the end time of the word right before it*.

Also, an off-by-one error made it so the second-to-last word could be expanded over the last word.

With these changes it shouldn't be possible for words to go over each other anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeline word resizing validation to prevent overlaps with adjacent synchronized words.
  * Resizing now correctly checks both preceding and following words, including edge positions and unsynchronized words.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->