### PR TITLE
fix(encoding): race-free ensure_latest_wheel + skip redundant installs

### DIFF
--- a/backend/services/gce_encoding/main.py
+++ b/backend/services/gce_encoding/main.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
@@ -604,6 +605,30 @@ def run_render_video(job_id: str, work_dir: Path, request: "RenderVideoRequest")
 WHEEL_INSTALL_TIMEOUT = int(os.environ.get("WHEEL_INSTALL_TIMEOUT", "900"))
 WHEEL_INSTALL_ATTEMPTS = int(os.environ.get("WHEEL_INSTALL_ATTEMPTS", "3"))
 
+# Serialize wheel checks. ensure_latest_wheel() runs on the light executor
+# (>1 thread) and is invoked at the start of every job, so without a lock two
+# concurrent jobs race on the same /tmp wheel path (`gsutil cp` clobbers the
+# file mid-copy) and the same venv (`pip install` runs twice at once) —
+# corrupting each other so one job fails with "wheel/dependencies not ready"
+# (incident 2026-08-15, job 374dec26, three jobs hitting a fresh fallback boot).
+# The lock makes the first caller do the work while the rest wait, then take the
+# already-verified fast path below.
+_wheel_lock = threading.Lock()
+# Version we've already downloaded+installed+verified in THIS process. Lets a
+# job skip the whole download/install/verify when the environment is already
+# current — the common case, since startup.sh installs the wheel at boot and
+# only the first job after a new deploy actually needs to install.
+_verified_wheel_version: Optional[str] = None
+
+
+def _installed_karaoke_gen_version() -> Optional[str]:
+    '''Return the karaoke-gen version currently importable in this venv, or None.'''
+    try:
+        from importlib.metadata import version as _get_version
+        return _get_version("karaoke-gen")
+    except Exception:
+        return None
+
 # Modules exercised by the render (OutputGenerator) and encode
 # (LocalEncodingService) code paths. Importing these confirms the whole
 # dependency tree they pull in — including transitive deps like tenacity — is
@@ -639,16 +664,29 @@ def verify_wheel_imports():
 
 
 def ensure_latest_wheel():
-    '''Download, install, and verify the latest karaoke-gen wheel from GCS.
+    '''Ensure the latest karaoke-gen wheel is installed & verified (thread-safe).
 
     Called at the start of each job to enable hot code updates without restart.
