### PR TITLE
fix(frontend): make only the word list scrollable in the lyrics review edit modal

### DIFF
--- a/frontend/components/lyrics-review/modals/EditModal.tsx
+++ b/frontend/components/lyrics-review/modals/EditModal.tsx
@@ -410,7 +410,7 @@ export default function EditModal({
             </p>
           </div>
         ) : editedSegment ? (
-          <div className="flex-1 overflow-auto space-y-4">
+          <div className="flex flex-col flex-1 space-y-4 overflow-hidden">
             {timingFixCount > 0 && (
               <div
                 role="status"
@@ -445,20 +445,22 @@ export default function EditModal({
               />
             )}
 
-            {/* Word list */}
-            <EditWordList
-              words={editedSegment.words}
-              onWordUpdate={handleWordChange}
-              onSplitWord={handleSplitWord}
-              onMergeWords={handleMergeWords}
-              onAddWord={handleAddWord}
-              onRemoveWord={handleRemoveWord}
-              onReplaceAllWords={handleReplaceAllWords}
-              onSplitSegment={handleSplitSegment}
-              onAddSegment={handleAddSegmentAt}
-              onMergeSegment={handleMergeSegment}
-              isGlobal={isGlobal}
-            />
+            <div className="overflow-auto">
+              {/* Word list */}
+              <EditWordList
+                words={editedSegment.words}
+                onWordUpdate={handleWordChange}
+                onSplitWord={handleSplitWord}
+                onMergeWords={handleMergeWords}
+                onAddWord={handleAddWord}
+                onRemoveWord={handleRemoveWord}
+                onReplaceAllWords={handleReplaceAllWords}
+                onSplitSegment={handleSplitSegment}
+                onAddSegment={handleAddSegmentAt}
+                onMergeSegment={handleMergeSegment}
+                isGlobal={isGlobal}
+              />
+            </div>
           </div>
         ) : (
           <div className="flex items-center justify-center flex-1">

--- a/frontend/components/lyrics-review/modals/EditModal.tsx
+++ b/frontend/components/lyrics-review/modals/EditModal.tsx
@@ -445,7 +445,7 @@ export default function EditModal({
               />
             )}
 
-            <div className="overflow-auto">
+            <div className="overflow-auto px-[12px]">
               {/* Word list */}
               <EditWordList
                 words={editedSegment.words}

--- a/frontend/components/lyrics-review/modals/EditModal.tsx
+++ b/frontend/components/lyrics-review/modals/EditModal.tsx
@@ -424,25 +424,27 @@ export default function EditModal({
 
             {/* Timeline editor with Tap To Sync */}
             {editedSegment.words.some((w) => w.start_time !== null) && (
-              <EditTimelineSection
-                words={editedSegment.words}
-                startTime={startTime}
-                endTime={endTime}
-                originalStartTime={originalSegment?.start_time ?? null}
-                originalEndTime={originalSegment?.end_time ?? null}
-                currentStartTime={editedSegment.start_time}
-                currentEndTime={editedSegment.end_time}
-                currentTime={currentTime}
-                isManualSyncing={isManualSyncing}
-                syncWordIndex={syncWordIndex}
-                isSpacebarPressed={isSpacebarPressed}
-                onWordUpdate={handleWordChange}
-                onPlaySegment={onPlaySegment}
-                startManualSync={startManualSync}
-                isGlobal={isGlobal}
-                onTapStart={handleTapStart}
-                onTapEnd={handleTapEnd}
-              />
+              <div className="flex-grow">
+                <EditTimelineSection
+                  words={editedSegment.words}
+                  startTime={startTime}
+                  endTime={endTime}
+                  originalStartTime={originalSegment?.start_time ?? null}
+                  originalEndTime={originalSegment?.end_time ?? null}
+                  currentStartTime={editedSegment.start_time}
+                  currentEndTime={editedSegment.end_time}
+                  currentTime={currentTime}
+                  isManualSyncing={isManualSyncing}
+                  syncWordIndex={syncWordIndex}
+                  isSpacebarPressed={isSpacebarPressed}
+                  onWordUpdate={handleWordChange}
+                  onPlaySegment={onPlaySegment}
+                  startManualSync={startManualSync}
+                  isGlobal={isGlobal}
+                  onTapStart={handleTapStart}
+                  onTapEnd={handleTapEnd}
+                />
+              </div>
             )}
 
             <div className="overflow-auto px-[12px]">


### PR DESCRIPTION
I found myself scrolling back and forth between the two for adjusting timings.

This also solves an issue where the scrollbar would make the last word's right resize handle inaccessible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the edit modal layout for better usability.
  * Added dedicated scrolling for the word list while keeping the timeline flexible.
  * Prevented content overflow within the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->