### PR TITLE
fix(audio-search): recover parked jobs — edit + re-search + own-audio fallback

### DIFF
--- a/backend/api/routes/audio_search.py
+++ b/backend/api/routes/audio_search.py
@@ -235,6 +235,49 @@ class AudioSelectRequest(BaseModel):
     acknowledged_credits: Optional[int] = Field(None, description="Expected total credits after this selection (anti-mismatch guard)")
 
 
+class ProvideUrlRequest(BaseModel):
+    """Request to attach a YouTube/yt-dlp URL to an existing parked job."""
+    url: str = Field(..., description="Audio source URL (YouTube, SoundCloud, or other yt-dlp supported site)")
+
+
+class AttachUploadUrlsRequest(BaseModel):
+    """Request for a signed upload URL to attach a file to an existing parked job."""
+    filename: str = Field(..., description="Original filename with extension")
+    content_type: str = Field("application/octet-stream", description="MIME type of the file")
+
+
+class AttachUploadUrlsResponse(BaseModel):
+    """Signed URL to upload an audio file for an existing job."""
+    job_id: str
+    gcs_path: str
+    upload_url: str
+
+
+class AttachResponse(BaseModel):
+    """Response after attaching a URL/file source to a parked job."""
+    status: str
+    job_id: str
+    message: str
+
+
+class ResearchRequest(BaseModel):
+    """Request to re-run the audio search for an existing parked job.
+
+    Both fields are optional: when a caller edits the artist/title (e.g. to fix
+    a typo or shorten an over-long title that returned nothing), the corrected
+    values are used for the search AND applied to the job. When omitted, the
+    job's existing search terms are re-used (a plain retry of a failed search).
+    """
+    artist: Optional[str] = Field(None, description="Corrected artist to search + apply (blank = keep existing)")
+    title: Optional[str] = Field(None, description="Corrected title to search + apply (blank = keep existing)")
+
+    @validator('artist', 'title')
+    def normalize_text_fields(cls, v):
+        if v is not None and isinstance(v, str):
+            return normalize_text(v)
+        return v
+
+
 class AudioSelectResponse(BaseModel):
     """Response from audio source selection."""
     status: str
@@ -580,6 +623,55 @@ async def _download_audio_and_trigger_workers(
         job_manager.fail_job(job_id, f"Audio download failed: {e}")
 
 
+def _build_result_response(r: AudioSearchResult) -> AudioSearchResultResponse:
+    """Serialize an AudioSearchResult into the rich API response shape.
+
+    raw_result may be a dict (remote flacfetch API) or a Release object
+    (local flacfetch); both expose the same enriched display fields.
+    Shared by the search, standalone-search, and re-search endpoints so the
+    result shape stays identical across all three.
+    """
+    raw_dict: Dict[str, Any] = {}
+    if r.raw_result:
+        if isinstance(r.raw_result, dict):
+            raw_dict = r.raw_result
+        else:
+            try:
+                raw_dict = r.raw_result.to_dict()
+            except AttributeError:
+                pass  # Not a Release object
+
+    return AudioSearchResultResponse(
+        index=r.index,
+        title=r.title,
+        artist=r.artist,
+        provider=r.provider,
+        url=r.url,
+        duration=r.duration,
+        quality=r.quality,
+        source_id=r.source_id,
+        seeders=raw_dict.get('seeders') or r.seeders,
+        target_file=raw_dict.get('target_file') or r.target_file,
+        year=raw_dict.get('year'),
+        label=raw_dict.get('label'),
+        edition_info=raw_dict.get('edition_info'),
+        release_type=raw_dict.get('release_type'),
+        channel=raw_dict.get('channel'),
+        view_count=raw_dict.get('view_count'),
+        size_bytes=raw_dict.get('size_bytes'),
+        target_file_size=raw_dict.get('target_file_size'),
+        track_pattern=raw_dict.get('track_pattern'),
+        match_score=raw_dict.get('match_score'),
+        formatted_size=raw_dict.get('formatted_size'),
+        formatted_duration=raw_dict.get('formatted_duration'),
+        formatted_views=raw_dict.get('formatted_views'),
+        is_lossless=raw_dict.get('is_lossless'),
+        quality_str=raw_dict.get('quality_str'),
+        # Remote API uses 'quality_data', local uses 'quality' for the dict
+        quality_data=raw_dict.get('quality_data') or raw_dict.get('quality'),
+    )
+
+
 @router.post("/audio-search/search", response_model=AudioSearchResponse)
 async def search_audio(
     request: Request,
@@ -886,59 +978,8 @@ async def search_audio(
         )
         
         # Convert to response format with full Release data for rich display
-        result_responses = []
-        for r in search_results:
-            # Get full serialized data from raw_result if available
-            # raw_result can be either:
-            # - A dict (from remote flacfetch API)
-            # - A Release object (from local flacfetch)
-            raw_dict = {}
-            if r.raw_result:
-                if isinstance(r.raw_result, dict):
-                    # Remote flacfetch API returns dicts directly
-                    raw_dict = r.raw_result
-                else:
-                    # Local flacfetch returns Release objects
-                    try:
-                        raw_dict = r.raw_result.to_dict()
-                    except AttributeError:
-                        pass  # Not a Release object
-            
-            result_responses.append(
-                AudioSearchResultResponse(
-                    index=r.index,
-                    title=r.title,
-                    artist=r.artist,
-                    provider=r.provider,
-                    url=r.url,
-                    duration=r.duration,
-                    quality=r.quality,
-                    source_id=r.source_id,
-                    seeders=raw_dict.get('seeders') or r.seeders,
-                    target_file=raw_dict.get('target_file') or r.target_file,
-                    # Additional fields for rich display
-                    year=raw_dict.get('year'),
-                    label=raw_dict.get('label'),
-                    edition_info=raw_dict.get('edition_info'),
-                    release_type=raw_dict.get('release_type'),
-                    channel=raw_dict.get('channel'),
-                    view_count=raw_dict.get('view_count'),
-                    size_bytes=raw_dict.get('size_bytes'),
-                    target_file_size=raw_dict.get('target_file_size'),
-                    track_pattern=raw_dict.get('track_pattern'),
-                    match_score=raw_dict.get('match_score'),
-                    # Pre-computed display fields
-                    formatted_size=raw_dict.get('formatted_size'),
-                    formatted_duration=raw_dict.get('formatted_duration'),
-                    formatted_views=raw_dict.get('formatted_views'),
-                    is_lossless=raw_dict.get('is_lossless'),
-                    quality_str=raw_dict.get('quality_str'),
-                    # Full quality object for Release.from_dict()
-                    # Remote API uses 'quality_data', local uses 'quality' for the dict
-                    quality_data=raw_dict.get('quality_data') or raw_dict.get('quality'),
-                )
-            )
-        
+        result_responses = [_build_result_response(r) for r in search_results]
+
         return AudioSearchResponse(
             status="awaiting_selection",
             job_id=job_id,
@@ -1012,50 +1053,10 @@ async def search_audio_standalone(
             raise HTTPException(status_code=500, detail=f"Search failed: {e}")
 
         # Build result response objects
-        result_responses: List[AudioSearchResultResponse] = []
-        results_dicts: List[Dict[str, Any]] = []
-        for r in search_results:
-            raw_dict: Dict[str, Any] = {}
-            if r.raw_result:
-                if isinstance(r.raw_result, dict):
-                    raw_dict = r.raw_result
-                else:
-                    try:
-                        raw_dict = r.raw_result.to_dict()
-                    except AttributeError:
-                        pass
-
-            result_responses.append(
-                AudioSearchResultResponse(
-                    index=r.index,
-                    title=r.title,
-                    artist=r.artist,
-                    provider=r.provider,
-                    url=r.url,
-                    duration=r.duration,
-                    quality=r.quality,
-                    source_id=r.source_id,
-                    seeders=raw_dict.get('seeders') or r.seeders,
-                    target_file=raw_dict.get('target_file') or r.target_file,
-                    year=raw_dict.get('year'),
-                    label=raw_dict.get('label'),
-                    edition_info=raw_dict.get('edition_info'),
-                    release_type=raw_dict.get('release_type'),
-                    channel=raw_dict.get('channel'),
-                    view_count=raw_dict.get('view_count'),
-                    size_bytes=raw_dict.get('size_bytes'),
-                    target_file_size=raw_dict.get('target_file_size'),
-                    track_pattern=raw_dict.get('track_pattern'),
-                    match_score=raw_dict.get('match_score'),
-                    formatted_size=raw_dict.get('formatted_size'),
-                    formatted_duration=raw_dict.get('formatted_duration'),
-                    formatted_views=raw_dict.get('formatted_views'),
-                    is_lossless=raw_dict.get('is_lossless'),
-                    quality_str=raw_dict.get('quality_str'),
-                    quality_data=raw_dict.get('quality_data') or raw_dict.get('quality'),
-                )
-            )
-            results_dicts.append(r.to_dict())
+        result_responses: List[AudioSearchResultResponse] = [
+            _build_result_response(r) for r in search_results
+        ]
+        results_dicts: List[Dict[str, Any]] = [r.to_dict() for r in search_results]
 
         # Store session in Firestore (TTL: 7 days)
         # Long TTL so users who leave a tab open mid-flow don't hit "Search expired".
@@ -1127,6 +1128,319 @@ async def get_audio_search_results(
         "results": search_results,
         "results_count": len(search_results),
     }
+
+
+@router.post("/audio-search/{job_id}/research", response_model=AudioSearchResponse)
+async def research_audio(
+    job_id: str,
+    request: Request,
+    body: ResearchRequest,
+    auth_result: AuthResult = Depends(require_auth),
+):
+    """
+    Re-run the audio search for an existing job that is awaiting selection.
+
+    Handles the dead-end where a search returned nothing (or a transient
+    failure parked the job with no sources): the user can retry, or edit the
+    artist/title and search again. The job stays in AWAITING_AUDIO_SELECTION;
+    its cached results are replaced with the fresh ones (which may be empty —
+    that is a normal outcome, returned as a 200 with an empty list, not an
+    error, so the UI can offer the manual fallback).
+
+    Editing the artist/title also applies the correction to the job's display
+    artist/title (used for title screens, filenames, lyrics), so the whole
+    pipeline runs on the corrected metadata.
+    """
+    locale = get_locale_from_request(request)
+
+    job = job_manager.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail=t(locale, "audioSearch.jobNotFound", job_id=job_id))
+
+    if job.status != JobStatus.AWAITING_AUDIO_SELECTION:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Job is not awaiting audio selection (status: {job.status})"
+        )
+
+    # Resolve the terms to search. A non-blank edited value overrides; otherwise
+    # fall back to the job's existing search terms (then its display fields).
+    edited_artist = (body.artist or "").strip()
+    edited_title = (body.title or "").strip()
+    artist = edited_artist or job.audio_search_artist or job.artist or ""
+    title = edited_title or job.audio_search_title or job.title or ""
+
+    if not artist or not title:
+        raise HTTPException(status_code=400, detail="Both artist and title are required to search")
+
+    # Apply the edit to the job before searching so a corrected typo/title flows
+    # through the rest of the pipeline (search terms + display metadata).
+    prev_artist = job.audio_search_artist or job.artist
+    prev_title = job.audio_search_title or job.title
+    if artist != prev_artist or title != prev_title:
+        job_manager.update_job(job_id, {
+            'audio_search_artist': artist,
+            'audio_search_title': title,
+            'artist': artist,
+            'title': title,
+        })
+        logger.info(f"[job:{job_id}] Re-search with edited terms: {artist} - {title}")
+
+    job_manager.transition_to_state(
+        job_id=job_id,
+        new_status=JobStatus.SEARCHING_AUDIO,
+        progress=5,
+        message=f"Searching for: {artist} - {title}",
+        raise_on_invalid=False,
+    )
+
+    audio_search_service = get_audio_search_service()
+    try:
+        search_results = await audio_search_service.search_async(artist, title)
+    except NoResultsError:
+        search_results = []
+    except AudioSearchError as e:
+        # Restore the awaiting state so the job isn't stranded, then surface the error.
+        job_manager.transition_to_state(
+            job_id=job_id,
+            new_status=JobStatus.AWAITING_AUDIO_SELECTION,
+            progress=10,
+            message="Search failed. Please try again or provide your own audio.",
+            raise_on_invalid=False,
+        )
+        raise HTTPException(status_code=502, detail=f"Search failed: {e}")
+
+    # Replace cached results (empty is fine — the UI offers the manual fallback).
+    results_dicts = [r.to_dict() for r in search_results]
+    remote_id = getattr(audio_search_service, "last_remote_search_id", None)
+    job_manager.update_job(job_id, {
+        'state_data.audio_search_results': results_dicts,
+        'state_data.audio_search_count': len(results_dicts),
+        # Overwrite (or clear) the stale remote_search_id from the prior search.
+        'state_data.remote_search_id': remote_id,
+    })
+
+    job_manager.transition_to_state(
+        job_id=job_id,
+        new_status=JobStatus.AWAITING_AUDIO_SELECTION,
+        progress=10,
+        message=(
+            f"Found {len(results_dicts)} audio sources. Waiting for selection."
+            if results_dicts else
+            "No audio sources found. Edit the details and search again, or provide your own audio."
+        ),
+        raise_on_invalid=False,
+    )
+
+    return AudioSearchResponse(
+        status="awaiting_selection",
+        job_id=job_id,
+        message=f"Re-search complete: {len(results_dicts)} audio sources.",
+        results=[_build_result_response(r) for r in search_results],
+        results_count=len(results_dicts),
+        auto_download=False,
+        server_version=VERSION,
+    )
+
+
+def _require_awaiting_selection(job_id: str, locale: str):
+    """Load a job and assert it is parked awaiting audio selection.
+
+    Shared guard for the manual-fallback endpoints (URL / file upload). Returns
+    the job or raises 404 (missing) / 400 (wrong state).
+    """
+    job = job_manager.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail=t(locale, "audioSearch.jobNotFound", job_id=job_id))
+    if job.status != JobStatus.AWAITING_AUDIO_SELECTION:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Job is not awaiting audio selection (status: {job.status})"
+        )
+    return job
+
+
+@router.post("/audio-search/{job_id}/provide-url", response_model=AttachResponse)
+async def provide_url_for_job(
+    job_id: str,
+    request: Request,
+    background_tasks: BackgroundTasks,
+    body: ProvideUrlRequest,
+    auth_result: AuthResult = Depends(require_auth),
+):
+    """
+    Attach a YouTube/yt-dlp URL to a parked job and start processing.
+
+    The manual escape hatch when audio search finds nothing usable: the user
+    pastes a source URL for a job already in AWAITING_AUDIO_SELECTION. The job
+    was already created and charged, so we do NOT create a new job or deduct
+    base credits — the post-download duration reconcile handles final billing.
+
+    Mirrors create_job_from_url's inline download (so generic yt-dlp sites work),
+    but transitions the existing parked job AWAITING_AUDIO_SELECTION →
+    DOWNLOADING_AUDIO → DOWNLOADING rather than creating a job.
+    """
+    locale = get_locale_from_request(request)
+    # Validation helpers live in file_upload; import lazily to avoid a heavy
+    # import at module load (and any import cycle).
+    from backend.api.routes.file_upload import (
+        _is_youtube_url,
+        _validate_url,
+        _unsupported_url_platform,
+        _drm_unsupported_detail,
+    )
+
+    job = _require_awaiting_selection(job_id, locale)
+
+    url = (body.url or "").strip()
+
+    # Reject DRM-protected streaming links (Apple Music, Spotify, Tidal, …) upfront.
+    unsupported_platform = _unsupported_url_platform(url)
+    if unsupported_platform:
+        raise HTTPException(status_code=400, detail=_drm_unsupported_detail(locale, unsupported_platform))
+
+    if not _validate_url(url):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid URL. Please provide a valid YouTube, Vimeo, SoundCloud, or other supported video URL."
+        )
+
+    youtube_service = get_youtube_download_service()
+
+    # For YouTube URLs, check availability early (geo/private/removed/bot/age).
+    if _is_youtube_url(url):
+        availability = await youtube_service.check_availability(url)
+        if availability and not availability.get("available"):
+            if availability.get("is_geo_restricted"):
+                detail = ("This YouTube video is not available in our server's region. "
+                          "Try using a different source for this song.")
+            elif availability.get("is_private"):
+                detail = "This YouTube video is private and cannot be downloaded."
+            elif availability.get("is_removed"):
+                detail = "This YouTube video has been removed and cannot be downloaded."
+            elif availability.get("is_bot_blocked"):
+                detail = ("We're temporarily unable to access YouTube to download this video. "
+                          "Please try again in a few minutes, or search for this song from another source.")
+            elif availability.get("is_age_restricted"):
+                detail = "This YouTube video is age-restricted and cannot be downloaded."
+            else:
+                detail = f"This YouTube video is unavailable: {availability.get('error', 'unknown error')}"
+            raise HTTPException(status_code=400, detail=detail)
+
+    # Transition into the download state BEFORE downloading so the job reflects
+    # progress and start_job_processing's DOWNLOADING_AUDIO → DOWNLOADING is valid.
+    job_manager.transition_to_state(
+        job_id=job_id,
+        new_status=JobStatus.DOWNLOADING_AUDIO,
+        progress=10,
+        message=f"Downloading from provided URL: {job.artist} - {job.title}",
+        raise_on_invalid=False,
+    )
+
+    try:
+        audio_gcs_path = await youtube_service.download(
+            url=url, job_id=job_id, artist=job.artist, title=job.title,
+        )
+    except YouTubeDownloadError as e:
+        # Put the job back in the queue so the user can retry / pick another source.
+        job_manager.transition_to_state(
+            job_id=job_id,
+            new_status=JobStatus.AWAITING_AUDIO_SELECTION,
+            progress=10,
+            message="Download from that URL failed. Try another URL or search again.",
+            raise_on_invalid=False,
+        )
+        raise HTTPException(status_code=502, detail=f"Download failed: {e}")
+
+    job_manager.update_job(job_id, {
+        'audio_source_type': 'url',
+        'url': url,
+        'input_media_gcs_path': audio_gcs_path,
+        'filename': os.path.basename(audio_gcs_path),
+    })
+
+    # start_job_processing transitions DOWNLOADING_AUDIO → DOWNLOADING, runs the
+    # duration reconcile (final billing), and triggers audio + lyrics workers.
+    background_tasks.add_task(
+        job_manager.start_job_processing, job_id, 15,
+        "Audio downloaded, starting processing",
+    )
+
+    return AttachResponse(status="success", job_id=job_id, message="URL accepted, download complete, processing started")
+
+
+@router.post("/audio-search/{job_id}/attach-upload-url", response_model=AttachUploadUrlsResponse)
+async def attach_upload_url(
+    job_id: str,
+    request: Request,
+    body: AttachUploadUrlsRequest,
+    auth_result: AuthResult = Depends(require_auth),
+):
+    """
+    Issue a signed GCS upload URL to attach an audio file to a parked job.
+
+    Step 1 of the manual file-upload fallback: the client PUTs the file to the
+    returned URL, then calls /attach-upload-complete. No job is created here.
+    """
+    locale = get_locale_from_request(request)
+    _require_awaiting_selection(job_id, locale)
+
+    filename = os.path.basename((body.filename or "").strip()) or "audio"
+    gcs_path = f"uploads/{job_id}/audio/{filename}"
+    upload_url = storage_service.generate_signed_upload_url(
+        gcs_path, content_type=body.content_type or "application/octet-stream", expiration_minutes=60,
+    )
+    return AttachUploadUrlsResponse(job_id=job_id, gcs_path=gcs_path, upload_url=upload_url)
+
+
+@router.post("/audio-search/{job_id}/attach-upload-complete", response_model=AttachResponse)
+async def attach_upload_complete(
+    job_id: str,
+    request: Request,
+    background_tasks: BackgroundTasks,
+    auth_result: AuthResult = Depends(require_auth),
+):
+    """
+    Finalise a file upload attached to a parked job and start processing.
+
+    Step 2 of the manual file-upload fallback: verifies the uploaded audio landed
+    in GCS, points the job at it, and starts processing. Like the URL path, the
+    job was already created/charged, so no new job and no base-credit deduction.
+    """
+    locale = get_locale_from_request(request)
+    from backend.api.routes.file_upload import _select_mixed_audio_files
+
+    job = _require_awaiting_selection(job_id, locale)
+
+    prefix = f"uploads/{job_id}/audio/"
+    files = storage_service.list_files(prefix)
+    audio_files = [f for f in files if not f.rstrip("/").endswith("/")]
+    if not audio_files:
+        raise HTTPException(status_code=400, detail="No uploaded audio file found. Upload the file first.")
+
+    selected = _select_mixed_audio_files(audio_files)
+    audio_gcs_path = selected[0] if isinstance(selected, list) and selected else (selected or audio_files[0])
+
+    job_manager.update_job(job_id, {
+        'audio_source_type': 'upload',
+        'input_media_gcs_path': audio_gcs_path,
+        'filename': os.path.basename(audio_gcs_path),
+    })
+
+    job_manager.transition_to_state(
+        job_id=job_id,
+        new_status=JobStatus.DOWNLOADING_AUDIO,
+        progress=10,
+        message=f"File uploaded: {job.artist} - {job.title}",
+        raise_on_invalid=False,
+    )
+
+    background_tasks.add_task(
+        job_manager.start_job_processing, job_id, 15,
+        "File uploaded, starting processing",
+    )
+
+    return AttachResponse(status="success", job_id=job_id, message="Upload accepted, processing started")
 
 
 @router.post("/audio-search/{job_id}/select", response_model=AudioSelectResponse)

