### PR TITLE
feat(frontend): add vocals waveform visualizer in timeline edit view

### DIFF
--- a/backend/api/routes/review.py
+++ b/backend/api/routes/review.py
@@ -19,7 +19,7 @@ import json
 import os
 import tempfile
 from pathlib import Path
-from typing import Dict, Any, List, Optional, Set, Tuple
+from typing import Dict, Any, List, Literal, Optional, Set, Tuple
 
 from fastapi import APIRouter, HTTPException, Request, Depends, Form, File, UploadFile
 from fastapi.responses import RedirectResponse
@@ -372,6 +372,15 @@ async def get_correction_data(
         raise HTTPException(status_code=500, detail=t("en", "review.correctionsLoadFailed", error=str(e)))
 
 
+@router.get("/{job_id}/audio/vocals")
+async def get_vocals_audio(
+    job_id: str,
+    auth_info: Tuple[str, str] = Depends(require_review_auth)
+):
+    """Stream the vocals audio file for playback."""
+    return await _stream_audio(job_id, stem="vocals")
+
+
 @router.get("/{job_id}/audio/{audio_hash}")
 async def get_audio_with_hash(
     job_id: str,
@@ -392,7 +401,7 @@ async def get_audio_no_hash(
     return await _stream_audio(job_id)
 
 
-async def _stream_audio(job_id: str):
+async def _stream_audio(job_id: str, stem: Literal["input"] | Literal["vocals"] = "input"):
     """
     Redirect to a signed GCS URL for audio playback in the review interface.
 
@@ -407,7 +416,13 @@ async def _stream_audio(job_id: str):
     if not job:
         raise HTTPException(status_code=404, detail=t("en", "review.jobNotFound"))
 
-    audio_gcs_path = job.input_media_gcs_path
+    audio_gcs_path = None
+    if stem == "input":
+        audio_gcs_path = job.input_media_gcs_path
+    elif stem == "vocals":
+        stem_file_urls = job.file_urls.get("stems")
+        if stem_file_urls:
+            audio_gcs_path = stem_file_urls["vocals"]
     if not audio_gcs_path:
         raise HTTPException(status_code=404, detail=t("en", "review.audioNotFound"))
 

--- a/frontend/components/lyrics-review/EditTimelineSection.tsx
+++ b/frontend/components/lyrics-review/EditTimelineSection.tsx
@@ -111,7 +111,7 @@ export default function EditTimelineSection({
   return (
     <>
       {/* Timeline Editor */}
-      <div className={cn('mb-0', isMobile ? 'h-20' : 'h-[120px]')}>
+      <div className={cn('mb-0', isMobile ? 'h-30' : 'h-[120px]')}>
         <TimelineEditor
           words={words}
           startTime={startTime}

--- a/frontend/components/lyrics-review/LyricsAnalyzer.tsx
+++ b/frontend/components/lyrics-review/LyricsAnalyzer.tsx
@@ -62,6 +62,7 @@ import AutoCorrectPanel from './AutoCorrectPanel'
 import { useAutoCorrect } from '@/hooks/useAutoCorrect'
 import { getWordsFromIds } from '@/lib/lyrics-review/utils/wordUtils'
 import { applyOffsetToCorrectionData, applyOffsetToSegment } from '@/lib/lyrics-review/utils/timingUtils'
+import { VocalsAudioDataLoader } from './VocalsAudioDataLoader'
 
 // Add type for window augmentation
 declare global {
@@ -81,6 +82,7 @@ interface ApiClient {
   addLyrics: (source: string, lyrics: string) => Promise<CorrectionData>
   searchLyrics?: (artist: string, title: string, forceSources?: string[]) => Promise<SearchLyricsResponse>
   getAudioUrl: (hash: string) => string
+  getVocalsAudioUrl: () => string
   generatePreviewVideo: (data: CorrectionData, isDuet?: boolean) => Promise<{
     status: string
     message?: string
@@ -153,6 +155,8 @@ export default function LyricsAnalyzer({
   const [timingOffsetMs, setTimingOffsetMs] = useState(0)
   const [reviewMode, setReviewMode] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const [vocalsAudioUrl, setVocalsAudioUrl] = useState<string | null>(null)
 
   // Success screen state (for auto-close after submission)
   const [showSuccess, setShowSuccess] = useState(false)
@@ -569,6 +573,12 @@ export default function LyricsAnalyzer({
       window.location.href = `/app/jobs/local/instrumental`
     }
   }, [showInstrumentalReview, isLocalMode])
+
+  useEffect(() => {
+    if (!apiClient) return
+
+    setVocalsAudioUrl(apiClient.getVocalsAudioUrl())
+  }, [apiClient])
 
   // Countdown effect for success screen (auto-close/redirect after submission)
   useEffect(() => {
@@ -1352,330 +1362,332 @@ export default function LyricsAnalyzer({
   }
 
   return (
-    <div className="max-w-full overflow-x-hidden">
-      <Header
-        isReadOnly={isReadOnly}
-        onFileLoad={onFileLoad}
-        data={data}
-        onMetricClick={metricClickHandlers}
-        effectiveMode={effectiveMode}
-        onModeChange={setInteractionMode}
-        apiClient={apiClient}
-        audioHash={audioHash}
-        onTimeUpdate={setCurrentAudioTime}
-        onHandlerToggle={handleHandlerToggle}
-        isUpdatingHandlers={isUpdatingHandlers}
-        onHandlerClick={handleHandlerClick}
-        onFindReplace={() => setIsFindReplaceModalOpen(true)}
-        onEditAll={handleReplaceAllLyrics}
-        onTimingOffset={handleOpenTimingOffsetModal}
-        timingOffsetMs={timingOffsetMs}
-        onUndo={handleUndo}
-        onRedo={handleRedo}
-        canUndo={canUndo}
-        canRedo={canRedo}
-        onResetCorrections={handleResetCorrections}
-        statsVisible={statsVisible}
-        onStatsToggle={() => setStatsVisible((v) => !v)}
-        reviewMode={reviewMode}
-        onReviewModeToggle={setReviewMode}
-        onAcceptAllCorrections={handleAcceptAllCorrections}
-        onAcceptHighConfidenceCorrections={handleAcceptHighConfidenceCorrections}
-        onRevertAllCorrections={handleRevertAllCorrections}
-        isDuet={isDuet}
-        onToggleDuet={() => setIsDuet(d => !d)}
-        onAutoCorrect={
-          !isLocalMode && jobId
-            ? () =>
-                autoCorrect.acceptedCount > 0
-                  ? setAutoCorrectDetailsOpen((o) => !o)
-                  : setIsAutoCorrectModalOpen(true)
-            : undefined
-        }
-        autoCorrectedCount={autoCorrect.acceptedCount}
-      />
-
-      <AutoCorrectPanel
-        controller={autoCorrect}
-        isReadOnly={isReadOnly}
-        open={autoCorrectDetailsOpen}
-        onClose={() => setAutoCorrectDetailsOpen(false)}
-        onRerun={() => {
-          setAutoCorrectDetailsOpen(false)
-          setIsAutoCorrectModalOpen(true)
-        }}
-      />
-
-      <div className={cn('grid gap-2', isMobile ? 'grid-cols-1' : 'grid-cols-2')}>
-        <TranscriptionView
-          data={displayData}
-          mode={effectiveMode}
-          onElementClick={setModalContent}
-          onWordClick={handleWordClick}
-          flashingType={flashingType}
-          flashingHandler={flashingHandler}
-          highlightInfo={highlightInfo}
-          onPlaySegment={handlePlaySegment}
-          currentTime={isAnyModalOpen ? undefined : currentAudioTime}
-          anchors={data.anchor_sequences}
-          onDataChange={(updatedData) => {
-            updateDataWithHistory(updatedData, 'direct data change')
-          }}
+    <VocalsAudioDataLoader audioUrl={vocalsAudioUrl}>
+      <div className="max-w-full overflow-x-hidden">
+        <Header
+          isReadOnly={isReadOnly}
+          onFileLoad={onFileLoad}
+          data={data}
+          onMetricClick={metricClickHandlers}
+          effectiveMode={effectiveMode}
+          onModeChange={setInteractionMode}
+          apiClient={apiClient}
+          audioHash={audioHash}
+          onTimeUpdate={setCurrentAudioTime}
+          onHandlerToggle={handleHandlerToggle}
+          isUpdatingHandlers={isUpdatingHandlers}
+          onHandlerClick={handleHandlerClick}
+          onFindReplace={() => setIsFindReplaceModalOpen(true)}
+          onEditAll={handleReplaceAllLyrics}
+          onTimingOffset={handleOpenTimingOffsetModal}
+          timingOffsetMs={timingOffsetMs}
+          onUndo={handleUndo}
+          onRedo={handleRedo}
+          canUndo={canUndo}
+          canRedo={canRedo}
+          onResetCorrections={handleResetCorrections}
+          statsVisible={statsVisible}
+          onStatsToggle={() => setStatsVisible((v) => !v)}
           reviewMode={reviewMode}
-          onRevertCorrection={handleRevertCorrection}
-          onEditCorrection={handleEditCorrection}
-          onAcceptCorrection={handleAcceptCorrection}
-          onShowCorrectionDetail={handleShowCorrectionDetail}
-          activeGapWordIds={activeGapWordIds}
-          advancedMode={advancedMode}
-          onAdvancedModeToggle={handleAdvancedModeToggle}
-          editedWordIds={editedWordIds}
-          aiCorrectedWordIds={aiCorrectedWordIds}
-          aiOriginalTextByWordId={aiOriginalTextByWordId}
-          aiEstimatedWordIds={aiEstimatedWordIds}
+          onReviewModeToggle={setReviewMode}
+          onAcceptAllCorrections={handleAcceptAllCorrections}
+          onAcceptHighConfidenceCorrections={handleAcceptHighConfidenceCorrections}
+          onRevertAllCorrections={handleRevertAllCorrections}
           isDuet={isDuet}
-          onSegmentSingerChange={(segmentIdx, next) => {
-            const segments = [...data.corrected_segments]
-            segments[segmentIdx] = { ...segments[segmentIdx], singer: next }
-            updateDataWithHistory({ ...data, corrected_segments: segments }, 'singer change')
-          }}
-          onSegmentFocus={setFocusedSegmentIndex}
+          onToggleDuet={() => setIsDuet(d => !d)}
+          onAutoCorrect={
+            !isLocalMode && jobId
+              ? () =>
+                  autoCorrect.acceptedCount > 0
+                    ? setAutoCorrectDetailsOpen((o) => !o)
+                    : setIsAutoCorrectModalOpen(true)
+              : undefined
+          }
+          autoCorrectedCount={autoCorrect.acceptedCount}
         />
-        <ReferenceView
-          referenceSources={data.reference_lyrics}
-          anchors={data.anchor_sequences}
-          gaps={data.gap_sequences}
-          mode={effectiveMode}
-          onElementClick={setModalContent}
-          onWordClick={handleWordClick}
-          flashingType={flashingType}
-          highlightInfo={highlightInfo}
-          currentSource={currentSource}
-          onSourceChange={setCurrentSource}
-          corrected_segments={data.corrected_segments}
-          corrections={data.corrections}
-          onAddLyrics={() => setIsAddLyricsModalOpen(true)}
-          onAddLyricsInline={handleAddLyrics}
-          onSearchLyrics={handleSearchLyrics}
+
+        <AutoCorrectPanel
+          controller={autoCorrect}
+          isReadOnly={isReadOnly}
+          open={autoCorrectDetailsOpen}
+          onClose={() => setAutoCorrectDetailsOpen(false)}
+          onRerun={() => {
+            setAutoCorrectDetailsOpen(false)
+            setIsAutoCorrectModalOpen(true)
+          }}
+        />
+
+        <div className={cn('grid gap-2', isMobile ? 'grid-cols-1' : 'grid-cols-2')}>
+          <TranscriptionView
+            data={displayData}
+            mode={effectiveMode}
+            onElementClick={setModalContent}
+            onWordClick={handleWordClick}
+            flashingType={flashingType}
+            flashingHandler={flashingHandler}
+            highlightInfo={highlightInfo}
+            onPlaySegment={handlePlaySegment}
+            currentTime={isAnyModalOpen ? undefined : currentAudioTime}
+            anchors={data.anchor_sequences}
+            onDataChange={(updatedData) => {
+              updateDataWithHistory(updatedData, 'direct data change')
+            }}
+            reviewMode={reviewMode}
+            onRevertCorrection={handleRevertCorrection}
+            onEditCorrection={handleEditCorrection}
+            onAcceptCorrection={handleAcceptCorrection}
+            onShowCorrectionDetail={handleShowCorrectionDetail}
+            activeGapWordIds={activeGapWordIds}
+            advancedMode={advancedMode}
+            onAdvancedModeToggle={handleAdvancedModeToggle}
+            editedWordIds={editedWordIds}
+            aiCorrectedWordIds={aiCorrectedWordIds}
+            aiOriginalTextByWordId={aiOriginalTextByWordId}
+            aiEstimatedWordIds={aiEstimatedWordIds}
+            isDuet={isDuet}
+            onSegmentSingerChange={(segmentIdx, next) => {
+              const segments = [...data.corrected_segments]
+              segments[segmentIdx] = { ...segments[segmentIdx], singer: next }
+              updateDataWithHistory({ ...data, corrected_segments: segments }, 'singer change')
+            }}
+            onSegmentFocus={setFocusedSegmentIndex}
+          />
+          <ReferenceView
+            referenceSources={data.reference_lyrics}
+            anchors={data.anchor_sequences}
+            gaps={data.gap_sequences}
+            mode={effectiveMode}
+            onElementClick={setModalContent}
+            onWordClick={handleWordClick}
+            flashingType={flashingType}
+            highlightInfo={highlightInfo}
+            currentSource={currentSource}
+            onSourceChange={setCurrentSource}
+            corrected_segments={data.corrected_segments}
+            corrections={data.corrections}
+            onAddLyrics={() => setIsAddLyricsModalOpen(true)}
+            onAddLyricsInline={handleAddLyrics}
+            onSearchLyrics={handleSearchLyrics}
+            defaultArtist={data.metadata?.artist || ''}
+            defaultTitle={data.metadata?.title || ''}
+          />
+        </div>
+
+        {/* Spacer for sticky footer */}
+        {!isReadOnly && apiClient && <div className="h-16" />}
+
+        {/* Sticky footer bar */}
+        {!isReadOnly && apiClient && (
+          <div className="fixed bottom-0 left-0 right-0 bg-background border-t shadow-lg py-3 px-4 z-50 flex justify-center items-center gap-4 flex-wrap">
+            <GapNavigator
+              currentGapIndex={currentGapIndex}
+              totalGaps={uncorrectedGaps.length}
+              onPrevGap={handlePrevGap}
+              onNextGap={handleNextGap}
+            />
+            {data.gap_sequences.length > 0 && (
+              <div className="flex items-center gap-1.5">
+                <div className="w-16 h-1.5 bg-muted rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-green-500 rounded-full transition-all"
+                    style={{
+                      width: `${data.gap_sequences.length > 0 ? ((data.gap_sequences.length - uncorrectedGaps.length) / data.gap_sequences.length) * 100 : 0}%`,
+                    }}
+                  />
+                </div>
+                {uncorrectedGaps.length === 0 ? (
+                  <span className="text-xs text-green-500 flex items-center gap-0.5">
+                    <CheckCircle2 className="h-3.5 w-3.5" />
+                    All gaps reviewed
+                  </span>
+                ) : (
+                  <span className="text-xs text-muted-foreground whitespace-nowrap">
+                    {data.gap_sequences.length - uncorrectedGaps.length}/{data.gap_sequences.length} gaps reviewed
+                  </span>
+                )}
+              </div>
+            )}
+            {apiClient?.saveReviewSession && (
+              <>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => saveSession('manual')}
+                  disabled={history.length <= 1}
+                >
+                  Save Progress
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleOpenSessionBrowser}
+                >
+                  Session History
+                </Button>
+              </>
+            )}
+            <span className="text-sm text-muted-foreground">Lyrics look good?</span>
+            <Button onClick={handleFinishReview} disabled={isReviewComplete}>
+              {isReviewComplete ? 'Review Complete' : 'Preview Video'}
+              <Video className="ml-2 h-4 w-4" />
+            </Button>
+          </div>
+        )}
+
+        {/* Modals */}
+        <EditModal
+          open={Boolean(editModalSegment)}
+          onClose={() => {
+            setEditModalSegment(null)
+            handleSetModalSpacebarHandler(undefined)
+          }}
+          segment={
+            editModalSegment?.segment
+              ? timingOffsetMs !== 0
+                ? applyOffsetToSegment(editModalSegment.segment, timingOffsetMs)
+                : editModalSegment.segment
+              : null
+          }
+          segmentIndex={editModalSegment?.index ?? null}
+          originalSegment={
+            editModalSegment?.originalSegment
+              ? timingOffsetMs !== 0
+                ? applyOffsetToSegment(editModalSegment.originalSegment, timingOffsetMs)
+                : editModalSegment.originalSegment
+              : null
+          }
+          onSave={handleUpdateSegment}
+          onDelete={handleDeleteSegment}
+          onAddSegment={handleAddSegment}
+          onSplitSegment={handleSplitSegment}
+          onMergeSegment={handleMergeSegment}
+          onPlaySegment={handlePlaySegment}
+          currentTime={currentAudioTime}
+          originalTranscribedSegment={
+            editModalSegment?.segment &&
+            editModalSegment?.index !== null &&
+            originalData.original_segments
+              ? (() => {
+                  const origSegment =
+                    originalData.original_segments.find(
+                      (s: LyricsSegment) => s.id === editModalSegment.segment.id
+                    ) || null
+                  return origSegment && timingOffsetMs !== 0
+                    ? applyOffsetToSegment(origSegment, timingOffsetMs)
+                    : origSegment
+                })()
+              : null
+          }
+        />
+
+        <ReviewChangesModal
+          open={isReviewModalOpen}
+          onClose={() => setIsReviewModalOpen(false)}
+          data={data}
+          onSubmit={handleSubmitToServer}
+          isSubmitting={isSubmitting}
+          apiClient={apiClient}
+          timingOffsetMs={timingOffsetMs}
+          isDuet={isDuet}
+        />
+
+        <AddLyricsModal
+          open={isAddLyricsModalOpen}
+          onClose={() => setIsAddLyricsModalOpen(false)}
+          onAdd={handleAddLyrics}
+          onSearch={handleSearchLyrics}
           defaultArtist={data.metadata?.artist || ''}
           defaultTitle={data.metadata?.title || ''}
         />
-      </div>
 
-      {/* Spacer for sticky footer */}
-      {!isReadOnly && apiClient && <div className="h-16" />}
+        <FindReplaceModal
+          open={isFindReplaceModalOpen}
+          onClose={() => setIsFindReplaceModalOpen(false)}
+          onReplace={handleFindReplace}
+          data={data}
+        />
 
-      {/* Sticky footer bar */}
-      {!isReadOnly && apiClient && (
-        <div className="fixed bottom-0 left-0 right-0 bg-background border-t shadow-lg py-3 px-4 z-50 flex justify-center items-center gap-4 flex-wrap">
-          <GapNavigator
-            currentGapIndex={currentGapIndex}
-            totalGaps={uncorrectedGaps.length}
-            onPrevGap={handlePrevGap}
-            onNextGap={handleNextGap}
+        <TimingOffsetModal
+          open={isTimingOffsetModalOpen}
+          onClose={() => setIsTimingOffsetModalOpen(false)}
+          currentOffset={timingOffsetMs}
+          onApply={handleApplyTimingOffset}
+        />
+
+        <ReplaceAllLyricsModal
+          open={isReplaceAllLyricsModalOpen}
+          onClose={() => setIsReplaceAllLyricsModalOpen(false)}
+          onSave={handleSaveReplaceAllLyrics}
+          onPlaySegment={handlePlaySegment}
+          currentTime={currentAudioTime}
+          setModalSpacebarHandler={handleSetModalSpacebarHandler}
+          existingSegments={data.corrected_segments}
+          jobId={jobId ?? ''}
+          artist={data.metadata?.artist}
+          title={data.metadata?.title}
+          authToken={getAccessToken() ?? undefined}
+        />
+
+        <AutoCorrectModal
+          open={isAutoCorrectModalOpen}
+          onClose={() => setIsAutoCorrectModalOpen(false)}
+          onRun={(settings) => void autoCorrect.run(settings)}
+          onCancelRun={autoCorrect.cancel}
+          status={autoCorrect.status}
+          error={autoCorrect.error}
+          hasReferences={autoCorrect.hasReferences}
+        />
+
+        <EditFeedbackBar
+          entry={lastEditEntry}
+          visible={showFeedbackBar}
+          onFeedback={handleEditFeedback}
+          onDismiss={() => setShowFeedbackBar(false)}
+        />
+
+        {selectedCorrection && (
+          <CorrectionDetailCard
+            open={correctionDetailOpen}
+            onClose={() => {
+              setCorrectionDetailOpen(false)
+              setSelectedCorrection(null)
+            }}
+            originalWord={selectedCorrection.originalWord}
+            correctedWord={selectedCorrection.correctedWord}
+            category={selectedCorrection.category}
+            confidence={selectedCorrection.confidence}
+            reason={selectedCorrection.reason}
+            handler={selectedCorrection.handler}
+            source={selectedCorrection.source}
+            onRevert={() => {
+              handleRevertCorrection(selectedCorrection.wordId)
+              setCorrectionDetailOpen(false)
+              setSelectedCorrection(null)
+            }}
+            onEdit={() => {
+              handleEditCorrection(selectedCorrection.wordId)
+              setCorrectionDetailOpen(false)
+              setSelectedCorrection(null)
+            }}
+            onAccept={() => {
+              handleAcceptCorrection(selectedCorrection.wordId)
+              setCorrectionDetailOpen(false)
+              setSelectedCorrection(null)
+            }}
           />
-          {data.gap_sequences.length > 0 && (
-            <div className="flex items-center gap-1.5">
-              <div className="w-16 h-1.5 bg-muted rounded-full overflow-hidden">
-                <div
-                  className="h-full bg-green-500 rounded-full transition-all"
-                  style={{
-                    width: `${data.gap_sequences.length > 0 ? ((data.gap_sequences.length - uncorrectedGaps.length) / data.gap_sequences.length) * 100 : 0}%`,
-                  }}
-                />
-              </div>
-              {uncorrectedGaps.length === 0 ? (
-                <span className="text-xs text-green-500 flex items-center gap-0.5">
-                  <CheckCircle2 className="h-3.5 w-3.5" />
-                  All gaps reviewed
-                </span>
-              ) : (
-                <span className="text-xs text-muted-foreground whitespace-nowrap">
-                  {data.gap_sequences.length - uncorrectedGaps.length}/{data.gap_sequences.length} gaps reviewed
-                </span>
-              )}
-            </div>
-          )}
-          {apiClient?.saveReviewSession && (
-            <>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => saveSession('manual')}
-                disabled={history.length <= 1}
-              >
-                Save Progress
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleOpenSessionBrowser}
-              >
-                Session History
-              </Button>
-            </>
-          )}
-          <span className="text-sm text-muted-foreground">Lyrics look good?</span>
-          <Button onClick={handleFinishReview} disabled={isReviewComplete}>
-            {isReviewComplete ? 'Review Complete' : 'Preview Video'}
-            <Video className="ml-2 h-4 w-4" />
-          </Button>
-        </div>
-      )}
+        )}
 
-      {/* Modals */}
-      <EditModal
-        open={Boolean(editModalSegment)}
-        onClose={() => {
-          setEditModalSegment(null)
-          handleSetModalSpacebarHandler(undefined)
-        }}
-        segment={
-          editModalSegment?.segment
-            ? timingOffsetMs !== 0
-              ? applyOffsetToSegment(editModalSegment.segment, timingOffsetMs)
-              : editModalSegment.segment
-            : null
-        }
-        segmentIndex={editModalSegment?.index ?? null}
-        originalSegment={
-          editModalSegment?.originalSegment
-            ? timingOffsetMs !== 0
-              ? applyOffsetToSegment(editModalSegment.originalSegment, timingOffsetMs)
-              : editModalSegment.originalSegment
-            : null
-        }
-        onSave={handleUpdateSegment}
-        onDelete={handleDeleteSegment}
-        onAddSegment={handleAddSegment}
-        onSplitSegment={handleSplitSegment}
-        onMergeSegment={handleMergeSegment}
-        onPlaySegment={handlePlaySegment}
-        currentTime={currentAudioTime}
-        originalTranscribedSegment={
-          editModalSegment?.segment &&
-          editModalSegment?.index !== null &&
-          originalData.original_segments
-            ? (() => {
-                const origSegment =
-                  originalData.original_segments.find(
-                    (s: LyricsSegment) => s.id === editModalSegment.segment.id
-                  ) || null
-                return origSegment && timingOffsetMs !== 0
-                  ? applyOffsetToSegment(origSegment, timingOffsetMs)
-                  : origSegment
-              })()
-            : null
-        }
-      />
-
-      <ReviewChangesModal
-        open={isReviewModalOpen}
-        onClose={() => setIsReviewModalOpen(false)}
-        data={data}
-        onSubmit={handleSubmitToServer}
-        isSubmitting={isSubmitting}
-        apiClient={apiClient}
-        timingOffsetMs={timingOffsetMs}
-        isDuet={isDuet}
-      />
-
-      <AddLyricsModal
-        open={isAddLyricsModalOpen}
-        onClose={() => setIsAddLyricsModalOpen(false)}
-        onAdd={handleAddLyrics}
-        onSearch={handleSearchLyrics}
-        defaultArtist={data.metadata?.artist || ''}
-        defaultTitle={data.metadata?.title || ''}
-      />
-
-      <FindReplaceModal
-        open={isFindReplaceModalOpen}
-        onClose={() => setIsFindReplaceModalOpen(false)}
-        onReplace={handleFindReplace}
-        data={data}
-      />
-
-      <TimingOffsetModal
-        open={isTimingOffsetModalOpen}
-        onClose={() => setIsTimingOffsetModalOpen(false)}
-        currentOffset={timingOffsetMs}
-        onApply={handleApplyTimingOffset}
-      />
-
-      <ReplaceAllLyricsModal
-        open={isReplaceAllLyricsModalOpen}
-        onClose={() => setIsReplaceAllLyricsModalOpen(false)}
-        onSave={handleSaveReplaceAllLyrics}
-        onPlaySegment={handlePlaySegment}
-        currentTime={currentAudioTime}
-        setModalSpacebarHandler={handleSetModalSpacebarHandler}
-        existingSegments={data.corrected_segments}
-        jobId={jobId ?? ''}
-        artist={data.metadata?.artist}
-        title={data.metadata?.title}
-        authToken={getAccessToken() ?? undefined}
-      />
-
-      <AutoCorrectModal
-        open={isAutoCorrectModalOpen}
-        onClose={() => setIsAutoCorrectModalOpen(false)}
-        onRun={(settings) => void autoCorrect.run(settings)}
-        onCancelRun={autoCorrect.cancel}
-        status={autoCorrect.status}
-        error={autoCorrect.error}
-        hasReferences={autoCorrect.hasReferences}
-      />
-
-      <EditFeedbackBar
-        entry={lastEditEntry}
-        visible={showFeedbackBar}
-        onFeedback={handleEditFeedback}
-        onDismiss={() => setShowFeedbackBar(false)}
-      />
-
-      {selectedCorrection && (
-        <CorrectionDetailCard
-          open={correctionDetailOpen}
-          onClose={() => {
-            setCorrectionDetailOpen(false)
-            setSelectedCorrection(null)
-          }}
-          originalWord={selectedCorrection.originalWord}
-          correctedWord={selectedCorrection.correctedWord}
-          category={selectedCorrection.category}
-          confidence={selectedCorrection.confidence}
-          reason={selectedCorrection.reason}
-          handler={selectedCorrection.handler}
-          source={selectedCorrection.source}
-          onRevert={() => {
-            handleRevertCorrection(selectedCorrection.wordId)
-            setCorrectionDetailOpen(false)
-            setSelectedCorrection(null)
-          }}
-          onEdit={() => {
-            handleEditCorrection(selectedCorrection.wordId)
-            setCorrectionDetailOpen(false)
-            setSelectedCorrection(null)
-          }}
-          onAccept={() => {
-            handleAcceptCorrection(selectedCorrection.wordId)
-            setCorrectionDetailOpen(false)
-            setSelectedCorrection(null)
-          }}
-        />
-      )}
-
-      {!isReadOnly && (
-        <SessionRestoreDialog
-          open={sessionRestoreOpen}
-          onClose={() => setSessionRestoreOpen(false)}
-          onRestore={handleSessionRestore}
-          sessions={savedSessions}
-          apiClient={sessionClient as LyricsReviewApiClient}
-          isLoading={sessionsLoading}
-        />
-      )}
-    </div>
+        {!isReadOnly && (
+          <SessionRestoreDialog
+            open={sessionRestoreOpen}
+            onClose={() => setSessionRestoreOpen(false)}
+            onRestore={handleSessionRestore}
+            sessions={savedSessions}
+            apiClient={sessionClient as LyricsReviewApiClient}
+            isLoading={sessionsLoading}
+          />
+        )}
+      </div>
+    </VocalsAudioDataLoader>
   )
 }

--- a/frontend/components/lyrics-review/TimelineEditor.tsx
+++ b/frontend/components/lyrics-review/TimelineEditor.tsx
@@ -302,7 +302,7 @@ export default function TimelineEditor({
 
       <VocalsAudioDataLoaderContext.Consumer>
         {({ audioData: vocalsAudioData }) => (
-          <WaveformVisualizer
+          vocalsAudioData && <WaveformVisualizer
             startTime={startTime}
             endTime={endTime}
             audioData={vocalsAudioData}

--- a/frontend/components/lyrics-review/TimelineEditor.tsx
+++ b/frontend/components/lyrics-review/TimelineEditor.tsx
@@ -3,6 +3,8 @@
 import { useRef, useState } from 'react'
 import { Word } from '@/lib/lyrics-review/types'
 import { cn } from '@/lib/utils'
+import { WaveformVisualizer } from './WaveformVisualizer'
+import { VocalsAudioDataLoaderContext } from './VocalsAudioDataLoader'
 
 interface TimelineEditorProps {
   words: Word[]
@@ -227,7 +229,7 @@ export default function TimelineEditor({
   return (
     <div
       ref={containerRef}
-      className="relative h-[75px] bg-card rounded my-2 px-2 border border-border"
+      className="relative h-[115px] bg-card rounded my-2 px-2 border border-border"
       onMouseMove={handleMouseMove}
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseUp}
@@ -295,6 +297,17 @@ export default function TimelineEditor({
           </div>
         )
       })}
+
+      <VocalsAudioDataLoaderContext.Consumer>
+        {({ audioData: vocalsAudioData }) => (
+          <WaveformVisualizer
+            startTime={startTime}
+            endTime={endTime}
+            audioData={vocalsAudioData}
+            className="absolute top-[75px] left-0 w-[100%] h-[35px]"
+          />
+        )}
+      </VocalsAudioDataLoaderContext.Consumer>
     </div>
   )
 }

--- a/frontend/components/lyrics-review/TimelineEditor.tsx
+++ b/frontend/components/lyrics-review/TimelineEditor.tsx
@@ -229,14 +229,14 @@ export default function TimelineEditor({
   return (
     <div
       ref={containerRef}
-      className="relative h-[115px] bg-card rounded my-2 px-2 border border-border"
+      className="relative bg-card rounded my-2 border border-border"
       onMouseMove={handleMouseMove}
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseUp}
     >
       {/* Timeline ruler */}
       <div
-        className="absolute top-0 left-0 right-0 h-10 border-b border-border cursor-pointer"
+        className="h-10 border-b border-border cursor-pointer"
         onClick={handleTimelineClick}
       >
         {generateTimelineMarks()}
@@ -251,52 +251,54 @@ export default function TimelineEditor({
       )}
 
       {/* Word blocks */}
-      {words.map((word, index) => {
-        if (word.start_time === null || word.end_time === null) return null
+      <div className="relative h-[30px]">
+        {words.map((word, index) => {
+          if (word.start_time === null || word.end_time === null) return null
 
-        const leftPosition = timeToPosition(word.start_time)
-        const rightPosition = timeToPosition(word.end_time)
-        const width = rightPosition - leftPosition
+          const leftPosition = timeToPosition(word.start_time)
+          const rightPosition = timeToPosition(word.end_time)
+          const width = rightPosition - leftPosition
 
-        return (
-          <div
-            key={index}
-            className={cn(
-              'absolute h-[30px] top-10 bg-primary rounded text-primary-foreground px-2 py-1',
-              'cursor-move select-none flex items-center text-sm font-sans transition-colors',
-              isWordHighlighted(word) && 'bg-purple-500 dark:bg-purple-600'
-            )}
-            style={{
-              left: `${leftPosition}%`,
-              width: `${width}%`,
-              maxWidth: `calc(${100 - leftPosition}%)`,
-            }}
-            onMouseDown={(e) => {
-              e.stopPropagation()
-              handleMouseDown(e, index, 'move')
-            }}
-            onContextMenu={(e) => handleContextMenu(e, index)}
-          >
-            {/* Left resize handle */}
+          return (
             <div
-              className="absolute top-0 left-0 w-2.5 h-full cursor-col-resize hover:bg-primary-foreground/20 rounded-l"
+              key={index}
+              className={cn(
+                'absolute bg-primary rounded text-primary-foreground px-2 py-1',
+                'cursor-move select-none flex items-center text-sm font-sans transition-colors',
+                isWordHighlighted(word) && 'bg-purple-500 dark:bg-purple-600'
+              )}
+              style={{
+                left: `${leftPosition}%`,
+                width: `${width}%`,
+                maxWidth: `calc(${100 - leftPosition}%)`,
+              }}
               onMouseDown={(e) => {
                 e.stopPropagation()
-                handleMouseDown(e, index, 'resize-left')
+                handleMouseDown(e, index, 'move')
               }}
-            />
-            {word.text}
-            {/* Right resize handle */}
-            <div
-              className="absolute top-0 right-0 w-2.5 h-full cursor-col-resize hover:bg-primary-foreground/20 rounded-r"
-              onMouseDown={(e) => {
-                e.stopPropagation()
-                handleMouseDown(e, index, 'resize-right')
-              }}
-            />
-          </div>
-        )
-      })}
+              onContextMenu={(e) => handleContextMenu(e, index)}
+            >
+              {/* Left resize handle */}
+              <div
+                className="absolute top-0 left-0 w-2.5 h-full cursor-col-resize hover:bg-primary-foreground/20 rounded-l"
+                onMouseDown={(e) => {
+                  e.stopPropagation()
+                  handleMouseDown(e, index, 'resize-left')
+                }}
+              />
+              {word.text}
+              {/* Right resize handle */}
+              <div
+                className="absolute top-0 right-0 w-2.5 h-full cursor-col-resize hover:bg-primary-foreground/20 rounded-r"
+                onMouseDown={(e) => {
+                  e.stopPropagation()
+                  handleMouseDown(e, index, 'resize-right')
+                }}
+              />
+            </div>
+          )
+        })}
+      </div>
 
       <VocalsAudioDataLoaderContext.Consumer>
         {({ audioData: vocalsAudioData }) => (
@@ -304,7 +306,7 @@ export default function TimelineEditor({
             startTime={startTime}
             endTime={endTime}
             audioData={vocalsAudioData}
-            className="absolute top-[75px] left-0 w-[100%] h-[35px]"
+            className="w-[100%] h-[35px]"
           />
         )}
       </VocalsAudioDataLoaderContext.Consumer>

--- a/frontend/components/lyrics-review/VocalsAudioDataLoader.tsx
+++ b/frontend/components/lyrics-review/VocalsAudioDataLoader.tsx
@@ -1,0 +1,30 @@
+import { AudioData, fetchAudioData } from '@/lib/audio-data'
+import { createContext, PropsWithChildren, useEffect, useState } from 'react'
+
+export const VocalsAudioDataLoaderContext = createContext<{ audioData: AudioData | null }>({ audioData: null })
+
+export interface AudioDataLoaderProps extends PropsWithChildren {
+	audioUrl: string | null
+}
+
+export const VocalsAudioDataLoader = ({ audioUrl, children }: AudioDataLoaderProps) => {
+	const [audioData, setAudioData] = useState<AudioData | null>(null)
+
+	useEffect(() => {
+		if (!audioUrl) return
+
+		fetchAudioData(audioUrl).then((audioData) => {
+			setAudioData(audioData)
+		})
+
+		return () => {
+			setAudioData(null)
+		}
+	}, [audioUrl])
+
+	return (
+		<VocalsAudioDataLoaderContext.Provider value={{ audioData }}>
+			{children}
+		</VocalsAudioDataLoaderContext.Provider>
+	)
+}

--- a/frontend/components/lyrics-review/WaveformVisualizer.tsx
+++ b/frontend/components/lyrics-review/WaveformVisualizer.tsx
@@ -1,0 +1,89 @@
+import { HTMLProps, useCallback, useEffect, useRef, useState } from 'react'
+import { AudioData } from '@/lib/audio-data'
+import { useAudioReady } from '@/lib/lyrics-review/hooks/useAudioReady'
+
+export interface WaveformVisualizerProps extends Omit<HTMLProps<HTMLCanvasElement>, 'width' | 'height'> {
+	startTime: number
+	endTime: number
+	audioData: AudioData | null
+}
+
+export const WaveformVisualizer = ({
+	startTime,
+	endTime,
+	audioData,
+	className,
+	... canvasProps
+}: WaveformVisualizerProps) => {
+	const containerRef = useRef<HTMLDivElement | null>(null)
+	const canvasCtxRef = useRef<CanvasRenderingContext2D | null>(null)
+	const audioReady = useAudioReady()
+	const [canvasSize, setCanvasSize] = useState<{ width: number; height: number; }>({ width: 0, height: 0 })
+
+	useEffect(() => {
+		if (!containerRef.current) return
+
+		const resizeObserver = new ResizeObserver((entries) => {
+			const size = entries.at(-1)!.contentBoxSize[0]
+			setCanvasSize({
+				width: size.inlineSize,
+				height: size.blockSize
+			})
+		})
+		resizeObserver.observe(containerRef.current, {
+			box: 'content-box'
+		})
+
+		return () => {
+			resizeObserver.disconnect()
+		}
+	}, [containerRef.current])
+
+	const readAudioData = useCallback((startTime: number, endTime: number) => {
+		if (audioData == null) return null
+
+		const startIndex = Math.floor(startTime / audioData.duration * audioData.buffer.length)
+		const endIndex = Math.floor(endTime / audioData.duration * audioData.buffer.length)
+		return audioData.buffer.slice(startIndex, endIndex)
+	}, [audioData])
+
+	useEffect(() => {
+		render(startTime, endTime)
+	}, [audioReady.ready, startTime, endTime, canvasSize])
+
+	const render = (startTime: number, endTime: number) => {
+		const ctx = canvasCtxRef.current
+		if (!ctx) return
+
+		ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height)
+
+		ctx.fillStyle = 'orange'
+
+		const audioData = readAudioData(startTime, endTime)
+		if (!audioData) return
+
+		for (let x = 0; x < ctx.canvas.width; x++) {
+			const dataPoint = audioData[Math.floor(x / ctx.canvas.width * audioData.length)]
+			const dataPointHeight = dataPoint * ctx.canvas.height
+
+			ctx.fillRect(x, (ctx.canvas.height - dataPointHeight) / 2, 1, dataPointHeight)
+		}
+	}
+
+	return (
+		<div
+			ref={containerRef}
+			className={className}
+		>
+			<canvas
+				ref={(el) => {
+					canvasCtxRef.current = el?.getContext('2d') ?? null
+				}}
+				className={"w-[100%] h-[100%]"}
+				width={canvasSize.width}
+				height={canvasSize.height}
+				{... canvasProps}
+			></canvas>
+		</div>
+	)
+}

--- a/frontend/components/lyrics-review/WaveformVisualizer.tsx
+++ b/frontend/components/lyrics-review/WaveformVisualizer.tsx
@@ -1,4 +1,5 @@
 import { HTMLProps, useCallback, useEffect, useRef, useState } from 'react'
+import colors from 'tailwindcss/colors'
 import { AudioData } from '@/lib/audio-data'
 import { useAudioReady } from '@/lib/lyrics-review/hooks/useAudioReady'
 
@@ -6,6 +7,7 @@ export interface WaveformVisualizerProps extends Omit<HTMLProps<HTMLCanvasElemen
 	startTime: number
 	endTime: number
 	audioData: AudioData | null
+	barColor?: string
 }
 
 export const WaveformVisualizer = ({
@@ -13,6 +15,7 @@ export const WaveformVisualizer = ({
 	endTime,
 	audioData,
 	className,
+	barColor = colors.yellow['500'],
 	... canvasProps
 }: WaveformVisualizerProps) => {
 	const containerRef = useRef<HTMLDivElement | null>(null)
@@ -57,7 +60,7 @@ export const WaveformVisualizer = ({
 
 		ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height)
 
-		ctx.fillStyle = 'orange'
+		ctx.fillStyle = barColor
 
 		const audioData = readAudioData(startTime, endTime)
 		if (!audioData) return

--- a/frontend/components/lyrics-review/WaveformVisualizer.tsx
+++ b/frontend/components/lyrics-review/WaveformVisualizer.tsx
@@ -67,7 +67,7 @@ export const WaveformVisualizer = ({
 
 		for (let x = 0; x < ctx.canvas.width; x++) {
 			const dataPoint = audioData[Math.floor(x / ctx.canvas.width * audioData.length)]
-			const dataPointHeight = dataPoint * ctx.canvas.height
+			const dataPointHeight = Math.abs(dataPoint) * ctx.canvas.height
 
 			ctx.fillRect(x, (ctx.canvas.height - dataPointHeight) / 2, 1, dataPointHeight)
 		}

--- a/frontend/components/lyrics-review/WaveformVisualizer.tsx
+++ b/frontend/components/lyrics-review/WaveformVisualizer.tsx
@@ -66,10 +66,16 @@ export const WaveformVisualizer = ({
 		if (!audioData) return
 
 		for (let x = 0; x < ctx.canvas.width; x++) {
-			const dataPoint = audioData[Math.floor(x / ctx.canvas.width * audioData.length)]
-			const dataPointHeight = Math.abs(dataPoint) * ctx.canvas.height
+			const dataPointIndex = Math.floor((x - 0.5) / ctx.canvas.width * audioData.length)
+			const nextDataPointIndex = Math.floor((x + 0.5) / ctx.canvas.width * audioData.length)
 
-			ctx.fillRect(x, (ctx.canvas.height - dataPointHeight) / 2, 1, dataPointHeight)
+			const amplitude = audioData
+				.slice(dataPointIndex, nextDataPointIndex)
+				.reduce((maxAmplitude, point) => Math.max(maxAmplitude, Math.abs(point)), 0)
+
+			const barHeight = amplitude * ctx.canvas.height
+
+			ctx.fillRect(x, (ctx.canvas.height - barHeight) / 2, 1, barHeight)
 		}
 	}
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -3213,6 +3213,7 @@ export interface LyricsReviewApiClient {
   addLyrics: (source: string, lyrics: string) => Promise<CorrectionData>
   searchLyrics: (artist: string, title: string, forceSources?: string[]) => Promise<SearchLyricsResponse>
   getAudioUrl: (hash: string) => string
+  getVocalsAudioUrl: () => string
   generatePreviewVideo: (data: CorrectionData, isDuet?: boolean) => Promise<{
     status: string
     message?: string
@@ -3349,6 +3350,15 @@ export function createLyricsReviewApiClient(jobId: string): LyricsReviewApiClien
     getAudioUrl(hash: string): string {
       const token = getAccessToken()
       const base = `${API_BASE_URL}/api/review/${jobId}/audio/${hash}`
+      return token ? `${base}?token=${encodeURIComponent(token)}` : base
+    },
+
+    /**
+     * Get vocals audio URL for playback
+     */
+    getVocalsAudioUrl(): string {
+      const token = getAccessToken()
+      const base = `${API_BASE_URL}/api/review/${jobId}/audio/vocals`
       return token ? `${base}?token=${encodeURIComponent(token)}` : base
     },
 

--- a/frontend/lib/audio-data.ts
+++ b/frontend/lib/audio-data.ts
@@ -1,0 +1,34 @@
+export interface AudioData {
+	duration: number
+	buffer: Float32Array
+}
+
+export async function fetchAudioData(url: string): Promise<AudioData> {
+	const arrayBuffer = await fetch(url).then((response) => response.arrayBuffer())
+
+	const context = new AudioContext()
+
+	try {
+		const decodedAudioBuffer = await context.decodeAudioData(arrayBuffer)
+
+		const channelZeroData = decodedAudioBuffer.getChannelData(0)
+		const combinedAudioBuffer: Float32Array = new Float32Array(channelZeroData)
+
+		for (let channelIdx = 1; channelIdx < decodedAudioBuffer.numberOfChannels; channelIdx++) {
+			const channelData = decodedAudioBuffer.getChannelData(channelIdx)
+			for (let i = 0; i < combinedAudioBuffer.length; i++) {
+				if (channelData[i] > combinedAudioBuffer[i]) {
+					combinedAudioBuffer[i] = channelData[i]
+				}
+			}
+		}
+
+		return {
+			duration: decodedAudioBuffer.duration,
+			buffer: combinedAudioBuffer
+		}
+	} finally {
+		context.close()
+	}
+}
+

--- a/frontend/lib/audio-data.ts
+++ b/frontend/lib/audio-data.ts
@@ -17,7 +17,8 @@ export async function fetchAudioData(url: string): Promise<AudioData> {
 		for (let channelIdx = 1; channelIdx < decodedAudioBuffer.numberOfChannels; channelIdx++) {
 			const channelData = decodedAudioBuffer.getChannelData(channelIdx)
 			for (let i = 0; i < combinedAudioBuffer.length; i++) {
-				if (channelData[i] > combinedAudioBuffer[i]) {
+				const channelDataPoint = Math.abs(channelData[i])
+				if (channelDataPoint > combinedAudioBuffer[i]) {
 					combinedAudioBuffer[i] = channelData[i]
 				}
 			}

--- a/karaoke_gen/lyrics_transcriber/review/server.py
+++ b/karaoke_gen/lyrics_transcriber/review/server.py
@@ -72,6 +72,7 @@ class ReviewServer:
         correction_result: CorrectionResult,
         output_config: OutputConfig,
         audio_filepath: str,
+        vocals_filepath: str,
         logger: logging.Logger,
         # Instrumental review data (optional - for combined review flow)
         instrumental_options: Optional[List[Dict[str, Any]]] = None,
@@ -85,7 +86,8 @@ class ReviewServer:
         Args:
             correction_result: The lyrics correction result to review
             output_config: Output configuration
-            audio_filepath: Path to the main audio file (vocals)
+            audio_filepath: Path to the main audio file
+            vocals_filepath: Path the vocals (lead & backing) audio file
             logger: Logger instance
             instrumental_options: List of instrumental options for selection
                 Each option: {"id": str, "label": str, "audio_path": str}
@@ -97,6 +99,7 @@ class ReviewServer:
         self.correction_result = correction_result
         self.output_config = output_config
         self.audio_filepath = audio_filepath
+        self.vocals_filepath = vocals_filepath
         self.logger = logger or logging.getLogger(__name__)
         self.review_completed = False
         self.corrections_saved = False  # Flag for intermediate save (before instrumental review)
@@ -416,6 +419,8 @@ class ReviewServer:
         async def get_audio_with_job_id(job_id: str, audio_hash: str):
             if audio_hash in _stem_names:
                 return await self.get_instrumental_audio(audio_hash)
+            elif audio_hash == "vocals":
+                return await self.get_vocals_audio()
             return await self.get_audio(audio_hash)
         self.app.add_api_route("/api/review/{job_id}/audio/{audio_hash}", get_audio_with_job_id, methods=["GET"])
 
@@ -1059,6 +1064,25 @@ class ReviewServer:
         audio_path = path_map.get(stem_type)
         if not audio_path or not os.path.exists(audio_path):
             raise HTTPException(status_code=404, detail=f"Instrumental audio not found: {stem_type}")
+
+        # Determine content type based on file extension
+        ext = os.path.splitext(audio_path)[1].lower()
+        content_types = {
+            ".flac": "audio/flac",
+            ".mp3": "audio/mpeg",
+            ".wav": "audio/wav",
+            ".m4a": "audio/mp4",
+        }
+        content_type = content_types.get(ext, "application/octet-stream")
+
+        return FileResponse(audio_path, media_type=content_type, filename=os.path.basename(audio_path))
+
+    async def get_vocals_audio(self):
+        """Stream the vocals audio file."""
+
+        audio_path = self.vocals_filepath
+        if not audio_path or not os.path.exists(audio_path):
+            raise HTTPException(status_code=404, detail="Vocals audio not found")
 
         # Determine content type based on file extension
         ext = os.path.splitext(audio_path)[1].lower()

--- a/karaoke_gen/utils/gen_cli.py
+++ b/karaoke_gen/utils/gen_cli.py
@@ -213,11 +213,15 @@ def run_combined_review(
             backing_vocals_path = None
 
     clean_instrumental_path = None
+    vocals_path = None
     clean_result = separated.get("clean_instrumental", {})
     if isinstance(clean_result, dict) and clean_result.get("instrumental"):
         clean_instrumental_path = _resolve_path_for_cwd(clean_result["instrumental"], track_dir)
         if not os.path.exists(clean_instrumental_path):
             clean_instrumental_path = None
+        vocals_path = _resolve_path_for_cwd(clean_result["vocals"], track_dir)
+        if not os.path.exists(vocals_path):
+            raise Exception("Vocals audio not found")
 
     with_backing_path = None
     combined_result = separated.get("combined_instrumentals", {})
@@ -303,6 +307,7 @@ def run_combined_review(
             correction_result=correction_result,
             output_config=output_config,
             audio_filepath=resolved_audio or "",
+            vocals_filepath=vocals_path,
             logger=logger,
             # Instrumental review data
             instrumental_options=instrumental_options,


### PR DESCRIPTION
This should make it easier to line up words to their spoken parts.

<img width="967" height="279" alt="firefox_Ppmeqt51Zw" src="https://github.com/user-attachments/assets/d1a3528d-0538-49be-8f16-26a9bd23e8ff" />

- Add new `/jobs/{job_id}/audio/vocals` endpoint to review routes, which returns the (lead + backing) vocals stem from the separation job (if present)
- Implement \<VocalsAudioDataLoader> and context, wrapping \<LyricsAnalyzer>, which is used to fetch and process the audio vocals data, and storing it in a context which is later consumed by \<TimelineEditor>
  - The audio data is combined into one channel by taking the maximum value of each channel if present.
- Implement \<WaveformVisualizer>, which renders a waveform representation of the audio data from a start to an ending time

---

> [!WARNING]
> I wasn't able to test my changes in `backend/api/routes/review.py`, so I'm keeping this as a draft.
Could someone with a working setup to run the backend verify the changes?

> [!WARNING]
> This currently loads the entire vocal audio data as a `Float32Array`. The only optimization done to it is merging all channels into one.
> The data in RAM + rendering the waveform noticeably decreases the performance of the app on my machine. Truncating the data should be done next (possibly a separate MR?).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added vocals audio playback to lyrics review.
  - Added a waveform visualization aligned with the selected timeline segment.
  - Improved mobile timeline layout with additional vertical space.
  - Added support for loading and displaying separated vocals audio.

- **Bug Fixes**
  - Review now reports an appropriate not-found response when vocals audio is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->