### PR TITLE
fix(jobs): show job/log timestamps in the viewer's local timezone

### DIFF
--- a/backend/services/firestore_service.py
+++ b/backend/services/firestore_service.py
@@ -3,7 +3,7 @@ Firestore database operations for job management.
 """
 import logging
 from typing import Optional, Dict, Any, List
-from datetime import datetime
+from datetime import datetime, timezone
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 
@@ -87,7 +87,9 @@ class FirestoreService:
             # Create timeline event
             timeline_event = TimelineEvent(
                 status=status.value,
-                timestamp=datetime.utcnow().isoformat(),
+                # Timezone-aware UTC so the serialized ISO string carries a
+                # "+00:00" offset (see job_manager.create_job for rationale).
+                timestamp=datetime.now(timezone.utc).isoformat(),
                 progress=progress,
                 message=message,
                 metadata=timeline_metadata,

--- a/backend/services/job_manager.py
+++ b/backend/services/job_manager.py
@@ -10,7 +10,7 @@ This module handles the complete job lifecycle including:
 """
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, Dict, Any, List
 
 from backend.config import settings
@@ -80,7 +80,10 @@ class JobManager:
 
         job_id = str(uuid.uuid4())[:8]
         
-        now = datetime.utcnow()
+        # Timezone-aware UTC so the serialized ISO string carries a "+00:00"
+        # offset. A naive datetime.utcnow() serializes with no offset, and the
+        # frontend's Date() parser then mis-reads it as local time.
+        now = datetime.now(timezone.utc)
         job = Job(
             job_id=job_id,
             status=JobStatus.PENDING,  # New state machine starts with PENDING

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -6,6 +6,31 @@ Key insights for future AI agents working on this codebase.
 
 ---
 
+## Naive `datetime.utcnow()` → wrong timezone in the UI (Aug 2026)
+
+Job `created_at` and timeline/log timestamps were built from naive
+`datetime.utcnow()` and serialized via `model_dump(mode='json')` /
+`.isoformat()`, producing ISO strings with **no timezone offset**
+(`"2026-08-14T18:10:25.123456"`). Firestore stored them as plain strings and
+returned them verbatim. The frontend's `new Date(str)` parses an offset-less
+ISO date-time as **local** time, so the raw UTC wall-clock was shown
+unconverted — off by the viewer's UTC offset.
+
+Two-part fix:
+- **Display layer (`frontend/lib/utils.ts` → `parseServerDate`)**: treat
+  offset-less ISO date-times as UTC (append `Z`). This corrects *all* existing
+  data immediately, no migration. Use it for any backend timestamp before
+  `new Date()`/`toLocaleString()`.
+- **Write layer**: `datetime.now(timezone.utc)` so new strings carry `+00:00`.
+
+Takeaways: (1) never serialize a naive datetime to the client — always
+timezone-aware UTC; (2) fixing at the display layer beats a data migration when
+old rows are already ambiguous; (3) datetime arithmetic must guard for both
+naive and aware (`if dt.tzinfo is None: dt = dt.replace(tzinfo=timezone.utc)`),
+as `job_health_service` already did.
+
+---
+
 ## Cloudflare edge in front of Cloud Run — the SSL "dragon" (Jul 2026)
 
 Putting `api.nomadkaraoke.com` behind Cloudflare (WAF/rate-limit/origin-lock)

--- a/frontend/app/[locale]/app/page.tsx
+++ b/frontend/app/[locale]/app/page.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation"
 import { api, Job, getAccessToken } from "@/lib/api"
 import { useAuth } from "@/lib/auth"
 import { useAdminSettings } from "@/lib/admin-settings"
+import { parseServerDate } from "@/lib/utils"
 import { useJobNotifications, useVisibilityRefresh } from "@/hooks/use-notifications"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -293,7 +294,7 @@ function AppPageContent() {
               </p>
               <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
                 {user.referred_by_code && <>Referred with code <strong>{user.referred_by_code}</strong> · </>}
-                Expires {new Date(user.referral_discount_expires_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                Expires {parseServerDate(user.referral_discount_expires_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
               </p>
             </div>
             <button

--- a/frontend/components/credits/BuyCreditsDialog.tsx
+++ b/frontend/components/credits/BuyCreditsDialog.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { api, CreditPackage, getReferralInterstitial } from '@/lib/api'
 import { useAuth } from '@/lib/auth'
 import { useTranslations, useLocale } from 'next-intl'
+import { parseServerDate } from '@/lib/utils'
 
 interface BuyCreditsDialogProps {
   open: boolean
@@ -101,7 +102,7 @@ export function BuyCreditsDialog({ open, onClose }: BuyCreditsDialogProps) {
               )}
               {user.referral_discount_expires_at && (
                 <p className="text-green-600/70 dark:text-green-400/70 text-xs mt-1">
-                  {tRef('appliedAtCheckout')} · {tRef('expires', { date: new Date(user.referral_discount_expires_at).toLocaleDateString(locale, { year: 'numeric', month: 'short', day: 'numeric' }) })}
+                  {tRef('appliedAtCheckout')} · {tRef('expires', { date: parseServerDate(user.referral_discount_expires_at).toLocaleDateString(locale, { year: 'numeric', month: 'short', day: 'numeric' }) })}
                 </p>
               )}
             </div>

--- a/frontend/components/job/JobCard.tsx
+++ b/frontend/components/job/JobCard.tsx
@@ -14,6 +14,7 @@ import { BuyCreditsDialog } from "@/components/credits/BuyCreditsDialog"
 import { getJobStep, formatStepIndicator, getJobProgressPercent, isWaitingForEncodingCapacity, isVisibilityChangeInProgress } from "@/lib/job-status"
 import { useAuth } from "@/lib/auth"
 import { useDurationConfirm } from "@/hooks/use-duration-confirm"
+import { parseServerDate } from "@/lib/utils"
 
 /**
  * StatusIndicator component - Shows step-based progress with visual indicator
@@ -113,7 +114,7 @@ export function JobCard({ job, onRefresh, showAdminControls }: JobCardProps) {
       onNeedRefresh: onRefresh,
     })
 
-  const createdAt = new Date(job.created_at).toLocaleString()
+  const createdAt = parseServerDate(job.created_at).toLocaleString()
   const isInteractive = job.status === "awaiting_review" ||
                         job.status === "in_review" ||
                         job.status === "awaiting_instrumental_selection" ||

--- a/frontend/components/job/JobLogs.tsx
+++ b/frontend/components/job/JobLogs.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react"
 import { api, JobLog } from "@/lib/api"
 import { Loader2, AlertCircle } from "lucide-react"
+import { parseServerDate } from "@/lib/utils"
 
 interface JobLogsProps {
   jobId: string
@@ -73,7 +74,7 @@ export function JobLogs({ jobId, limit = 50 }: JobLogsProps) {
             style={log.level !== "ERROR" && log.level !== "WARNING" && log.level !== "INFO" ? { color: 'var(--text-muted)' } : undefined}
           >
             <span className="shrink-0" style={{ color: 'var(--text-muted)', opacity: 0.7 }}>
-              {new Date(log.timestamp).toLocaleTimeString()}
+              {parseServerDate(log.timestamp).toLocaleTimeString()}
             </span>
             <span className="shrink-0 font-semibold w-12">
               {log.level}

--- a/frontend/components/referrals/ReferralDashboard.tsx
+++ b/frontend/components/referrals/ReferralDashboard.tsx
@@ -17,6 +17,7 @@ import {
   Loader2, Banknote, Settings,
 } from 'lucide-react';
 import ReferralToolsDialog from './ReferralToolsDialog';
+import { parseServerDate } from '@/lib/utils';
 
 function formatCents(cents: number): string {
   return `$${(cents / 100).toFixed(2)}`;
@@ -505,7 +506,7 @@ export default function ReferralDashboard() {
           <div className="space-y-2">
             {data.recent_payouts.map((p) => (
               <div key={p.id} className="flex justify-between text-sm">
-                <span style={{ color: 'var(--text-muted)' }}>{new Date(p.created_at).toLocaleDateString()}</span>
+                <span style={{ color: 'var(--text-muted)' }}>{parseServerDate(p.created_at).toLocaleDateString()}</span>
                 <span className="font-mono">{formatCents(p.amount_cents)}</span>
               </div>
             ))}

--- a/frontend/lib/__tests__/utils.test.ts
+++ b/frontend/lib/__tests__/utils.test.ts
@@ -1,0 +1,48 @@
+import { parseServerDate } from '../utils'
+
+describe('parseServerDate', () => {
+  it('treats an offset-less ISO timestamp (naive UTC) as UTC', () => {
+    // Backend serializes datetime.utcnow() with no timezone designator.
+    // This should be interpreted as UTC, NOT local time.
+    const d = parseServerDate('2026-08-14T18:10:25')
+    expect(d.getTime()).toBe(Date.UTC(2026, 7, 14, 18, 10, 25))
+  })
+
+  it('treats an offset-less timestamp with fractional seconds as UTC', () => {
+    const d = parseServerDate('2026-08-14T18:10:25.123456')
+    expect(d.getTime()).toBe(Date.UTC(2026, 7, 14, 18, 10, 25, 123))
+  })
+
+  it('respects an explicit Z (UTC) designator', () => {
+    const d = parseServerDate('2026-08-14T18:10:25Z')
+    expect(d.getTime()).toBe(Date.UTC(2026, 7, 14, 18, 10, 25))
+  })
+
+  it('respects an explicit +00:00 offset', () => {
+    const d = parseServerDate('2026-08-14T18:10:25+00:00')
+    expect(d.getTime()).toBe(Date.UTC(2026, 7, 14, 18, 10, 25))
+  })
+
+  it('respects a non-UTC offset', () => {
+    // 18:10 at +02:00 == 16:10 UTC
+    const d = parseServerDate('2026-08-14T18:10:25+02:00')
+    expect(d.getTime()).toBe(Date.UTC(2026, 7, 14, 16, 10, 25))
+  })
+
+  it('passes through Date instances unchanged', () => {
+    const original = new Date(Date.UTC(2026, 7, 14, 18, 10, 25))
+    expect(parseServerDate(original)).toBe(original)
+  })
+
+  it('accepts epoch milliseconds', () => {
+    const ms = Date.UTC(2026, 7, 14, 18, 10, 25)
+    expect(parseServerDate(ms).getTime()).toBe(ms)
+  })
+
+  it('does not append Z to non-ISO-datetime strings (date-only)', () => {
+    // Date-only strings are already parsed as UTC by the Date constructor;
+    // appending Z would be invalid. Ensure we leave them alone.
+    const d = parseServerDate('2026-08-14')
+    expect(d.getTime()).toBe(Date.UTC(2026, 7, 14))
+  })
+})

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -4,3 +4,28 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Parse a timestamp returned by the backend into a Date.
+ *
+ * Backend timestamps (job.created_at, log timestamps, etc.) are UTC but are
+ * frequently serialized from naive `datetime.utcnow()` values, producing ISO
+ * strings with NO timezone offset (e.g. "2026-08-14T18:10:25.123456"). The
+ * JS `Date` constructor parses such offset-less date-time strings as *local*
+ * time, which displays the raw UTC wall-clock unconverted (off by the viewer's
+ * UTC offset). To fix this we treat offset-less timestamps as UTC by appending
+ * "Z". Strings that already carry an offset ("Z" or "+HH:MM"/"-HH:MM") — or that
+ * aren't the expected ISO date-time shape — are passed through unchanged.
+ */
+export function parseServerDate(value: string | number | Date): Date {
+  if (value instanceof Date) return value
+  if (typeof value === 'number') return new Date(value)
+
+  // ISO date-time with no timezone designator → assume UTC.
+  // Matches "YYYY-MM-DDTHH:MM:SS" with optional fractional seconds and no
+  // trailing Z / ±HH:MM offset.
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?$/.test(value)) {
+    return new Date(`${value}Z`)
+  }
+  return new Date(value)
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.192.8"
+version = "0.192.9"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Problem

Job dates on the dashboard displayed the raw UTC wall-clock instead of the viewer's local time. e.g. a job submitted at ~4:10 PM local (viewer at UTC-2) showed as `8/14/2026, 6:10:25 PM`.

## Root cause

`created_at` (and timeline/log timestamps) were built from naive `datetime.utcnow()` and serialized via `model_dump(mode='json')` / `.isoformat()`, producing ISO strings with **no timezone offset** (`"2026-08-14T18:10:25.123456"`). Firestore stored them as plain strings and returned them verbatim. The frontend's `new Date(str)` parses an offset-less ISO date-time as **local** time, so the UTC value was shown unconverted — off by the viewer's UTC offset.

## Fix

**Frontend (fixes all existing + new data, no migration):**
- New `parseServerDate()` util in `frontend/lib/utils.ts` — treats offset-less ISO date-times as UTC (appends `Z`); passes through strings that already carry `Z`/`±HH:MM`, plus `Date`/epoch inputs.
- Applied at every customer-facing server-timestamp display: `JobCard` created-at, `JobLogs` timestamps, referral payout dates, and referral-discount expiry (`BuyCreditsDialog` + dashboard).
- 8 unit tests covering naive/`Z`/`+00:00`/non-UTC-offset/date-only/epoch/`Date` cases.

**Backend (makes stored timestamps unambiguous going forward):**
- `create_job` and timeline events now use `datetime.now(timezone.utc)`, so serialized ISO strings carry a `+00:00` offset. Arithmetic consumers (`job_health_service`) already guard for both naive and aware datetimes.

## Testing
- Backend: 210 targeted tests pass (job_manager / firestore / timeline / job_health / countdown).
- Frontend: full suite 1108 tests pass (85 suites), including the new util tests.

## Notes
- `/admin/*` pages (English-only, internal) still use `new Date()` directly; they benefit from the backend change for new jobs but were left otherwise untouched as out of scope.
- CodeRabbit local review was rate-limited (free OSS quota), so this PR intentionally omits `@coderabbitai ignore` to let the bot review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)