--- a/backend/api/routes/audio_search.py
+++ b/backend/api/routes/audio_search.py
@@ -253,6 +253,11 @@ class AttachUploadUrlsResponse(BaseModel):
     upload_url: str
 
 
+class AttachUploadCompleteRequest(BaseModel):
+    """Finalise an upload; gcs_path (from attach-upload-url) pins the exact file."""
+    gcs_path: Optional[str] = Field(None, description="The gcs_path returned by attach-upload-url")
+
+
 class AttachResponse(BaseModel):
     """Response after attaching a URL/file source to a parked job."""
     status: str
@@ -1152,6 +1157,7 @@ async def research_audio(
     pipeline runs on the corrected metadata.
     """
     locale = get_locale_from_request(request)
+    _require_audio_search_enabled(request, locale)
 
     job = job_manager.get_job(job_id)
     if not job:
@@ -1243,11 +1249,37 @@ async def research_audio(
     )
 
 
+# Audio formats accepted by the manual file-upload fallback (case-insensitive).
+_AUDIO_UPLOAD_EXTENSIONS = {".mp3", ".wav", ".flac", ".m4a", ".ogg"}
+
+# Upper bound on an inline (non-YouTube) URL download so a hung yt-dlp fetch can
+# never leave a parked job stuck in DOWNLOADING_AUDIO. Kept under typical proxy
+# request timeouts; YouTube URLs bypass this via the async download worker.
+URL_DOWNLOAD_TIMEOUT_SECONDS = 240
+
+
+def _require_audio_search_enabled(request: Request, locale: str) -> None:
+    """Apply the tenant `audio_search` feature gate (mirrors /search).
+
+    White-label portals that don't offer audio search must not be able to drive
+    the recovery endpoints (re-search / provide-url / upload) either.
+    """
+    tenant_config = get_tenant_config_from_request(request)
+    if tenant_config and not tenant_config.features.audio_search:
+        raise HTTPException(status_code=403, detail=t(locale, "audioSearch.notEnabled"))
+
+
 def _require_awaiting_selection(job_id: str, locale: str):
     """Load a job and assert it is parked awaiting audio selection.
 
     Shared guard for the manual-fallback endpoints (URL / file upload). Returns
     the job or raises 404 (missing) / 400 (wrong state).
+
+    Note: like the sibling /select endpoint (which Bulk Mode already relies on),
+    this does not enforce per-user job ownership — bulk jobs are owned by a
+    service account, so a per-user check here would lock the real submitter out
+    of recovering their own parked job. Ownership hardening, if desired, must be
+    applied uniformly across the whole audio-search surface, not just here.
     """
     job = job_manager.get_job(job_id)
     if not job:
@@ -1276,11 +1308,13 @@ async def provide_url_for_job(
     was already created and charged, so we do NOT create a new job or deduct
     base credits — the post-download duration reconcile handles final billing.
 
-    Mirrors create_job_from_url's inline download (so generic yt-dlp sites work),
-    but transitions the existing parked job AWAITING_AUDIO_SELECTION →
-    DOWNLOADING_AUDIO → DOWNLOADING rather than creating a job.
+    YouTube URLs are handed to the async audio-download Cloud Run Job (survives
+    request/instance shutdown, no long-blocking request). Generic yt-dlp URLs are
+    downloaded inline (the worker has no generic path) but bounded by a timeout so
+    a slow/hung download can never strand the job in DOWNLOADING_AUDIO.
     """
     locale = get_locale_from_request(request)
+    _require_audio_search_enabled(request, locale)
     # Validation helpers live in file_upload; import lazily to avoid a heavy
     # import at module load (and any import cycle).
     from backend.api.routes.file_upload import (
@@ -1306,9 +1340,10 @@ async def provide_url_for_job(
         )
 
     youtube_service = get_youtube_download_service()
+    is_youtube = _is_youtube_url(url)
 
     # For YouTube URLs, check availability early (geo/private/removed/bot/age).
-    if _is_youtube_url(url):
+    if is_youtube:
         availability = await youtube_service.check_availability(url)
         if availability and not availability.get("available"):
             if availability.get("is_geo_restricted"):
@@ -1327,8 +1362,15 @@ async def provide_url_for_job(
                 detail = f"This YouTube video is unavailable: {availability.get('error', 'unknown error')}"
             raise HTTPException(status_code=400, detail=detail)
 
-    # Transition into the download state BEFORE downloading so the job reflects
-    # progress and start_job_processing's DOWNLOADING_AUDIO → DOWNLOADING is valid.
+    # Point the job at the URL source and enter the download state. The
+    # audio-download worker (and generic inline path below) read these fields
+    # when selected_audio_index is unset (which it is for a parked job).
+    job_manager.update_job(job_id, {
+        'audio_source_type': 'url',
+        'url': url,
+        'source_name': 'YouTube' if is_youtube else 'url',
+        'download_url': url,
+    })
     job_manager.transition_to_state(
         job_id=job_id,
         new_status=JobStatus.DOWNLOADING_AUDIO,
@@ -1337,24 +1379,40 @@ async def provide_url_for_job(
         raise_on_invalid=False,
     )
 
-    try:
-        audio_gcs_path = await youtube_service.download(
-            url=url, job_id=job_id, artist=job.artist, title=job.title,
-        )
-    except YouTubeDownloadError as e:
-        # Put the job back in the queue so the user can retry / pick another source.
+    def _requeue(msg: str) -> None:
         job_manager.transition_to_state(
             job_id=job_id,
             new_status=JobStatus.AWAITING_AUDIO_SELECTION,
             progress=10,
-            message="Download from that URL failed. Try another URL or search again.",
+            message=msg,
             raise_on_invalid=False,
         )
+
+    if is_youtube:
+        # Async: the Cloud Run download job downloads + reconciles + triggers
+        # workers itself, so the request returns immediately.
+        worker_service = get_worker_service()
+        triggered = await worker_service.trigger_audio_download_worker(job_id)
+        if not triggered:
+            _requeue("Couldn't start the download. Please try again.")
+            raise HTTPException(status_code=502, detail="Failed to trigger audio download worker")
+        return AttachResponse(status="success", job_id=job_id, message="URL accepted, download started")
+
+    # Generic yt-dlp URL: no async worker path exists, so download inline —
+    # bounded so a hung download can't strand the job in DOWNLOADING_AUDIO.
+    try:
+        audio_gcs_path = await asyncio.wait_for(
+            youtube_service.download(url=url, job_id=job_id, artist=job.artist, title=job.title),
+            timeout=URL_DOWNLOAD_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        _requeue("That download took too long. Try another URL or search again.")
+        raise HTTPException(status_code=504, detail="Download timed out")
+    except YouTubeDownloadError as e:
+        _requeue("Download from that URL failed. Try another URL or search again.")
         raise HTTPException(status_code=502, detail=f"Download failed: {e}")
 
     job_manager.update_job(job_id, {
-        'audio_source_type': 'url',
-        'url': url,
         'input_media_gcs_path': audio_gcs_path,
         'filename': os.path.basename(audio_gcs_path),
     })
@@ -1383,9 +1441,20 @@ async def attach_upload_url(
     returned URL, then calls /attach-upload-complete. No job is created here.
     """
     locale = get_locale_from_request(request)
+    _require_audio_search_enabled(request, locale)
     _require_awaiting_selection(job_id, locale)
 
-    filename = os.path.basename((body.filename or "").strip()) or "audio"
+    # Normalise Windows separators before basename so "..\\evil.exe" can't be
+    # stored verbatim, then validate the extension against the audio allow-list.
+    raw = (body.filename or "").strip().replace("\\", "/")
+    filename = os.path.basename(raw) or "audio"
+    ext = os.path.splitext(filename)[1].lower()
+    if ext not in _AUDIO_UPLOAD_EXTENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail="Unsupported audio format. Use MP3, WAV, FLAC, M4A, or OGG.",
+        )
+
     gcs_path = f"uploads/{job_id}/audio/{filename}"
     upload_url = storage_service.generate_signed_upload_url(
         gcs_path, content_type=body.content_type or "application/octet-stream", expiration_minutes=60,
@@ -1398,6 +1467,7 @@ async def attach_upload_complete(
     job_id: str,
     request: Request,
     background_tasks: BackgroundTasks,
+    body: AttachUploadCompleteRequest = AttachUploadCompleteRequest(),
     auth_result: AuthResult = Depends(require_auth),
 ):
     """
@@ -1408,6 +1478,7 @@ async def attach_upload_complete(
     job was already created/charged, so no new job and no base-credit deduction.
     """
     locale = get_locale_from_request(request)
+    _require_audio_search_enabled(request, locale)
     from backend.api.routes.file_upload import _select_mixed_audio_files
 
     job = _require_awaiting_selection(job_id, locale)
@@ -1418,8 +1489,17 @@ async def attach_upload_complete(
     if not audio_files:
         raise HTTPException(status_code=400, detail="No uploaded audio file found. Upload the file first.")
 
-    selected = _select_mixed_audio_files(audio_files)
-    audio_gcs_path = selected[0] if isinstance(selected, list) and selected else (selected or audio_files[0])
+    # Prefer the exact object the client uploaded to (from attach-upload-url),
+    # validated to live under this job's prefix and to actually exist — never
+    # trust an arbitrary client path, and don't depend on list ordering.
+    requested = (body.gcs_path or "").strip()
+    if requested:
+        if not requested.startswith(prefix) or requested not in audio_files:
+            raise HTTPException(status_code=400, detail="Uploaded file not found for this job.")
+        audio_gcs_path = requested
+    else:
+        selected = _select_mixed_audio_files(audio_files)
+        audio_gcs_path = selected[0] if isinstance(selected, list) and selected else (selected or audio_files[0])
 
     job_manager.update_job(job_id, {
         'audio_source_type': 'upload',

--- a/backend/tests/api/test_audio_search_research_attach.py
+++ b/backend/tests/api/test_audio_search_research_attach.py
@@ -200,16 +200,20 @@ class TestResearch:
 
 
 class TestProvideUrl:
-    def test_youtube_url_downloads_and_starts(self, mock_job_manager):
+    def test_youtube_url_uses_async_worker(self, mock_job_manager):
+        """YouTube URLs go through the async download worker (no blocking request)."""
         from fastapi.testclient import TestClient
         from backend.main import app
 
         yt = MagicMock()
         yt.check_availability = AsyncMock(return_value={"available": True})
-        yt.download = AsyncMock(return_value="uploads/park-1/audio/song.webm")
+        yt.download = AsyncMock()
+        ws = MagicMock()
+        ws.trigger_audio_download_worker = AsyncMock(return_value=True)
 
         with patch.multiple("backend.api.routes.audio_search", job_manager=mock_job_manager), \
-                patch("backend.api.routes.audio_search.get_youtube_download_service", return_value=yt):
+                patch("backend.api.routes.audio_search.get_youtube_download_service", return_value=yt), \
+                patch("backend.api.routes.audio_search.get_worker_service", return_value=ws):
             client = TestClient(app)
             resp = client.post(
                 "/api/audio-search/park-1/provide-url",
@@ -217,10 +221,54 @@ class TestProvideUrl:
             )
 
         assert resp.status_code == 200, resp.text
+        ws.trigger_audio_download_worker.assert_awaited_once_with("park-1")
+        yt.download.assert_not_awaited()  # async worker does the download, not inline
+        # job pointed at the URL source for the worker's job-level fallback
+        srcd = [c for c in mock_job_manager.update_job.call_args_list
+                if c.args[1].get("source_name") == "YouTube" and c.args[1].get("download_url")]
+        assert srcd
+
+    def test_youtube_worker_trigger_failure_requeues(self, mock_job_manager):
+        from fastapi.testclient import TestClient
+        from backend.main import app
+
+        yt = MagicMock()
+        yt.check_availability = AsyncMock(return_value={"available": True})
+        ws = MagicMock()
+        ws.trigger_audio_download_worker = AsyncMock(return_value=False)
+
+        with patch.multiple("backend.api.routes.audio_search", job_manager=mock_job_manager), \
+                patch("backend.api.routes.audio_search.get_youtube_download_service", return_value=yt), \
+                patch("backend.api.routes.audio_search.get_worker_service", return_value=ws):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/audio-search/park-1/provide-url",
+                json={"url": "https://www.youtube.com/watch?v=abcdefghijk"},
+            )
+        assert resp.status_code == 502
+        statuses = [c.kwargs.get("new_status") for c in mock_job_manager.transition_to_state.call_args_list]
+        assert JobStatus.AWAITING_AUDIO_SELECTION in statuses
+
+    def test_generic_url_downloads_inline_and_starts(self, mock_job_manager):
+        """Non-YouTube (yt-dlp) URLs download inline, then start processing."""
+        from fastapi.testclient import TestClient
+        from backend.main import app
+
+        yt = MagicMock()
+        yt.download = AsyncMock(return_value="uploads/park-1/audio/song.opus")
+
+        with patch.multiple("backend.api.routes.audio_search", job_manager=mock_job_manager), \
+                patch("backend.api.routes.audio_search.get_youtube_download_service", return_value=yt):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/audio-search/park-1/provide-url",
+                json={"url": "https://soundcloud.com/artist/track"},
+            )
+
+        assert resp.status_code == 200, resp.text
         yt.download.assert_awaited_once()
-        # pointed the job at the downloaded audio
         pathed = [c for c in mock_job_manager.update_job.call_args_list
-                  if c.args[1].get("input_media_gcs_path")]
+                  if c.args[1].get("input_media_gcs_path") == "uploads/park-1/audio/song.opus"]
         assert pathed
         mock_job_manager.start_job_processing.assert_awaited()
 
@@ -244,24 +292,25 @@ class TestProvideUrl:
 
         yt = MagicMock()
         yt.check_availability = AsyncMock(return_value={"available": False, "is_private": True})
-        yt.download = AsyncMock()
+        ws = MagicMock()
+        ws.trigger_audio_download_worker = AsyncMock(return_value=True)
 
         with patch.multiple("backend.api.routes.audio_search", job_manager=mock_job_manager), \
-                patch("backend.api.routes.audio_search.get_youtube_download_service", return_value=yt):
+                patch("backend.api.routes.audio_search.get_youtube_download_service", return_value=yt), \
+                patch("backend.api.routes.audio_search.get_worker_service", return_value=ws):
             client = TestClient(app)
             resp = client.post(
                 "/api/audio-search/park-1/provide-url",
                 json={"url": "https://www.youtube.com/watch?v=abcdefghijk"},
             )
         assert resp.status_code == 400
-        yt.download.assert_not_awaited()
+        ws.trigger_audio_download_worker.assert_not_awaited()
 
-    def test_download_failure_requeues_and_502(self, mock_job_manager):
+    def test_generic_download_failure_requeues_and_502(self, mock_job_manager):
         from fastapi.testclient import TestClient
         from backend.main import app
 
         yt = MagicMock()
-        yt.check_availability = AsyncMock(return_value={"available": True})
         yt.download = AsyncMock(side_effect=YouTubeDownloadError("dead"))
 
         with patch.multiple("backend.api.routes.audio_search", job_manager=mock_job_manager), \
@@ -269,7 +318,7 @@ class TestProvideUrl:
             client = TestClient(app)
             resp = client.post(
                 "/api/audio-search/park-1/provide-url",
-                json={"url": "https://www.youtube.com/watch?v=abcdefghijk"},
+                json={"url": "https://soundcloud.com/artist/track"},
             )
         assert resp.status_code == 502
         # restored to awaiting so the user can retry
@@ -317,6 +366,23 @@ class TestAttachUpload:
         assert data["gcs_path"] == "uploads/park-1/audio/my song.flac"
         assert data["upload_url"] == "https://signed.example/put"
 
+    def test_attach_upload_url_rejects_bad_extension(self, mock_job_manager):
+        from fastapi.testclient import TestClient
+        from backend.main import app
+
+        storage = MagicMock()
+        storage.generate_signed_upload_url.return_value = "https://signed.example/put"
+
+        with patch.multiple("backend.api.routes.audio_search",
+                            job_manager=mock_job_manager, storage_service=storage):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/audio-search/park-1/attach-upload-url",
+                json={"filename": "..\\evil.exe", "content_type": "application/octet-stream"},
+            )
+        assert resp.status_code == 400
+        storage.generate_signed_upload_url.assert_not_called()
+
     def test_attach_complete_starts_processing(self, mock_job_manager):
         from fastapi.testclient import TestClient
         from backend.main import app
@@ -327,13 +393,33 @@ class TestAttachUpload:
         with patch.multiple("backend.api.routes.audio_search",
                             job_manager=mock_job_manager, storage_service=storage):
             client = TestClient(app)
-            resp = client.post("/api/audio-search/park-1/attach-upload-complete")
+            resp = client.post(
+                "/api/audio-search/park-1/attach-upload-complete",
+                json={"gcs_path": "uploads/park-1/audio/my_song.flac"},
+            )
 
         assert resp.status_code == 200, resp.text
         pathed = [c for c in mock_job_manager.update_job.call_args_list
                   if c.args[1].get("input_media_gcs_path") == "uploads/park-1/audio/my_song.flac"]
         assert pathed
         mock_job_manager.start_job_processing.assert_awaited()
+
+    def test_attach_complete_rejects_gcs_path_outside_prefix(self, mock_job_manager):
+        from fastapi.testclient import TestClient
+        from backend.main import app
+
+        storage = MagicMock()
+        storage.list_files.return_value = ["uploads/park-1/audio/my_song.flac"]
+
+        with patch.multiple("backend.api.routes.audio_search",
+                            job_manager=mock_job_manager, storage_service=storage):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/audio-search/park-1/attach-upload-complete",
+                json={"gcs_path": "uploads/other-job/audio/steal.flac"},
+            )
+        assert resp.status_code == 400
+        mock_job_manager.start_job_processing.assert_not_awaited()
 
     def test_attach_complete_400_when_no_file(self, mock_job_manager):
         from fastapi.testclient import TestClient
@@ -345,6 +431,6 @@ class TestAttachUpload:
         with patch.multiple("backend.api.routes.audio_search",
                             job_manager=mock_job_manager, storage_service=storage):
             client = TestClient(app)
-            resp = client.post("/api/audio-search/park-1/attach-upload-complete")
+            resp = client.post("/api/audio-search/park-1/attach-upload-complete", json={})
         assert resp.status_code == 400
         mock_job_manager.start_job_processing.assert_not_awaited()

--- a/backend/tests/api/test_audio_search_research_attach.py
+++ b/backend/tests/api/test_audio_search_research_attach.py
@@ -1,0 +1,350 @@
+"""
+Tests for the parked-job recovery endpoints on audio-search:
+
+- POST /api/audio-search/{job_id}/research      — retry / edit-and-re-search
+- POST /api/audio-search/{job_id}/provide-url   — attach a YouTube/yt-dlp URL
+- POST /api/audio-search/{job_id}/attach-upload-url      — signed URL for upload
+- POST /api/audio-search/{job_id}/attach-upload-complete — finalise an upload
+
+These cover the "0 results / dead-end" bulk-mode scenario where a job is parked
+in AWAITING_AUDIO_SELECTION with no usable sources and the user needs a way out.
+"""
+from __future__ import annotations
+
+from datetime import datetime, UTC
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.models.job import Job, JobStatus
+from backend.services.audio_search_service import AudioSearchResult, NoResultsError, AudioSearchError
+from backend.services.auth_service import UserType, AuthResult
+from backend.services.youtube_download_service import YouTubeDownloadError
+
+NOW = datetime.now(UTC)
+
+
+@pytest.fixture(autouse=True)
+def _auth_overrides():
+    from backend.api.dependencies import require_auth, require_admin
+    from backend.main import app
+
+    async def mock_require_auth():
+        return AuthResult(
+            is_valid=True, user_type=UserType.STRIPE, remaining_uses=5,
+            message="test", is_admin=False, user_email="buyer@example.com",
+        )
+
+    app.dependency_overrides[require_auth] = mock_require_auth
+    app.dependency_overrides[require_admin] = mock_require_auth
+    yield
+    app.dependency_overrides.pop(require_auth, None)
+    app.dependency_overrides.pop(require_admin, None)
+
+
+def _parked_job(job_id="park-1", artist="Arctic Monkeys", title="The View From the Afternoon",
+                status=JobStatus.AWAITING_AUDIO_SELECTION) -> Job:
+    return Job(
+        job_id=job_id, status=status, created_at=NOW, updated_at=NOW,
+        user_email="buyer@example.com", artist=artist, title=title,
+        audio_search_artist=artist, audio_search_title=title,
+        state_data={"credits_charged": 1, "audio_search_results": []},
+    )
+
+
+def _result(idx=0, title="The View From the Afternoon", artist="Arctic Monkeys"):
+    r = AudioSearchResult(
+        index=idx, title=title, artist=artist, provider="RED",
+        url="", duration=180, quality="FLAC", source_id=f"id{idx}",
+    )
+    r.raw_result = {"target_file": f"{title}.flac", "is_lossless": True, "seeders": 20}
+    return r
+
+
+@pytest.fixture
+def mock_job_manager():
+    jm = MagicMock()
+    jm.get_job.return_value = _parked_job()
+    jm.update_job.return_value = None
+    jm.transition_to_state.return_value = True
+    jm.start_job_processing = AsyncMock(return_value=None)
+    return jm
+
+
+# ---------------------------------------------------------------------------
+# research (re-search)
+# ---------------------------------------------------------------------------
+
+
+class TestResearch:
+    def _patched(self, jm, search_mock):
+        return patch.multiple(
+            "backend.api.routes.audio_search",
+            job_manager=jm,
+        ), patch(
+            "backend.api.routes.audio_search.get_audio_search_service",
+            return_value=search_mock,
+        )
+
+    def test_research_returns_results(self, mock_job_manager):
+        from fastapi.testclient import TestClient
+        from backend.main import app
+
+        search = MagicMock()
+        search.search_async = AsyncMock(return_value=[_result(0), _result(1)])
+        search.last_remote_search_id = "remote-xyz"
+
+        p1, p2 = self._patched(mock_job_manager, search)
+        with p1, p2:
+            client = TestClient(app)
+            resp = client.post("/api/audio-search/park-1/research", json={})
+
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["results_count"] == 2
+        assert len(data["results"]) == 2
+        # results were cached back onto the job
+        cached = [c for c in mock_job_manager.update_job.call_args_list
+                  if "state_data.audio_search_results" in c.args[1]]
+        assert cached, "expected results to be cached on the job"
+
+    def test_research_empty_is_200_not_error(self, mock_job_manager):
+        from fastapi.testclient import TestClient
+        from backend.main import app
+
+        search = MagicMock()
+        search.search_async = AsyncMock(side_effect=NoResultsError("nothing"))
+        search.last_remote_search_id = None
+
+        p1, p2 = self._patched(mock_job_manager, search)
+        with p1, p2:
+            client = TestClient(app)
+            resp = client.post("/api/audio-search/park-1/research", json={})
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["results_count"] == 0
+
+    def test_research_applies_edited_terms(self, mock_job_manager):
+        from fastapi.testclient import TestClient
+        from backend.main import app
+
+        search = MagicMock()
+        search.search_async = AsyncMock(return_value=[_result(0)])
+        search.last_remote_search_id = None
+
+        p1, p2 = self._patched(mock_job_manager, search)
+        with p1, p2:
+            client = TestClient(app)
+            resp = client.post(
+                "/api/audio-search/park-1/research",
+                json={"artist": "Arctic Monkeys", "title": "The View from the Afternoon"},
+            )
+
+        assert resp.status_code == 200, resp.text
+        # search ran with the edited (normalized) title
+        search.search_async.assert_awaited_once()
+        args = search.search_async.await_args.args
+        assert args[0] == "Arctic Monkeys"
+        assert args[1] == "The View from the Afternoon"
+        # edit applied to the job (search terms + display metadata)
+        applied = [c for c in mock_job_manager.update_job.call_args_list
+                   if c.args[1].get("title") == "The View from the Afternoon"]
+        assert applied, "expected edited title applied to job"
+
+    def test_research_502_on_search_error(self, mock_job_manager):
+        from fastapi.testclient import TestClient
+        from backend.main import app
+
+        search = MagicMock()
+        search.search_async = AsyncMock(side_effect=AudioSearchError("boom"))
+
+        p1, p2 = self._patched(mock_job_manager, search)
+        with p1, p2:
+            client = TestClient(app)
+            resp = client.post("/api/audio-search/park-1/research", json={})
+
+        assert resp.status_code == 502
+
+    def test_research_rejects_wrong_status(self, mock_job_manager):
+        from fastapi.testclient import TestClient
+        from backend.main import app
+
+        mock_job_manager.get_job.return_value = _parked_job(status=JobStatus.DOWNLOADING)
+        search = MagicMock()
+        search.search_async = AsyncMock(return_value=[])
+
+        p1, p2 = self._patched(mock_job_manager, search)
+        with p1, p2:
+            client = TestClient(app)
+            resp = client.post("/api/audio-search/park-1/research", json={})
+
+        assert resp.status_code == 400
+        search.search_async.assert_not_awaited()
+
+    def test_research_404_missing_job(self, mock_job_manager):
+        from fastapi.testclient import TestClient
+        from backend.main import app
+
+        mock_job_manager.get_job.return_value = None
+        search = MagicMock()
+        p1, p2 = self._patched(mock_job_manager, search)
+        with p1, p2:
+            client = TestClient(app)
+            resp = client.post("/api/audio-search/nope/research", json={})
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# provide-url
+# ---------------------------------------------------------------------------
+
+
+class TestProvideUrl:
+    def test_youtube_url_downloads_and_starts(self, mock_job_manager):
+        from fastapi.testclient import TestClient
+        from backend.main import app
+
+        yt = MagicMock()
+        yt.check_availability = AsyncMock(return_value={"available": True})
+        yt.download = AsyncMock(return_value="uploads/park-1/audio/song.webm")
+
+        with patch.multiple("backend.api.routes.audio_search", job_manager=mock_job_manager), \
+                patch("backend.api.routes.audio_search.get_youtube_download_service", return_value=yt):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/audio-search/park-1/provide-url",
+                json={"url": "https://www.youtube.com/watch?v=abcdefghijk"},
+            )
+
+        assert resp.status_code == 200, resp.text
+        yt.download.assert_awaited_once()
+        # pointed the job at the downloaded audio
+        pathed = [c for c in mock_job_manager.update_job.call_args_list
+                  if c.args[1].get("input_media_gcs_path")]
+        assert pathed
+        mock_job_manager.start_job_processing.assert_awaited()
+
+    def test_drm_url_rejected(self, mock_job_manager):
+        from fastapi.testclient import TestClient
+        from backend.main import app
+
+        yt = MagicMock()
+        with patch.multiple("backend.api.routes.audio_search", job_manager=mock_job_manager), \
+                patch("backend.api.routes.audio_search.get_youtube_download_service", return_value=yt):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/audio-search/park-1/provide-url",
+                json={"url": "https://open.spotify.com/track/xyz"},
+            )
+        assert resp.status_code == 400
+
+    def test_unavailable_youtube_rejected(self, mock_job_manager):
+        from fastapi.testclient import TestClient
+        from backend.main import app
+
+        yt = MagicMock()
+        yt.check_availability = AsyncMock(return_value={"available": False, "is_private": True})
+        yt.download = AsyncMock()
+
+        with patch.multiple("backend.api.routes.audio_search", job_manager=mock_job_manager), \
+                patch("backend.api.routes.audio_search.get_youtube_download_service", return_value=yt):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/audio-search/park-1/provide-url",
+                json={"url": "https://www.youtube.com/watch?v=abcdefghijk"},
+            )
+        assert resp.status_code == 400
+        yt.download.assert_not_awaited()
+
+    def test_download_failure_requeues_and_502(self, mock_job_manager):
+        from fastapi.testclient import TestClient
+        from backend.main import app
+
+        yt = MagicMock()
+        yt.check_availability = AsyncMock(return_value={"available": True})
+        yt.download = AsyncMock(side_effect=YouTubeDownloadError("dead"))
+
+        with patch.multiple("backend.api.routes.audio_search", job_manager=mock_job_manager), \
+                patch("backend.api.routes.audio_search.get_youtube_download_service", return_value=yt):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/audio-search/park-1/provide-url",
+                json={"url": "https://www.youtube.com/watch?v=abcdefghijk"},
+            )
+        assert resp.status_code == 502
+        # restored to awaiting so the user can retry
+        statuses = [c.kwargs.get("new_status") for c in mock_job_manager.transition_to_state.call_args_list]
+        assert JobStatus.AWAITING_AUDIO_SELECTION in statuses
+
+    def test_provide_url_rejects_wrong_status(self, mock_job_manager):
+        from fastapi.testclient import TestClient
+        from backend.main import app
+
+        mock_job_manager.get_job.return_value = _parked_job(status=JobStatus.DOWNLOADING)
+        yt = MagicMock()
+        with patch.multiple("backend.api.routes.audio_search", job_manager=mock_job_manager), \
+                patch("backend.api.routes.audio_search.get_youtube_download_service", return_value=yt):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/audio-search/park-1/provide-url",
+                json={"url": "https://www.youtube.com/watch?v=abcdefghijk"},
+            )
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# attach upload
+# ---------------------------------------------------------------------------
+
+
+class TestAttachUpload:
+    def test_attach_upload_url_returns_signed_url(self, mock_job_manager):
+        from fastapi.testclient import TestClient
+        from backend.main import app
+
+        storage = MagicMock()
+        storage.generate_signed_upload_url.return_value = "https://signed.example/put"
+
+        with patch.multiple("backend.api.routes.audio_search",
+                            job_manager=mock_job_manager, storage_service=storage):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/audio-search/park-1/attach-upload-url",
+                json={"filename": "my song.flac", "content_type": "audio/flac"},
+            )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["gcs_path"] == "uploads/park-1/audio/my song.flac"
+        assert data["upload_url"] == "https://signed.example/put"
+
+    def test_attach_complete_starts_processing(self, mock_job_manager):
+        from fastapi.testclient import TestClient
+        from backend.main import app
+
+        storage = MagicMock()
+        storage.list_files.return_value = ["uploads/park-1/audio/my_song.flac"]
+
+        with patch.multiple("backend.api.routes.audio_search",
+                            job_manager=mock_job_manager, storage_service=storage):
+            client = TestClient(app)
+            resp = client.post("/api/audio-search/park-1/attach-upload-complete")
+
+        assert resp.status_code == 200, resp.text
+        pathed = [c for c in mock_job_manager.update_job.call_args_list
+                  if c.args[1].get("input_media_gcs_path") == "uploads/park-1/audio/my_song.flac"]
+        assert pathed
+        mock_job_manager.start_job_processing.assert_awaited()
+
+    def test_attach_complete_400_when_no_file(self, mock_job_manager):
+        from fastapi.testclient import TestClient
+        from backend.main import app
+
+        storage = MagicMock()
+        storage.list_files.return_value = []
+
+        with patch.multiple("backend.api.routes.audio_search",
+                            job_manager=mock_job_manager, storage_service=storage):
+            client = TestClient(app)
+            resp = client.post("/api/audio-search/park-1/attach-upload-complete")
+        assert resp.status_code == 400
+        mock_job_manager.start_job_processing.assert_not_awaited()

--- a/docs/API.md
+++ b/docs/API.md
@@ -956,6 +956,46 @@ post-download and may trigger an `AWAITING_DURATION_CONFIRM` pause if the actual
 server-computed credit total and returns 409 on mismatch. If omitted, the server deducts the
 computed cost without client confirmation.
 
+#### Recover a Parked Job (re-search / provide own audio)
+
+When a search returns nothing usable (0 results, a transient failure, or the auto-picked
+source is unusable) the job stays in `AWAITING_AUDIO_SELECTION` with no selectable sources.
+These endpoints let the user out of that dead-end without creating a new job or re-charging
+base credits (the job was already charged at creation; final duration billing is reconciled
+post-download). All require the job to be in `AWAITING_AUDIO_SELECTION` (else `400`).
+
+```http
+POST /api/audio-search/{job_id}/research
+Content-Type: application/json
+
+{ "artist": "Arctic Monkeys", "title": "The View From the Afternoon" }  // both optional
+```
+
+Re-runs the audio search. Blank/omitted fields re-use the job's existing search terms (a plain
+retry); provided values are applied to the job's search terms **and** display artist/title, then
+searched. Returns the same shape as `/search` (`results`, `results_count`). An empty result set is
+a normal `200` (not an error) so the client can offer the manual fallback below. `502` on a hard
+search-service error.
+
+```http
+POST /api/audio-search/{job_id}/provide-url
+Content-Type: application/json
+
+{ "url": "https://youtube.com/watch?v=..." }
+```
+
+Attaches a YouTube/yt-dlp URL to the parked job, downloads it, and starts processing
+(`AWAITING_AUDIO_SELECTION → DOWNLOADING_AUDIO → DOWNLOADING`). Rejects DRM/streaming links and
+unavailable videos with `400`; `502` if the download fails (the job is returned to the queue).
+
+```http
+POST /api/audio-search/{job_id}/attach-upload-url        // → { upload_url, gcs_path }
+POST /api/audio-search/{job_id}/attach-upload-complete   // after PUTting the file
+```
+
+Two-step manual file upload for a parked job: request a signed GCS upload URL, `PUT` the audio
+file to it, then call `attach-upload-complete` to point the job at the file and start processing.
+
 #### Standalone Search (Guided Flow — Step 2)
 
 ```http
@@ -2302,7 +2342,9 @@ routes require auth.
 
 ### Progress
 
-- `GET /api/bulk/{batch_id}` → `{batch_id,total,counts:{searching,awaiting_selection,processing,complete,failed},jobs:[{job_id,artist,title,status,auto_selected}]}`. Ownership-scoped (admins see any); `404` for another user's batch. Parked jobs are completed via the existing `/api/audio-search/{job_id}/select` flow.
+- `GET /api/bulk/{batch_id}` → `{batch_id,total,counts:{searching,awaiting_selection,processing,complete,failed},jobs:[{job_id,artist,title,status,auto_selected}]}`. Ownership-scoped (admins see any); `404` for another user's batch. Parked jobs are completed via the existing `/api/audio-search/{job_id}/select` flow, or recovered
+via `/research` (re-search / edit terms) and `/provide-url` · `/attach-upload-*` (own audio) when a
+search returned nothing usable.
 
 ## Webhooks
 

--- a/frontend/components/audio-search/AudioSearchDialog.tsx
+++ b/frontend/components/audio-search/AudioSearchDialog.tsx
@@ -14,8 +14,9 @@ import {
   checkFilenameMismatch,
 } from "@/lib/audio-search-utils"
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
-import { Loader2, Music2, ChevronDown, ChevronUp, Lightbulb } from "lucide-react"
+import { Loader2, Music2, ChevronDown, ChevronUp, Lightbulb, Search, Youtube, Upload } from "lucide-react"
 import { ResultCostChip } from "./ResultCostChip"
 
 // Version from pyproject.toml (single source of truth)
@@ -26,10 +27,11 @@ interface AudioSearchDialogProps {
   open: boolean
   onClose: () => void
   onSelect: () => void
+  searchArtist?: string
   searchTitle?: string
 }
 
-export function AudioSearchDialog({ jobId, open, onClose, onSelect, searchTitle }: AudioSearchDialogProps) {
+export function AudioSearchDialog({ jobId, open, onClose, onSelect, searchArtist, searchTitle }: AudioSearchDialogProps) {
   const t = useTranslations('audioSearch')
   const [results, setResults] = useState<ExtendedAudioSearchResult[]>([])
   const [isLoading, setIsLoading] = useState(true)
@@ -38,33 +40,51 @@ export function AudioSearchDialog({ jobId, open, onClose, onSelect, searchTitle 
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set())
   const [showGuidance, setShowGuidance] = useState(false)
 
-  // Debug: Log component version on mount
-  useEffect(() => {
-    console.log(`[AudioSearchDialog] App version: ${APP_VERSION}`)
-  }, [])
+  // Editable search terms + recovery actions (edit → re-search, or provide own audio).
+  const [editArtist, setEditArtist] = useState(searchArtist || "")
+  const [editTitle, setEditTitle] = useState(searchTitle || "")
+  const [isResearching, setIsResearching] = useState(false)
+  const [actionError, setActionError] = useState("")
+  // Fallback (own audio) — auto-opens when a search returns nothing.
+  const [fallbackMode, setFallbackMode] = useState<"url" | "upload" | null>(null)
+  const [youtubeUrl, setYoutubeUrl] = useState("")
+  const [uploadFile, setUploadFile] = useState<File | null>(null)
+  const [isSubmittingSource, setIsSubmittingSource] = useState(false)
+
+  // The title used for filename-mismatch badges tracks the (possibly edited) terms.
+  const effectiveTitle = editTitle || searchTitle
 
   // Load results when dialog opens
   useEffect(() => {
     if (open) {
-      console.log(`[AudioSearchDialog v${APP_VERSION}] Dialog opened for job: ${jobId}`)
       loadResults()
       setExpandedCategories(new Set()) // Reset expanded state
       setShowGuidance(false)
+      setFallbackMode(null)
+      setActionError("")
+      setYoutubeUrl("")
+      setUploadFile(null)
+      // Seed editable terms from props; refined again from the API response below.
+      setEditArtist(searchArtist || "")
+      setEditTitle(searchTitle || "")
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, jobId])
 
   async function loadResults() {
     setIsLoading(true)
     setError("")
     try {
-      console.log(`[AudioSearchDialog v${APP_VERSION}] Loading results...`)
       const data = await api.getAudioSearchResults(jobId)
-      console.log(`[AudioSearchDialog v${APP_VERSION}] Raw API response:`, data)
-      console.log(`[AudioSearchDialog v${APP_VERSION}] Results count: ${data.results?.length || 0}`)
       setResults((data.results || []) as ExtendedAudioSearchResult[])
+      // Prefer the job's stored search terms so the edit fields reflect reality.
+      if (data.artist) setEditArtist(data.artist)
+      if (data.title) setEditTitle(data.title)
+      if ((data.results || []).length === 0) setFallbackMode(null)
     } catch (err: any) {
-      console.error(`[AudioSearchDialog v${APP_VERSION}] Failed to load search results:`, err)
-      setError(err.message || "Failed to load search results")
+      // A parked job with no cached results returns 400 — that's the dead-end we
+      // are fixing, not a hard error. Show it as an empty state, not a red banner.
+      setResults([])
     } finally {
       setIsLoading(false)
     }
@@ -72,8 +92,6 @@ export function AudioSearchDialog({ jobId, open, onClose, onSelect, searchTitle 
 
   // Group results by category
   const groupedResults = useMemo(() => groupResults(results), [results])
-
-  // Count total categories
   const totalCategories = groupedResults.length
 
   async function handleSelect(index: number) {
@@ -84,24 +102,73 @@ export function AudioSearchDialog({ jobId, open, onClose, onSelect, searchTitle 
       onSelect()
       onClose()
     } catch (err: any) {
-      console.error("Failed to select audio:", err)
-      setError(err.message || "Failed to select audio")
+      setError(err.message || t('selectFailed'))
     } finally {
       setIsSelecting(null)
+    }
+  }
+
+  async function handleResearch() {
+    if (!editArtist.trim() || !editTitle.trim() || isResearching) return
+    setIsResearching(true)
+    setActionError("")
+    setError("")
+    try {
+      const data = await api.researchAudio(jobId, { artist: editArtist.trim(), title: editTitle.trim() })
+      const fresh = (data.results || []) as ExtendedAudioSearchResult[]
+      setResults(fresh)
+      setExpandedCategories(new Set())
+      // Nothing found again → surface the own-audio fallback.
+      setFallbackMode(fresh.length === 0 ? (fallbackMode ?? null) : null)
+    } catch (err: any) {
+      setActionError(err.message || t('researchFailed'))
+    } finally {
+      setIsResearching(false)
+    }
+  }
+
+  async function handleProvideUrl() {
+    const url = youtubeUrl.trim()
+    if (!url || isSubmittingSource) return
+    setIsSubmittingSource(true)
+    setActionError("")
+    try {
+      await api.provideUrlForJob(jobId, url)
+      onSelect()
+      onClose()
+    } catch (err: any) {
+      setActionError(err.message || t('urlFailed'))
+    } finally {
+      setIsSubmittingSource(false)
+    }
+  }
+
+  async function handleUpload() {
+    if (!uploadFile || isSubmittingSource) return
+    setIsSubmittingSource(true)
+    setActionError("")
+    try {
+      await api.attachUploadToJob(jobId, uploadFile)
+      onSelect()
+      onClose()
+    } catch (err: any) {
+      setActionError(err.message || t('uploadFailed'))
+    } finally {
+      setIsSubmittingSource(false)
     }
   }
 
   function toggleCategory(category: string) {
     setExpandedCategories(prev => {
       const next = new Set(prev)
-      if (next.has(category)) {
-        next.delete(category)
-      } else {
-        next.add(category)
-      }
+      if (next.has(category)) next.delete(category)
+      else next.add(category)
       return next
     })
   }
+
+  const hasResults = results.length > 0
+  const busy = isResearching || isSubmittingSource
 
   return (
     <Dialog open={open} onOpenChange={(open) => !open && onClose()}>
@@ -116,8 +183,113 @@ export function AudioSearchDialog({ jobId, open, onClose, onSelect, searchTitle 
           </DialogTitle>
         </div>
 
-        {/* Guidance header (collapsed by default) */}
-        {!isLoading && results.length > 0 && (
+        {/* Refine bar: edit the search terms and search again. Always available so a
+            wrong-track match or a no-results dead-end is never a trap. */}
+        <div className="px-4 py-2 border-b border-border bg-secondary/30 shrink-0 space-y-2">
+          <div className="flex flex-col sm:flex-row sm:items-end gap-2">
+            <div className="flex-1 min-w-0">
+              <label className="block text-[10px] text-muted-foreground mb-0.5">{t('artistLabel')}</label>
+              <Input
+                value={editArtist}
+                onChange={(e) => setEditArtist(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') handleResearch() }}
+                placeholder={t('artistLabel')}
+                disabled={busy}
+                className="h-8 text-xs bg-background"
+              />
+            </div>
+            <div className="flex-1 min-w-0">
+              <label className="block text-[10px] text-muted-foreground mb-0.5">{t('titleLabel')}</label>
+              <Input
+                value={editTitle}
+                onChange={(e) => setEditTitle(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') handleResearch() }}
+                placeholder={t('titleLabel')}
+                disabled={busy}
+                className="h-8 text-xs bg-background"
+              />
+            </div>
+            <Button
+              size="sm"
+              onClick={handleResearch}
+              disabled={busy || !editArtist.trim() || !editTitle.trim()}
+              className="h-8 text-xs bg-[var(--brand-pink)] hover:bg-[var(--brand-pink-hover)] text-white shrink-0"
+            >
+              {isResearching ? <Loader2 className="w-3.5 h-3.5 animate-spin mr-1" /> : <Search className="w-3.5 h-3.5 mr-1" />}
+              {t('searchAgain')}
+            </Button>
+          </div>
+
+          {/* Provide-your-own-audio fallback */}
+          <div className="flex items-center gap-3 text-[10px]">
+            <button
+              onClick={() => setFallbackMode(fallbackMode === "url" ? null : "url")}
+              className={`flex items-center gap-1 hover:text-foreground transition-colors ${fallbackMode === "url" ? 'text-[var(--brand-pink)]' : 'text-muted-foreground'}`}
+            >
+              <Youtube className="w-3 h-3" /> {t('pasteUrl')}
+            </button>
+            <button
+              onClick={() => setFallbackMode(fallbackMode === "upload" ? null : "upload")}
+              className={`flex items-center gap-1 hover:text-foreground transition-colors ${fallbackMode === "upload" ? 'text-[var(--brand-pink)]' : 'text-muted-foreground'}`}
+            >
+              <Upload className="w-3 h-3" /> {t('uploadFileAction')}
+            </button>
+          </div>
+
+          {fallbackMode === "url" && (
+            <div className="flex flex-col sm:flex-row gap-2">
+              <Input
+                type="url"
+                value={youtubeUrl}
+                onChange={(e) => setYoutubeUrl(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') handleProvideUrl() }}
+                placeholder={t('urlPlaceholder')}
+                disabled={busy}
+                className="h-8 text-xs bg-background flex-1"
+              />
+              <Button
+                size="sm"
+                onClick={handleProvideUrl}
+                disabled={busy || !youtubeUrl.trim()}
+                className="h-8 text-xs bg-[var(--brand-pink)] hover:bg-[var(--brand-pink-hover)] text-white shrink-0"
+              >
+                {isSubmittingSource ? <Loader2 className="w-3.5 h-3.5 animate-spin mr-1" /> : null}
+                {t('useThisUrl')}
+              </Button>
+            </div>
+          )}
+
+          {fallbackMode === "upload" && (
+            <div className="flex flex-col sm:flex-row gap-2 items-stretch sm:items-center">
+              <label className="flex-1 border border-dashed border-border rounded px-2 py-1.5 text-[10px] text-muted-foreground cursor-pointer hover:border-[var(--brand-pink)] truncate">
+                <input
+                  type="file"
+                  accept=".mp3,.wav,.flac,.m4a,.ogg,audio/*"
+                  onChange={(e) => setUploadFile(e.target.files?.[0] || null)}
+                  className="sr-only"
+                  disabled={busy}
+                />
+                {uploadFile ? uploadFile.name : t('chooseFile')}
+              </label>
+              <Button
+                size="sm"
+                onClick={handleUpload}
+                disabled={busy || !uploadFile}
+                className="h-8 text-xs bg-[var(--brand-pink)] hover:bg-[var(--brand-pink-hover)] text-white shrink-0"
+              >
+                {isSubmittingSource ? <Loader2 className="w-3.5 h-3.5 animate-spin mr-1" /> : null}
+                {t('useThisFile')}
+              </Button>
+            </div>
+          )}
+
+          {actionError && (
+            <p className="text-[10px] text-red-400">{actionError}</p>
+          )}
+        </div>
+
+        {/* Guidance header (collapsed by default) — only meaningful when there are results */}
+        {!isLoading && hasResults && (
           <div className="px-4 py-1.5 border-b border-border bg-secondary/30">
             <button
               onClick={() => setShowGuidance(!showGuidance)}
@@ -148,12 +320,13 @@ export function AudioSearchDialog({ jobId, open, onClose, onSelect, searchTitle 
         {isLoading ? (
           <div className="flex-1 flex items-center justify-center py-12">
             <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
-            <span className="ml-2 text-sm text-muted-foreground">Loading...</span>
+            <span className="ml-2 text-sm text-muted-foreground">{t('loading')}</span>
           </div>
-        ) : results.length === 0 ? (
-          <div className="flex-1 flex flex-col items-center justify-center py-12 text-muted-foreground">
+        ) : !hasResults ? (
+          <div className="flex-1 flex flex-col items-center justify-center py-12 text-muted-foreground px-6 text-center">
             <Music2 className="w-8 h-8 mb-2 opacity-50" />
-            <p className="text-sm">{t('noAudioSources')}</p>
+            <p className="text-sm font-medium text-foreground">{t('noAudioSources')}</p>
+            <p className="text-xs mt-1.5 max-w-md">{t('noResultsHelp')}</p>
           </div>
         ) : (
           <div className="flex-1 overflow-y-auto min-h-0 p-4">
@@ -190,7 +363,7 @@ export function AudioSearchDialog({ jobId, open, onClose, onSelect, searchTitle 
                     {/* Results in category */}
                     <div className="divide-y divide-slate-700/50">
                       {displayResults.map((result) => {
-                        const mismatch = searchTitle ? checkFilenameMismatch(searchTitle, result) : null
+                        const mismatch = effectiveTitle ? checkFilenameMismatch(effectiveTitle, result) : null
                         const hasMismatch = mismatch?.isMismatch ?? false
 
                         return (
@@ -226,7 +399,7 @@ export function AudioSearchDialog({ jobId, open, onClose, onSelect, searchTitle 
                                 )}
                                 {hasMismatch && (
                                   <span
-                                    title={`Expected "${searchTitle}" but filename is "${mismatch!.filename}"${mismatch!.suggestedTrack ? ` (looks like "${mismatch!.suggestedTrack}")` : ''}`}
+                                    title={`Expected "${effectiveTitle}" but filename is "${mismatch!.filename}"${mismatch!.suggestedTrack ? ` (looks like "${mismatch!.suggestedTrack}")` : ''}`}
                                     className="text-[8px] px-1 py-0.5 rounded font-medium bg-yellow-600/20 text-yellow-400 cursor-help"
                                   >
                                     {t('wrongTrack')}

--- a/frontend/components/audio-search/AudioSearchDialog.tsx
+++ b/frontend/components/audio-search/AudioSearchDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo } from "react"
 import { useTranslations } from 'next-intl'
-import { api } from "@/lib/api"
+import { api, ApiError } from "@/lib/api"
 import {
   ExtendedAudioSearchResult,
   groupResults,
@@ -83,8 +83,14 @@ export function AudioSearchDialog({ jobId, open, onClose, onSelect, searchArtist
       if ((data.results || []).length === 0) setFallbackMode(null)
     } catch (err: any) {
       // A parked job with no cached results returns 400 — that's the dead-end we
-      // are fixing, not a hard error. Show it as an empty state, not a red banner.
-      setResults([])
+      // are fixing, so render it as the empty state (with the refine bar), not a
+      // red banner. Any other failure (network / 5xx / session) is a real error.
+      if (err instanceof ApiError && err.status === 400) {
+        setResults([])
+      } else {
+        setResults([])
+        setError(err?.message || t('selectFailed'))
+      }
     } finally {
       setIsLoading(false)
     }
@@ -118,8 +124,8 @@ export function AudioSearchDialog({ jobId, open, onClose, onSelect, searchArtist
       const fresh = (data.results || []) as ExtendedAudioSearchResult[]
       setResults(fresh)
       setExpandedCategories(new Set())
-      // Nothing found again → surface the own-audio fallback.
-      setFallbackMode(fresh.length === 0 ? (fallbackMode ?? null) : null)
+      // Nothing found again → auto-open the own-audio fallback; results → close it.
+      setFallbackMode(prev => (fresh.length === 0 ? (prev ?? "url") : null))
     } catch (err: any) {
       setActionError(err.message || t('researchFailed'))
     } finally {

--- a/frontend/components/audio-search/__tests__/AudioSearchDialog.test.tsx
+++ b/frontend/components/audio-search/__tests__/AudioSearchDialog.test.tsx
@@ -1,16 +1,26 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { AudioSearchDialog } from '../AudioSearchDialog'
-import { api } from '@/lib/api'
+import { api, ApiError } from '@/lib/api'
 
-jest.mock('@/lib/api', () => ({
-  api: {
-    getAudioSearchResults: jest.fn(),
-    selectAudioResult: jest.fn(),
-    researchAudio: jest.fn(),
-    provideUrlForJob: jest.fn(),
-    attachUploadToJob: jest.fn(),
-  },
-}))
+jest.mock('@/lib/api', () => {
+  class ApiError extends Error {
+    status: number
+    constructor(message: string, status: number) {
+      super(message)
+      this.status = status
+    }
+  }
+  return {
+    ApiError,
+    api: {
+      getAudioSearchResults: jest.fn(),
+      selectAudioResult: jest.fn(),
+      researchAudio: jest.fn(),
+      provideUrlForJob: jest.fn(),
+      attachUploadToJob: jest.fn(),
+    },
+  }
+})
 
 const mockApi = api as jest.Mocked<typeof api>
 
@@ -105,7 +115,7 @@ describe('AudioSearchDialog recovery UX', () => {
   })
 
   it('treats a 400 (no cached results) as an empty state, not a red error', async () => {
-    mockApi.getAudioSearchResults.mockRejectedValue(new Error('No search results available'))
+    mockApi.getAudioSearchResults.mockRejectedValue(new ApiError('No search results available', 400))
 
     render(
       <AudioSearchDialog jobId="j1" open onClose={jest.fn()} onSelect={jest.fn()}
@@ -114,5 +124,18 @@ describe('AudioSearchDialog recovery UX', () => {
 
     await screen.findByText('No audio sources found')
     expect(screen.queryByText('No search results available')).not.toBeInTheDocument()
+  })
+
+  it('surfaces a non-400 (network/500) failure as an error banner', async () => {
+    mockApi.getAudioSearchResults.mockRejectedValue(new ApiError('Server exploded', 500))
+
+    render(
+      <AudioSearchDialog jobId="j1" open onClose={jest.fn()} onSelect={jest.fn()}
+        searchArtist="Arctic Monkeys" searchTitle="The View From the Afternoon" />
+    )
+
+    // Empty state still renders (refine bar available), but the real error shows too.
+    await screen.findByText('No audio sources found')
+    expect(screen.getByText('Server exploded')).toBeInTheDocument()
   })
 })

--- a/frontend/components/audio-search/__tests__/AudioSearchDialog.test.tsx
+++ b/frontend/components/audio-search/__tests__/AudioSearchDialog.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { AudioSearchDialog } from '../AudioSearchDialog'
+import { api } from '@/lib/api'
+
+jest.mock('@/lib/api', () => ({
+  api: {
+    getAudioSearchResults: jest.fn(),
+    selectAudioResult: jest.fn(),
+    researchAudio: jest.fn(),
+    provideUrlForJob: jest.fn(),
+    attachUploadToJob: jest.fn(),
+  },
+}))
+
+const mockApi = api as jest.Mocked<typeof api>
+
+const aResult = (index = 0) => ({
+  index,
+  title: 'The View From the Afternoon',
+  artist: 'Arctic Monkeys',
+  provider: 'RED',
+  is_lossless: true,
+  seeders: 30,
+  target_file: 'The View From the Afternoon.flac',
+  quality_data: {},
+})
+
+describe('AudioSearchDialog recovery UX', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders no-results help and the refine bar when the job has no sources', async () => {
+    mockApi.getAudioSearchResults.mockResolvedValue({
+      status: 'success', job_id: 'j1', results: [], total_results: 0,
+      artist: 'Arctic Monkeys', title: 'The View From the Afternoon',
+    } as any)
+
+    render(
+      <AudioSearchDialog jobId="j1" open onClose={jest.fn()} onSelect={jest.fn()}
+        searchArtist="Arctic Monkeys" searchTitle="The View From the Afternoon" />
+    )
+
+    await screen.findByText('No audio sources found')
+    expect(screen.getByText(/couldn't find any audio sources/i)).toBeInTheDocument()
+    // Editable terms seeded from the API response
+    expect(screen.getByDisplayValue('Arctic Monkeys')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('The View From the Afternoon')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /search again/i })).toBeInTheDocument()
+  })
+
+  it('re-searches with edited terms and shows the fresh results', async () => {
+    mockApi.getAudioSearchResults.mockResolvedValue({
+      status: 'success', job_id: 'j1', results: [], total_results: 0,
+      artist: 'Arctic Monkeys', title: 'The View From teh Afternoon',
+    } as any)
+    mockApi.researchAudio.mockResolvedValue({
+      status: 'awaiting_selection', job_id: 'j1', results: [aResult(0)], total_results: 1, results_count: 1,
+    } as any)
+
+    render(
+      <AudioSearchDialog jobId="j1" open onClose={jest.fn()} onSelect={jest.fn()}
+        searchArtist="Arctic Monkeys" searchTitle="The View From teh Afternoon" />
+    )
+
+    await screen.findByText('No audio sources found')
+
+    const titleInput = screen.getByDisplayValue('The View From teh Afternoon')
+    fireEvent.change(titleInput, { target: { value: 'The View From the Afternoon' } })
+    fireEvent.click(screen.getByRole('button', { name: /search again/i }))
+
+    await waitFor(() => {
+      expect(mockApi.researchAudio).toHaveBeenCalledWith('j1', {
+        artist: 'Arctic Monkeys', title: 'The View From the Afternoon',
+      })
+    })
+    // Results now render (RED category chip + a Select button)
+    await waitFor(() => expect(screen.getByRole('button', { name: /select/i })).toBeInTheDocument())
+  })
+
+  it('submits a provided URL and advances the job', async () => {
+    mockApi.getAudioSearchResults.mockResolvedValue({
+      status: 'success', job_id: 'j1', results: [], total_results: 0,
+    } as any)
+    mockApi.provideUrlForJob.mockResolvedValue({ status: 'success', job_id: 'j1', message: 'ok' } as any)
+    const onSelect = jest.fn()
+    const onClose = jest.fn()
+
+    render(
+      <AudioSearchDialog jobId="j1" open onClose={onClose} onSelect={onSelect}
+        searchArtist="Arctic Monkeys" searchTitle="Riot Van" />
+    )
+
+    await screen.findByText('No audio sources found')
+    fireEvent.click(screen.getByRole('button', { name: /paste url/i }))
+    const urlInput = await screen.findByPlaceholderText(/youtube\.com/i)
+    fireEvent.change(urlInput, { target: { value: 'https://youtube.com/watch?v=abc' } })
+    fireEvent.click(screen.getByRole('button', { name: /use this url/i }))
+
+    await waitFor(() =>
+      expect(mockApi.provideUrlForJob).toHaveBeenCalledWith('j1', 'https://youtube.com/watch?v=abc')
+    )
+    await waitFor(() => expect(onSelect).toHaveBeenCalled())
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('treats a 400 (no cached results) as an empty state, not a red error', async () => {
+    mockApi.getAudioSearchResults.mockRejectedValue(new Error('No search results available'))
+
+    render(
+      <AudioSearchDialog jobId="j1" open onClose={jest.fn()} onSelect={jest.fn()}
+        searchArtist="Arctic Monkeys" searchTitle="The View From the Afternoon" />
+    )
+
+    await screen.findByText('No audio sources found')
+    expect(screen.queryByText('No search results available')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/components/job/JobCard.tsx
+++ b/frontend/components/job/JobCard.tsx
@@ -279,6 +279,7 @@ export function JobCard({ job, onRefresh, showAdminControls }: JobCardProps) {
         open={showAudioSearch}
         onClose={() => setShowAudioSearch(false)}
         onSelect={onRefresh}
+        searchArtist={job.artist}
         searchTitle={job.title}
       />
 

--- a/frontend/components/job/bulk/BulkBatchProgress.tsx
+++ b/frontend/components/job/bulk/BulkBatchProgress.tsx
@@ -84,6 +84,7 @@ export function BulkBatchProgress({ batchId, onStartAnother, onJobsChanged }: Bu
         <AudioSearchDialog
           jobId={selectingJob.job_id}
           open={true}
+          searchArtist={selectingJob.artist}
           searchTitle={selectingJob.title}
           onClose={() => setSelectingJob(null)}
           onSelect={() => {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1487,11 +1487,12 @@ export const api = {
       headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
       body: JSON.stringify({ filename: file.name, content_type: contentType }),
     });
-    const { upload_url } = await handleResponse<{ upload_url: string; gcs_path: string }>(signed);
+    const { upload_url, gcs_path } = await handleResponse<{ upload_url: string; gcs_path: string }>(signed);
     await this.uploadFileToSignedUrl(upload_url, file, contentType);
     const done = await fetch(`${API_BASE_URL}/api/audio-search/${jobId}/attach-upload-complete`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+      body: JSON.stringify({ gcs_path }),
     });
     return handleResponse(done);
   },

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -326,6 +326,10 @@ export interface AudioSearchResponse {
   job_id: string;
   results: AudioSearchResult[];
   total_results: number;
+  results_count?: number;
+  // Present on GET /results and POST /research — the job's current search terms.
+  artist?: string;
+  title?: string;
   message?: string;
 }
 
@@ -1440,6 +1444,58 @@ export const api = {
     return handleResponse(response);
   },
   
+  /**
+   * Re-run the audio search for a parked job, optionally with edited
+   * artist/title. Empty results are a normal 200 (no sources found), not an error.
+   */
+  async researchAudio(
+    jobId: string,
+    edits?: { artist?: string; title?: string }
+  ): Promise<AudioSearchResponse> {
+    const response = await fetch(`${API_BASE_URL}/api/audio-search/${jobId}/research`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+      body: JSON.stringify({ artist: edits?.artist, title: edits?.title }),
+    });
+    return handleResponse(response);
+  },
+
+  /**
+   * Attach a YouTube/yt-dlp URL to a parked job and start processing.
+   * Manual fallback when audio search finds nothing usable.
+   */
+  async provideUrlForJob(
+    jobId: string,
+    url: string
+  ): Promise<{ status: string; job_id: string; message: string }> {
+    const response = await fetch(`${API_BASE_URL}/api/audio-search/${jobId}/provide-url`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+      body: JSON.stringify({ url }),
+    });
+    return handleResponse(response);
+  },
+
+  /**
+   * Attach an uploaded audio file to a parked job:
+   * 1) request a signed upload URL, 2) PUT the file, 3) mark complete.
+   */
+  async attachUploadToJob(jobId: string, file: File): Promise<{ status: string; message: string }> {
+    const contentType = file.type || 'application/octet-stream';
+    const signed = await fetch(`${API_BASE_URL}/api/audio-search/${jobId}/attach-upload-url`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+      body: JSON.stringify({ filename: file.name, content_type: contentType }),
+    });
+    const { upload_url } = await handleResponse<{ upload_url: string; gcs_path: string }>(signed);
+    await this.uploadFileToSignedUrl(upload_url, file, contentType);
+    const done = await fetch(`${API_BASE_URL}/api/audio-search/${jobId}/attach-upload-complete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+    });
+    return handleResponse(done);
+  },
+
   /**
    * Get job logs
    */

--- a/frontend/messages/ar.json
+++ b/frontend/messages/ar.json
@@ -760,7 +760,22 @@
     "views": "{count} مشاهدات",
     "moreVersions": "+{count} المزيد",
     "select": "تحديد",
-    "creditCost": "{credits} رصيد"
+    "creditCost": "{credits} رصيد",
+    "chooseFile": "اختر ملفاً صوتياً (MP3، WAV، FLAC، M4A، OGG)",
+    "noResultsHelp": "لم نتمكن من العثور على أي مصادر صوتية. حاول تعديل اسم الفنان أو العنوان أعلاه وابحث مرة أخرى، أو أضف ملفك الصوتي باستخدام رابط أو برفع ملف.",
+    "pasteUrl": "لصق الرابط",
+    "researchFailed": "فشل البحث. يرجى المحاولة مرة أخرى.",
+    "searchAgain": "البحث مرة أخرى",
+    "selectFailed": "فشل تحديد الصوت",
+    "uploadFailed": "فشل الرفع. يرجى المحاولة مرة أخرى.",
+    "urlFailed": "تعذر استخدام هذا الرابط. جرب مصدراً آخر.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "استخدم هذا الملف",
+    "useThisUrl": "استخدم هذا الرابط",
+    "artistLabel": "فنان",
+    "loading": "جاري التحميل...",
+    "titleLabel": "العنوان",
+    "uploadFileAction": "رفع ملف"
   },
   "audioEditor": {
     "loading": "جاري تحميل محرر الصوت...",

--- a/frontend/messages/ca.json
+++ b/frontend/messages/ca.json
@@ -760,7 +760,22 @@
     "views": "{count} visualitzacions",
     "moreVersions": "+{count} més",
     "select": "Selecciona",
-    "creditCost": "{credits} crèdits"
+    "creditCost": "{credits} crèdits",
+    "chooseFile": "Tria un fitxer d'àudio (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "No hem pogut trobar cap font d'àudio. Prova d'editar l'artista o el títol de dalt i torna a cercar, o afegeix el teu propi àudio amb un URL o pujant un fitxer.",
+    "pasteUrl": "Enganxa l'URL",
+    "researchFailed": "La cerca ha fallat. Si us plau, torna-ho a provar.",
+    "searchAgain": "Torna a cercar",
+    "selectFailed": "No s'ha pogut seleccionar l'àudio",
+    "uploadFailed": "La pujada ha fallat. Si us plau, torna-ho a provar.",
+    "urlFailed": "No s'ha pogut utilitzar aquest URL. Prova una altra font.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Utilitza aquest fitxer",
+    "useThisUrl": "Utilitza aquest URL",
+    "artistLabel": "Artista",
+    "loading": "Carregant...",
+    "titleLabel": "Títol",
+    "uploadFileAction": "Puja un fitxer"
   },
   "audioEditor": {
     "loading": "Carregant l'editor d'àudio...",

--- a/frontend/messages/cs.json
+++ b/frontend/messages/cs.json
@@ -760,7 +760,22 @@
     "views": "{count} zhlédnutí",
     "moreVersions": "+{count} dalších",
     "select": "Vybrat",
-    "creditCost": "{credits} kreditů"
+    "creditCost": "{credits} kreditů",
+    "chooseFile": "Vyber zvukový soubor (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Nepodařilo se nám najít žádné zdroje zvuku. Zkus upravit interpreta nebo název výše a hledat znovu, případně přidej vlastní zvuk pomocí URL adresy nebo nahráním souboru.",
+    "pasteUrl": "Vlož URL",
+    "researchFailed": "Hledání selhalo. Zkus to prosím znovu.",
+    "searchAgain": "Hledat znovu",
+    "selectFailed": "Nepodařilo se vybrat zvuk",
+    "uploadFailed": "Nahrávání selhalo. Zkus to prosím znovu.",
+    "urlFailed": "Tuto URL adresu nelze použít. Zkus jiný zdroj.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Použít tento soubor",
+    "useThisUrl": "Použít tuto URL",
+    "artistLabel": "Umělec",
+    "loading": "Načítám...",
+    "titleLabel": "Název",
+    "uploadFileAction": "Nahrát soubor"
   },
   "audioEditor": {
     "loading": "Načítání editoru zvuku...",

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -760,7 +760,22 @@
     "views": "{count} visninger",
     "moreVersions": "+{count} mere",
     "select": "Vælg",
-    "creditCost": "{credits} kreditter"
+    "creditCost": "{credits} kreditter",
+    "chooseFile": "Vælg en lydfil (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Vi kunne ikke finde nogen lydkilder. Prøv at ændre kunstneren eller titlen ovenfor og søg igen, eller tilføj din egen lyd via en URL eller filupload.",
+    "pasteUrl": "Indsæt URL",
+    "researchFailed": "Søgning mislykkedes. Prøv igen.",
+    "searchAgain": "Søg igen",
+    "selectFailed": "Kunne ikke vælge lyd",
+    "uploadFailed": "Upload mislykkedes. Prøv igen.",
+    "urlFailed": "Kunne ikke bruge den URL. Prøv en anden kilde.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Brug denne fil",
+    "useThisUrl": "Brug denne URL",
+    "artistLabel": "Kunstner",
+    "loading": "Indlæser...",
+    "titleLabel": "Titel",
+    "uploadFileAction": "Upload fil"
   },
   "audioEditor": {
     "loading": "Indlæser lydredigeringsprogram...",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -760,7 +760,22 @@
     "views": "{count} Aufrufe",
     "moreVersions": "+{count} weitere",
     "select": "Auswählen",
-    "creditCost": "{credits} Guthaben"
+    "creditCost": "{credits} Guthaben",
+    "chooseFile": "Wähle eine Audiodatei (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Wir konnten keine Audioquellen finden. Versuche, den Künstler oder Titel oben zu bearbeiten und erneut zu suchen, oder verwende dein eigenes Audio per URL oder Datei-Upload.",
+    "pasteUrl": "URL einfügen",
+    "researchFailed": "Suche fehlgeschlagen. Bitte versuche es erneut.",
+    "searchAgain": "Erneut suchen",
+    "selectFailed": "Audio konnte nicht ausgewählt werden",
+    "uploadFailed": "Upload fehlgeschlagen. Bitte versuche es erneut.",
+    "urlFailed": "Diese URL konnte nicht verwendet werden. Versuche eine andere Quelle.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Diese Datei verwenden",
+    "useThisUrl": "Diese URL verwenden",
+    "artistLabel": "Künstler",
+    "loading": "Laden...",
+    "titleLabel": "Titel",
+    "uploadFileAction": "Datei hochladen"
   },
   "audioEditor": {
     "loading": "Lade Audio-Editor...",

--- a/frontend/messages/el.json
+++ b/frontend/messages/el.json
@@ -760,7 +760,22 @@
     "views": "{count} προβολές",
     "moreVersions": "+{count} ακόμα",
     "select": "Επιλογή",
-    "creditCost": "{credits} μονάδες"
+    "creditCost": "{credits} μονάδες",
+    "chooseFile": "Επίλεξε ένα αρχείο ήχου (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Δεν μπορέσαμε να βρούμε πηγές ήχου. Δοκίμασε να επεξεργαστείς τον καλλιτέχνη ή τον τίτλο παραπάνω και να αναζητήσεις ξανά, ή πρόσθεσε τον δικό σου ήχο με ένα URL ή ανεβάζοντας ένα αρχείο.",
+    "pasteUrl": "Επικόλληση URL",
+    "researchFailed": "Η αναζήτηση απέτυχε. Παρακαλώ δοκίμασε ξανά.",
+    "searchAgain": "Αναζήτησε ξανά",
+    "selectFailed": "Αποτυχία επιλογής ήχου",
+    "uploadFailed": "Το ανέβασμα απέτυχε. Παρακαλώ δοκίμασε ξανά.",
+    "urlFailed": "Δεν ήταν δυνατή η χρήση αυτού του URL. Δοκίμασε μια άλλη πηγή.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Χρησιμοποίησε αυτό το αρχείο",
+    "useThisUrl": "Χρησιμοποίησε αυτό το URL",
+    "artistLabel": "Καλλιτέχνης",
+    "loading": "Φόρτωση...",
+    "titleLabel": "Τίτλος",
+    "uploadFileAction": "Ανέβασμα αρχείου"
   },
   "audioEditor": {
     "loading": "Φόρτωση επεξεργαστή ήχου...",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -763,7 +763,22 @@
     "views": "{count} views",
     "moreVersions": "+{count} more",
     "select": "Select",
-    "creditCost": "{credits} credits"
+    "creditCost": "{credits} credits",
+    "loading": "Loading...",
+    "artistLabel": "Artist",
+    "titleLabel": "Title",
+    "searchAgain": "Search again",
+    "pasteUrl": "Paste URL",
+    "uploadFileAction": "Upload file",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisUrl": "Use this URL",
+    "useThisFile": "Use this file",
+    "chooseFile": "Choose an audio file (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "We couldn't find any audio sources. Try editing the artist or title above and searching again, or provide your own audio with a URL or file upload.",
+    "selectFailed": "Failed to select audio",
+    "researchFailed": "Search failed. Please try again.",
+    "urlFailed": "Couldn't use that URL. Try another source.",
+    "uploadFailed": "Upload failed. Please try again."
   },
   "audioEditor": {
     "loading": "Loading audio editor...",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -760,7 +760,22 @@
     "views": "{count} vistas",
     "moreVersions": "+{count} más",
     "select": "Seleccionar",
-    "creditCost": "{credits} créditos"
+    "creditCost": "{credits} créditos",
+    "chooseFile": "Elige un archivo de audio (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "No pudimos encontrar ninguna fuente de audio. Intenta editar el artista o el título arriba y buscar de nuevo, o proporciona tu propio audio con una URL o subiendo un archivo.",
+    "pasteUrl": "Pegar URL",
+    "researchFailed": "Error en la búsqueda. Por favor, inténtalo de nuevo.",
+    "searchAgain": "Buscar de nuevo",
+    "selectFailed": "Error al seleccionar el audio",
+    "uploadFailed": "Error en la subida. Por favor, inténtalo de nuevo.",
+    "urlFailed": "No se pudo usar esa URL. Intenta con otra fuente.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Usar este archivo",
+    "useThisUrl": "Usar esta URL",
+    "artistLabel": "Artista",
+    "loading": "Cargando...",
+    "titleLabel": "Título",
+    "uploadFileAction": "Subir archivo"
   },
   "audioEditor": {
     "loading": "Cargando editor de audio...",

--- a/frontend/messages/fi.json
+++ b/frontend/messages/fi.json
@@ -760,7 +760,22 @@
     "views": "{count} katselukertaa",
     "moreVersions": "+{count} muuta",
     "select": "Valitse",
-    "creditCost": "{credits} krediittiä"
+    "creditCost": "{credits} krediittiä",
+    "chooseFile": "Valitse äänitiedosto (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Emme löytäneet äänilähteitä. Kokeile muokata esittäjää tai kappaleen nimeä yllä ja hae uudelleen, tai lisää oma äänitiedostosi URL-osoitteella tai lataamalla tiedosto.",
+    "pasteUrl": "Liitä URL-osoite",
+    "researchFailed": "Haku epäonnistui. Yritä uudelleen.",
+    "searchAgain": "Hae uudelleen",
+    "selectFailed": "Äänitiedoston valinta epäonnistui",
+    "uploadFailed": "Lataus epäonnistui. Yritä uudelleen.",
+    "urlFailed": "Tuota URL-osoitetta ei voitu käyttää. Kokeile toista lähdettä.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Käytä tätä tiedostoa",
+    "useThisUrl": "Käytä tätä URL-osoitetta",
+    "artistLabel": "Artisti",
+    "loading": "Ladataan...",
+    "titleLabel": "Nimi",
+    "uploadFileAction": "Lataa tiedosto"
   },
   "audioEditor": {
     "loading": "Ladataan äänieditoria...",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -760,7 +760,22 @@
     "views": "{count} vues",
     "moreVersions": "+{count} de plus",
     "select": "Sélectionner",
-    "creditCost": "{credits} crédits"
+    "creditCost": "{credits} crédits",
+    "chooseFile": "Choisis un fichier audio (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Nous n'avons trouvé aucune source audio. Essaie de modifier l'artiste ou le titre ci-dessus et de chercher à nouveau, ou ajoute ton propre audio via une URL ou en important un fichier.",
+    "pasteUrl": "Coller l'URL",
+    "researchFailed": "La recherche a échoué. Réessaie.",
+    "searchAgain": "Chercher à nouveau",
+    "selectFailed": "Impossible de sélectionner l'audio",
+    "uploadFailed": "L'importation a échoué. Réessaie.",
+    "urlFailed": "Impossible d'utiliser cette URL. Essaie une autre source.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Utiliser ce fichier",
+    "useThisUrl": "Utiliser cette URL",
+    "artistLabel": "Artiste",
+    "loading": "Chargement...",
+    "titleLabel": "Titre",
+    "uploadFileAction": "Importer un fichier"
   },
   "audioEditor": {
     "loading": "Chargement de l'éditeur audio...",

--- a/frontend/messages/he.json
+++ b/frontend/messages/he.json
@@ -760,7 +760,22 @@
     "views": "{count} צפיות",
     "moreVersions": "+{count} נוספים",
     "select": "בחר",
-    "creditCost": "{credits} קרדיטים"
+    "creditCost": "{credits} קרדיטים",
+    "chooseFile": "בחירת קובץ שמע (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "לא הצלחנו למצוא מקורות שמע. נסו לערוך את שם האמן או השיר למעלה ולחפש שוב, או הוסיפו שמע משלכם באמצעות קישור או העלאת קובץ.",
+    "pasteUrl": "הדבקת קישור",
+    "researchFailed": "החיפוש נכשל. אנא נסו שוב.",
+    "searchAgain": "חיפוש מחדש",
+    "selectFailed": "בחירת השמע נכשלה",
+    "uploadFailed": "ההעלאה נכשלה. אנא נסו שוב.",
+    "urlFailed": "לא הצלחנו להשתמש בקישור הזה. נסו מקור אחר.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "שימוש בקובץ זה",
+    "useThisUrl": "שימוש בקישור זה",
+    "artistLabel": "אומן",
+    "loading": "טוען...",
+    "titleLabel": "כותרת",
+    "uploadFileAction": "העלאת קובץ"
   },
   "audioEditor": {
     "loading": "טוען עורך אודיו...",

--- a/frontend/messages/hi.json
+++ b/frontend/messages/hi.json
@@ -760,7 +760,22 @@
     "views": "{count} व्यूज़",
     "moreVersions": "+{count} और",
     "select": "चुनो",
-    "creditCost": "{credits} क्रेडिट"
+    "creditCost": "{credits} क्रेडिट",
+    "chooseFile": "एक ऑडियो फ़ाइल चुनो (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "हमें कोई ऑडियो स्रोत नहीं मिला। ऊपर दिए गए कलाकार या शीर्षक को बदलकर फिर से खोजने की कोशिश करो, या URL या फ़ाइल अपलोड करके अपना खुद का ऑडियो जोड़ो।",
+    "pasteUrl": "URL पेस्ट करो",
+    "researchFailed": "खोज विफल रही। कृपया फिर से कोशिश करो।",
+    "searchAgain": "फिर से खोजो",
+    "selectFailed": "ऑडियो चुनने में विफल",
+    "uploadFailed": "अपलोड विफल रहा। कृपया फिर से कोशिश करो।",
+    "urlFailed": "उस URL का उपयोग नहीं हो सका। किसी दूसरे स्रोत की कोशिश करो।",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "इस फ़ाइल का उपयोग करो",
+    "useThisUrl": "इस URL का उपयोग करो",
+    "artistLabel": "कलाकार",
+    "loading": "लोड हो रहा है...",
+    "titleLabel": "टाइटल",
+    "uploadFileAction": "फ़ाइल अपलोड करो"
   },
   "audioEditor": {
     "loading": "ऑडियो एडिटर लोड हो रहा है...",

--- a/frontend/messages/hr.json
+++ b/frontend/messages/hr.json
@@ -760,7 +760,22 @@
     "views": "{count} pregleda",
     "moreVersions": "+{count} više",
     "select": "Odaberi",
-    "creditCost": "{credits} kredita"
+    "creditCost": "{credits} kredita",
+    "chooseFile": "Odaberi audio datoteku (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Nismo uspjeli pronaći nijedan audio izvor. Pokušaj izmijeniti izvođača ili naslov iznad i pretražiti ponovno, ili dodaj vlastiti audio putem URL-a ili učitavanjem datoteke.",
+    "pasteUrl": "Zalijepi URL",
+    "researchFailed": "Pretraživanje nije uspjelo. Pokušaj ponovno.",
+    "searchAgain": "Pretraži ponovno",
+    "selectFailed": "Odabir audija nije uspio",
+    "uploadFailed": "Učitavanje nije uspjelo. Pokušaj ponovno.",
+    "urlFailed": "Nismo mogli upotrijebiti taj URL. Pokušaj s drugim izvorom.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Koristi ovu datoteku",
+    "useThisUrl": "Koristi ovaj URL",
+    "artistLabel": "Izvođač",
+    "loading": "Učitavanje...",
+    "titleLabel": "Naslov",
+    "uploadFileAction": "Prenesi datoteku"
   },
   "audioEditor": {
     "loading": "Učitavanje audio uređivača...",

--- a/frontend/messages/hu.json
+++ b/frontend/messages/hu.json
@@ -760,7 +760,22 @@
     "views": "{count} megtekintés",
     "moreVersions": "+{count} további",
     "select": "Kiválasztás",
-    "creditCost": "{credits} kredit"
+    "creditCost": "{credits} kredit",
+    "chooseFile": "Válassz egy hangfájlt (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Nem találtunk hangforrást. Próbáld meg módosítani a fenti előadót vagy címet, és keress újra, vagy adj meg egy saját hangfájlt URL-en keresztül vagy feltöltéssel.",
+    "pasteUrl": "URL beillesztése",
+    "researchFailed": "A keresés nem sikerült. Kérlek, próbáld újra.",
+    "searchAgain": "Új keresés",
+    "selectFailed": "Nem sikerült kiválasztani a hanganyagot",
+    "uploadFailed": "A feltöltés nem sikerült. Kérlek, próbáld újra.",
+    "urlFailed": "Ezt az URL-t nem tudtuk használni. Próbálj meg egy másik forrást.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Használd ezt a fájlt",
+    "useThisUrl": "Használd ezt az URL-t",
+    "artistLabel": "Előadó",
+    "loading": "Betöltés...",
+    "titleLabel": "Cím",
+    "uploadFileAction": "Fájl feltöltése"
   },
   "audioEditor": {
     "loading": "Hangszerkesztő betöltése...",

--- a/frontend/messages/id.json
+++ b/frontend/messages/id.json
@@ -760,7 +760,22 @@
     "views": "{count} tayangan",
     "moreVersions": "+{count} lainnya",
     "select": "Pilih",
-    "creditCost": "{credits} kredit"
+    "creditCost": "{credits} kredit",
+    "chooseFile": "Pilih file audio (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Kami tidak dapat menemukan sumber audio. Coba edit nama artis atau judul di atas dan cari lagi, atau gunakan audio Anda sendiri melalui URL atau unggah file.",
+    "pasteUrl": "Tempel URL",
+    "researchFailed": "Pencarian gagal. Silakan coba lagi.",
+    "searchAgain": "Cari lagi",
+    "selectFailed": "Gagal memilih audio",
+    "uploadFailed": "Gagal mengunggah. Silakan coba lagi.",
+    "urlFailed": "Tidak dapat menggunakan URL tersebut. Coba sumber lain.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Gunakan file ini",
+    "useThisUrl": "Gunakan URL ini",
+    "artistLabel": "Artis",
+    "loading": "Memuat...",
+    "titleLabel": "Judul",
+    "uploadFileAction": "Unggah file"
   },
   "audioEditor": {
     "loading": "Memuat editor audio...",

--- a/frontend/messages/it.json
+++ b/frontend/messages/it.json
@@ -760,7 +760,22 @@
     "views": "{count} visualizzazioni",
     "moreVersions": "+{count} altre",
     "select": "Seleziona",
-    "creditCost": "{credits} crediti"
+    "creditCost": "{credits} crediti",
+    "chooseFile": "Scegli un file audio (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Non abbiamo trovato nessuna fonte audio. Prova a modificare l'artista o il titolo qui sopra e cerca di nuovo, oppure fornisci il tuo audio tramite URL o caricando un file.",
+    "pasteUrl": "Incolla URL",
+    "researchFailed": "Ricerca non riuscita. Riprova.",
+    "searchAgain": "Cerca di nuovo",
+    "selectFailed": "Impossibile selezionare l'audio",
+    "uploadFailed": "Caricamento non riuscito. Riprova.",
+    "urlFailed": "Impossibile usare quell'URL. Prova un'altra fonte.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Usa questo file",
+    "useThisUrl": "Usa questo URL",
+    "artistLabel": "Artista",
+    "loading": "Caricamento in corso...",
+    "titleLabel": "Titolo",
+    "uploadFileAction": "Carica file"
   },
   "audioEditor": {
     "loading": "Caricamento editor audio...",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -760,7 +760,22 @@
     "views": "{count} 回視聴",
     "moreVersions": "他 {count} 件",
     "select": "選択",
-    "creditCost": "{credits} クレジット"
+    "creditCost": "{credits} クレジット",
+    "chooseFile": "音声ファイルを選択 (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "音源が見つかりませんでした。上のアーティスト名やタイトルを編集して再検索するか、URLまたはファイルのアップロードでご自身の音源を追加してみてください。",
+    "pasteUrl": "URLを貼り付け",
+    "researchFailed": "検索に失敗しました。もう一度お試しください。",
+    "searchAgain": "もう一度検索",
+    "selectFailed": "音源の選択に失敗しました",
+    "uploadFailed": "アップロードに失敗しました。もう一度お試しください。",
+    "urlFailed": "そのURLは使用できませんでした。別の音源をお試しください。",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "このファイルを使用",
+    "useThisUrl": "このURLを使用",
+    "artistLabel": "アーティスト",
+    "loading": "読み込み中...",
+    "titleLabel": "タイトル",
+    "uploadFileAction": "ファイルをアップロード"
   },
   "audioEditor": {
     "loading": "オーディオエディタを読み込み中...",

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -760,7 +760,22 @@
     "views": "조회수 {count}회",
     "moreVersions": "+{count}개 더 보기",
     "select": "선택",
-    "creditCost": "{credits} 크레딧"
+    "creditCost": "{credits} 크레딧",
+    "chooseFile": "오디오 파일을 선택해 주세요 (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "오디오 소스를 찾을 수 없습니다. 위에서 아티스트나 제목을 수정하여 다시 검색하거나, URL 또는 파일 업로드로 직접 오디오를 추가해 주세요.",
+    "pasteUrl": "URL 붙여넣기",
+    "researchFailed": "검색에 실패했습니다. 다시 시도해 주세요.",
+    "searchAgain": "다시 검색하기",
+    "selectFailed": "오디오 선택에 실패했습니다",
+    "uploadFailed": "업로드에 실패했습니다. 다시 시도해 주세요.",
+    "urlFailed": "해당 URL은 사용할 수 없습니다. 다른 소스로 시도해 주세요.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "이 파일 사용하기",
+    "useThisUrl": "이 URL 사용하기",
+    "artistLabel": "아티스트",
+    "loading": "로딩 중...",
+    "titleLabel": "제목",
+    "uploadFileAction": "파일 업로드"
   },
   "audioEditor": {
     "loading": "오디오 편집기 불러오는 중...",

--- a/frontend/messages/ms.json
+++ b/frontend/messages/ms.json
@@ -760,7 +760,22 @@
     "views": "{count} tontonan",
     "moreVersions": "+{count} lagi",
     "select": "Pilih",
-    "creditCost": "{credits} kredit"
+    "creditCost": "{credits} kredit",
+    "chooseFile": "Pilih fail audio (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Kami tidak menemui sebarang sumber audio. Cuba sunting artis atau tajuk di atas dan cari semula, atau gunakan audio anda sendiri melalui URL atau muat naik fail.",
+    "pasteUrl": "Tampal URL",
+    "researchFailed": "Carian gagal. Sila cuba lagi.",
+    "searchAgain": "Cari semula",
+    "selectFailed": "Gagal memilih audio",
+    "uploadFailed": "Muat naik gagal. Sila cuba lagi.",
+    "urlFailed": "Tidak dapat menggunakan URL tersebut. Cuba sumber lain.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Gunakan fail ini",
+    "useThisUrl": "Gunakan URL ini",
+    "artistLabel": "Artis",
+    "loading": "Memuatkan...",
+    "titleLabel": "Tajuk",
+    "uploadFileAction": "Muat naik fail"
   },
   "audioEditor": {
     "loading": "Memuatkan editor audio...",

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -760,7 +760,22 @@
     "views": "{count} visninger",
     "moreVersions": "+{count} flere",
     "select": "Velg",
-    "creditCost": "{credits} kreditter"
+    "creditCost": "{credits} kreditter",
+    "chooseFile": "Velg en lydfil (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Vi fant ingen lydkilder. Prøv å endre artist eller tittel ovenfor og søk på nytt, eller legg til din egen lyd via en URL eller filopplasting.",
+    "pasteUrl": "Lim inn URL",
+    "researchFailed": "Søket mislyktes. Prøv igjen.",
+    "searchAgain": "Søk på nytt",
+    "selectFailed": "Kunne ikke velge lyd",
+    "uploadFailed": "Opplastingen mislyktes. Prøv igjen.",
+    "urlFailed": "Kunne ikke bruke den URL-en. Prøv en annen kilde.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Bruk denne filen",
+    "useThisUrl": "Bruk denne URL-en",
+    "artistLabel": "Artist",
+    "loading": "Laster...",
+    "titleLabel": "Tittel",
+    "uploadFileAction": "Last opp fil"
   },
   "audioEditor": {
     "loading": "Laster inn lydredigering...",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -760,7 +760,22 @@
     "views": "{count} weergaven",
     "moreVersions": "+{count} meer",
     "select": "Selecteren",
-    "creditCost": "{credits} credits"
+    "creditCost": "{credits} credits",
+    "chooseFile": "Kies een audiobestand (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "We konden geen audiobronnen vinden. Probeer de artiest of titel hierboven aan te passen en opnieuw te zoeken, of voeg je eigen audio toe via een URL of bestandsupload.",
+    "pasteUrl": "Plak URL",
+    "researchFailed": "Zoeken mislukt. Probeer het opnieuw.",
+    "searchAgain": "Opnieuw zoeken",
+    "selectFailed": "Audio selecteren mislukt",
+    "uploadFailed": "Uploaden mislukt. Probeer het opnieuw.",
+    "urlFailed": "We konden die URL niet gebruiken. Probeer een andere bron.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Gebruik dit bestand",
+    "useThisUrl": "Gebruik deze URL",
+    "artistLabel": "Artiest",
+    "loading": "Laden...",
+    "titleLabel": "Titel",
+    "uploadFileAction": "Bestand uploaden"
   },
   "audioEditor": {
     "loading": "Audio-editor laden...",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -760,7 +760,22 @@
     "views": "{count} wyświetleń",
     "moreVersions": "+{count} więcej",
     "select": "Wybierz",
-    "creditCost": "{credits} kredytów"
+    "creditCost": "{credits} kredytów",
+    "chooseFile": "Wybierz plik audio (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Nie znaleźliśmy żadnych źródeł audio. Spróbuj edytować wykonawcę lub tytuł powyżej i wyszukać ponownie, albo dodaj własne audio za pomocą adresu URL lub przesyłając plik.",
+    "pasteUrl": "Wklej adres URL",
+    "researchFailed": "Wyszukiwanie nie powiodło się. Spróbuj ponownie.",
+    "searchAgain": "Wyszukaj ponownie",
+    "selectFailed": "Nie udało się wybrać audio",
+    "uploadFailed": "Przesyłanie nie powiodło się. Spróbuj ponownie.",
+    "urlFailed": "Nie można użyć tego adresu URL. Spróbuj innego źródła.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Użyj tego pliku",
+    "useThisUrl": "Użyj tego adresu URL",
+    "artistLabel": "Wykonawca",
+    "loading": "Wczytywanie...",
+    "titleLabel": "Tytuł",
+    "uploadFileAction": "Wgraj plik"
   },
   "audioEditor": {
     "loading": "Wczytywanie edytora audio...",

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -760,7 +760,22 @@
     "views": "{count} visualizações",
     "moreVersions": "+{count} mais",
     "select": "Selecionar",
-    "creditCost": "{credits} créditos"
+    "creditCost": "{credits} créditos",
+    "chooseFile": "Escolha um arquivo de áudio (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Não conseguimos encontrar nenhuma fonte de áudio. Tente editar o artista ou título acima e pesquisar novamente, ou envie seu próprio áudio via URL ou upload de arquivo.",
+    "pasteUrl": "Colar URL",
+    "researchFailed": "Falha na pesquisa. Por favor, tente novamente.",
+    "searchAgain": "Pesquisar novamente",
+    "selectFailed": "Falha ao selecionar o áudio",
+    "uploadFailed": "Falha no upload. Por favor, tente novamente.",
+    "urlFailed": "Não foi possível usar esse URL. Tente outra fonte.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Usar este arquivo",
+    "useThisUrl": "Usar este URL",
+    "artistLabel": "Artista",
+    "loading": "Carregando...",
+    "titleLabel": "Título",
+    "uploadFileAction": "Enviar arquivo"
   },
   "audioEditor": {
     "loading": "Carregando editor de áudio...",

--- a/frontend/messages/ro.json
+++ b/frontend/messages/ro.json
@@ -760,7 +760,22 @@
     "views": "{count} vizualizări",
     "moreVersions": "+{count} mai multe",
     "select": "Selectează",
-    "creditCost": "{credits} credite"
+    "creditCost": "{credits} credite",
+    "chooseFile": "Alege un fișier audio (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Nu am putut găsi nicio sursă audio. Încearcă să editezi artistul sau titlul de mai sus și să cauți din nou, sau adaugă propriul fișier audio printr-un URL sau prin încărcare.",
+    "pasteUrl": "Lipește URL-ul",
+    "researchFailed": "Căutarea a eșuat. Încearcă din nou.",
+    "searchAgain": "Caută din nou",
+    "selectFailed": "Nu s-a putut selecta fișierul audio",
+    "uploadFailed": "Încărcarea a eșuat. Încearcă din nou.",
+    "urlFailed": "Nu am putut folosi acel URL. Încearcă o altă sursă.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Folosește acest fișier",
+    "useThisUrl": "Folosește acest URL",
+    "artistLabel": "Artist",
+    "loading": "Se încarcă...",
+    "titleLabel": "Titlu",
+    "uploadFileAction": "Încarcă fișier"
   },
   "audioEditor": {
     "loading": "Se încarcă editorul audio...",

--- a/frontend/messages/ru.json
+++ b/frontend/messages/ru.json
@@ -760,7 +760,22 @@
     "views": "{count} просмотров",
     "moreVersions": "Еще +{count}",
     "select": "Выбрать",
-    "creditCost": "{credits} кредитов"
+    "creditCost": "{credits} кредитов",
+    "chooseFile": "Выбери аудиофайл (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Мы не смогли найти аудио. Попробуй изменить исполнителя или название выше и поискать снова, либо добавь свое аудио по URL или загрузи файл.",
+    "pasteUrl": "Вставь URL",
+    "researchFailed": "Ошибка поиска. Попробуй еще раз.",
+    "searchAgain": "Искать снова",
+    "selectFailed": "Не удалось выбрать аудио",
+    "uploadFailed": "Ошибка загрузки. Попробуй еще раз.",
+    "urlFailed": "Не удалось использовать этот URL. Попробуй другой источник.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Использовать этот файл",
+    "useThisUrl": "Использовать этот URL",
+    "artistLabel": "Исполнитель",
+    "loading": "Загрузка...",
+    "titleLabel": "Название",
+    "uploadFileAction": "Загрузить файл"
   },
   "audioEditor": {
     "loading": "Загрузка аудиоредактора...",

--- a/frontend/messages/sk.json
+++ b/frontend/messages/sk.json
@@ -760,7 +760,22 @@
     "views": "{count} zhliadnutí",
     "moreVersions": "+{count} ďalších",
     "select": "Vybrať",
-    "creditCost": "{credits} kreditov"
+    "creditCost": "{credits} kreditov",
+    "chooseFile": "Vyber zvukový súbor (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Nenašli sme žiadne zdroje zvuku. Skús upraviť interpreta alebo názov vyššie a vyhľadať znova, alebo pridaj vlastný zvuk pomocou URL adresy či nahratím súboru.",
+    "pasteUrl": "Vlož URL",
+    "researchFailed": "Vyhľadávanie zlyhalo. Skús to znova.",
+    "searchAgain": "Hľadať znova",
+    "selectFailed": "Nepodarilo sa vybrať zvuk",
+    "uploadFailed": "Nahrávanie zlyhalo. Skús to znova.",
+    "urlFailed": "Túto URL adresu nebolo možné použiť. Skús iný zdroj.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Použiť tento súbor",
+    "useThisUrl": "Použiť túto URL",
+    "artistLabel": "Interpret",
+    "loading": "Načítava sa...",
+    "titleLabel": "Názov",
+    "uploadFileAction": "Nahrať súbor"
   },
   "audioEditor": {
     "loading": "Načítava sa editor zvuku...",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -760,7 +760,22 @@
     "views": "{count} visningar",
     "moreVersions": "+{count} fler",
     "select": "Välj",
-    "creditCost": "{credits} krediter"
+    "creditCost": "{credits} krediter",
+    "chooseFile": "Välj en ljudfil (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Vi kunde inte hitta några ljudkällor. Prova att ändra artist eller titel ovan och sök igen, eller lägg till ditt eget ljud via en URL eller filuppladdning.",
+    "pasteUrl": "Klistra in URL",
+    "researchFailed": "Sökningen misslyckades. Försök igen.",
+    "searchAgain": "Sök igen",
+    "selectFailed": "Det gick inte att välja ljud",
+    "uploadFailed": "Uppladdningen misslyckades. Försök igen.",
+    "urlFailed": "Det gick inte att använda den URL:en. Prova en annan källa.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Använd den här filen",
+    "useThisUrl": "Använd den här URL:en",
+    "artistLabel": "Artist",
+    "loading": "Laddar...",
+    "titleLabel": "Titel",
+    "uploadFileAction": "Ladda upp fil"
   },
   "audioEditor": {
     "loading": "Laddar ljudredigerare...",

--- a/frontend/messages/th.json
+++ b/frontend/messages/th.json
@@ -760,7 +760,22 @@
     "views": "{count} ยอดดู",
     "moreVersions": "อีก +{count}",
     "select": "เลือก",
-    "creditCost": "{credits} เครดิต"
+    "creditCost": "{credits} เครดิต",
+    "chooseFile": "เลือกไฟล์เสียง (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "เราไม่พบแหล่งที่มาของเสียงเลย ลองแก้ไขชื่อศิลปินหรือชื่อเพลงด้านบนแล้วค้นหาอีกครั้ง หรือใช้ไฟล์เสียงของคุณเองโดยการระบุ URL หรืออัปโหลดไฟล์",
+    "pasteUrl": "วาง URL",
+    "researchFailed": "ค้นหาไม่สำเร็จ กรุณาลองใหม่อีกครั้ง",
+    "searchAgain": "ค้นหาอีกครั้ง",
+    "selectFailed": "เลือกไฟล์เสียงไม่สำเร็จ",
+    "uploadFailed": "อัปโหลดไม่สำเร็จ กรุณาลองใหม่อีกครั้ง",
+    "urlFailed": "ไม่สามารถใช้ URL นั้นได้ ลองใช้แหล่งที่มาอื่น",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "ใช้ไฟล์นี้",
+    "useThisUrl": "ใช้ URL นี้",
+    "artistLabel": "ศิลปิน",
+    "loading": "กำลังโหลด...",
+    "titleLabel": "ชื่อเพลง",
+    "uploadFileAction": "อัปโหลดไฟล์"
   },
   "audioEditor": {
     "loading": "กำลังโหลดโปรแกรมแก้ไขเสียง...",

--- a/frontend/messages/tl.json
+++ b/frontend/messages/tl.json
@@ -760,7 +760,22 @@
     "views": "{count} views",
     "moreVersions": "+{count} pa",
     "select": "Piliin",
-    "creditCost": "{credits} credits"
+    "creditCost": "{credits} credits",
+    "chooseFile": "Pumili ng audio file (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Wala kaming nahanap na audio sources. Subukang i-edit ang artist o pamagat sa itaas at maghanap ulit, o magbigay ng sarili mong audio gamit ang URL o file upload.",
+    "pasteUrl": "I-paste ang URL",
+    "researchFailed": "Nabigo ang paghahanap. Pakisubukan ulit.",
+    "searchAgain": "Maghanap ulit",
+    "selectFailed": "Hindi napili ang audio",
+    "uploadFailed": "Nabigo ang pag-upload. Pakisubukan ulit.",
+    "urlFailed": "Hindi magamit ang URL na iyon. Subukan ang ibang source.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Gamitin ang file na ito",
+    "useThisUrl": "Gamitin ang URL na ito",
+    "artistLabel": "Artist",
+    "loading": "Nagloload...",
+    "titleLabel": "Pamagat",
+    "uploadFileAction": "Mag-upload ng file"
   },
   "audioEditor": {
     "loading": "Nilo-load ang audio editor...",

--- a/frontend/messages/tr.json
+++ b/frontend/messages/tr.json
@@ -760,7 +760,22 @@
     "views": "{count} görüntülenme",
     "moreVersions": "+{count} daha",
     "select": "Seç",
-    "creditCost": "{credits} kredi"
+    "creditCost": "{credits} kredi",
+    "chooseFile": "Bir ses dosyası seç (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Hiçbir ses kaynağı bulamadık. Yukarıdaki sanatçı veya başlık bilgisini düzenleyip tekrar aramayı dene ya da bir URL veya dosya yükleyerek kendi ses dosyanı ekle.",
+    "pasteUrl": "URL'yi yapıştır",
+    "researchFailed": "Arama başarısız oldu. Lütfen tekrar dene.",
+    "searchAgain": "Tekrar ara",
+    "selectFailed": "Ses seçilemedi",
+    "uploadFailed": "Yükleme başarısız oldu. Lütfen tekrar dene.",
+    "urlFailed": "Bu URL kullanılamadı. Başka bir kaynak dene.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Bu dosyayı kullan",
+    "useThisUrl": "Bu URL'yi kullan",
+    "artistLabel": "Sanatçı",
+    "loading": "Yükleniyor...",
+    "titleLabel": "Başlık",
+    "uploadFileAction": "Dosya yükle"
   },
   "audioEditor": {
     "loading": "Ses düzenleyici yükleniyor...",

--- a/frontend/messages/uk.json
+++ b/frontend/messages/uk.json
@@ -760,7 +760,22 @@
     "views": "{count} переглядів",
     "moreVersions": "+ще {count}",
     "select": "Вибрати",
-    "creditCost": "{credits} кредитів"
+    "creditCost": "{credits} кредитів",
+    "chooseFile": "Вибери аудіофайл (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Ми не змогли знайти жодних аудіоджерел. Спробуй змінити виконавця або назву вище та повторити пошук, або додай власне аудіо за допомогою URL чи завантаж файл.",
+    "pasteUrl": "Встав URL",
+    "researchFailed": "Помилка пошуку. Будь ласка, спробуй ще раз.",
+    "searchAgain": "Шукати знову",
+    "selectFailed": "Не вдалося вибрати аудіо",
+    "uploadFailed": "Помилка завантаження. Будь ласка, спробуй ще раз.",
+    "urlFailed": "Не вдалося використати цей URL. Спробуй інше джерело.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Використати цей файл",
+    "useThisUrl": "Використати цей URL",
+    "artistLabel": "Виконавець",
+    "loading": "Завантаження...",
+    "titleLabel": "Назва",
+    "uploadFileAction": "Завантажити файл"
   },
   "audioEditor": {
     "loading": "Завантаження аудіоредактора...",

--- a/frontend/messages/vi.json
+++ b/frontend/messages/vi.json
@@ -760,7 +760,22 @@
     "views": "{count} lượt xem",
     "moreVersions": "+{count} phiên bản khác",
     "select": "Chọn",
-    "creditCost": "{credits} credit"
+    "creditCost": "{credits} credit",
+    "chooseFile": "Chọn tệp âm thanh (MP3, WAV, FLAC, M4A, OGG)",
+    "noResultsHelp": "Chúng tôi không tìm thấy nguồn âm thanh nào. Bạn hãy thử chỉnh sửa tên nghệ sĩ hoặc tiêu đề ở trên và tìm kiếm lại, hoặc tự cung cấp âm thanh bằng URL hoặc tải tệp lên.",
+    "pasteUrl": "Dán URL",
+    "researchFailed": "Tìm kiếm thất bại. Vui lòng thử lại.",
+    "searchAgain": "Tìm kiếm lại",
+    "selectFailed": "Không thể chọn âm thanh",
+    "uploadFailed": "Tải lên thất bại. Vui lòng thử lại.",
+    "urlFailed": "Không thể sử dụng URL đó. Bạn hãy thử một nguồn khác.",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "Sử dụng tệp này",
+    "useThisUrl": "Sử dụng URL này",
+    "artistLabel": "Nghệ sĩ",
+    "loading": "Đang tải...",
+    "titleLabel": "Tiêu đề",
+    "uploadFileAction": "Tải tệp lên"
   },
   "audioEditor": {
     "loading": "Đang tải trình chỉnh sửa âm thanh...",

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -760,7 +760,22 @@
     "views": "{count} 次观看",
     "moreVersions": "还有 {count} 个",
     "select": "选择",
-    "creditCost": "{credits} 积分"
+    "creditCost": "{credits} 积分",
+    "chooseFile": "选择音频文件（MP3、WAV、FLAC、M4A、OGG）",
+    "noResultsHelp": "未能找到任何音频源。请尝试修改上方的歌手或歌曲名并重新搜索，或者通过提供网址或上传文件来使用您自己的音频。",
+    "pasteUrl": "粘贴网址",
+    "researchFailed": "搜索失败。请重试。",
+    "searchAgain": "重新搜索",
+    "selectFailed": "选择音频失败",
+    "uploadFailed": "上传失败。请重试。",
+    "urlFailed": "无法使用该网址。请尝试其他来源。",
+    "urlPlaceholder": "https://youtube.com/watch?v=...",
+    "useThisFile": "使用此文件",
+    "useThisUrl": "使用此网址",
+    "artistLabel": "歌手",
+    "loading": "加载中...",
+    "titleLabel": "标题",
+    "uploadFileAction": "上传文件"
   },
   "audioEditor": {
     "loading": "正在加载音频编辑器...",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.192.7"
+version = "0.192.8"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Problem

In Bulk Mode (and single jobs), the "Choose audio" dialog was a **hard dead-end**. When a search returned nothing usable — 0 results, a transient flacfetch failure, or an auto-picked source that's unusable — the bulk worker parks the job in `AWAITING_AUDIO_SELECTION` with **empty** cached results. The dialog then showed "No audio sources found" with **no retry, no way to edit the title, and no manual source**, so the user was trapped.

Real-world trigger (batch `4af58968a64a`): two Arctic Monkeys tracks parked with 0 results (one a transient miss on a common track, one an over-long title), and three more stuck downloading the **same dead RED torrent** — all with no path forward.

## What this does

Adds a full recovery path to the shared `AudioSearchDialog` (used by bulk **and** single jobs):

- **Edit + Search again** — always-available editable artist/title with a re-search button. Edits apply to the job's search terms *and* display metadata.
- **Provide your own audio** — paste a YouTube/yt-dlp URL, or upload a file.
- **Graceful empty state** — a 400 (no cached results) renders as the empty state with the refine bar, not a red error; real network/5xx errors still surface.

### Backend (`audio_search.py`) — all guarded to `AWAITING_AUDIO_SELECTION`, tenant-gated, no new job, no double-charge (final duration billing reconciles post-download)
- `POST /{job_id}/research` — retry / edit-and-re-search. Empty results are a normal `200`.
- `POST /{job_id}/provide-url` — YouTube URLs go through the **async** audio-download worker; generic yt-dlp URLs download inline, bounded by a timeout (never strands a job).
- `POST /{job_id}/attach-upload-url` + `/attach-upload-complete` — signed-URL upload of the user's own file (extension allow-list + traversal-safe; the complete step pins the exact uploaded object).
- Factored the triplicated result serialization into `_build_result_response`.

## Testing
- 20 backend endpoint tests + 5 frontend dialog tests (all green); broader audio/jobs sweeps pass.
- i18n: 15 new `audioSearch` keys across all 33 locales.

## Review
Local CodeRabbit review completed (2 cycles, all 6 findings addressed, final pass 0 findings).

@coderabbitai ignore