### PR TITLE
feat(frontend): read API base url from query parameters in localhost frontend

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -12,7 +12,7 @@ import type { CorrectionData, CorrectionAnnotation, EditLog, SearchLyricsRespons
 const isLocalHostname = typeof window !== 'undefined' &&
   (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
 export const API_BASE_URL = isLocalHostname
-  ? ''  // Relative URL - goes to the local server
+  ? new URLSearchParams(location.search).get('baseApiUrl') || ('' /* Relative URL - goes to the local server */)
   : (process.env.NEXT_PUBLIC_API_URL || 'https://api.nomadkaraoke.com');
 
 // Token management - stored in localStorage (client-side only)


### PR DESCRIPTION
Allows for running the frontend dev server + the live karaoke-gen CLI for the backend.

I chose this query param name because I found references in agent plan .md files about it. I haven't looked into why it didn't end up making it into `api.ts` in the end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for overriding the local API URL through the `baseApiUrl` query parameter.
  * Preserved the existing relative API URL behavior when no override is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->