-    In-progress jobs continue with their version, new jobs get latest code.
+    Serialized via `_wheel_lock` so concurrent jobs can't race on the shared
+    /tmp wheel path or venv; the first caller installs/verifies while the rest
+    wait and then hit the already-verified fast path.
+    '''
+    with _wheel_lock:
+        return _ensure_latest_wheel_locked()
+
+
+def _ensure_latest_wheel_locked():
+    '''Download, install, and verify the latest karaoke-gen wheel from GCS.
+
+    MUST be called holding `_wheel_lock`. In-progress jobs continue with their
+    version, new jobs get latest code.
 
     Retries the install and verifies the full import chain before returning, so
     a transient/partial dependency install can't leave the worker running jobs
     against a broken environment. Returns True only when the wheel is installed
     AND its render/encode imports succeed.
     '''
+    global _verified_wheel_version
     try:
         logger.info("Checking for latest karaoke-gen wheel in GCS...")
 
@@ -681,7 +719,28 @@ def ensure_latest_wheel():
 
         wheel_uris.sort(key=extract_version)
         latest_uri = wheel_uris[-1]
+        latest_version = str(extract_version(latest_uri))
         wheel_path = os.path.join("/tmp", latest_uri.rsplit("/", 1)[-1])
+
+        # Fast path: if the environment is already at the latest version, skip
+        # the download/install entirely. This is the common case (startup.sh
+        # installs the wheel at boot) and — together with `_wheel_lock` — is what
+        # stops concurrent jobs from re-downloading/re-installing and racing.
+        if _verified_wheel_version == latest_version:
+            # Already validated in this process — nothing to do.
+            return True
+        installed_version = _installed_karaoke_gen_version()
+        if installed_version == latest_version:
+            # Right version is present but not yet verified in this process.
+            # Confirm the import chain (cheap) rather than reinstalling; only
+            # fall through to a full reinstall if a prior install was partial.
+            if verify_wheel_imports():
+                _verified_wheel_version = latest_version
+                logger.info(f"karaoke-gen {latest_version} already installed and verified; skipping wheel install")
+                return True
+            logger.warning(
+                f"karaoke-gen {latest_version} present but import chain incomplete; reinstalling"
+            )
 
         cp_result = subprocess.run(
             ["gsutil", "cp", latest_uri, wheel_path],
@@ -720,6 +779,7 @@ def ensure_latest_wheel():
             # the render/encode paths need are actually importable before we let
             # a job run against this environment.
             if verify_wheel_imports():
+                _verified_wheel_version = latest_version
                 logger.info(f"Successfully installed and verified wheel: {wheel_path}")
                 return True
 

--- a/backend/tests/test_gce_encoding_serialization.py
+++ b/backend/tests/test_gce_encoding_serialization.py
@@ -211,4 +211,5 @@ class TestEnsureLatestWheelConcurrency:
                 t.join()
 
         assert results == [True, True, True]
-        assert counter["cp"] == 1  # exactly one download despite 3 concurrent callers
+        assert counter["cp"] == 1   # exactly one download despite 3 concurrent callers
+        assert counter["pip"] == 1  # and exactly one install (no concurrent venv writes)

--- a/backend/tests/test_gce_encoding_serialization.py
+++ b/backend/tests/test_gce_encoding_serialization.py
@@ -118,3 +118,97 @@ class TestJobStatusModel:
             queue_position=worker._heavy_queue_position("missing"),
         )
         assert s.status == "pending"
+
+
+_LATEST_WHEEL_URI = (
+    "gs://karaoke-gen-storage-nomadkaraoke/wheels/karaoke_gen-0.194.0-py3-none-any.whl"
+)
+
+
+def _fake_subprocess(counter):
+    """subprocess.run stub that dispatches by command and counts cp/pip calls."""
+    from types import SimpleNamespace
+
+    def _run(cmd, **kwargs):
+        head = cmd[:2]
+        if head == ["gsutil", "ls"]:
+            return SimpleNamespace(returncode=0, stdout=_LATEST_WHEEL_URI + "\n", stderr="")
+        if head == ["gsutil", "cp"]:
+            counter["cp"] += 1
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "pip" in cmd:
+            counter["pip"] += 1
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    return _run
+
+
+class TestEnsureLatestWheelConcurrency:
+    """ensure_latest_wheel must be idempotent + race-free: it runs on the light
+    lane (>1 thread) at the start of every job, so concurrent calls used to
+    clobber the shared /tmp wheel path and venv (incident 2026-08-15, 374dec26)."""
+
+    def test_fast_path_when_already_verified_this_process(self, worker):
+        worker._verified_wheel_version = "0.194.0"
+        counter = {"cp": 0, "pip": 0}
+        with patch.object(worker.subprocess, "run", _fake_subprocess(counter)), \
+             patch.object(worker, "verify_wheel_imports", return_value=True) as vwi:
+            assert worker.ensure_latest_wheel() is True
+        assert counter == {"cp": 0, "pip": 0}   # no download, no install
+        vwi.assert_not_called()                  # no reverify either
+
+    def test_installed_version_verifies_without_reinstall(self, worker):
+        worker._verified_wheel_version = None
+        counter = {"cp": 0, "pip": 0}
+        with patch.object(worker.subprocess, "run", _fake_subprocess(counter)), \
+             patch.object(worker, "_installed_karaoke_gen_version", return_value="0.194.0"), \
+             patch.object(worker, "verify_wheel_imports", return_value=True):
+            assert worker.ensure_latest_wheel() is True
+        # Right version already present → verify only, no cp/pip.
+        assert counter == {"cp": 0, "pip": 0}
+        assert worker._verified_wheel_version == "0.194.0"
+
+    def test_installs_when_version_differs(self, worker):
+        worker._verified_wheel_version = None
+        counter = {"cp": 0, "pip": 0}
+        with patch.object(worker.subprocess, "run", _fake_subprocess(counter)), \
+             patch.object(worker, "_installed_karaoke_gen_version", return_value="0.193.0"), \
+             patch.object(worker, "verify_wheel_imports", return_value=True):
+            assert worker.ensure_latest_wheel() is True
+        assert counter["cp"] == 1 and counter["pip"] >= 1
+        assert worker._verified_wheel_version == "0.194.0"
+
+    def test_concurrent_calls_install_at_most_once(self, worker):
+        """The lock + version cache guarantee only ONE thread installs even when
+        several race in on a fresh boot; the rest hit the verified fast path."""
+        import threading
+        import time
+
+        worker._verified_wheel_version = None
+        counter = {"cp": 0, "pip": 0}
+        base = _fake_subprocess(counter)
+
+        def slow_run(cmd, **kwargs):
+            if cmd[:2] == ["gsutil", "cp"]:
+                time.sleep(0.2)  # widen the race window
+            return base(cmd, **kwargs)
+
+        results = []
+        barrier = threading.Barrier(3)
+
+        def call():
+            barrier.wait()
+            results.append(worker.ensure_latest_wheel())
+
+        with patch.object(worker.subprocess, "run", slow_run), \
+             patch.object(worker, "_installed_karaoke_gen_version", return_value="0.193.0"), \
+             patch.object(worker, "verify_wheel_imports", return_value=True):
+            threads = [threading.Thread(target=call) for _ in range(3)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        assert results == [True, True, True]
+        assert counter["cp"] == 1  # exactly one download despite 3 concurrent callers

--- a/backend/tests/test_gce_encoding_worker.py
+++ b/backend/tests/test_gce_encoding_worker.py
@@ -571,6 +571,19 @@ class TestEnsureLatestWheelVerification:
     True when it imports; retry a failed/partial install; callers fail fast.
     """
 
+    @pytest.fixture(autouse=True)
+    def _reset_wheel_cache(self, monkeypatch):
+        """ensure_latest_wheel caches the verified version in a module global and
+        can fast-path when the installed version already matches. Reset the cache
+        and pin the "installed" version to None around each test so these
+        download/install-flow tests run deterministically regardless of the test
+        venv's real karaoke-gen version."""
+        from backend.services.gce_encoding import main
+        main._verified_wheel_version = None
+        monkeypatch.setattr(main, "_installed_karaoke_gen_version", lambda: None)
+        yield
+        main._verified_wheel_version = None
+
     # A couple of versioned wheels plus the (filtered-out) current wheel, as
     # `gsutil ls` would emit them.
     DEFAULT_LS = (

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -112,6 +112,8 @@ gcloud compute ssh encoding-worker --zone=us-central1-c --project=nomadkaraoke \
 
 **Fixed in v0.192.7:** `ensure_latest_wheel()` now downloads only the single latest wheel (was: copying the entire ~6 GiB `wheels/` dir every job with a 60 s timeout), retries the install (3× at 900 s), and **verifies the render/encode import chain** before returning — a clean `pip` exit is no longer trusted. Callers fail the job with a clear retryable error instead of proceeding. Fresh workers pick this up via the wheel-at-boot.
 
+**Also fixed in v0.194.1 (concurrency race):** `ensure_latest_wheel()` runs on the *light* lane (>1 thread) at the start of every job, so on a fresh boot several jobs would call it at once and race on the shared `/tmp` wheel path (`gsutil cp` clobbered mid-copy) and the venv (two `pip install`s at once) — one job then failed with `wheel/dependencies not ready ... retry on a healthy worker` (2026-08-15, job 374dec26, 3 jobs on a fresh n2f boot). Now it's guarded by a process-wide lock **and** short-circuits when the installed version already matches the latest GCS wheel (the common case — startup.sh installs it at boot). So only the *first* job after a new wheel actually installs; the rest wait briefly then take the verified fast path. A single job failing this way can simply be retried once a worker is warm.
+
 **Manual repair (if a running VM is stuck on an old wheel):** the venv is root-owned, so use `sudo`:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.194.0"
+version = "0.194.1"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Problem

Follow-up to #908. During the OOM-fix verification, a fresh n2 fallback booted and three renders hit it at once; one (`374dec26`) failed with `karaoke-gen wheel/dependencies not ready on this worker after retries; job should be retried on a healthy worker`.

**Root cause:** `ensure_latest_wheel()` runs on the **light** executor (>1 thread) at the start of every job — the heavy-lane serialization (`ENCODING_HEAVY_CONCURRENCY=1`) does **not** cover it. So concurrent jobs on a fresh boot raced on the shared `/tmp/karaoke_gen-<v>.whl` path (`gsutil cp` clobbered mid-copy) and the venv (two `pip install`s at once). It also re-downloaded + re-installed the wheel on **every** job even when the installed version already matched.

## Fix (`backend/services/gce_encoding/main.py`)
- **Process-wide lock** (`threading.Lock`) around the whole check/download/install/verify so only one caller does the work; the rest wait.
- **"Already current" fast path:** compare the installed `karaoke-gen` version to the latest GCS wheel; if they match (the common case — `startup.sh` installs it at boot), skip download/install entirely. A per-process verified-version cache makes repeat calls a no-op. Only the *first* job after a new wheel actually installs.

Net effect: on a fresh boot, the first job installs (under the lock) and the rest take the fast path — no clobbering, no redundant installs, no spurious "wheel not ready" failures.

## Testing
- New tests: fast path (already-verified / installed-matches → zero `cp`/`pip`), full install when the version differs, and **3 concurrent callers install exactly once** (`cp==1`, `pip==1`).
- Existing wheel-verification tests get an autouse cache reset so the new module global can't leak between tests.
- Encoding suite: 163 passed.
- Local CodeRabbit review completed; feedback addressed.

## Deploy note
Same as #908: the worker picks this up on a fresh boot / service restart (it ships in the wheel). No infra changes.

@coderabbitai ignore