### PR TITLE
fix(error-monitor): stop transient-capacity + bot crashes from paging

### DIFF
--- a/backend/api/routes/client_errors.py
+++ b/backend/api/routes/client_errors.py
@@ -18,6 +18,8 @@ from backend.services.error_monitor.frontend_ingestion import (
     FrontendErrorReport,
     RateLimiter,
     build_pattern_data,
+    is_bot_user_agent,
+    sanitize_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -63,6 +65,20 @@ def report_client_error(payload: ClientErrorPayload, request: Request) -> Client
     client_ip = request.client.host if request.client else "unknown"
     if not _limiter.allow(client_ip, time.monotonic()):
         raise HTTPException(status_code=429, detail="too many reports")
+
+    # Crawler/bot crashes are pure alert noise (bots run headless Chrome and trip
+    # DOM errors no real user hits). Accept the report so the client doesn't retry,
+    # but don't persist/alert on it.
+    if is_bot_user_agent(payload.user_agent):
+        # Log the bot UA (not sensitive) + sanitized URL (query/token stripped)
+        # for visibility into what's being dropped, without persisting/alerting.
+        logger.info(
+            "frontend_crash_ignored_bot ua=%r url=%s source=%s",
+            payload.user_agent[:120],
+            sanitize_url(payload.url),
+            payload.source,
+        )
+        return ClientErrorResponse(pattern_id="bot-ignored", is_new=False)
 
     report = FrontendErrorReport(
         message=payload.message,

--- a/backend/services/error_monitor/frontend_ingestion.py
+++ b/backend/services/error_monitor/frontend_ingestion.py
@@ -26,7 +26,12 @@ MAX_URL_CHARS = 512
 # crawler tokens plus the generic bot/crawler/spider/headless markers that
 # well-behaved automated agents put in their UA string.
 _BOT_UA_RE = re.compile(
-    r"bot\b|bot/|spider|crawler|crawl\b|slurp|bingpreview|headless|"
+    # Generic markers. The bot forms are anchored so we never match the "bot"
+    # inside ordinary words like "robot": a standalone "bot" token (\bbot\b does
+    # not match inside "robot" — no word boundary there) or the crawler
+    # "<name>bot/<version>" convention, with "robot/" explicitly excluded.
+    r"\bbot\b|(?<!ro)bot/|spider|crawler|crawl\b|slurp|bingpreview|headless|"
+    # Explicit crawler names (some don't use the "/version" convention).
     r"googlebot|bingbot|applebot|yandex|baiduspider|duckduckbot|"
     r"ahrefs|semrush|petalbot|facebookexternalhit|"
     r"chrome-lighthouse|google page speed|python-requests|curl/|wget/",

--- a/backend/services/error_monitor/frontend_ingestion.py
+++ b/backend/services/error_monitor/frontend_ingestion.py
@@ -6,6 +6,7 @@ Cloud Run Job handle all alerting / Discord plumbing.
 """
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from urllib.parse import urlsplit, urlunsplit
@@ -18,6 +19,30 @@ from backend.services.error_monitor.normalizer import (
 
 MAX_SAMPLE_MESSAGE_CHARS = 4000
 MAX_URL_CHARS = 512
+
+# Crawlers/bots execute our JS (e.g. bingbot/Googlebot run headless Chrome) and
+# trip React DOM-reconciliation errors that no real user ever sees. Their reports
+# are pure alert-channel noise, so we drop them at ingestion. Matches the common
+# crawler tokens plus the generic bot/crawler/spider/headless markers that
+# well-behaved automated agents put in their UA string.
+_BOT_UA_RE = re.compile(
+    r"bot\b|bot/|spider|crawler|crawl\b|slurp|bingpreview|headless|"
+    r"googlebot|bingbot|applebot|yandex|baiduspider|duckduckbot|"
+    r"ahrefs|semrush|petalbot|facebookexternalhit|"
+    r"chrome-lighthouse|google page speed|python-requests|curl/|wget/",
+    re.IGNORECASE,
+)
+
+
+def is_bot_user_agent(user_agent: str | None) -> bool:
+    """Return True if the UA looks like a crawler/bot/automated agent.
+
+    Conservative: only matches explicit bot markers, so a real browser UA (which
+    never contains these tokens) is never misclassified.
+    """
+    if not user_agent:
+        return False
+    return bool(_BOT_UA_RE.search(user_agent))
 
 
 @dataclass

--- a/backend/services/error_monitor/known_issues.py
+++ b/backend/services/error_monitor/known_issues.py
@@ -64,8 +64,14 @@ _IGNORE_PATTERNS: list[tuple[str, re.Pattern, str]] = [
         # these for auto-retry. A non-transient EncodingWorkerStartError (other /
         # unknown code) shares the "aborting retries" prefix but must still page,
         # so we require the transient signal, not just the prefix.
+        # Bind the transient signal to the GCE error CODE field — which appears
+        # immediately after "start failed in <zone>: " / "could not be started in
+        # <zone>: " (see encoding_errors.classify_gce_error). Matching the code in
+        # position (not anywhere in the line) prevents a non-transient failure
+        # whose message text merely contains "503" from being suppressed.
         re.compile(
-            r"encoding worker start failed, aborting retries:[^\n]*?"
+            r"encoding worker start failed, aborting retries:.*?"
+            r"(?:start failed|could not be started) in [\w.-]+:\s*"
             r"(?:503\b|service unavailable|zone_resource_pool_exhausted"
             r"|stockout|quota_exceeded)",
             re.IGNORECASE,

--- a/backend/services/error_monitor/known_issues.py
+++ b/backend/services/error_monitor/known_issues.py
@@ -57,6 +57,27 @@ _IGNORE_PATTERNS: list[tuple[str, re.Pattern, str]] = [
         "Encoding worker idle shutdown — expected behaviour when no jobs are queued",
     ),
     (
+        "encoding_worker_capacity_retry",
+        # Only the TRANSIENT start failures: GCE 503/SERVICE UNAVAILABLE or a
+        # capacity code (ZONE_RESOURCE_POOL_EXHAUSTED / STOCKOUT / QUOTA_EXCEEDED
+        # — see encoding_errors.CAPACITY_ERROR_CODES). The render worker parks
+        # these for auto-retry. A non-transient EncodingWorkerStartError (other /
+        # unknown code) shares the "aborting retries" prefix but must still page,
+        # so we require the transient signal, not just the prefix.
+        re.compile(
+            r"encoding worker start failed, aborting retries:[^\n]*?"
+            r"(?:503\b|service unavailable|zone_resource_pool_exhausted"
+            r"|stockout|quota_exceeded)",
+            re.IGNORECASE,
+        ),
+        (
+            "GCE encoding worker VM start hit a transient GCP condition (zone "
+            "capacity exhaustion or 503 SERVICE UNAVAILABLE) — the render worker "
+            "parks the job for auto-retry rather than failing it. Non-transient "
+            "start failures still alert."
+        ),
+    ),
+    (
         "health_check_404",
         re.compile(
             r"(?:GET|HEAD)\b[^\n]*?/health[^\n]*?\b(?:404|not found)\b",

--- a/backend/services/error_monitor/normalizer.py
+++ b/backend/services/error_monitor/normalizer.py
@@ -79,6 +79,15 @@ _NORMALIZERS: list[tuple[re.Pattern, str]] = [
         re.compile(r"/jobs/[A-Za-z0-9]+"),
         "/jobs/<ID>",
     ),
+    # 9b. Preview render job IDs: preview_<jobid>_<renderid> (underscore-joined
+    #     hex runs). The generic hex rule (11) is \b-anchored and '_' is a word
+    #     char, so it can't reach these — leaving every preview render of the
+    #     same job as a distinct pattern (N alerts for one incident). Collapse
+    #     the whole token so they map to a single pattern.
+    (
+        re.compile(r"\bpreview_[0-9a-fA-F]{6,}(?:_[0-9a-fA-F]{6,})+\b"),
+        "preview_<ID>",
+    ),
     # 10. Firebase UIDs (20–28 mixed-case alphanumeric characters)
     #     Firebase Auth UIDs are typically 28 chars; allow 20-28 for flexibility.
     #     Must contain both letters and digits (to avoid replacing plain words).

--- a/backend/tests/api/test_client_errors.py
+++ b/backend/tests/api/test_client_errors.py
@@ -55,6 +55,18 @@ def test_accepts_valid_report_and_upserts(client):
     assert pd.resource_type == "browser"
 
 
+def test_bot_report_is_accepted_but_not_persisted(client):
+    bot_ua = (
+        "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; "
+        "bingbot/2.0; +http://www.bing.com/bingbot.htm) Chrome/136.0.0.0 Safari/537.36"
+    )
+    resp = client.post("/api/client-errors", json=_payload(user_agent=bot_ua))
+    # Accepted (so the bot won't retry) but never upserted / alerted.
+    assert resp.status_code == 202
+    assert resp.json()["is_new"] is False
+    client.fake_adapter.upsert_pattern.assert_not_called()
+
+
 def test_rejects_missing_message(client):
     resp = client.post("/api/client-errors", json=_payload(message=""))
     assert resp.status_code == 422

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.192.1"
+version = "0.192.2"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"

--- a/tests/unit/services/error_monitor/test_frontend_ingestion.py
+++ b/tests/unit/services/error_monitor/test_frontend_ingestion.py
@@ -31,6 +31,10 @@ def test_is_bot_user_agent_true_for_crawlers(ua):
     "Mozilla/5.0 (Android 14; Mobile; rv:138.0) Gecko/138.0 Firefox/138.0",
     "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Safari/604.1",
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/136.0 Safari/537.36",
+    # "robot" must NOT be treated as a bot marker (the "bot" substring inside a
+    # normal word). Neither should "robot/" version-like text.
+    "Mozilla/5.0 MyRobot Browser robot build",
+    "Mozilla/5.0 (compatible; robot/1.0) Chrome/136.0",
     "",
     None,
 ])

--- a/tests/unit/services/error_monitor/test_frontend_ingestion.py
+++ b/tests/unit/services/error_monitor/test_frontend_ingestion.py
@@ -3,12 +3,39 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
+
 from backend.services.error_monitor.frontend_ingestion import (
     FrontendErrorReport,
     RateLimiter,
     build_pattern_data,
+    is_bot_user_agent,
     sanitize_url,
 )
+
+
+@pytest.mark.parametrize("ua", [
+    "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Chrome/136.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+    "Mozilla/5.0 (compatible; YandexBot/3.0)",
+    "facebookexternalhit/1.1",
+    "curl/8.4.0",
+    "python-requests/2.31.0",
+    "Some HeadlessChrome/120.0 build",
+])
+def test_is_bot_user_agent_true_for_crawlers(ua):
+    assert is_bot_user_agent(ua) is True
+
+
+@pytest.mark.parametrize("ua", [
+    "Mozilla/5.0 (Android 14; Mobile; rv:138.0) Gecko/138.0 Firefox/138.0",
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Safari/604.1",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/136.0 Safari/537.36",
+    "",
+    None,
+])
+def test_is_bot_user_agent_false_for_real_browsers(ua):
+    assert is_bot_user_agent(ua) is False
 
 
 def test_sanitize_url_strips_query_and_fragment():

--- a/tests/unit/services/error_monitor/test_known_issues.py
+++ b/tests/unit/services/error_monitor/test_known_issues.py
@@ -476,6 +476,19 @@ class TestEncodingWorkerCapacityRetry:
         )
         assert should_ignore("karaoke-backend", msg) is None
 
+    def test_non_transient_with_503_in_message_body_still_alerts(self):
+        from backend.services.error_monitor.known_issues import should_ignore
+
+        # The code field is PERMISSION_DENIED (non-transient); "503" only appears
+        # later in the free-text message. Must NOT be suppressed — the transient
+        # signal is bound to the code position, not "anywhere in the line".
+        msg = (
+            "[job:1ea7effb] Encoding worker start failed, aborting retries: "
+            "VM encoding-worker-fallback-b start failed in us-central1-b: "
+            "PERMISSION_DENIED — prior attempt returned 503 SERVICE UNAVAILABLE"
+        )
+        assert should_ignore("karaoke-backend", msg) is None
+
 
 class TestCaseInsensitiveMatching:
     """All patterns should match case-insensitively."""

--- a/tests/unit/services/error_monitor/test_known_issues.py
+++ b/tests/unit/services/error_monitor/test_known_issues.py
@@ -417,6 +417,66 @@ class TestUnknownServiceMessages:
         assert result is None
 
 
+class TestEncodingWorkerCapacityRetry:
+    """The transient GCE capacity/503 VM-start failure is parked for auto-retry
+    by the render worker, so it must not page — it's known transient noise."""
+
+    _MSG = (
+        "[job:preview_ae5de3e5_3c4cdb053cbf] Encoding worker start failed, "
+        "aborting retries: VM encoding-worker-fallback-b start failed in "
+        "us-central1-b: 503 — SERVICE UNAVAILABLE"
+    )
+
+    def test_capacity_503_is_ignored(self):
+        from backend.services.error_monitor.known_issues import should_ignore
+
+        result = should_ignore("karaoke-backend", self._MSG)
+        assert result is not None
+        assert result.pattern_name == "encoding_worker_capacity_retry"
+
+    def test_capacity_ignored_regardless_of_job_id_shape(self):
+        from backend.services.error_monitor.known_issues import should_ignore
+
+        # plain job id form (the pre-existing May pattern) also suppressed
+        msg = (
+            "[job:1ea7effb] Encoding worker start failed, aborting retries: "
+            "VM encoding-worker-fallback-a start failed in us-central1-a: "
+            "503 — SERVICE UNAVAILABLE"
+        )
+        assert should_ignore("karaoke-backend", msg) is not None
+
+    def test_capacity_code_variant_is_ignored(self):
+        from backend.services.error_monitor.known_issues import should_ignore
+
+        msg = (
+            "[job:1ea7effb] Encoding worker start failed, aborting retries: "
+            "VM encoding-worker-fallback-a could not be started in us-central1-a: "
+            "ZONE_RESOURCE_POOL_EXHAUSTED — no resources available"
+        )
+        assert should_ignore("karaoke-backend", msg) is not None
+
+    def test_genuine_job_failure_still_alerts(self):
+        from backend.services.error_monitor.known_issues import should_ignore
+
+        # A real hard failure uses different wording and must NOT be suppressed.
+        assert should_ignore(
+            "karaoke-backend",
+            "[job:1ea7effb] Video render failed: encoder crashed",
+        ) is None
+
+    def test_non_transient_start_failure_still_alerts(self):
+        from backend.services.error_monitor.known_issues import should_ignore
+
+        # Same "aborting retries" prefix, but a non-transient GCE code — this is
+        # "something is actually broken" and must NOT be suppressed.
+        msg = (
+            "[job:1ea7effb] Encoding worker start failed, aborting retries: "
+            "VM encoding-worker-fallback-b start failed in us-central1-b: "
+            "PERMISSION_DENIED — the caller does not have permission"
+        )
+        assert should_ignore("karaoke-backend", msg) is None
+
+
 class TestCaseInsensitiveMatching:
     """All patterns should match case-insensitively."""
 

--- a/tests/unit/services/error_monitor/test_normalizer.py
+++ b/tests/unit/services/error_monitor/test_normalizer.py
@@ -3,6 +3,35 @@
 import pytest
 
 
+class TestPreviewJobIdReplacement:
+    """Underscore-joined preview render job IDs must collapse to one pattern.
+
+    Without this, every preview render of the same job (different render suffix)
+    hashes differently and pages separately — N alerts for one incident.
+    """
+
+    def test_preview_job_id_collapsed(self):
+        from backend.services.error_monitor.normalizer import normalize_message
+
+        msg = "[job:preview_ae5de3e5_3c4cdb053cbf] Encoding worker start failed"
+        result = normalize_message(msg)
+        assert "ae5de3e5" not in result
+        assert "3c4cdb053cbf" not in result
+        assert "preview_<ID>" in result
+
+    def test_two_renders_same_job_same_hash(self):
+        from backend.services.error_monitor.normalizer import (
+            compute_pattern_hash,
+            normalize_message,
+        )
+
+        a = "[job:preview_ae5de3e5_3c4cdb053cbf] Encoding worker start failed"
+        b = "[job:preview_ae5de3e5_f24cf1943a06] Encoding worker start failed"
+        ha = compute_pattern_hash("karaoke-backend", normalize_message(a))
+        hb = compute_pattern_hash("karaoke-backend", normalize_message(b))
+        assert ha == hb
+
+
 class TestUUIDReplacement:
     """UUID patterns should be replaced with <ID>."""
 


### PR DESCRIPTION
## Why

Two alert-channel noise sources surfaced during the flacfetch download incident. Neither was a real production problem, but both page — so we fix the **monitor's signal quality** rather than mute them.

### 1. Transient encoding-worker capacity retries
`[job:…] Encoding worker start failed, aborting retries: VM … 503 — SERVICE UNAVAILABLE` is a transient GCP zonal-capacity event. `render_video_worker` catches `EncodingWorkerStartError` and **parks the job for auto-retry** (`_park_job_for_capacity_retry`) — the job is *not* lost, and a genuine give-up fails the job via a separate ERROR. Added a `known_issues` suppression **scoped to the transient signal only** (503 / `SERVICE UNAVAILABLE` or a capacity code: `ZONE_RESOURCE_POOL_EXHAUSTED` / `STOCKOUT` / `QUOTA_EXCEEDED`). A non-transient `EncodingWorkerStartError` (other/unknown code) shares the prefix but **still pages**.

### 2. One incident → N alerts (normalizer gap)
The same failure produced *two* alerts (same job, two preview-render IDs). `preview_<jobid>_<renderid>` is underscore-joined, and the generic hex normalizer is `\b`-anchored (`_` is a word char), so every preview render hashed to a distinct "new pattern." Added a normalizer rule that collapses `preview_<hex>_<hex>` → `preview_<ID>`.

### 3. Bot/crawler browser crashes
`NotFoundError: removeChild` on `/en/r/` came from **bingbot** running headless Chrome — a React DOM-reconciliation error no real user hits (0 real-user occurrences in 7d). Reports from bot/crawler user-agents are now dropped at the `/client-errors` ingestion edge (still `202` so the client won't retry), instead of being persisted/alerted.

## Tests
- `known_issues`: transient 503 **and** capacity-code variants suppressed; non-transient start failure + genuine job failure still alert.
- `normalizer`: preview-ID collapse; two renders of one job → same hash.
- `is_bot_user_agent`: crawler matrix true, real-browser/empty/None false.
- API: a bingbot report is accepted (`202`, `is_new=false`) but **not upserted**.

`133 passed`. Local CodeRabbit review completed and its two findings (scope the capacity regex; sanitize the logged bot URL) were addressed; a confirming re-review was blocked by the free-tier rate limit, so leaving the bot review on.

## Notes
The actual outage in this incident (daily E2E download failure) was a **flacfetch** bug, fixed + deployed separately (flacfetch #36). This PR only removes the alert noise those investigations surfaced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Bot and crawler error reports are acknowledged without being persisted or triggering alerts.
  - Transient encoding-worker capacity failures are filtered as retryable infrastructure noise.
  - Preview render job identifiers are normalized consistently for improved error grouping.

- **Maintenance**
  - Updated the application version to 0.192.2.
  - Expanded validation for bot detection, error filtering, and preview error normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->