### PR TITLE
fix(ci): bump Windows GHA runner 2.334.0 → 2.336.0 (missed in #902)

### DIFF
--- a/infrastructure/scripts/runner-image-provision.ps1
+++ b/infrastructure/scripts/runner-image-provision.ps1
@@ -28,7 +28,7 @@ $ProgressPreference = "SilentlyContinue"
 $VARIANT = "gpu-windows"
 $PYTHON_VERSION = "3.12.10"
 $GIT_VERSION = "2.45.2"
-$RUNNER_VERSION = "2.334.0"   # keep in sync with runner-image-provision.sh
+$RUNNER_VERSION = "2.336.0"   # keep in sync with runner-image-provision.sh
 
 $MARKER_DIR = "C:\provision-markers"
 $READY_FILE = "C:\runner-image-ready"


### PR DESCRIPTION
## Follow-up to #902
#902 bumped the runner pin to `2.336.0` in the Linux provision + startup scripts but **missed the Windows image bake** — `infrastructure/scripts/runner-image-provision.ps1` still pinned deprecated `v2.334.0` (my grep only covered `.sh/.py/.yml`).

Symptom: the `gpu-windows` image rebuild failed downloading `actions-runner-win-x64-2.334.0.zip`, and even on success would bake a deprecated runner (→ Windows GPU runners self-terminate, same failure mode as #902).

## Fix
One-line bump in `runner-image-provision.ps1` to match (`2.336.0`). Then rebuild the `gha-runner-gpu-windows` image (dispatched from this branch).

Infra-only, image-build-consumed script (no Pulumi graph impact — same as #902). The Linux `gpu` image already rebuilt successfully on 2.336.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Windows build runner environment to use a newer runner version.
  * No other provisioning behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->