### PR TITLE
fix: harden admin reset against render/video worker supersession race

### DIFF
--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -1203,7 +1203,7 @@ async def reset_job(
     job_manager.update_job(job_id, updates)
 
     # Clear the state data keys and error state using direct Firestore update
-    from google.cloud.firestore_v1 import DELETE_FIELD, ArrayUnion
+    from google.cloud.firestore_v1 import DELETE_FIELD, ArrayUnion, Increment
 
     job_ref = user_service.db.collection("jobs").document(job_id)
 
@@ -1218,6 +1218,14 @@ async def reset_job(
     # Always clear error state on reset (confusing to have old errors after reset)
     clear_updates["error_message"] = DELETE_FIELD
     clear_updates["error_details"] = DELETE_FIELD
+
+    # Advance the supersession fence: a reset is a "stop what you're doing" event.
+    # Any render/video worker still in flight (e.g. the operator hit "Review"
+    # mid-render) will observe the bumped generation and discard its stale result
+    # instead of overwriting fresh outputs or failing this reset. See
+    # backend/workers/supersede.py. Atomic with the clears above so an in-flight
+    # worker can never observe a half-applied reset.
+    clear_updates["state_data.worker_generation"] = Increment(1)
 
     # Add timeline event
     clear_updates["timeline"] = ArrayUnion([timeline_event])

--- a/backend/services/job_manager.py
+++ b/backend/services/job_manager.py
@@ -786,6 +786,34 @@ class JobManager:
         self.update_job(job_id, {'state_data': state_data})
         logger.debug(f"Job {job_id} state_data updated: {key} = {value}")
 
+    def bump_worker_generation(self, job_id: str) -> Optional[int]:
+        """
+        Atomically increment the ``state_data.worker_generation`` fence.
+
+        Every trigger of a long-running render/video worker bumps this counter.
+        A worker captures the value at start; if it later differs, a newer run
+        has superseded it and its (now stale) result must be discarded rather
+        than written back or used to fail the job. See
+        :mod:`backend.workers.supersede`.
+
+        Returns the new generation, or ``None`` if the update failed (best-effort
+        — a failed bump must never block triggering the worker).
+        """
+        try:
+            from google.cloud.firestore_v1 import Increment
+            self.firestore.update_job(job_id, {
+                'state_data.worker_generation': Increment(1),
+            })
+            job = self.get_job(job_id)
+            new_generation = (job.state_data or {}).get('worker_generation') if job else None
+            logger.info(f"Job {job_id}: bumped worker_generation to {new_generation}")
+            return new_generation
+        except Exception as e:
+            # Never let a fence bump block worker dispatch — the status fence
+            # (Layer A) still protects against the reset race on its own.
+            logger.warning(f"Job {job_id}: failed to bump worker_generation: {e}")
+            return None
+
     def update_processing_metadata(self, job_id: str, section: str, data) -> None:
         """
         Write data into processing_metadata[section] using Firestore dot-notation.

--- a/backend/services/worker_service.py
+++ b/backend/services/worker_service.py
@@ -513,6 +513,7 @@ class WorkerService:
         uses Cloud Run Jobs for execution (supports >30 min encoding).
         Otherwise, uses Cloud Tasks or direct HTTP.
         """
+        self._bump_worker_generation(job_id)
         self._warmup_encoding_worker(job_id)
         if self._use_cloud_tasks and self.settings.use_cloud_run_jobs_for_video:
             return await self._trigger_cloud_run_job(job_id)
@@ -606,8 +607,26 @@ class WorkerService:
     
     async def trigger_render_video_worker(self, job_id: str) -> bool:
         """Trigger render video worker (post-review)."""
+        self._bump_worker_generation(job_id)
         self._warmup_encoding_worker(job_id)
         return await self.trigger_worker("render-video", job_id)
+
+    def _bump_worker_generation(self, job_id: str) -> None:
+        """
+        Advance the supersession fence before dispatching a render/video worker.
+
+        Bumping here (the single choke point for both workers) means every run
+        captures a unique generation at start. If an older run of the same stage
+        is still in flight — because an admin reset then re-triggered the job —
+        it will observe the newer generation and discard its stale result
+        instead of overwriting fresh outputs or failing the job. Best-effort:
+        a failed bump is logged and ignored (the status fence still applies).
+        """
+        try:
+            from backend.services.job_manager import JobManager
+            JobManager().bump_worker_generation(job_id)
+        except Exception as e:
+            logger.warning(f"[job:{job_id}] Failed to bump worker generation before trigger: {e}")
 
     async def schedule_idle_reminder(
         self,

--- a/backend/tests/test_admin_job_reset.py
+++ b/backend/tests/test_admin_job_reset.py
@@ -1116,3 +1116,51 @@ class TestResetJobToAwaitingAudioEdit:
             # We check the update_job call for status change
             update_args = mock_jm.update_job.call_args[0][1]
             assert update_args["status"] == "awaiting_audio_edit"
+
+
+class TestResetBumpsWorkerGenerationFence:
+    """A reset is a 'stop what you're doing' event for in-flight workers.
+
+    It must atomically bump state_data.worker_generation so a render/video worker
+    that is still running (e.g. operator hit "Review" mid-render) detects it has
+    been superseded and discards its stale result instead of failing the reset.
+    Regression guard for the 7f457087 admin-reset race.
+    """
+
+    def test_reset_increments_worker_generation(self, client, mock_job):
+        from backend.services.user_service import get_user_service
+
+        mock_user_service = Mock()
+        mock_job_ref = Mock()
+        mock_user_service.db.collection.return_value.document.return_value = mock_job_ref
+
+        app.dependency_overrides[get_user_service] = lambda: mock_user_service
+        try:
+            # Patch the Increment symbol the endpoint imports so the assertion is
+            # robust even when another test replaced firestore_v1 with a mock.
+            with patch('backend.api.routes.admin.JobManager') as mock_jm_class, \
+                 patch('google.cloud.firestore_v1.Increment') as mock_incr:
+                mock_incr.return_value = "INCREMENT(1)"
+                mock_jm = Mock()
+                mock_jm.get_job.return_value = mock_job
+                mock_jm.update_job.return_value = None
+                mock_jm_class.return_value = mock_jm
+
+                response = client.post(
+                    "/api/admin/jobs/test-job-123/reset",
+                    json={"target_state": "awaiting_review"},
+                )
+        finally:
+            del app.dependency_overrides[get_user_service]
+
+        assert response.status_code == 200
+        mock_incr.assert_called_once_with(1)  # atomic +1 on the fence
+
+        # The clear_updates payload sent to job_ref.update() must carry the fence bump.
+        update_payloads = [c.args[0] for c in mock_job_ref.update.call_args_list if c.args]
+        fence_updates = [
+            p for p in update_payloads
+            if isinstance(p, dict) and "state_data.worker_generation" in p
+        ]
+        assert fence_updates, "Reset must bump state_data.worker_generation"
+        assert fence_updates[-1]["state_data.worker_generation"] == "INCREMENT(1)"

--- a/backend/tests/test_worker_supersede_race.py
+++ b/backend/tests/test_worker_supersede_race.py
@@ -84,8 +84,9 @@ def test_bump_worker_generation_uses_atomic_increment():
 
     jm = JobManager.__new__(JobManager)  # bypass __init__/Firestore connect
     jm.firestore = MagicMock()
+    # Post-increment read reflects Increment(1) applied to a job at generation 5.
     bumped_job = MagicMock()
-    bumped_job.state_data = {"worker_generation": 5}
+    bumped_job.state_data = {"worker_generation": 6}
     jm.get_job = MagicMock(return_value=bumped_job)
 
     # Patch the Increment symbol the production code imports so this assertion is
@@ -95,7 +96,11 @@ def test_bump_worker_generation_uses_atomic_increment():
         mock_incr.return_value = "INCREMENT(1)"
         result = jm.bump_worker_generation("job-x")
 
-    assert result == 5
+    # The returned value is informational (logging only) — workers never consume
+    # it as a token; they compare their captured generation against the current
+    # one. Correctness therefore only needs the fence to CHANGE, not to hand back
+    # a unique per-dispatch token, so concurrent bumps sharing a read are benign.
+    assert result == 6
     mock_incr.assert_called_once_with(1)  # atomic +1, not a read-modify-write
     args, _ = jm.firestore.update_job.call_args
     payload = args[1]
@@ -213,15 +218,16 @@ async def test_render_superseded_by_generation_bump_does_not_fail_job():
 
 
 @pytest.mark.asyncio
-async def test_invalid_terminal_transition_is_graceful_not_failure():
+async def test_invalid_terminal_transition_is_graceful_when_superseded():
     """
-    The tight-window case: status/generation still look valid when we check, but
-    the reset lands during the terminal transition itself. transition_to_state
-    raises InvalidStateTransitionError — the worker must bail gracefully, exactly
-    reproducing and fixing the 7f457087 incident.
+    The reset lands during the terminal transition itself: transition_to_state
+    raises InvalidStateTransitionError AND a re-read confirms supersession (the
+    reset moved the job to awaiting_review). The worker must bail gracefully,
+    exactly reproducing and fixing the 7f457087 incident.
     """
     job_start = _render_job(generation=1)
-    job_after = _render_job(generation=1)  # not superseded by the pre-write checks
+    job_after = _render_job(generation=1)
+    job_after.status = "awaiting_review"  # reset confirmed on re-read in the handler
 
     invalid = InvalidStateTransitionError(
         "Invalid state transition for job 7f457087: in_review -> instrumental_selected",
@@ -237,6 +243,28 @@ async def test_invalid_terminal_transition_is_graceful_not_failure():
 
     assert result is False
     jm.fail_job.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_invalid_transition_when_not_superseded_still_fails():
+    """
+    An InvalidStateTransitionError that is NOT explained by supersession is a real
+    workflow defect — it must still fail the job (loudly) rather than be silently
+    swallowed and leave the job stuck. Guards against over-broad error suppression.
+    """
+    job_start = _render_job(generation=1)
+    job_after = _render_job(generation=1)  # same gen + still rendering_video => NOT superseded
+
+    invalid = InvalidStateTransitionError(
+        "Invalid state transition for job x: rendering_video -> instrumental_selected",
+        job_id="x",
+    )
+    result, jm = await _run_gce_render(
+        job_start, job_after, transition_side_effect=[True, invalid]
+    )
+
+    assert result is False
+    jm.fail_job.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_worker_supersede_race.py
+++ b/backend/tests/test_worker_supersede_race.py
@@ -1,0 +1,261 @@
+"""
+Regression tests for the admin-reset / render race (job 7f457087).
+
+Scenario: an operator hits the admin "Review" reset button while a render is
+still in flight. The render finishes a moment later and attempts its normal
+terminal transition (rendering_video -> instrumental_selected), which is now
+illegal because the job was reset back to review. Previously this raised
+InvalidStateTransitionError, was caught by the worker's generic handler, and
+flipped a perfectly-good reset to `failed` with the confusing message:
+
+    Video render failed: Invalid state transition for job 7f457087:
+    in_review -> instrumental_selected
+
+These tests lock in the hardened behaviour:
+
+  * A superseded render (status reset OR generation bumped) is discarded
+    quietly — it must NOT call fail_job and must NOT write stale outputs.
+  * An InvalidStateTransitionError at the terminal step is treated as
+    supersession (graceful bail), never a job failure.
+  * A normal, un-superseded render still transitions to INSTRUMENTAL_SELECTED.
+"""
+
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import pytest
+
+from backend.models.job import JobStatus
+from backend.exceptions import InvalidStateTransitionError
+from backend.workers.supersede import capture_generation, check_superseded
+
+
+# ---------------------------------------------------------------------------
+# supersede helper unit tests
+# ---------------------------------------------------------------------------
+
+def _job(generation=0, status=JobStatus.RENDERING_VIDEO):
+    job = MagicMock()
+    job.state_data = {"worker_generation": generation}
+    job.status = status
+    return job
+
+
+def test_capture_generation_defaults_to_zero():
+    job = MagicMock()
+    job.state_data = {}
+    assert capture_generation(job) == 0
+    job.state_data = None
+    assert capture_generation(job) == 0
+
+
+def test_check_superseded_none_when_current():
+    jm = MagicMock()
+    jm.get_job.return_value = _job(generation=3, status=JobStatus.RENDERING_VIDEO)
+    assert check_superseded(jm, "j", 3, {JobStatus.RENDERING_VIDEO}) is None
+
+
+def test_check_superseded_detects_generation_bump():
+    jm = MagicMock()
+    jm.get_job.return_value = _job(generation=4, status=JobStatus.RENDERING_VIDEO)
+    reason = check_superseded(jm, "j", 3, {JobStatus.RENDERING_VIDEO})
+    assert reason and "generation" in reason
+
+
+def test_check_superseded_detects_status_reset():
+    jm = MagicMock()
+    # Status strings are how Job.status deserialises (use_enum_values=True)
+    jm.get_job.return_value = _job(generation=3, status="awaiting_review")
+    reason = check_superseded(jm, "j", 3, {JobStatus.RENDERING_VIDEO})
+    assert reason and "status" in reason
+
+
+def test_check_superseded_when_job_deleted():
+    jm = MagicMock()
+    jm.get_job.return_value = None
+    assert check_superseded(jm, "j", 0, {JobStatus.RENDERING_VIDEO})
+
+
+# ---------------------------------------------------------------------------
+# JobManager.bump_worker_generation
+# ---------------------------------------------------------------------------
+
+def test_bump_worker_generation_uses_atomic_increment():
+    from backend.services.job_manager import JobManager
+
+    jm = JobManager.__new__(JobManager)  # bypass __init__/Firestore connect
+    jm.firestore = MagicMock()
+    bumped_job = MagicMock()
+    bumped_job.state_data = {"worker_generation": 5}
+    jm.get_job = MagicMock(return_value=bumped_job)
+
+    # Patch the Increment symbol the production code imports so this assertion is
+    # robust even when another test has replaced the firestore_v1 module with a
+    # mock (real-vs-mock class identity would otherwise flake in the full suite).
+    with patch("google.cloud.firestore_v1.Increment") as mock_incr:
+        mock_incr.return_value = "INCREMENT(1)"
+        result = jm.bump_worker_generation("job-x")
+
+    assert result == 5
+    mock_incr.assert_called_once_with(1)  # atomic +1, not a read-modify-write
+    args, _ = jm.firestore.update_job.call_args
+    payload = args[1]
+    assert payload["state_data.worker_generation"] == "INCREMENT(1)"
+
+
+def test_bump_worker_generation_is_best_effort():
+    """A failed bump must never raise — the status fence still protects us."""
+    from backend.services.job_manager import JobManager
+
+    jm = JobManager.__new__(JobManager)
+    jm.firestore = MagicMock()
+    jm.firestore.update_job.side_effect = RuntimeError("firestore down")
+    jm.get_job = MagicMock()
+
+    assert jm.bump_worker_generation("job-x") is None
+
+
+# ---------------------------------------------------------------------------
+# render worker (GCE path) supersession behaviour
+# ---------------------------------------------------------------------------
+
+def _render_job(generation=1):
+    job = MagicMock()
+    job.artist = "John Maus"
+    job.title = "The Fear"
+    job.input_media_gcs_path = "jobs/test/audio.flac"
+    job.style_assets = {}
+    job.style_params_gcs_path = None
+    job.subtitle_offset_ms = 0
+    job.prep_only = False
+    job.state_data = {"worker_generation": generation, "is_duet": False}
+    job.file_urls = {}
+    job.status = JobStatus.RENDERING_VIDEO
+    return job
+
+
+def _gce_result():
+    return {
+        "output_files": ["gs://test-bucket/jobs/test/videos/with_vocals.mkv"],
+        "metadata": {},
+    }
+
+
+async def _run_gce_render(job_start, job_after, transition_side_effect=None):
+    """Drive process_render_video down the GCE path with controlled get_job snapshots."""
+    from backend.workers import render_video_worker as rvw
+
+    jm = MagicMock()
+    seq = [job_start]
+
+    def _get_job(_job_id):
+        return seq.pop(0) if seq else job_after
+
+    jm.get_job.side_effect = _get_job
+    if transition_side_effect is not None:
+        jm.transition_to_state.side_effect = transition_side_effect
+    else:
+        jm.transition_to_state.return_value = True
+
+    encoding_service = MagicMock()
+    encoding_service.is_enabled = True
+    encoding_service.render_video_on_gce = AsyncMock(return_value=_gce_result())
+
+    storage = MagicMock()
+    storage.file_exists.return_value = False
+
+    worker_service = MagicMock()
+    worker_service.trigger_video_worker = AsyncMock(return_value=True)
+
+    with patch.object(rvw, "JobManager", return_value=jm), \
+         patch.object(rvw, "StorageService", return_value=storage), \
+         patch.object(rvw, "get_settings"), \
+         patch.object(rvw, "create_job_logger", return_value=MagicMock()), \
+         patch.object(rvw, "setup_job_logging", return_value=MagicMock()), \
+         patch.object(rvw, "validate_worker_can_run", return_value=None), \
+         patch.object(rvw, "get_encoding_service", return_value=encoding_service), \
+         patch("backend.services.worker_service.get_worker_service", return_value=worker_service):
+        result = await rvw.process_render_video("7f457087")
+
+    return result, jm
+
+
+@pytest.mark.asyncio
+async def test_render_superseded_by_status_reset_does_not_fail_job():
+    """Admin reset moved the job to awaiting_review mid-render → discard, don't fail."""
+    job_start = _render_job(generation=1)
+    job_after = _render_job(generation=1)
+    job_after.status = "awaiting_review"  # reset out from under the render
+
+    result, jm = await _run_gce_render(job_start, job_after)
+
+    assert result is False
+    jm.fail_job.assert_not_called()
+    # No stale outputs written and no terminal INSTRUMENTAL_SELECTED transition
+    jm.update_file_url.assert_not_called()
+    instrumental_transitions = [
+        c for c in jm.transition_to_state.call_args_list
+        if c.kwargs.get("new_status") == JobStatus.INSTRUMENTAL_SELECTED
+    ]
+    assert not instrumental_transitions
+
+
+@pytest.mark.asyncio
+async def test_render_superseded_by_generation_bump_does_not_fail_job():
+    """A newer render was triggered (generation bumped) → discard the stale run."""
+    job_start = _render_job(generation=1)
+    job_after = _render_job(generation=2)  # newer run took over
+
+    result, jm = await _run_gce_render(job_start, job_after)
+
+    assert result is False
+    jm.fail_job.assert_not_called()
+    jm.update_file_url.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_invalid_terminal_transition_is_graceful_not_failure():
+    """
+    The tight-window case: status/generation still look valid when we check, but
+    the reset lands during the terminal transition itself. transition_to_state
+    raises InvalidStateTransitionError — the worker must bail gracefully, exactly
+    reproducing and fixing the 7f457087 incident.
+    """
+    job_start = _render_job(generation=1)
+    job_after = _render_job(generation=1)  # not superseded by the pre-write checks
+
+    invalid = InvalidStateTransitionError(
+        "Invalid state transition for job 7f457087: in_review -> instrumental_selected",
+        job_id="7f457087",
+        from_status="in_review",
+        to_status="instrumental_selected",
+        valid_transitions=["review_complete", "awaiting_review", "failed"],
+    )
+    # 1st transition (RENDERING_VIDEO) ok, 2nd (INSTRUMENTAL_SELECTED) raises
+    result, jm = await _run_gce_render(
+        job_start, job_after, transition_side_effect=[True, invalid]
+    )
+
+    assert result is False
+    jm.fail_job.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_normal_render_still_completes():
+    """Un-superseded render must still write outputs and transition to INSTRUMENTAL_SELECTED."""
+    job_start = _render_job(generation=1)
+    job_after = _render_job(generation=1)  # same gen, still rendering_video
+
+    result, jm = await _run_gce_render(job_start, job_after)
+
+    assert result is True
+    jm.fail_job.assert_not_called()
+    instrumental_transitions = [
+        c for c in jm.transition_to_state.call_args_list
+        if c.kwargs.get("new_status") == JobStatus.INSTRUMENTAL_SELECTED
+    ]
+    assert instrumental_transitions, "Normal render must reach INSTRUMENTAL_SELECTED"
+    # with_vocals output recorded
+    assert any(
+        c.args[1:3] == ("videos", "with_vocals")
+        for c in jm.update_file_url.call_args_list
+    )

--- a/backend/tests/test_worker_supersede_race.py
+++ b/backend/tests/test_worker_supersede_race.py
@@ -240,6 +240,54 @@ async def test_invalid_terminal_transition_is_graceful_not_failure():
 
 
 @pytest.mark.asyncio
+async def test_progress_callback_skips_update_when_superseded():
+    """A stale render's progress ticks must not drag a reset job's progress bar."""
+    from backend.workers import render_video_worker as rvw
+
+    job_start = _render_job(generation=1)
+    superseded = _render_job(generation=2)  # reset bumped the fence mid-render
+
+    jm = MagicMock()
+    calls = {"n": 0}
+
+    def _get_job(_job_id):
+        calls["n"] += 1
+        return job_start if calls["n"] == 1 else superseded
+
+    jm.get_job.side_effect = _get_job
+    jm.transition_to_state.return_value = True
+
+    async def _render(_job_id, _config, progress_callback=None):
+        progress_callback(50)  # encoder emits a tick on the now-stale job
+        return _gce_result()
+
+    encoding_service = MagicMock()
+    encoding_service.is_enabled = True
+    encoding_service.render_video_on_gce = AsyncMock(side_effect=_render)
+
+    storage = MagicMock()
+    storage.file_exists.return_value = False
+
+    with patch.object(rvw, "JobManager", return_value=jm), \
+         patch.object(rvw, "StorageService", return_value=storage), \
+         patch.object(rvw, "get_settings"), \
+         patch.object(rvw, "create_job_logger", return_value=MagicMock()), \
+         patch.object(rvw, "setup_job_logging", return_value=MagicMock()), \
+         patch.object(rvw, "validate_worker_can_run", return_value=None), \
+         patch.object(rvw, "get_encoding_service", return_value=encoding_service):
+        result = await rvw.process_render_video("7f457087")
+
+    assert result is False  # bails after render (superseded)
+    jm.fail_job.assert_not_called()
+    # No progress write happened during the superseded tick
+    progress_writes = [
+        c for c in jm.update_job.call_args_list
+        if len(c.args) > 1 and isinstance(c.args[1], dict) and "progress" in c.args[1]
+    ]
+    assert not progress_writes, "Superseded render must not stamp progress onto the job"
+
+
+@pytest.mark.asyncio
 async def test_normal_render_still_completes():
     """Un-superseded render must still write outputs and transition to INSTRUMENTAL_SELECTED."""
     job_start = _render_job(generation=1)

--- a/backend/workers/render_video_worker.py
+++ b/backend/workers/render_video_worker.py
@@ -207,6 +207,16 @@ async def process_render_video(job_id: str) -> bool:
                         # gets logged via the error monitor, and (2) flood the
                         # timeline with redundant "transitioned" events for
                         # every tick.
+                        #
+                        # Supersession guard: if the job was reset/cancelled or a
+                        # newer render took over while this (now stale) render is
+                        # still emitting ticks, don't stamp our progress onto the
+                        # job — that would drag a reset job's progress bar back to
+                        # ~75-82% while it sits in awaiting_review.
+                        if check_superseded(
+                            job_manager, job_id, captured_generation, {JobStatus.RENDERING_VIDEO}
+                        ):
+                            return
                         scaled = 75 + int(progress * 0.07)  # Map 0-100 to 75-82
                         job_manager.update_job(job_id, {
                             'progress': scaled,
@@ -226,8 +236,17 @@ async def process_render_video(job_id: str) -> bool:
 
                     # Supersession fence: if the job was reset/cancelled or a newer
                     # render was triggered while we rendered, discard this stale
-                    # result rather than overwriting fresh outputs or (below) failing
-                    # the job on an invalid terminal transition.
+                    # result rather than recording its file_urls / transitioning
+                    # (which would fail on an invalid terminal transition below).
+                    #
+                    # Residual (accepted): the GCE render already wrote the with_vocals
+                    # object under the shared jobs/{job_id}/ prefix before this check, so
+                    # a stale run can leave stale bytes there. A newer generation always
+                    # re-renders and overwrites the same object, so the worst case is a
+                    # transient stale object — never a failed job or a bad downstream
+                    # trigger (those are blocked here + by the InvalidStateTransition
+                    # guard). Fully closing the GCS window needs generation-scoped output
+                    # prefixes + a conditional promote on the encoder side (follow-up).
                     superseded = check_superseded(
                         job_manager, job_id, captured_generation, {JobStatus.RENDERING_VIDEO}
                     )

--- a/backend/workers/render_video_worker.py
+++ b/backend/workers/render_video_worker.py
@@ -524,6 +524,17 @@ async def process_render_video(job_id: str) -> bool:
                         # Supersession fence: bail before overwriting outputs if
                         # the job was reset/cancelled or a newer render started
                         # while we rendered (mirrors the GCE path above).
+                        #
+                        # Same accepted residual as the GCE path: earlier writes in
+                        # this path (lyrics_metadata countdown padding, GCS objects
+                        # under the shared jobs/{job_id}/ prefix) can still land on a
+                        # newer generation in the narrow window before this check. A
+                        # newer render re-renders and overwrites them, and the
+                        # InvalidStateTransition guard blocks any bad downstream
+                        # trigger, so the worst case is transient stale bytes/metadata.
+                        # Fully closing it needs generation-scoped output paths +
+                        # conditional promote (deferred follow-up). NB: prod renders
+                        # via the GCE path; this local path is dev/fallback only.
                         superseded = check_superseded(
                             job_manager, job_id, captured_generation, {JobStatus.RENDERING_VIDEO}
                         )
@@ -647,14 +658,34 @@ async def process_render_video(job_id: str) -> bool:
         # instrumental_selected is no longer valid), the operator moved the job
         # deliberately. Discard our stale result quietly instead of clobbering
         # their reset with a spurious "failed" (the original 7f457087 incident).
-        # The generation/status fences above normally catch this first; this
-        # guarantees it even if the reset lands inside the transition window.
+        #
+        # But an InvalidStateTransitionError does NOT by itself prove supersession
+        # — it also fires for genuine workflow defects (a bad initial transition,
+        # a state-machine bug). CONFIRM supersession before swallowing the error;
+        # otherwise fall through to the real failure path so a non-superseded job
+        # surfaces instead of silently stalling.
         duration = time.time() - start_time
-        job_log.warning(f"Render superseded mid-transition, discarding stale result: {e}")
-        logger.info(
-            f"[job:{job_id}] WORKER_END worker=render-video status=superseded "
-            f"duration={duration:.1f}s reason={e}"
+        supersede_reason = check_superseded(
+            job_manager, job_id, captured_generation, {JobStatus.RENDERING_VIDEO}
         )
+        if supersede_reason:
+            job_log.warning(
+                f"Render superseded mid-transition, discarding stale result: "
+                f"{supersede_reason} ({e})"
+            )
+            logger.info(
+                f"[job:{job_id}] WORKER_END worker=render-video status=superseded "
+                f"duration={duration:.1f}s reason={supersede_reason}"
+            )
+            return False
+        # Not superseded: this is a real defect, not the reset race. Fail loudly.
+        error_text = str(e) or repr(e)
+        job_log.error(f"Video render failed (unexpected invalid transition): {error_text}")
+        logger.error(
+            f"[job:{job_id}] WORKER_END worker=render-video status=error "
+            f"duration={duration:.1f}s error={error_text}"
+        )
+        job_manager.fail_job(job_id, f"Video render failed: {error_text}")
         return False
     except Exception as e:
         duration = time.time() - start_time

--- a/backend/workers/render_video_worker.py
+++ b/backend/workers/render_video_worker.py
@@ -35,9 +35,11 @@ from typing import Optional, Dict, Any
 from dataclasses import dataclass
 
 from backend.models.job import JobStatus
+from backend.exceptions import InvalidStateTransitionError
 from backend.services.job_manager import JobManager
 from backend.services.storage_service import StorageService
 from backend.services.job_health_service import validate_worker_can_run
+from backend.workers.supersede import capture_generation, check_superseded
 from backend.config import get_settings
 from backend.workers.registry import worker_registry
 from backend.workers.worker_logging import create_job_logger, setup_job_logging, job_logging_context
@@ -122,6 +124,12 @@ async def process_render_video(job_id: str) -> bool:
         logger.error(f"[job:{job_id}] Job not found in Firestore")
         job_log.error(f"Job {job_id} not found in Firestore!")
         return False
+
+    # Capture the supersession fence at start. If an admin reset (or a newer
+    # render trigger) advances the generation while we render, our result is
+    # stale and must be discarded instead of overwriting fresh outputs or
+    # failing the job. See backend/workers/supersede.py.
+    captured_generation = capture_generation(job)
 
     # Validate job status is appropriate for render video worker
     # This helps catch bugs where the worker is triggered incorrectly
@@ -215,6 +223,21 @@ async def process_render_video(job_id: str) -> bool:
 
                     job_log.info(f"GCE render_video complete in {render_duration:.1f}s")
                     logger.info(f"[job:{job_id}] GCE render_video complete in {render_duration:.1f}s")
+
+                    # Supersession fence: if the job was reset/cancelled or a newer
+                    # render was triggered while we rendered, discard this stale
+                    # result rather than overwriting fresh outputs or (below) failing
+                    # the job on an invalid terminal transition.
+                    superseded = check_superseded(
+                        job_manager, job_id, captured_generation, {JobStatus.RENDERING_VIDEO}
+                    )
+                    if superseded:
+                        job_log.warning(f"Render superseded, discarding stale GCE result: {superseded}")
+                        logger.info(
+                            f"[job:{job_id}] WORKER_END worker=render-video status=superseded "
+                            f"reason={superseded}"
+                        )
+                        return False
 
                     # Parse response and update Firestore
                     output_files = result.get("output_files", [])
@@ -479,6 +502,20 @@ async def process_render_video(job_id: str) -> bool:
                             title=job.title
                         )
 
+                        # Supersession fence: bail before overwriting outputs if
+                        # the job was reset/cancelled or a newer render started
+                        # while we rendered (mirrors the GCE path above).
+                        superseded = check_superseded(
+                            job_manager, job_id, captured_generation, {JobStatus.RENDERING_VIDEO}
+                        )
+                        if superseded:
+                            job_log.warning(f"Render superseded, discarding stale local result: {superseded}")
+                            logger.info(
+                                f"[job:{job_id}] WORKER_END worker=render-video status=superseded "
+                                f"reason={superseded}"
+                            )
+                            return False
+
                         # 9. Upload video to GCS
                         if outputs.video and os.path.exists(outputs.video):
                             video_size = os.path.getsize(outputs.video)
@@ -583,6 +620,22 @@ async def process_render_video(job_id: str) -> bool:
             f"duration={duration:.1f}s code={e.code} zone={e.zone} kind={'capacity' if is_capacity else 'start_error'}"
         )
         _park_job_for_capacity_retry(job_manager, job_id, e)
+        return False
+    except InvalidStateTransitionError as e:
+        # Safety net for the reset race: if our terminal transition became illegal
+        # because the job was reset/cancelled out from under us mid-render (e.g.
+        # admin "Review" reset while rendering_video -> the transition to
+        # instrumental_selected is no longer valid), the operator moved the job
+        # deliberately. Discard our stale result quietly instead of clobbering
+        # their reset with a spurious "failed" (the original 7f457087 incident).
+        # The generation/status fences above normally catch this first; this
+        # guarantees it even if the reset lands inside the transition window.
+        duration = time.time() - start_time
+        job_log.warning(f"Render superseded mid-transition, discarding stale result: {e}")
+        logger.info(
+            f"[job:{job_id}] WORKER_END worker=render-video status=superseded "
+            f"duration={duration:.1f}s reason={e}"
+        )
         return False
     except Exception as e:
         duration = time.time() - start_time

--- a/backend/workers/supersede.py
+++ b/backend/workers/supersede.py
@@ -1,0 +1,89 @@
+"""
+Worker supersession fencing.
+
+A long-running worker (render-video, video) can be "superseded" mid-flight when
+an operator resets the job (admin "Review"/"Audio"/"Reprocess" buttons), a user
+cancels it, or a newer run of the same stage is triggered. When that happens the
+worker's result is stale and must be DISCARDED — not written back and, above all,
+not used to fail a job the operator deliberately moved.
+
+Two independent nets detect supersession:
+
+1. Status fence (Layer A) — the job is no longer in a status this worker owns.
+   Catches admin resets that move the job backwards (e.g. rendering_video ->
+   awaiting_review) even when no new worker has been triggered yet.
+
+2. Generation fence (Layer B) — ``state_data.worker_generation`` is bumped every
+   time a render/video worker is triggered. A worker captures the generation at
+   start; if it later differs, a newer run has taken over. This closes the race
+   where a stale run finishes just after a new one started and would otherwise
+   overwrite the newer run's outputs.
+
+Together these guarantee that no sequence of admin resets / re-submissions can
+push a job into an invalid state or clobber a fresher render.
+"""
+
+from typing import Iterable, Optional
+
+from backend.models.job import JobStatus
+
+
+def capture_generation(job) -> int:
+    """Read the worker-generation fence off a job snapshot (0 if unset)."""
+    state_data = getattr(job, "state_data", None) or {}
+    try:
+        return int(state_data.get("worker_generation", 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _normalize_status(status) -> Optional[JobStatus]:
+    """Job.status is deserialised with use_enum_values=True (a plain str)."""
+    if isinstance(status, JobStatus):
+        return status
+    try:
+        return JobStatus(status)
+    except (ValueError, TypeError):
+        return None
+
+
+def check_superseded(
+    job_manager,
+    job_id: str,
+    captured_generation: int,
+    expected_statuses: Iterable[JobStatus],
+) -> Optional[str]:
+    """
+    Re-read the job and decide whether this worker has been superseded.
+
+    Args:
+        job_manager: JobManager instance (re-reads fresh from Firestore).
+        job_id: Job being processed.
+        captured_generation: Value from :func:`capture_generation` at worker start.
+        expected_statuses: Statuses this worker legitimately owns right now.
+
+    Returns:
+        A human-readable reason string if superseded, else ``None``.
+    """
+    job = job_manager.get_job(job_id)
+    if job is None:
+        return "job no longer exists"
+
+    current_generation = capture_generation(job)
+    if current_generation != captured_generation:
+        return (
+            f"worker generation changed "
+            f"({captured_generation} -> {current_generation}) — a newer run took over"
+        )
+
+    status = _normalize_status(job.status)
+    expected = set(expected_statuses)
+    if status not in expected:
+        status_value = status.value if status else repr(job.status)
+        expected_values = sorted(s.value for s in expected)
+        return (
+            f"job status is {status_value}, no longer one of {expected_values} "
+            f"(reset or cancelled out from under this worker)"
+        )
+
+    return None

--- a/backend/workers/video_worker.py
+++ b/backend/workers/video_worker.py
@@ -32,6 +32,7 @@ from typing import Optional, Dict, Any
 from pathlib import Path
 
 from backend.models.job import JobStatus
+from backend.exceptions import InvalidStateTransitionError
 from backend.services.job_manager import JobManager
 from backend.services.storage_service import StorageService
 from backend.services.job_health_service import validate_worker_can_run
@@ -422,6 +423,18 @@ async def generate_video_orchestrated(job_id: str) -> bool:
             # This allows the worker to be re-triggered after admin reset
             job_manager.update_state_data(job_id, 'video_progress', {'stage': 'complete'})
             return True
+
+    except InvalidStateTransitionError as e:
+        # The job was reset/cancelled out from under us mid-encode (e.g. admin
+        # reset while generating_video/encoding). Discard our stale result quietly
+        # rather than failing a job the operator deliberately moved. See
+        # backend/workers/supersede.py and render_video_worker for the same guard.
+        duration = time.time() - start_time
+        logger.info(
+            f"[job:{job_id}] WORKER_END worker=video orchestrator=true status=superseded "
+            f"duration={duration:.1f}s reason={e}"
+        )
+        return False
 
     except Exception as e:
         duration = time.time() - start_time
@@ -957,6 +970,17 @@ async def generate_video_legacy(job_id: str) -> bool:
             job_manager.update_state_data(job_id, 'video_progress', {'stage': 'complete'})
             return True
 
+    except InvalidStateTransitionError as e:
+        # Job reset/cancelled out from under us mid-encode — discard the stale
+        # result quietly instead of failing the operator's reset (see the
+        # orchestrated path and render_video_worker for the same guard).
+        duration = time.time() - start_time
+        logger.info(
+            f"[job:{job_id}] WORKER_END worker=video status=superseded "
+            f"duration={duration:.1f}s reason={e}"
+        )
+        return False
+
     except Exception as e:
         duration = time.time() - start_time
         logger.error(f"[job:{job_id}] WORKER_END worker=video status=error duration={duration:.1f}s error={e}")
@@ -966,7 +990,7 @@ async def generate_video_legacy(job_id: str) -> bool:
             error_details={"stage": "video_generation", "error": str(e)}
         )
         return False
-        
+
     finally:
         # Restore original working directory
         os.chdir(original_cwd)

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1437,3 +1437,43 @@ CJK token like `立ち向かう`) and counts the inter-token space the renderer 
   splitters map zero words and would return `[]`, silently dropping lyrics.
 - The CJK font is a **system fallback** (Noto Sans CJK); the configured karaoke
   font (Montserrat/Avenir) has no CJK glyphs. See `video_generator._find_cjk_font`.
+
+## Long-Running Workers Must Be Fenced Against Supersession (Aug 2026)
+
+**Symptom:** An operator reset a `rendering_video` job via the admin "Review"
+button, then the job flipped itself to `failed` seconds later with *"Invalid
+state transition … in_review -> instrumental_selected"* (job `7f457087`). The
+reset was fine; the job died on its own.
+
+**Root cause:** Admin reset hard-writes the status backwards but does **not**
+stop the render worker already running on the encoder. When that render
+finished it ran its normal terminal transition (`rendering_video ->
+instrumental_selected`), now illegal, and the worker's generic `except
+Exception` handler called `fail_job()` — clobbering the operator's reset. A
+classic stale-worker / lost-update race: whoever finishes last wins, and the
+loser is a perfectly good reset.
+
+**Fix (v0.192.4):** Fence long-running render/video workers against
+supersession with two independent nets (`backend/workers/supersede.py`):
+1. **Status fence** — re-read the job before writing outputs / transitioning;
+   if it's no longer in the status this worker owns, discard the result.
+2. **Generation fence** — `state_data.worker_generation`, atomically
+   `Increment`ed by every admin reset *and* every render/video trigger. A worker
+   captures it at start; if it later differs, a newer run took over.
+Plus a targeted `except InvalidStateTransitionError` **before** the generic
+handler in both workers: a terminal transition that became illegal is treated
+as supersession (log + `return False`), never `fail_job()`.
+
+**Principles for next time:**
+- A worker must **never** `fail_job()` because its *own* success transition
+  became illegal — that only happens when something deliberately moved the job.
+- Bump the fence at the **trigger choke point** (`trigger_render_video_worker` /
+  `trigger_video_worker`), so every run gets a unique generation without having
+  to hunt down every caller. Cloud Tasks/Run retries re-invoke the worker (not
+  the trigger), so they keep the same generation — correct, it's the same run.
+- Check the fence **before writing outputs**, not just before the terminal
+  transition — otherwise a stale render can overwrite a newer render's video.
+- Test-isolation gotcha: assert an atomic bump via
+  `patch("google.cloud.firestore_v1.Increment")` + `assert_called_once_with(1)`,
+  not `isinstance(..., Increment)` — another test in the suite replaces the
+  firestore module with a mock, so real-vs-mock class identity flakes.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -209,6 +209,18 @@ gcloud compute instances describe encoding-worker-a \
 
 ---
 
+## Job flips to `failed` right after an admin reset (reset/render race)
+
+**Symptoms:** An operator hit an admin **Reset** button (e.g. "Review") on a job that was `rendering_video`, and moments later the job went to `failed` with a message like *"Video render failed: Invalid state transition for job …: in_review -> instrumental_selected"*. The reset itself looked fine, but the job died on its own.
+
+**Cause (fixed in v0.192.4):** The reset moved the job backwards while the render worker was still running on the encoder. When that render finished it attempted its normal terminal transition (`rendering_video -> instrumental_selected`), which was now illegal, and the worker's generic error handler flipped the job to `failed` — clobbering the operator's reset. First seen on job `7f457087`.
+
+**Auto-handling (v0.192.4+):** Long-running render/video workers are now fenced against supersession — a reset or a newer trigger causes the in-flight worker to **discard its stale result quietly** instead of failing the job. Two nets: a **status fence** (job no longer in the status the worker owns) and a **generation fence** (`state_data.worker_generation`, bumped by every reset and every render/video trigger). An `InvalidStateTransitionError` at the terminal step is treated as supersession, not failure. So resetting a rendering job is now safe at any timing — no manual action needed.
+
+**If you still see a `failed` job from an older occurrence:** use the admin **Retry** endpoint. For a job that has corrections + screens but no committed `instrumental_selection`, it returns cleanly to `awaiting_review` so the review (and instrumental choice) can be re-submitted.
+
+---
+
 ## Job in `download_pending_retry`
 
 **Symptoms:** Job status is `download_pending_retry` (introduced v0.192.3), step 3/10, message *"Still finding a good source for this track — … We'll keep trying automatically for up to 24 hours; no action needed."*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.192.3"
+version = "0.192.4"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Fixes the admin-reset / render race that flipped job `7f457087` to **failed** with *"Invalid state transition … in_review -> instrumental_selected"*. Hitting an admin **Reset** button (e.g. "Review") on a `rendering_video` job left the in-flight render running; when it finished it attempted its normal `rendering_video -> instrumental_selected` transition — now illegal — and the worker's generic handler clobbered the operator's reset with a spurious failure.
- Long-running render/video workers are now **fenced against supersession**, so any reset / cancel / re-trigger causes an in-flight worker to discard its stale result quietly instead of failing the job or overwriting fresher outputs. Resetting a rendering job is safe at any timing.

## Changes
- **`backend/workers/supersede.py`** (new): shared fencing helper with two independent nets — a **status fence** (job no longer in the status the worker owns) and a **generation fence** (`state_data.worker_generation`).
- **`JobManager.bump_worker_generation()`**: atomic Firestore `Increment(1)` on the fence (best-effort; never blocks dispatch).
- Fence bumped at every supersede point: the `trigger_render_video_worker` / `trigger_video_worker` choke points, and atomically within `admin.py reset_job`.
- **Render worker**: captures generation at start; supersede-checks before writing outputs (GCE + local paths); guards the progress callback so a stale render can't drag a reset job's progress bar; and — key fix — its `except InvalidStateTransitionError` now **confirms** supersession via `check_superseded()` before bailing gracefully, otherwise falls through to the real failure path so genuine workflow defects still surface.
- **Video worker**: same graceful/confirmed `InvalidStateTransitionError` handling in both the orchestrated and legacy paths.
- Docs: `TROUBLESHOOTING.md` (new reset/render-race runbook) + `LESSONS-LEARNED.md` (fencing principles).

## Known follow-up (documented in code)
Fully closing the residual GCS/metadata write window (a stale render can leave transient bytes under the shared `jobs/{job_id}/` prefix before the read-time check) requires **generation-scoped output prefixes + a conditional promote on the encoder side** — a larger cross-service change, deliberately deferred. The failed-job incident and any bad downstream trigger are fully fixed here; the worst residual is a transient stale object that a newer generation overwrites.

## Testing
- [x] `backend/tests/test_worker_supersede_race.py` (new): helper unit tests, atomic-increment, progress-callback guard, and render-worker scenarios — status-reset, generation-bump, confirmed-supersession-is-graceful (the `7f457087` repro), **not-superseded-still-fails**, and normal-completion.
- [x] `test_admin_job_reset.py`: reset bumps the generation fence.
- [x] Full backend suite green (3767 passed).

## Review
- [x] Local CodeRabbit review completed (3 cycles; final pass: no new findings)
- [x] Feedback addressed (over-broad `InvalidStateTransitionError` suppression fixed; TOCTOU residuals documented with a deferred follow-up)

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)