### PR TITLE
feat(infra): diversify encoding-worker fallbacks with n2-highcpu-32 (capacity resilience)

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -258,7 +258,7 @@ When two sequential human review steps can be combined into one, do it. We origi
 
 3. **`compute.instances.start` returns `503 SERVICE_UNAVAILABLE` for transient backend stress, not just capacity.** Initial fix only classified `ZONE_RESOURCE_POOL_EXHAUSTED` as transient/recoverable; `503` got the generic `EncodingWorkerStartError` and never triggered multi-zone fallback. Either treat the `EncodingWorkerStartError` parent class as fallback-worthy (what we did, PR #750) or expand the capacity error code list.
 
-4. **GCE `c4d-highcpu-32` capacity in `us-central1-f` is unreliable enough to be useless as a fallback.** Provisioning failed there at create time on multiple attempts (the very thing the fallback is meant to mitigate). `-a` and `-b` are stable. (PR #749)
+4. **GCE `c4d-highcpu-32` capacity in `us-central1-f` is unreliable enough to be useless as a fallback.** Provisioning failed there at create time on multiple attempts (the very thing the fallback is meant to mitigate). `-a` and `-b` were stable *at the time*. (PR #749) — **Superseded 2026-08-12:** see "Machine-family diversification" below; `-a`/`-b` are NOT immune — the whole `c4d-highcpu-32` family stocked out region-wide (a/b/c at once).
 
 5. **`google-auth ≥ 2.40` uses mTLS-over-HTTPS for the GCE metadata server when `/run/google-mds-mtls/` certs exist on the VM.** Newer GCE images ship those certs; the mTLS handshake then fails with `SSL CERTIFICATE_VERIFY_FAILED` on freshly-provisioned VMs. The worker can't refresh its SA token, all GCS reads/writes break. Fix: set `GCE_METADATA_MTLS_MODE=none` in the systemd EnvironmentFile to force HTTP-on-port-80 metadata access. (PR #750)
 
@@ -266,8 +266,21 @@ When two sequential human review steps can be combined into one, do it. We origi
 
 7. **`_request_with_retry` captured the URL once before the retry loop.** When the warmup-fallback updated the active URL override (e.g., switching from a dead primary to a live fallback), the retry loop kept hitting the original (dead) URL for all 8 attempts. Fix: thread the relative `path` through and re-resolve `_get_worker_url() + path` on retries after warmup has fired. (PR #752)
 
+### Machine-family diversification (August 2026)
+
+**Incident 2026-08-12:** `c4d-highcpu-32` hit a **region-wide `ZONE_RESOURCE_POOL_EXHAUSTED` stockout across `us-central1-a`, `-b` AND `-c` simultaneously.** Because the primary pair *and* both fallbacks were all the same machine family, every lane in `ensure_any_running` failed at once. Effects:
+- **Preview** (`POST /api/review/{id}/preview-video`) fell through to slow local Cloud-Run encoding (~130–160 s), which **exceeds Cloudflare's ~100 s edge timeout** → browser got a **524 / "NetworkError when attempting to fetch resource"** even though the backend actually returned 200. The 524 and the NetworkError are the same event; backend logs showing 200 are misleading because the client was already disconnected.
+- **Render** parked in `RENDER_PENDING_CAPACITY` and auto-retried (safe only if capacity returns within 24 h).
+
+**Root lesson:** zone diversity is not enough — a stockout is per **(machine family × region)**, and it can take out *every* zone of a family in a region at once. The fallback fleet must diversify **machine family**, not just zone.
+
+**Fix (Option B):** added `n2-highcpu-32` capacity fallbacks (`encoding-worker-fallback-n2c`/`-n2f` in `us-central1-c`/`-f`) — an independent, much deeper capacity pool. Runtime needed **no change** (`ensure_any_running` already iterates arbitrary `{vm,zone,ip}` candidates; `start_vm(zone=...)` is zone-generic); it's purely `infrastructure/config.py::EncodingWorkerConfig.FALLBACKS` (now carries per-VM `machine_type` + `disk_type`) + `encoding_worker_vm.py` + a new `encoding-worker-fallback-vms` secret version. Gotchas:
+- **n2 does not support `hyperdisk-balanced`** → its fallbacks use `pd-balanced` boot disks (per-VM `disk_type`).
+- **Keep the existing `-a`/`-b` entries byte-identical** (including the IP `description` string!) — changing even the Address description forces the Address to replace, which cascades to *replacing the c4d VM* (needs the very capacity that's out). Always `pulumi preview` and confirm the diff is purely additive (`+N to create`, no `+-replace` on existing encoding-worker VMs) before `pulumi up`.
+- **Preview-timeout is a separate, still-open fragility:** a synchronous preval that outlives the ~100 s edge timeout gives users an opaque 524. Fast-follow options: make preview async/polling (like render), fail fast to local encode when all VM starts stock out, or raise the edge read-timeout for that route.
+
 **Architecture summary (post-fixes):**
-- 4 GCE encoding workers: 2 primaries in `us-central1-c` (blue-green) + 2 capacity fallbacks in `us-central1-a` and `us-central1-b`. All idle by default; started on demand.
+- 6 GCE encoding workers: 2 primaries in `us-central1-c` (blue-green, `c4d-highcpu-32`) + 2 `c4d` capacity fallbacks in `us-central1-a`/`-b` + 2 `n2-highcpu-32` fallbacks in `us-central1-c`/`-f`. All idle by default; started on demand.
 - `EncodingWorkerCandidate` list iterated in `ensure_any_running` — primary first, fallbacks in declared order. Capacity errors fall through to next candidate; non-capacity start errors also fall through (broadened in PR #750).
 - New `RENDER_PENDING_CAPACITY` job state for transient infra failures — different from `FAILED` (which is for unrecoverable bugs).
 - Cloud Scheduler fires `/api/internal/retry-pending-render-jobs` every 5 min; 24h hard timeout per job.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -264,13 +264,19 @@ gcloud logging read 'protoPayload.methodName:"instances.start" AND "ZONE_RESOURC
   --format='value(timestamp, protoPayload.resourceName)'
 
 # Try starting a fallback in each family; if BOTH c4d and n2 refuse, it's severe — wait.
+# Synchronous (no --async) so the start op surfaces stockout inline, and we capture
+# gcloud's own exit status rather than piping (a pipe would return sed's status).
 for VM_ZONE in \
   "encoding-worker-fallback-a:us-central1-a" \
   "encoding-worker-fallback-b:us-central1-b" \
   "encoding-worker-fallback-n2c:us-central1-c" \
   "encoding-worker-fallback-n2f:us-central1-f"; do
-  gcloud compute instances start "${VM_ZONE%%:*}" --zone="${VM_ZONE##*:}" \
-    --project=nomadkaraoke --async 2>&1 | sed "s|^|${VM_ZONE%%:*}: |"
+  VM="${VM_ZONE%%:*}"; ZONE="${VM_ZONE##*:}"
+  if OUT=$(gcloud compute instances start "$VM" --zone="$ZONE" --project=nomadkaraoke 2>&1); then
+    echo "$VM: OK (started — remember to stop it)"
+  else
+    echo "$VM: FAILED — $(echo "$OUT" | tr '\n' ' ')"
+  fi
 done
 ```
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -233,7 +233,11 @@ gcloud compute instances describe encoding-worker-a \
 
 **Symptoms:** Job status is `render_pending_capacity` (introduced 2026-05-05). User-facing message says *"Encoding capacity is temporarily unavailable. Your job will retry automatically — no action needed."* (As of v0.192.3 a mid-render stall can also land here — see "orphaned render" above.)
 
-**Background — what this state means:** GCE returned `ZONE_RESOURCE_POOL_EXHAUSTED` or transient `503 SERVICE_UNAVAILABLE` from `compute.instances.start` on every encoding-worker VM (primary in `us-central1-c`, plus capacity fallbacks in `-a` and `-b`). The render worker parks the job in `RENDER_PENDING_CAPACITY` instead of failing it; Cloud Scheduler retries it every 5 min via `/api/internal/retry-pending-render-jobs`. Hard timeout is 24 hours (then transitions to `failed` with a clear permanent-failure message).
+**Background — what this state means:** GCE returned `ZONE_RESOURCE_POOL_EXHAUSTED` or transient `503 SERVICE_UNAVAILABLE` from `compute.instances.start` on every encoding-worker VM. The render worker parks the job in `RENDER_PENDING_CAPACITY` instead of failing it; Cloud Scheduler retries it every 5 min via `/api/internal/retry-pending-render-jobs`. Hard timeout is 24 hours (then transitions to `failed` with a clear permanent-failure message).
+
+The fallback fleet is diversified by **machine family** (since incident 2026-08-12): `c4d-highcpu-32` primaries in `us-central1-c` + `c4d` fallbacks in `-a`/`-b` + `n2-highcpu-32` fallbacks (`encoding-worker-fallback-n2c`/`-n2f`) in `-c`/`-f`. The n2 pool is much deeper, so a full `c4d` region-wide stockout (which took out a/b/c at once on 2026-08-12) should now still find n2 capacity. If you see EVERY candidate (c4d **and** n2) return stockout, that's a genuinely severe regional event — wait, or add a cross-region fallback.
+
+**Related symptom — preview 524 / "NetworkError":** the same capacity exhaustion also makes `POST /api/review/{id}/preview-video` fall back to slow local encoding (~130–160 s), which exceeds Cloudflare's ~100 s edge timeout → the browser shows a **524** or Firefox *"NetworkError when attempting to fetch resource"* even though the backend returns 200. If a user reports the review preview failing, check for a concurrent stockout; the already-rendered preview mp4 (if any) is fetchable via `GET /api/review/{id}/preview-video/{hash}` (302 → signed GCS URL) with a Bearer admin token. Completing the review does **not** require the preview.
 
 **Check how many retries have run:**
 ```bash
@@ -252,13 +256,21 @@ curl -X POST https://api.nomadkaraoke.com/api/internal/retry-pending-render-jobs
   -H "X-Admin-Token: $ADMIN_TOKEN"
 ```
 
-**Verify GCE has any capacity right now:**
+**Verify GCE has any capacity right now** (the real error reason is in the Compute op, not the app's "503"):
 ```bash
-# If this returns ZONE_RESOURCE_POOL_EXHAUSTED across all 4 zones, just wait
-for ZONE in us-central1-a us-central1-b us-central1-c us-central1-f; do
-  gcloud compute instances describe "encoding-worker-fallback-${ZONE##*-}" \
-    --zone=$ZONE --project=nomadkaraoke --format='value(status)' 2>/dev/null \
-    && echo "  ↑ in $ZONE"
+# See the actual stockout reason (ZONE_RESOURCE_POOL_EXHAUSTED / stockout) + vmType
+gcloud logging read 'protoPayload.methodName:"instances.start" AND "ZONE_RESOURCE_POOL_EXHAUSTED"' \
+  --project=nomadkaraoke --freshness=30m --limit=5 \
+  --format='value(timestamp, protoPayload.resourceName)'
+
+# Try starting a fallback in each family; if BOTH c4d and n2 refuse, it's severe — wait.
+for VM_ZONE in \
+  "encoding-worker-fallback-a:us-central1-a" \
+  "encoding-worker-fallback-b:us-central1-b" \
+  "encoding-worker-fallback-n2c:us-central1-c" \
+  "encoding-worker-fallback-n2f:us-central1-f"; do
+  gcloud compute instances start "${VM_ZONE%%:*}" --zone="${VM_ZONE##*:}" \
+    --project=nomadkaraoke --async 2>&1 | sed "s|^|${VM_ZONE%%:*}: |"
 done
 ```
 

--- a/docs/archive/2026-08-12-encoding-worker-machine-type-diversity-plan.md
+++ b/docs/archive/2026-08-12-encoding-worker-machine-type-diversity-plan.md
@@ -1,0 +1,83 @@
+# Encoding worker capacity resilience — machine-type diversification (Option B)
+
+**Date:** 2026-08-12
+**Trigger:** Live incident — `POST /api/review/98bbd8b0/preview-video` returned 524 (Cloudflare
+edge timeout) → browser "NetworkError". Final render for the same job also at risk.
+
+## Root cause (confirmed via prod logs)
+
+`c4d-highcpu-32` hit a **region-wide `ZONE_RESOURCE_POOL_EXHAUSTED` stockout** across
+`us-central1-a`, `-b`, and `-c` simultaneously. The encoding-worker fleet is:
+
+- primary pair `encoding-worker-{a,b}` — `c4d-highcpu-32`, `us-central1-c`
+- fallbacks `encoding-worker-fallback-{a,b}` — `c4d-highcpu-32`, `us-central1-a` / `-b`
+
+Every lane is the **same machine family in the same region**, so a single-family stockout
+exhausts all of them. `ensure_any_running` iterated all candidates, all returned 503/stockout,
+and:
+
+- **Preview** fell back to slow local Cloud-Run encoding (~130–160 s) → exceeded Cloudflare's
+  ~100 s edge timeout → **524 / NetworkError** (backend actually returned 200, but the client
+  was already disconnected).
+- **Render** parks in `RENDER_PENDING_CAPACITY` and auto-retries every 5 min (24 h window) —
+  safe only if c4d capacity returns within 24 h.
+
+Prior work (May 2026) already flagged this fragility: *gotcha #5 — "c4d-highcpu-32 capacity in
+us-central1-f is unreliable."* We diversified **zones** but never **machine family**.
+
+## Fix (Option B): diversify the fallback fleet across an independent capacity pool
+
+Add fallback VMs on **`n2-highcpu-32`** (Intel Cascade/Ice Lake) — the deepest, most broadly
+available pool on GCP — in `us-central1`. A c4d shortage cannot exhaust the n2 pool.
+
+Decisions (confirmed with operator):
+- Machine type: **n2-highcpu-32** (deepest pool). n2 does **not** support `hyperdisk-balanced`,
+  so these VMs use **`pd-balanced`** boot disks (per-VM disk-type override).
+- Region: **same region (us-central1)** — preserves GCS bucket locality; the idle-shutdown
+  function already iterates fallback zones generically. Cross-region is a possible fast-follow.
+
+The runtime **needs no logic change**: `ensure_any_running` already iterates arbitrary
+`{vm, zone, ip}` candidates and `start_vm(zone=...)` is zone-generic. VMs are provisioned
+**stopped**, so creating them needs no capacity; only an on-demand *start* draws from the n2 pool.
+
+### New fleet (after change)
+| VM | machine type | zone | disk |
+|----|--------------|------|------|
+| encoding-worker-fallback-a | c4d-highcpu-32 | us-central1-a | hyperdisk-balanced |
+| encoding-worker-fallback-b | c4d-highcpu-32 | us-central1-b | hyperdisk-balanced |
+| **encoding-worker-fallback-n2c** | **n2-highcpu-32** | us-central1-c | pd-balanced |
+| **encoding-worker-fallback-n2f** | **n2-highcpu-32** | us-central1-f | pd-balanced |
+
+## Change surface
+
+1. `infrastructure/config.py` — add `MachineTypes.ENCODING_WORKER_ALT = "n2-highcpu-32"`;
+   replace the parallel `FALLBACK_*` lists with a structured `FALLBACKS` list carrying
+   `machine_type` + `disk_type` per VM (a/b kept byte-identical so Pulumi does not recreate them).
+2. `infrastructure/compute/encoding_worker_vm.py` — build fallback IPs + VMs from `FALLBACKS`,
+   honouring per-VM `machine_type` and `disk_type`.
+3. Idle-shutdown function — **no change** (already zone-generic via the secret). Add a regression
+   test covering an n2 fallback entry.
+4. `encoding-worker-fallback-vms` **secret** — operator-set value: append the two n2 entries
+   `{vm, zone, ip}` (with the newly-allocated static IPs) after `pulumi up`.
+5. Tests — pure-Python config invariants (machine-type diversity present, n2⇒pd-balanced,
+   unique names/IPs) + idle-shutdown n2 case.
+6. Docs — `docs/LESSONS-LEARNED.md`, `docs/TROUBLESHOOTING.md`; version bump.
+
+## Operational rollout (after merge-ready code)
+
+1. `pulumi up` locally → provisions n2 IPs + VMs (stopped). Creating stopped VMs is not blocked
+   by the c4d stockout.
+2. Read the two allocated static IPs; add a new `encoding-worker-fallback-vms` secret version
+   including the n2 entries.
+3. Cloud Run picks up the new secret on next revision (or force a no-op deploy); the
+   `video-encoding-job` and idle-shutdown function read `:latest` too.
+4. Smoke test: manually `gcloud compute instances start` one n2 fallback → confirm `/health` 200
+   and a test encode succeeds on n2, then stop it.
+5. The live parked job (98bbd8b0) clears automatically once any capacity (n2 or recovered c4d)
+   is reachable.
+
+## Invariants to preserve (from May 2026 work)
+- Both Cloud Run service AND `video-encoding-job` read `ENCODING_WORKER_FALLBACK_VMS`.
+- `start_vm` inspects `operation.error_code` (never fire-and-forget).
+- Capacity-like errors stay typed as `EncodingWorkerStartError` so the render worker parks.
+- Idle-shutdown must stop the n2 fallbacks in their own zones (secret-driven — verified).

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -583,10 +583,12 @@ encoding_worker_instances = encoding_worker_vm.create_encoding_worker_vms(
     encoding_worker_ips, encoding_worker_sa
 )
 
-# Capacity-fallback Encoding Worker VMs in alternate zones
-# (us-central1-a, -f). Provisioned stopped; only started by the application
-# when the primary zone (us-central1-c) returns ZONE_RESOURCE_POOL_EXHAUSTED.
-# Cost when idle: ~$10/mo each for the boot disk.
+# Capacity-fallback Encoding Worker VMs — diversified across alternate zones
+# AND an alternate machine family (c4d in us-central1-a/-b + n2 in -c/-f) so a
+# region-wide c4d-highcpu-32 ZONE_RESOURCE_POOL_EXHAUSTED can't take out every
+# lane (incident 2026-08-12). Provisioned stopped; only started by the
+# application when the primary rejects a start. Cost when idle: ~$10/mo each.
+# See EncodingWorkerConfig.FALLBACKS for the fleet definition.
 encoding_worker_fallback_ips = encoding_worker_vm.create_encoding_worker_fallback_ips()
 encoding_worker_fallback_instances = encoding_worker_vm.create_encoding_worker_fallback_vms(
     encoding_worker_fallback_ips, encoding_worker_sa

--- a/infrastructure/compute/encoding_worker_vm.py
+++ b/infrastructure/compute/encoding_worker_vm.py
@@ -86,22 +86,23 @@ def create_encoding_worker_vms(
 
 
 def create_encoding_worker_fallback_ips() -> list[compute.Address]:
-    """Create static IPs for the multi-zone capacity-fallback VMs.
+    """Create static IPs for the capacity-fallback VMs.
 
-    These IPs live in alternate zones (e.g. us-central1-a, -f) to provide
-    zone-level resilience when the primary zone is out of c4d-highcpu-32
-    capacity (ZONE_RESOURCE_POOL_EXHAUSTED).
+    These IPs back the fallback fleet that absorbs a primary-family stockout —
+    both alternate zones AND an alternate machine family (n2-highcpu-32) so a
+    region-wide c4d-highcpu-32 ZONE_RESOURCE_POOL_EXHAUSTED can't take out every
+    lane. One IP per entry in EncodingWorkerConfig.FALLBACKS (order-aligned).
     """
     ips = []
-    for ip_name, zone_suffix in zip(
-        EncodingWorkerConfig.FALLBACK_IP_NAMES,
-        EncodingWorkerConfig.FALLBACK_ZONE_SUFFIXES,
-    ):
+    for fb in EncodingWorkerConfig.FALLBACKS:
+        ip_name = EncodingWorkerConfig.fallback_ip_name(fb["suffix"])
         ip = compute.Address(
             ip_name,
             name=ip_name,
             region=REGION,
             address_type="EXTERNAL",
+            # Keep this string byte-identical to the originally-deployed value so
+            # `pulumi up` does not diff (and needlessly churn) the existing a/b IPs.
             description=f"Static external IP for {ip_name} (zone-fallback)",
         )
         ips.append(ip)
@@ -112,45 +113,41 @@ def create_encoding_worker_fallback_vms(
     ips: list[compute.Address],
     service_account: serviceaccount.Account,
 ) -> list[compute.Instance]:
-    """Create capacity-fallback encoding worker VMs in alternate zones.
+    """Create capacity-fallback encoding worker VMs.
 
-    Provisioned stopped — they're only started by the application when
-    the primary zone (us-central1-c) rejects starts with
-    ZONE_RESOURCE_POOL_EXHAUSTED. Cost when stopped is just the boot disk
-    (~$10/mo for 100GB hyperdisk-balanced).
+    Provisioned stopped — only started by the application when the primary zone
+    rejects starts with ZONE_RESOURCE_POOL_EXHAUSTED. The fleet diversifies
+    across both alternate zones AND an alternate machine family
+    (n2-highcpu-32) so a region-wide c4d-highcpu-32 stockout cannot exhaust
+    every lane at once (incident 2026-08-12). Each entry's machine_type and
+    disk_type come from EncodingWorkerConfig.FALLBACKS — n2 uses pd-balanced
+    because it does not support hyperdisk-balanced. Cost when stopped is just
+    the boot disk (~$10/mo each).
     """
     startup_script = read_script("encoding_worker.sh")
     custom_image = f"projects/{PROJECT_ID}/global/images/family/encoding-worker"
 
     vms = []
-    for vm_name, ip, zone_suffix in zip(
-        EncodingWorkerConfig.FALLBACK_VM_NAMES,
-        ips,
-        EncodingWorkerConfig.FALLBACK_ZONE_SUFFIXES,
-    ):
-        zone = f"{REGION}-{zone_suffix}"
+    for fb, ip in zip(EncodingWorkerConfig.FALLBACKS, ips):
+        vm_name = EncodingWorkerConfig.fallback_vm_name(fb["suffix"])
+        zone = f"{REGION}-{fb['zone_suffix']}"
+        # Hyperdisk provisioned IOPS/throughput are deliberately NOT set: setting
+        # them forces a full VM replacement (boot-disk init params are immutable),
+        # and recreating a c4d VM depends on the exact capacity the fallback fleet
+        # exists to absorb. hyperdisk-balanced disks are pinned to the free
+        # baseline (3000 IOPS / 140 MB/s) live via `gcloud compute disks update`
+        # after any image rebuild that recreates them; pd-balanced (n2) needs no
+        # such tuning. See docs/archive/2026-06-14-gcp-cost-reduction-plan.md.
         vm = compute.Instance(
             vm_name,
             name=vm_name,
-            machine_type=MachineTypes.ENCODING_WORKER,
+            machine_type=fb["machine_type"],
             zone=zone,
             boot_disk=compute.InstanceBootDiskArgs(
                 initialize_params=compute.InstanceBootDiskInitializeParamsArgs(
                     image=custom_image,
                     size=DiskSizes.ENCODING_WORKER,
-                    type="hyperdisk-balanced",
-                    # NOTE: Hyperdisk provisioned IOPS/throughput are deliberately
-                    # NOT set here. Specifying them forces a full VM *replacement*
-                    # (the provider treats boot-disk init params as immutable), and
-                    # recreating a primary depends on us-central1-c capacity — the
-                    # exact shortage the fallback fleet exists to absorb. So the
-                    # disks are pinned to the Hyperdisk Balanced free baseline
-                    # (3000 IOPS / 140 MB/s) live via `gcloud compute disks update`
-                    # instead — non-disruptive, and pulumi does not manage this
-                    # attribute so there is no drift. They were over-provisioned at
-                    # 3600 IOPS / 290 MB/s (~$8.70/disk/mo wasted). Re-apply the
-                    # gcloud tune after any worker-image rebuild that recreates the
-                    # disks. See docs/archive/2026-06-14-gcp-cost-reduction-plan.md.
+                    type=fb["disk_type"],
                 ),
             ),
             network_interfaces=[compute.InstanceNetworkInterfaceArgs(

--- a/infrastructure/config.py
+++ b/infrastructure/config.py
@@ -48,6 +48,12 @@ class MachineTypes:
     GITHUB_BUILD_RUNNER = "e2-standard-8"  # 8 vCPU, 32GB RAM - dedicated Docker build runner
     GITHUB_GPU_RUNNER = "n1-standard-4"  # 4 vCPU, 15GB RAM - GPU runners need N1 series
     ENCODING_WORKER = "c4d-highcpu-32"  # 32 vCPU, AMD EPYC 9B45 Turin - 4.92x faster than c4-standard-8
+    # Capacity-fallback machine family, deliberately DIFFERENT from ENCODING_WORKER.
+    # c4d-highcpu-32 suffered a region-wide ZONE_RESOURCE_POOL_EXHAUSTED stockout across
+    # us-central1-a/-b/-c simultaneously (2026-08-12) which took out every same-family lane.
+    # n2-highcpu-32 (Intel Cascade/Ice Lake) draws from a much deeper, independent pool, so a
+    # c4d shortage cannot exhaust it. n2 does NOT support hyperdisk-balanced → uses pd-balanced.
+    ENCODING_WORKER_ALT = "n2-highcpu-32"  # 32 vCPU, Intel - deep-capacity fallback pool
     FLACFETCH = "e2-small"  # 0.5 vCPU, 2GB RAM
 
 
@@ -279,18 +285,45 @@ class EncodingWorkerConfig:
     FUNCTION_MEMORY = "512M"  # Increased from 256M — OOM with gRPC/Firestore/Compute client libs
     FUNCTION_TIMEOUT = 120  # 2 minutes
 
-    # Capacity-resilience fallback VMs in alternate zones.
-    # c4d-highcpu-32 is available in us-central1-a / -b / -c / -f. When the
-    # primary zone (-c) is exhausted, the manager falls back to -a or -b.
-    # us-central1-f was originally selected for the second fallback, but
-    # provisioning consistently failed there with ZONE_RESOURCE_POOL_EXHAUSTED
-    # at create time (2026-05-06) — capacity is too tight in -f for it to be
-    # useful as a fallback. -b has reliable capacity. These VMs are
-    # provisioned stopped (cost: ~$10/mo each for the boot disk) and only
-    # started by the application when the primary zone rejects capacity.
-    FALLBACK_VM_NAMES = ["encoding-worker-fallback-a", "encoding-worker-fallback-b"]
-    FALLBACK_IP_NAMES = ["encoding-worker-fallback-ip-a", "encoding-worker-fallback-ip-b"]
-    FALLBACK_ZONE_SUFFIXES = ["a", "b"]  # zones {REGION}-{suffix}
+    # Capacity-resilience fallback fleet. Each VM is provisioned STOPPED in an
+    # alternate zone / machine family and is started on demand only when the
+    # primary zone rejects a start with ZONE_RESOURCE_POOL_EXHAUSTED. Cost when
+    # stopped is just the boot disk (~$10/mo each).
+    #
+    # Machine-family diversity is DELIBERATE. The primary pair and the two c4d
+    # fallbacks are all c4d-highcpu-32, so a region-wide c4d stockout (observed
+    # 2026-08-12 across us-central1-a/-b/-c at once) exhausts every lane
+    # simultaneously and forces slow local encoding (→ 524 on preview, parked
+    # renders). The n2-highcpu-32 fallbacks draw from an independent, much deeper
+    # pool so a c4d shortage cannot take them out. n2 does not support
+    # hyperdisk-balanced, hence pd-balanced boot disks on those entries.
+    #
+    # Each entry: name/IP suffix, zone suffix ({REGION}-{zone_suffix}),
+    # machine_type, boot disk_type. ORDER MATTERS — IPs and VMs are zipped by
+    # position, and it defines candidate priority. Keep the c4d a/b entries
+    # first and byte-identical so Pulumi does not recreate the existing VMs.
+    FALLBACKS = [
+        {"suffix": "a", "zone_suffix": "a",
+         "machine_type": MachineTypes.ENCODING_WORKER, "disk_type": "hyperdisk-balanced"},
+        {"suffix": "b", "zone_suffix": "b",
+         "machine_type": MachineTypes.ENCODING_WORKER, "disk_type": "hyperdisk-balanced"},
+        {"suffix": "n2c", "zone_suffix": "c",
+         "machine_type": MachineTypes.ENCODING_WORKER_ALT, "disk_type": "pd-balanced"},
+        {"suffix": "n2f", "zone_suffix": "f",
+         "machine_type": MachineTypes.ENCODING_WORKER_ALT, "disk_type": "pd-balanced"},
+    ]
+
+    # Derived name lists (kept for readability / any external reference).
+    FALLBACK_VM_NAMES = [f"encoding-worker-fallback-{fb['suffix']}" for fb in FALLBACKS]
+    FALLBACK_IP_NAMES = [f"encoding-worker-fallback-ip-{fb['suffix']}" for fb in FALLBACKS]
+
+    @staticmethod
+    def fallback_vm_name(suffix: str) -> str:
+        return f"encoding-worker-fallback-{suffix}"
+
+    @staticmethod
+    def fallback_ip_name(suffix: str) -> str:
+        return f"encoding-worker-fallback-ip-{suffix}"
 
 
 class ErrorMonitorConfig:

--- a/infrastructure/functions/encoding_worker_idle/test_idle_shutdown.py
+++ b/infrastructure/functions/encoding_worker_idle/test_idle_shutdown.py
@@ -330,6 +330,46 @@ class TestFallbackVms:
         assert stop_calls[0].kwargs["instance"] == "encoding-worker-fallback-a"
         assert stop_calls[0].kwargs["zone"] == "us-central1-a"
 
+    def test_idle_n2_fallback_stopped_in_its_own_zone(self, mock_compute, mock_firestore, monkeypatch):
+        """The machine-family fallbacks (n2-highcpu-32 in us-central1-c/-f, added
+        2026-08-12 so a region-wide c4d stockout can't exhaust every lane) must be
+        reclaimed just like the c4d fallbacks. This guards that the idle sweep,
+        which is purely secret-driven, keeps working as the fleet grows — an
+        n2 fallback started during a capacity event must not leak."""
+        monkeypatch.setenv(
+            "ENCODING_WORKER_FALLBACK_VMS",
+            json.dumps([
+                {"vm": "encoding-worker-fallback-a", "zone": "us-central1-a", "ip": "1.1.1.1"},
+                {"vm": "encoding-worker-fallback-b", "zone": "us-central1-b", "ip": "2.2.2.2"},
+                {"vm": "encoding-worker-fallback-n2c", "zone": "us-central1-c", "ip": "3.3.3.3"},
+                {"vm": "encoding-worker-fallback-n2f", "zone": "us-central1-f", "ip": "4.4.4.4"},
+            ]),
+        )
+        recent = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+        _setup_firestore(mock_firestore, _make_config(last_activity_at=recent))
+
+        # Only the n2-f fallback is RUNNING+idle → it must be stopped in -f.
+        instances = {
+            "encoding-worker-a": _make_instance(status="RUNNING", ip="1.2.3.4"),
+            "encoding-worker-b": _make_instance(status="TERMINATED"),
+            "encoding-worker-fallback-a": _make_instance(status="TERMINATED"),
+            "encoding-worker-fallback-b": _make_instance(status="TERMINATED"),
+            "encoding-worker-fallback-n2c": _make_instance(status="TERMINATED"),
+            "encoding-worker-fallback-n2f": _make_instance(status="RUNNING", ip="4.4.4.4"),
+        }
+        mock_compute.get.side_effect = _zone_dispatching_get(instances)
+
+        with patch("main.check_active_jobs", return_value=0):
+            response, _ = main.idle_shutdown(MagicMock())
+
+        result = json.loads(response)
+        assert result["results"]["encoding-worker-fallback-n2f"] == "stopped"
+
+        stop_calls = mock_compute.stop.call_args_list
+        assert len(stop_calls) == 1
+        assert stop_calls[0].kwargs["instance"] == "encoding-worker-fallback-n2f"
+        assert stop_calls[0].kwargs["zone"] == "us-central1-f"
+
     def test_active_override_fallback_kept_alive_on_recent_activity(
         self, mock_compute, mock_firestore, fallback_env,
     ):

--- a/infrastructure/test_encoding_worker_config.py
+++ b/infrastructure/test_encoding_worker_config.py
@@ -1,0 +1,61 @@
+"""Invariants for the encoding-worker capacity-fallback fleet config.
+
+Guards the machine-family diversification added 2026-08-12 after a region-wide
+c4d-highcpu-32 ZONE_RESOURCE_POOL_EXHAUSTED stockout (us-central1-a/-b/-c at once)
+exhausted every same-family lane and forced slow local encoding (→ 524 on
+preview, parked renders).
+
+Run locally with: `pytest infrastructure/test_encoding_worker_config.py`
+(infrastructure is not part of the CI backend test gate — Pulumi validates the
+resource graph via `pulumi preview`).
+"""
+
+from config import EncodingWorkerConfig, MachineTypes
+
+
+def test_fallback_fleet_has_machine_family_diversity():
+    """At least one fallback must use a machine family OTHER than the primary,
+    otherwise a single-family stockout takes out every lane at once."""
+    families = {fb["machine_type"] for fb in EncodingWorkerConfig.FALLBACKS}
+    assert MachineTypes.ENCODING_WORKER in families
+    assert any(mt != MachineTypes.ENCODING_WORKER for mt in families), (
+        "fallback fleet is single-machine-family — a c4d stockout would exhaust "
+        "every lane (see incident 2026-08-12)"
+    )
+    assert MachineTypes.ENCODING_WORKER_ALT in families
+
+
+def test_n2_fallbacks_use_pd_balanced_disk():
+    """n2 does not support hyperdisk-balanced; those VMs must use pd-balanced,
+    else Pulumi/GCE rejects the instance at create time."""
+    for fb in EncodingWorkerConfig.FALLBACKS:
+        if fb["machine_type"].startswith("n2"):
+            assert fb["disk_type"] == "pd-balanced", fb
+
+
+def test_fallback_names_and_ips_are_unique_and_aligned():
+    """Names/IPs are zipped by position with FALLBACKS — they must stay aligned
+    and unique so no two VMs collide on a resource name or static IP."""
+    fb = EncodingWorkerConfig.FALLBACKS
+    suffixes = [f["suffix"] for f in fb]
+    assert len(set(suffixes)) == len(suffixes), "duplicate fallback suffix"
+    assert EncodingWorkerConfig.FALLBACK_VM_NAMES == [
+        EncodingWorkerConfig.fallback_vm_name(s) for s in suffixes
+    ]
+    assert EncodingWorkerConfig.FALLBACK_IP_NAMES == [
+        EncodingWorkerConfig.fallback_ip_name(s) for s in suffixes
+    ]
+    assert len(set(EncodingWorkerConfig.FALLBACK_VM_NAMES)) == len(fb)
+    assert len(set(EncodingWorkerConfig.FALLBACK_IP_NAMES)) == len(fb)
+
+
+def test_original_c4d_fallbacks_unchanged():
+    """The first two entries must remain the original c4d a/b fallbacks
+    (byte-identical) so `pulumi up` does NOT recreate the existing VMs —
+    recreating a c4d VM would need the very capacity we're trying to avoid
+    depending on."""
+    a, b = EncodingWorkerConfig.FALLBACKS[0], EncodingWorkerConfig.FALLBACKS[1]
+    assert a == {"suffix": "a", "zone_suffix": "a",
+                 "machine_type": MachineTypes.ENCODING_WORKER, "disk_type": "hyperdisk-balanced"}
+    assert b == {"suffix": "b", "zone_suffix": "b",
+                 "machine_type": MachineTypes.ENCODING_WORKER, "disk_type": "hyperdisk-balanced"}


### PR DESCRIPTION
## Problem

A **region-wide `c4d-highcpu-32` capacity stockout** (`ZONE_RESOURCE_POOL_EXHAUSTED` across `us-central1-a`, `-b`, and `-c` simultaneously, 2026-08-12) took out **every** encoding-worker lane at once, because the primary blue-green pair *and* both capacity fallbacks are all the same machine family.

Consequences observed in prod:
- **Lyrics-review preview** (`POST /api/review/{id}/preview-video`) fell back to slow local Cloud-Run encoding (~130–160 s), which **exceeds Cloudflare's ~100 s edge timeout** → users got a **524 / "NetworkError when attempting to fetch resource"** even though the backend actually returned 200.
- **Final renders** parked in `RENDER_PENDING_CAPACITY` and could only complete once c4d capacity returned (24 h auto-retry window).

Prior work (May 2026) diversified fallbacks across **zones** but not **machine family** — and a stockout is per *(machine family × region)*, so every zone of a family can go at once.

## Fix (Option B)

Add **`n2-highcpu-32`** capacity fallbacks (`encoding-worker-fallback-n2c` in `us-central1-c`, `-n2f` in `us-central1-f`) — an independent, much deeper capacity pool a c4d stockout cannot exhaust.

**Runtime is unchanged** — `ensure_any_running` already iterates arbitrary `{vm,zone,ip}` candidates, `start_vm(zone=)` is zone-generic, and the idle-shutdown function is secret-driven. This is purely IaC + a secret version:

- `infrastructure/config.py` — `EncodingWorkerConfig.FALLBACKS` now carries per-VM `machine_type` + `disk_type` (n2 uses `pd-balanced`; it doesn't support hyperdisk-balanced). Existing `a`/`b` entries kept **byte-identical** so `pulumi up` does not replace the live c4d VMs.
- `infrastructure/compute/encoding_worker_vm.py` — build fallback IPs/VMs from `FALLBACKS`.
- Tests: config invariants + n2 idle-shutdown regression (**29 pass**).
- Docs: `LESSONS-LEARNED`, `TROUBLESHOOTING`, plan doc.

## Rollout status (already applied locally)

- ✅ `pulumi up` (targeted) applied to `prod`: created 2 n2 IPs + 2 n2 VMs (stopped). Verified additive — the existing c4d VMs were **not** touched. (A pre-existing unrelated `runner-manager` drift from another worktree was deliberately **not** applied.)
- ✅ `encoding-worker-fallback-vms` secret updated to v2 with the two n2 entries (picked up by Cloud Run / `video-encoding-job` / idle function at next instance start).
- ✅ Smoke-tested: n2 VM boots the encoding-worker image and serves `/health`.

## Testing

- `pytest infrastructure/test_encoding_worker_config.py infrastructure/functions/encoding_worker_idle/test_idle_shutdown.py` → 29 passed.
- `pulumi preview` → `+4 to create`, no replacement of existing encoding-worker resources.

## Follow-up (separate)

Preview is synchronous and can outlive the ~100 s edge timeout → opaque 524. Durable fix is making preview async/polling (like render), or fail-fast to local when all VM starts stock out. Tracked in the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@coderabbitai ignore
