### PR TITLE
fix: surface made-for-you orders on dashboard + deep-link admin email

### DIFF
--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -1705,8 +1705,13 @@ class EmailService:
         # Use "ET" (Eastern Time) to be correct for both EST and EDT
         deadline_str = deadline_eastern.strftime("%B %d, %Y at %I:%M %p") + " ET"
 
-        # Link to /app/ with admin login token for one-click access
-        app_url = f"{self.frontend_url.rstrip('/')}/app/?admin_token={admin_login_token}"
+        # Link to /app/ with admin login token for one-click access, deep-linked to the
+        # awaiting-audio-selection queue so the made-for-you order is shown immediately
+        # (made-for-you cards render there; the status param pre-selects the filter).
+        app_url = (
+            f"{self.frontend_url.rstrip('/')}/app/"
+            f"?admin_token={admin_login_token}&status=awaiting_audio_selection"
+        )
 
         content = f"""
     <div class="order-info">

--- a/backend/services/firestore_service.py
+++ b/backend/services/firestore_service.py
@@ -198,6 +198,7 @@ class FirestoreService:
     SUMMARY_FIELD_PATHS = [
         'job_id', 'status', 'progress', 'created_at', 'artist', 'title',
         'error_message', 'non_interactive', 'outputs_deleted_at', 'user_email', 'is_private',
+        'made_for_you', 'customer_email',
         'url', 'filename', 'audio_search_artist', 'audio_search_title',
         'audio_source_type', 'source_name', 'source_id', 'target_file', 'download_url',
         'state_data.brand_code', 'state_data.youtube_url', 'state_data.dropbox_link',

--- a/backend/tests/test_email_service.py
+++ b/backend/tests/test_email_service.py
@@ -670,6 +670,30 @@ class TestMadeForYouAdminNotification:
         html_content = call_kwargs.get('html_content')
         assert "abc-def-123" in html_content
 
+    def test_send_admin_notification_link_deep_links_to_audio_queue(self):
+        """Admin 'Open Job' link must one-click login AND deep-link to the
+        awaiting-audio-selection queue so the made-for-you order is visible
+        (a bare /app link lands on a dashboard that filters it out)."""
+        service = EmailService()
+        service.provider = Mock()
+        service.provider.send_email.return_value = True
+
+        service.send_made_for_you_admin_notification(
+            to_email="admin@nomadkaraoke.com",
+            customer_email="customer@example.com",
+            artist="Test Artist",
+            title="Test Song",
+            job_id="job-123",
+            admin_login_token="tok-xyz",
+        )
+
+        call_kwargs = service.provider.send_email.call_args.kwargs
+        html_content = call_kwargs.get('html_content')
+        text_content = call_kwargs.get('text_content')
+        for body in (html_content, text_content):
+            assert "admin_token=tok-xyz" in body
+            assert "status=awaiting_audio_selection" in body
+
     def test_send_admin_notification_includes_audio_count(self):
         """Test admin notification includes audio source count."""
         service = EmailService()

--- a/backend/tests/test_routes_jobs.py
+++ b/backend/tests/test_routes_jobs.py
@@ -662,6 +662,21 @@ class TestSummaryEndpoint:
                       'audio_source_type', 'source_name', 'source_id', 'target_file', 'download_url']:
             assert field in paths, f"{field} must be in summary projection for source details modal"
 
+    def test_summary_projection_includes_made_for_you(self):
+        """Verify SUMMARY_FIELD_PATHS includes made_for_you (and customer_email).
+
+        The dashboard needs made_for_you in the summary payload so it can keep
+        made-for-you orders (which sit at awaiting_audio_selection) visible as
+        cards instead of filtering them out with self-service guided-flow jobs.
+        """
+        from backend.services.firestore_service import FirestoreService
+        paths = FirestoreService.SUMMARY_FIELD_PATHS
+        assert 'made_for_you' in paths, (
+            "'made_for_you' must be in summary projection so the dashboard can "
+            "surface made-for-you orders awaiting audio selection"
+        )
+        assert 'customer_email' in paths
+
     def test_prune_file_urls_keeps_allowed_keys(self):
         """Verify _prune_file_urls keeps only dashboard-required keys."""
         from backend.api.routes.jobs import _prune_file_urls

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1477,3 +1477,37 @@ as supersession (log + `return False`), never `fail_job()`.
   `patch("google.cloud.firestore_v1.Increment")` + `assert_called_once_with(1)`,
   not `isinstance(..., Increment)` — another test in the suite replaces the
   firestore module with a mock, so real-vs-mock class identity flakes.
+
+## Server-Created Jobs Must Fit the Dashboard's UI Assumptions (Aug 2026)
+
+**Symptom:** A paid "Made for you" Stripe order auto-created its job perfectly
+(webhook → `_handle_made_for_you_order`, job `b092648c` at
+`awaiting_audio_selection` with 10 audio sources found, admin notified) — yet
+the operator saw *nothing* on the dashboard and re-created the job by hand,
+producing a duplicate.
+
+**Root cause:** Two UI assumptions that only hold for *self-service* jobs:
+1. The dashboard filtered out **all** `awaiting_audio_selection` jobs, because
+   for a self-service user those are mid-wizard and owned by the guided-flow
+   component. Made-for-you jobs are created **server-side** by the Stripe
+   webhook, so they sit at that same status with **no active wizard session** —
+   and got silently dropped.
+2. The admin notification email's "Open Job" button linked to bare `/app/`,
+   i.e. the exact page that filters the job out.
+
+**Fix (v0.192.5):** `shouldShowJobOnDashboard()` keeps `made_for_you` jobs
+visible at `awaiting_audio_selection` (hiding only self-service ones); added
+`made_for_you`/`customer_email` to `SUMMARY_FIELD_PATHS` so the summary payload
+carries the flag; the email now deep-links to
+`/app/?admin_token=…&status=awaiting_audio_selection` (dashboard honors a
+`status` URL param).
+
+**Principles for next time:**
+- A UI filter written for one creation path (interactive wizard) will silently
+  swallow items from another path (server/webhook). When adding a server-created
+  job that reuses an interactive status, audit every place that status is
+  special-cased in the frontend.
+- A notification's action link must point at a view that actually **renders the
+  item** — verify the deep-link, don't assume "/app shows everything".
+- Any field a frontend filter branches on must be in `SUMMARY_FIELD_PATHS`, or
+  it arrives `undefined` and the branch silently takes the wrong path.

--- a/frontend/__tests__/job-status.test.ts
+++ b/frontend/__tests__/job-status.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for job-status.ts utility functions
  */
 
-import { getJobStep, formatStepIndicator, isBlockingStatus, isNotifiableBlockingStatus, getJobProgressPercent, sortJobsByDate, isAutoRetryPending, JobStep, STATUS_CONFIG } from '../lib/job-status';
+import { getJobStep, formatStepIndicator, isBlockingStatus, isNotifiableBlockingStatus, getJobProgressPercent, sortJobsByDate, isAutoRetryPending, shouldShowJobOnDashboard, JobStep, STATUS_CONFIG } from '../lib/job-status';
 import type { Job } from '../lib/api';
 
 // Helper to create a minimal Job object for testing
@@ -595,5 +595,21 @@ describe('isAutoRetryPending', () => {
   it('returns false for malformed expires_at', () => {
     expect(isAutoRetryPending({ state_data: { cloud_run_retry_pending: { expires_at: 'not-a-date' } } })).toBe(false);
     expect(isAutoRetryPending({ state_data: { cloud_run_retry_pending: {} } })).toBe(false);
+  });
+});
+
+describe('shouldShowJobOnDashboard', () => {
+  it('shows normal (non-audio-selection) jobs', () => {
+    expect(shouldShowJobOnDashboard({ status: 'complete' })).toBe(true);
+    expect(shouldShowJobOnDashboard({ status: 'awaiting_review' })).toBe(true);
+  });
+
+  it('hides self-service jobs still in the guided-flow at awaiting_audio_selection', () => {
+    expect(shouldShowJobOnDashboard({ status: 'awaiting_audio_selection' })).toBe(false);
+    expect(shouldShowJobOnDashboard({ status: 'awaiting_audio_selection', made_for_you: false })).toBe(false);
+  });
+
+  it('keeps made-for-you orders visible even at awaiting_audio_selection', () => {
+    expect(shouldShowJobOnDashboard({ status: 'awaiting_audio_selection', made_for_you: true })).toBe(true);
   });
 });

--- a/frontend/app/[locale]/app/page.tsx
+++ b/frontend/app/[locale]/app/page.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/components/ui/select"
 import { Music2, RefreshCw, Loader2, Search, Gift, X, Shield, ShieldOff } from "lucide-react"
 import { useTranslations } from "next-intl"
-import { sortJobsByDate } from "@/lib/job-status"
+import { sortJobsByDate, shouldShowJobOnDashboard } from "@/lib/job-status"
 import { WarmingUpLoader } from "@/components/WarmingUpLoader"
 import { JobCard } from "@/components/job"
 import { GuidedJobFlow } from "@/components/job/GuidedJobFlow"
@@ -88,9 +88,10 @@ function AppPageContent() {
   // Check if user is admin (for exclude_test parameter)
   const isAdmin = user?.role === "admin" || user?.email?.endsWith("@nomadkaraoke.com")
 
-  // Filter out in-progress search jobs (managed by the guided flow, not standalone cards)
+  // Hide self-service jobs still in the guided-flow wizard, but keep made-for-you orders
+  // visible even at awaiting_audio_selection (see shouldShowJobOnDashboard).
   const jobs = useMemo(
-    () => allJobs.filter(job => job.status !== 'awaiting_audio_selection'),
+    () => allJobs.filter(shouldShowJobOnDashboard),
     [allJobs]
   )
 
@@ -99,6 +100,20 @@ function AppPageContent() {
     const timer = setTimeout(() => setSearchQuery(searchInput), 300)
     return () => clearTimeout(timer)
   }, [searchInput])
+
+  // Honor a `status` URL param (e.g. made-for-you admin email deep-links to
+  // /app/?admin_token=...&status=awaiting_audio_selection). Applied on mount before
+  // the admin_token handler strips the query string, so the actionable queue is shown.
+  useEffect(() => {
+    const statusParam = searchParams.get("status")
+    if (statusParam) {
+      setStatusFilter(statusParam)
+      if (typeof window !== "undefined") {
+        localStorage.setItem("nomad-karaoke-status-filter", statusParam)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // Memoize loadJobs for use with visibility refresh
   const loadJobs = useCallback(async () => {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -145,6 +145,7 @@ export interface Job {
   brand_prefix?: string;
   // Customer order fields
   customer_email?: string;
+  made_for_you?: boolean;
   // Request tracking metadata
   request_metadata?: Record<string, any>;
 }

--- a/frontend/lib/job-status.ts
+++ b/frontend/lib/job-status.ts
@@ -322,3 +322,17 @@ export function sortJobsByDate(jobs: Job[]): Job[] {
   });
 }
 
+/**
+ * Whether a job should render as a standalone card on the main dashboard.
+ *
+ * Self-service jobs at `awaiting_audio_selection` are driven by the guided-flow
+ * wizard in the same browser session and must NOT appear as standalone cards
+ * (the wizard owns them). Made-for-you orders also sit at that status, but they
+ * are created server-side by the Stripe webhook with no active guided-flow
+ * session — so they'd otherwise be invisible to an admin. Keep those visible so
+ * their built-in "Open Audio Selection" action is reachable from the dashboard.
+ */
+export function shouldShowJobOnDashboard(job: Pick<Job, 'status' | 'made_for_you'>): boolean {
+  return job.status !== 'awaiting_audio_selection' || Boolean(job.made_for_you);
+}
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.192.4"
+version = "0.192.5"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Problem

A paid **"Made for you"** Stripe order *does* auto-create a job — the `checkout.session.completed` webhook runs `_handle_made_for_you_order`, which builds the job with the customer email, artist, and title, searches audio, and parks it at `awaiting_audio_selection` for an admin to pick the source. Verified in prod: order for *Kenny Chesney – Burn my Boat* correctly created job `b092648c` within seconds and emailed `madeforyou@nomadkaraoke.com`.

But the job was **invisible in practice**, so the operator re-created it by hand (duplicate):

1. **Dashboard hid it.** `/app` filtered out *all* `awaiting_audio_selection` jobs — a filter meant to hide self-service jobs mid-wizard. Made-for-you jobs are created server-side by the webhook with no active wizard session, so they got silently dropped.
2. **Email link went to the page that hides it.** The admin notification's "Open Job" button linked to bare `/app/`.

## Changes

- **`firestore_service.py`** — add `made_for_you` + `customer_email` to `SUMMARY_FIELD_PATHS` so the dashboard summary payload carries them.
- **`job-status.ts`** — new `shouldShowJobOnDashboard()` helper: hide self-service `awaiting_audio_selection` jobs, but keep `made_for_you` ones visible (their `JobCard` already has an "Open Audio Selection" button).
- **`app/[locale]/app/page.tsx`** — use the helper; honor a `?status=` URL param so email links can deep-link to the awaiting-audio-selection queue.
- **`email_service.py`** — made-for-you admin "Open Job" link now points to `/app/?admin_token=…&status=awaiting_audio_selection` (HTML + text).
- **Docs** — LESSONS-LEARNED entry: server-created jobs must fit dashboard UI assumptions.

## Testing

- Backend: `test_routes_jobs.py` summary-projection assertion for `made_for_you`; `test_email_service.py` asserts the deep-link carries both `admin_token` and `status=awaiting_audio_selection` (HTML + text). Affected files: **194 passed, 5 skipped**.
- Frontend: `job-status.test.ts` unit tests for `shouldShowJobOnDashboard` (**79 passed**). ESLint clean on changed files.
- CodeRabbit local review: **No findings** across all 9 files.

## Notes

- No new user-facing strings (email is backend English-only), so no i18n changes needed.
- Version bumped `0.192.4 → 0.192.5`.

@coderabbitai ignore