### PR TITLE
feat(encoding): mature multi-instance-type pool with availability-aware selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1192,6 +1192,9 @@ jobs:
                           "active_override_vm", "active_override_ip", "active_override_zone"]:
                   f.write(f"{key}={data.get(key, '')}\n")
               f.write(f"deploy_in_progress={str(data.get('deploy_in_progress', False)).lower()}\n")
+              # capacity_state is a map — emit as single-line JSON so the green
+              # selection step can demote recently-stocked-out machine types.
+              f.write(f"capacity_state={json.dumps(data.get('capacity_state') or {})}\n")
           print(f"Config: primary={data.get('primary_vm')}, secondary={data.get('secondary_vm')}, "
                 f"active_override={data.get('active_override_vm')}")
           PYEOF
@@ -1246,6 +1249,10 @@ jobs:
           sys.path.insert(0, "infrastructure/encoding-worker")
           import deploy_promote
 
+          try:
+              capacity_state = json.loads(os.environ.get("CAPACITY_STATE") or "{}")
+          except Exception:
+              capacity_state = {}
           config = {
               "primary_vm": os.environ.get("PRIMARY_VM") or None,
               "primary_ip": os.environ.get("PRIMARY_IP") or None,
@@ -1253,6 +1260,7 @@ jobs:
               "secondary_ip": os.environ.get("SECONDARY_IP") or None,
               "secondary_zone": "us-central1-c",
               "active_override_vm": os.environ.get("OVERRIDE_VM") or None,
+              "capacity_state": capacity_state,
           }
           raw = subprocess.run(
               ["gcloud", "secrets", "versions", "access", "latest",
@@ -1368,6 +1376,7 @@ jobs:
           OVERRIDE_VM: ${{ steps.config.outputs.active_override_vm }}
           OVERRIDE_IP: ${{ steps.config.outputs.active_override_ip }}
           OVERRIDE_ZONE: ${{ steps.config.outputs.active_override_zone }}
+          CAPACITY_STATE: ${{ steps.config.outputs.capacity_state }}
 
       - name: Wait for service health
         id: health

--- a/backend/services/encoding_service.py
+++ b/backend/services/encoding_service.py
@@ -265,12 +265,15 @@ class EncodingService:
             yield
 
     def _build_worker_candidates(self) -> list:
-        """Build the ordered candidate list for ensure_any_running.
+        """Build the ranked candidate list for ensure_any_running.
 
         Reads optional fallback VMs from settings (env var
-        ENCODING_WORKER_FALLBACK_VMS, JSON list of {vm, zone, ip}). Returns
-        an empty list when no worker manager / no configured fallbacks —
-        caller falls back to the single-VM ensure_primary_running path.
+        ENCODING_WORKER_FALLBACK_VMS, JSON list of {vm, zone, ip, machine_type?}).
+        The primary + all fallbacks are ranked by the shared preference logic
+        (fastest-first, demoting recently-stocked-out types) so runtime selection
+        stays in lock-step with the deploy green selection. Returns an empty list
+        when no worker manager / no configured fallbacks — caller falls back to
+        the single-VM ensure_primary_running path.
         """
         if not self._worker_manager:
             return []
@@ -281,42 +284,63 @@ class EncodingService:
             return []
 
         from backend.services.encoding_worker_manager import EncodingWorkerCandidate
+        from backend.services.encoding_worker_preference import (
+            PRIMARY_MACHINE_TYPE,
+            ordered_candidates,
+        )
 
-        # Primary always goes first. Single-zone deployments stop here.
-        candidates = [
-            EncodingWorkerCandidate(
-                vm_name=config.primary_vm,
-                zone=self._worker_manager._zone,
-                ip=config.primary_ip,
-            )
-        ]
+        # Build a dict pool (primary + fallbacks), each tagged with machine_type so
+        # the shared preference logic can rank them. The primary/secondary pair is
+        # always c4d; the config may override via primary_machine_type.
+        primary_mt = getattr(config, "primary_machine_type", None) or PRIMARY_MACHINE_TYPE
+        pool = [{
+            "vm": config.primary_vm,
+            "zone": self._worker_manager._zone,
+            "ip": config.primary_ip,
+            "machine_type": primary_mt,
+            "kind": "primary",
+            "is_primary": True,
+        }]
 
-        # Optional capacity-fallback VMs in alternate zones, configured via
-        # env var. Schema: '[{"vm":"encoding-worker-fallback-a","zone":"us-central1-a","ip":"34.x.x.x"}, ...]'
-        # The list is empty by default; user populates after `pulumi up`
-        # provisions the fallback VMs.
+        # Optional capacity-fallback VMs in alternate zones/families, configured via
+        # env var. Schema: '[{"vm":"encoding-worker-fallback-c4a","zone":"us-central1-a",
+        # "ip":"34.x.x.x","machine_type":"c4-highcpu-32"}, ...]'. machine_type is
+        # optional (inferred from the VM name for legacy entries). Empty by default;
+        # populated after `pulumi up` provisions the fallback VMs.
         import json as _json
         raw = self.settings.encoding_worker_fallback_vms
-        if not raw:
-            return candidates
-        try:
-            parsed = _json.loads(raw)
-        except (ValueError, TypeError) as e:
-            logger.warning(f"Invalid ENCODING_WORKER_FALLBACK_VMS JSON: {e}")
-            return candidates
-
-        for item in parsed:
+        if raw:
             try:
-                candidates.append(EncodingWorkerCandidate(
-                    vm_name=item["vm"],
-                    zone=item["zone"],
-                    ip=item["ip"],
-                ))
-            except (KeyError, TypeError) as e:
-                logger.warning(f"Skipping malformed fallback candidate {item}: {e}")
-                continue
+                parsed = _json.loads(raw)
+            except (ValueError, TypeError) as e:
+                logger.warning(f"Invalid ENCODING_WORKER_FALLBACK_VMS JSON: {e}")
+                parsed = []
+            for item in parsed:
+                try:
+                    pool.append({
+                        "vm": item["vm"],
+                        "zone": item["zone"],
+                        "ip": item["ip"],
+                        "machine_type": item.get("machine_type"),
+                        "kind": "fallback",
+                    })
+                except (KeyError, TypeError) as e:
+                    logger.warning(f"Skipping malformed fallback candidate {item}: {e}")
+                    continue
 
-        return candidates
+        # Rank fastest-first, demoting types that recently stocked out. Keeps the
+        # primary (c4d) at the top whenever it has capacity.
+        ranked = ordered_candidates(pool, capacity_state=config.capacity_state)
+        return [
+            EncodingWorkerCandidate(
+                vm_name=c["vm"],
+                zone=c["zone"],
+                ip=c["ip"],
+                machine_type=c.get("machine_type"),
+                is_primary=c.get("is_primary", False),
+            )
+            for c in ranked
+        ]
 
     def _load_credentials(self):
         """Load encoding worker URL and API key from config/secrets."""

--- a/backend/services/encoding_service.py
+++ b/backend/services/encoding_service.py
@@ -315,6 +315,12 @@ class EncodingService:
             except (ValueError, TypeError) as e:
                 logger.warning(f"Invalid ENCODING_WORKER_FALLBACK_VMS JSON: {e}")
                 parsed = []
+            # A non-list root (null, dict, scalar) parses fine but would blow up
+            # `for item in parsed` and escape this method during connection
+            # recovery — degrade to no fallbacks instead.
+            if not isinstance(parsed, list):
+                logger.warning("ENCODING_WORKER_FALLBACK_VMS must be a JSON list; ignoring")
+                parsed = []
             for item in parsed:
                 try:
                     pool.append({

--- a/backend/services/encoding_worker_manager.py
+++ b/backend/services/encoding_worker_manager.py
@@ -28,7 +28,7 @@ Usage:
 import asyncio
 import logging
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, UTC
 from typing import Any, Optional
 
@@ -106,6 +106,11 @@ class EncodingWorkerConfig:
     active_override_ip: Optional[str] = None
     active_override_zone: Optional[str] = None
     active_override_set_at: Optional[str] = None
+    # Availability-awareness state: {"<machine_type>@<zone>": last_stockout_iso}.
+    # Written when a candidate start hits a capacity/stockout error, read by the
+    # shared preference logic to demote recently-exhausted types. See
+    # backend/services/encoding_worker_preference.py.
+    capacity_state: dict = field(default_factory=dict)
 
     @property
     def primary_url(self) -> str:
@@ -135,16 +140,28 @@ class EncodingWorkerCandidate:
 
     Carries everything needed to talk to the worker: VM name + zone (so the
     GCE compute client targets the right zone) and external IP (so successful
-    starts can be persisted as the active URL override).
+    starts can be persisted as the active URL override). ``machine_type`` (e.g.
+    "c4d-highcpu-32") lets the manager record/clear per-(type,zone) capacity
+    state so the shared preference logic can demote a stocked-out type.
     """
 
     vm_name: str
     zone: str
     ip: str
+    machine_type: Optional[str] = None
+    # True iff this candidate is the blue-green PRIMARY VM. The override routing
+    # (set on fallback, clear on primary) keys off this flag, NOT list position —
+    # the preference logic may rank a fallback ahead of a stocked-out primary, so
+    # "first candidate" is no longer synonymous with "primary".
+    is_primary: bool = False
 
     @property
     def url(self) -> str:
         return f"http://{self.ip}:{ENCODING_WORKER_PORT}"
+
+    def _cooldown_dict(self) -> dict:
+        """Dict view for the shared preference helpers (cooldown_key)."""
+        return {"vm": self.vm_name, "zone": self.zone, "machine_type": self.machine_type}
 
 
 class EncodingWorkerManager:
@@ -190,6 +207,7 @@ class EncodingWorkerManager:
             active_override_ip=data.get("active_override_ip"),
             active_override_zone=data.get("active_override_zone"),
             active_override_set_at=data.get("active_override_set_at"),
+            capacity_state=data.get("capacity_state") or {},
         )
 
     def update_activity(self) -> None:
@@ -421,6 +439,9 @@ class EncodingWorkerManager:
         last_capacity_error: Optional[EncodingWorkerCapacityError] = None
         last_start_error: Optional[EncodingWorkerStartError] = None
         last_non_transient_error: Optional[EncodingWorkerStartError] = None
+        # When the caller marks a primary explicitly, route override off that flag;
+        # otherwise preserve the legacy "index 0 is the primary" behaviour.
+        has_explicit_primary = any(getattr(c, "is_primary", False) for c in candidates)
         for index, candidate in enumerate(candidates):
             try:
                 status = self.get_vm_status(candidate.vm_name, zone=candidate.zone)
@@ -435,7 +456,15 @@ class EncodingWorkerManager:
                     started = True
 
                 self.update_activity()
-                fell_back = index > 0
+                # A clean start means this type/zone has capacity again — clear
+                # any stale cooldown so the preference logic stops demoting it.
+                self._clear_stockout(candidate)
+                # "Fell back" = we did NOT land on the primary VM. Keyed off the
+                # explicit flag when present (ordering can rank a fallback ahead of
+                # a stocked-out primary, so it may not be index 0); otherwise the
+                # legacy position-based rule.
+                is_primary = candidate.is_primary if has_explicit_primary else (index == 0)
+                fell_back = not is_primary
                 if fell_back:
                     self._set_active_override(candidate)
                 else:
@@ -453,6 +482,9 @@ class EncodingWorkerManager:
                     "Candidate %s in %s exhausted (%s), trying next candidate",
                     candidate.vm_name, candidate.zone, cap_err.code,
                 )
+                # Record the stockout so the shared preference logic demotes this
+                # (type,zone) for a cooldown window instead of re-probing it first.
+                self._record_stockout(candidate)
                 last_capacity_error = cap_err
                 last_start_error = cap_err
                 continue
@@ -484,6 +516,42 @@ class EncodingWorkerManager:
             raise last_non_transient_error
         assert last_start_error is not None
         raise last_start_error
+
+    def _record_stockout(self, candidate) -> None:
+        """Mark a candidate's (machine_type, zone) as recently stocked out.
+
+        Merges a single key into the ``capacity_state`` map so concurrent starts
+        don't clobber each other's entries. Best-effort — a Firestore hiccup here
+        must never break the start path, so failures are logged and swallowed.
+        """
+        from backend.services.encoding_worker_preference import cooldown_key
+
+        key = cooldown_key(candidate._cooldown_dict())
+        if not key:
+            return
+        try:
+            self._doc_ref().set(
+                {"capacity_state": {key: datetime.now(UTC).isoformat()}}, merge=True
+            )
+            logger.info("Recorded stockout for %s", key)
+        except Exception as e:  # noqa: BLE001 — never fail the start path on telemetry
+            logger.warning("Could not record stockout for %s: %s", key, e)
+
+    def _clear_stockout(self, candidate) -> None:
+        """Clear a candidate's (machine_type, zone) cooldown after a clean start.
+
+        Sets the key to None (parsed as "not stocked out") via a merge so other
+        keys are untouched. Best-effort, like _record_stockout.
+        """
+        from backend.services.encoding_worker_preference import cooldown_key
+
+        key = cooldown_key(candidate._cooldown_dict())
+        if not key:
+            return
+        try:
+            self._doc_ref().set({"capacity_state": {key: None}}, merge=True)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Could not clear stockout for %s: %s", key, e)
 
     def _set_active_override(self, candidate) -> None:
         """Record a fallback VM as the active worker URL in Firestore."""

--- a/backend/services/encoding_worker_preference.py
+++ b/backend/services/encoding_worker_preference.py
@@ -1,0 +1,178 @@
+"""Shared, pure preference logic for encoding-worker candidate ordering.
+
+This is the SINGLE SOURCE OF TRUTH for how encode-worker VM candidates are ranked,
+used by BOTH:
+
+  * runtime worker selection —
+    ``backend/services/encoding_service._build_worker_candidates`` →
+    ``encoding_worker_manager.ensure_any_running``
+  * deploy green (staging) selection —
+    ``infrastructure/encoding-worker/deploy_promote.select_green_candidates``
+
+Keeping the ordering in one place stops the two call-sites from drifting (they
+previously used different ad-hoc heuristics: runtime = secret order, deploy =
+"n2 before c4d").
+
+Design:
+  * **Fastest-first base order.** Candidates sort by ``SPEED_RANK`` (lower =
+    faster), so the fastest available type (c4d) is always preferred when it can
+    start — the whole reason c4d was chosen. No behaviour change on a healthy day.
+  * **Availability-aware cooldown.** A type that recently failed to start with a
+    capacity/stockout error (recorded in Firestore ``capacity_state``) is
+    *demoted to the back* for ``COOLDOWN_SECONDS`` — long enough to stop paying
+    the ~2-min-per-attempt probe cost on a known-dead type, short enough to
+    re-probe and snap back to the faster type the moment capacity returns. It is
+    demoted, never dropped, so the pool always stays fully available.
+
+This module is intentionally **dependency-free (stdlib only)** so that
+``deploy_promote`` — which is loaded by path in CI with no backend package deps —
+can import it without pulling the heavy backend tree.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+# Lower rank = faster = preferred. Seeded from CPU architecture; refine with the
+# measured medians from infrastructure/encoding-worker/benchmark_types.py.
+#   c4d  AMD EPYC Turin (Zen5)      — current primary, fastest
+#   c4   Intel Emerald Rapids       — newest Intel perf tier
+#   n4d  AMD (Titanium)             — flexible/deep AMD
+#   c2d  AMD Milan (Zen3)           — mature, deep pool
+#   n2d  AMD Rome/Milan             — deep pool (32 GB floor)
+#   n2   Intel Cascade/Ice Lake     — current fallback (32 GB floor)
+SPEED_RANK: Dict[str, int] = {
+    "c4d-highcpu-32": 10,
+    "c4-highcpu-32": 20,
+    "n4d-highcpu-32": 30,
+    "c2d-highcpu-32": 50,
+    "n2d-highcpu-32": 60,
+    "n2-highcpu-32": 70,
+}
+
+# Rank for a candidate whose machine type is unknown and cannot be inferred:
+# treat as slowest-but-usable so it sorts LAST without ever being dropped.
+UNKNOWN_RANK = 1000
+
+# How long a type that just stocked out is demoted before it is re-probed.
+COOLDOWN_SECONDS = 900  # 15 minutes
+
+# Machine type of the blue-green primary/secondary pair (encoding-worker-a/-b).
+# They are always c4d; used when a candidate carries no explicit machine_type.
+PRIMARY_MACHINE_TYPE = "c4d-highcpu-32"
+
+# vm-name substring → machine type, for backward-compat inference when a fallback
+# entry predates the machine_type field. Checked in order — longer / more-specific
+# family tokens FIRST so "n2d" is not shadowed by "n2", nor "c4d" by "c4".
+_NAME_TOKEN_TO_TYPE = (
+    ("c4d", "c4d-highcpu-32"),
+    ("n4d", "n4d-highcpu-32"),
+    ("n2d", "n2d-highcpu-32"),
+    ("c2d", "c2d-highcpu-32"),
+    ("c4", "c4-highcpu-32"),
+    ("n2", "n2-highcpu-32"),
+)
+
+
+def _candidate_name(candidate: Dict[str, Any]) -> str:
+    """VM name from either dict shape ({"vm"} for deploy, {"vm_name"} for runtime)."""
+    return (candidate.get("vm") or candidate.get("vm_name") or "")
+
+
+def infer_machine_type(candidate: Dict[str, Any]) -> Optional[str]:
+    """Best-effort machine type: explicit ``machine_type`` field, else vm-name token.
+
+    Fallback secret entries created before the ``machine_type`` field carry only
+    vm/zone/ip; the VM-name family token (…-fallback-n2c, …-fallback-c4a) is the
+    only hint. Returns None when nothing matches (caller treats as UNKNOWN_RANK).
+    """
+    explicit = candidate.get("machine_type")
+    if explicit:
+        return explicit
+    name = _candidate_name(candidate).lower()
+    for token, mtype in _NAME_TOKEN_TO_TYPE:
+        if token in name:
+            return mtype
+    return None
+
+
+def _speed_rank(candidate: Dict[str, Any]) -> int:
+    return SPEED_RANK.get(infer_machine_type(candidate), UNKNOWN_RANK)
+
+
+def cooldown_key(candidate: Dict[str, Any]) -> Optional[str]:
+    """Firestore ``capacity_state`` key for a candidate: ``"<machine_type>@<zone>"``.
+
+    Zone-scoped because a stockout is per (machine family × zone). Returns None
+    when the machine type can't be determined (no cooldown tracking possible).
+    NOTE: keys deliberately avoid ``.`` so they are safe as Firestore map keys.
+    """
+    mtype = infer_machine_type(candidate)
+    if not mtype:
+        return None
+    zone = candidate.get("zone")
+    return f"{mtype}@{zone}" if zone else mtype
+
+
+def _parse_iso(value: Any) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:  # tolerate naive timestamps — assume UTC
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _recently_stocked_out(
+    candidate: Dict[str, Any],
+    capacity_state: Optional[Dict[str, Any]],
+    now: datetime,
+    cooldown_seconds: float,
+) -> bool:
+    """True if this candidate's (type@zone) — or its coarser type-only key — is in cooldown."""
+    if not capacity_state:
+        return False
+    key = cooldown_key(candidate)
+    if not key:
+        return False
+    ts = _parse_iso(capacity_state.get(key))
+    if ts is None:
+        # Fall back to a type-only signal (a coarser "this family is short").
+        mtype = infer_machine_type(candidate)
+        if mtype:
+            ts = _parse_iso(capacity_state.get(mtype))
+    if ts is None:
+        return False
+    return (now - ts).total_seconds() < cooldown_seconds
+
+
+def ordered_candidates(
+    pool: List[Dict[str, Any]],
+    capacity_state: Optional[Dict[str, Any]] = None,
+    now: Optional[datetime] = None,
+    cooldown_seconds: float = COOLDOWN_SECONDS,
+) -> List[Dict[str, Any]]:
+    """Rank ``pool`` fastest-first, demoting recently-stocked-out types to the back.
+
+    Args:
+        pool: candidate dicts, each ``{vm|vm_name, zone, ip, machine_type?, kind?}``.
+            Objects are returned as-is (not copied), only reordered — so callers can
+            round-trip their own richer objects through a dict view.
+        capacity_state: Firestore map ``{"<type>@<zone>"|"<type>": last_stockout_iso}``.
+            Absent/empty ⇒ pure fastest-first order (today's behaviour).
+        now: current UTC time (injectable for tests); defaults to ``datetime.now(UTC)``.
+        cooldown_seconds: demotion window; defaults to ``COOLDOWN_SECONDS``.
+
+    The speed sort is STABLE, so equal-rank candidates keep their input order —
+    callers express a secondary preference (e.g. zone spread) purely via input
+    ordering. The hot/cold partition is likewise stable within each group.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    ranked = sorted(pool, key=_speed_rank)  # stable: fastest first
+    hot = [c for c in ranked if not _recently_stocked_out(c, capacity_state, now, cooldown_seconds)]
+    cold = [c for c in ranked if _recently_stocked_out(c, capacity_state, now, cooldown_seconds)]
+    return hot + cold

--- a/backend/tests/test_deploy_promote.py
+++ b/backend/tests/test_deploy_promote.py
@@ -43,6 +43,12 @@ def _config(**over):
 
 class TestSelectGreenCandidates:
     def test_secondary_first_then_n2_before_c4d_excluding_override(self):
+        # LEGACY secret shape (no machine_type). The shared ranking infers n2 from
+        # the n2c/n2f names (rank 70) but CANNOT infer the bare c4d fallbacks a/b
+        # (no family token) → they get UNKNOWN_RANK and sort last. Net order here
+        # matches the pre-refactor "secondary, then n2, then c4d" result. Once the
+        # secret carries machine_type (post-rollout), a/b rank as c4d — see
+        # TestSelectGreenRankingSharedWithRuntime.
         cands = select_green_candidates(_config(), FALLBACKS)
         vms = [c["vm"] for c in cands]
         # c4d secondary leads; current override (n2f) excluded; n2c (n2) before c4d fallbacks.
@@ -162,3 +168,54 @@ class TestPromotePlanSecondaryBranch:
         u = plan["firestore_updates"]
         assert "active_override_vm" not in u  # nothing to clear
         assert [d["vm"] for d in plan["drain_and_stop"]] == ["encoding-worker-b"]
+
+
+class TestSelectGreenRankingSharedWithRuntime:
+    """Green selection now ranks via the shared preference (machine_type + cooldown)."""
+
+    # 6-type pool with explicit machine_type (mirrors the post-rollout secret).
+    POOL = [
+        {"vm": "encoding-worker-fallback-c4a", "zone": "us-central1-a", "ip": "10.0.0.1",
+         "machine_type": "c4-highcpu-32"},
+        {"vm": "encoding-worker-fallback-n4db", "zone": "us-central1-b", "ip": "10.0.0.2",
+         "machine_type": "n4d-highcpu-32"},
+        {"vm": "encoding-worker-fallback-c2df", "zone": "us-central1-f", "ip": "10.0.0.3",
+         "machine_type": "c2d-highcpu-32"},
+        {"vm": "encoding-worker-fallback-n2da", "zone": "us-central1-a", "ip": "10.0.0.4",
+         "machine_type": "n2d-highcpu-32"},
+        {"vm": "encoding-worker-fallback-n2c", "zone": "us-central1-c", "ip": "10.0.0.5",
+         "machine_type": "n2-highcpu-32"},
+    ]
+
+    def test_secondary_c4d_leads_then_fastest_fallbacks(self):
+        cfg = _config(active_override_vm=None)
+        vms = [c["vm"] for c in select_green_candidates(cfg, self.POOL)]
+        # c4d secondary (rank 10) first, then c4 > n4d > c2d > n2d > n2.
+        assert vms == [
+            "encoding-worker-a",              # secondary, c4d
+            "encoding-worker-fallback-c4a",   # c4
+            "encoding-worker-fallback-n4db",  # n4d
+            "encoding-worker-fallback-c2df",  # c2d
+            "encoding-worker-fallback-n2da",  # n2d
+            "encoding-worker-fallback-n2c",   # n2
+        ]
+
+    def test_c4d_stockout_demotes_secondary_below_deep_pool(self):
+        # c4d@us-central1-c (the secondary's zone) recently stocked out.
+        from datetime import datetime, timezone
+        cfg = _config(
+            active_override_vm=None,
+            capacity_state={"c4d-highcpu-32@us-central1-c": datetime.now(timezone.utc).isoformat()},
+        )
+        cands = select_green_candidates(cfg, self.POOL)
+        vms = [c["vm"] for c in cands]
+        # The c4d secondary is demoted to the back; a fast fallback (c4) now leads.
+        assert vms[0] == "encoding-worker-fallback-c4a"
+        assert vms[-1] == "encoding-worker-a"  # demoted secondary re-probed last
+        # kind survives the reordering so promote_plan still treats it correctly.
+        assert cands[-1]["kind"] == "secondary"
+
+    def test_machine_type_carried_through(self):
+        cands = select_green_candidates(_config(active_override_vm=None), self.POOL)
+        c4 = next(c for c in cands if c["vm"] == "encoding-worker-fallback-c4a")
+        assert c4["machine_type"] == "c4-highcpu-32"

--- a/backend/tests/test_encoding_service.py
+++ b/backend/tests/test_encoding_service.py
@@ -1140,3 +1140,14 @@ class TestBuildWorkerCandidates:
     def test_no_worker_manager_returns_empty(self, encoding_service):
         encoding_service._worker_manager = None
         assert encoding_service._build_worker_candidates() == []
+
+    def test_non_list_fallback_json_degrades_to_primary_only(self, encoding_service):
+        # A JSON scalar (e.g. "null") parses fine but must not blow up iteration.
+        svc = self._service_with_fallbacks(encoding_service, "null")
+        cands = svc._build_worker_candidates()
+        assert [c.vm_name for c in cands] == ["encoding-worker-a"]
+
+    def test_dict_fallback_json_degrades_to_primary_only(self, encoding_service):
+        svc = self._service_with_fallbacks(encoding_service, '{"vm": "x"}')
+        cands = svc._build_worker_candidates()
+        assert [c.vm_name for c in cands] == ["encoding-worker-a"]

--- a/backend/tests/test_encoding_service.py
+++ b/backend/tests/test_encoding_service.py
@@ -1066,3 +1066,77 @@ class TestWorkerUrlPinning:
 
         assert result["status"] == "complete"
         assert result["output_files"] == ["4k.mp4"]
+
+
+class TestBuildWorkerCandidates:
+    """_build_worker_candidates ranks primary + fallbacks via the shared preference."""
+
+    def _config(self, capacity_state=None):
+        cfg = MagicMock()
+        cfg.primary_vm = "encoding-worker-a"
+        cfg.primary_ip = "10.0.0.1"
+        cfg.primary_machine_type = None  # → defaults to c4d
+        cfg.capacity_state = capacity_state or {}
+        return cfg
+
+    def _service_with_fallbacks(self, encoding_service, fallbacks_json, capacity_state=None):
+        mgr = MagicMock()
+        mgr._zone = "us-central1-c"
+        mgr.get_config.return_value = self._config(capacity_state)
+        encoding_service._worker_manager = mgr
+        encoding_service.settings.encoding_worker_fallback_vms = fallbacks_json
+        return encoding_service
+
+    def test_primary_first_and_flagged(self, encoding_service):
+        svc = self._service_with_fallbacks(encoding_service, None)
+        cands = svc._build_worker_candidates()
+        assert cands[0].vm_name == "encoding-worker-a"
+        assert cands[0].is_primary is True
+        assert cands[0].machine_type == "c4d-highcpu-32"
+
+    def test_fallbacks_ranked_fastest_first(self, encoding_service):
+        import json
+        fallbacks = json.dumps([
+            {"vm": "encoding-worker-fallback-n2f", "zone": "us-central1-f", "ip": "10.0.0.5",
+             "machine_type": "n2-highcpu-32"},
+            {"vm": "encoding-worker-fallback-c4a", "zone": "us-central1-a", "ip": "10.0.0.6",
+             "machine_type": "c4-highcpu-32"},
+        ])
+        svc = self._service_with_fallbacks(encoding_service, fallbacks)
+        order = [c.vm_name for c in svc._build_worker_candidates()]
+        # c4d primary, then c4 (faster), then n2.
+        assert order == ["encoding-worker-a", "encoding-worker-fallback-c4a",
+                         "encoding-worker-fallback-n2f"]
+
+    def test_stocked_out_primary_demoted(self, encoding_service):
+        import json
+        from datetime import datetime, timezone
+        fallbacks = json.dumps([
+            {"vm": "encoding-worker-fallback-c4a", "zone": "us-central1-a", "ip": "10.0.0.6",
+             "machine_type": "c4-highcpu-32"},
+        ])
+        # c4d@us-central1-c stocked out "now" → demoted below c4.
+        cap = {"c4d-highcpu-32@us-central1-c": datetime.now(timezone.utc).isoformat()}
+        svc = self._service_with_fallbacks(encoding_service, fallbacks, capacity_state=cap)
+        cands = svc._build_worker_candidates()
+        order = [c.vm_name for c in cands]
+        assert order == ["encoding-worker-fallback-c4a", "encoding-worker-a"]
+        # is_primary still correctly attached to the demoted c4d.
+        primary = [c for c in cands if c.is_primary][0]
+        assert primary.vm_name == "encoding-worker-a"
+
+    def test_legacy_fallback_without_machine_type_inferred(self, encoding_service):
+        import json
+        fallbacks = json.dumps([
+            {"vm": "encoding-worker-fallback-n2c", "zone": "us-central1-c", "ip": "10.0.0.7"},
+        ])
+        svc = self._service_with_fallbacks(encoding_service, fallbacks)
+        cands = svc._build_worker_candidates()
+        n2 = [c for c in cands if "n2c" in c.vm_name][0]
+        assert n2.machine_type is None  # not fabricated on the object…
+        # …but inference placed it after the c4d primary.
+        assert [c.vm_name for c in cands] == ["encoding-worker-a", "encoding-worker-fallback-n2c"]
+
+    def test_no_worker_manager_returns_empty(self, encoding_service):
+        encoding_service._worker_manager = None
+        assert encoding_service._build_worker_candidates() == []

--- a/backend/tests/test_encoding_worker_manager.py
+++ b/backend/tests/test_encoding_worker_manager.py
@@ -934,3 +934,141 @@ class TestWaitForWorkerReady:
             )
 
         assert call_count["n"] == 3
+
+
+# ---------------------------------------------------------------------------
+# capacity_state (availability awareness) + is_primary override routing
+# ---------------------------------------------------------------------------
+
+
+class TestCapacityStateFeedback:
+    """ensure_any_running records/clears per-(type,zone) stockout state."""
+
+    def test_records_stockout_on_capacity_error(self, manager, mock_db, mock_compute):
+        mock_instance = MagicMock()
+        mock_instance.status = "TERMINATED"
+        mock_compute.get.return_value = mock_instance
+        # Primary c4d hits capacity; fallback n2 succeeds.
+        mock_compute.start.side_effect = [_capacity_op(), _ok_op()]
+
+        candidates = [
+            EncodingWorkerCandidate(vm_name="encoding-worker-a", zone="us-central1-c",
+                                    ip="10.0.0.1", machine_type="c4d-highcpu-32", is_primary=True),
+            EncodingWorkerCandidate(vm_name="encoding-worker-fallback-n2f", zone="us-central1-f",
+                                    ip="10.0.0.2", machine_type="n2-highcpu-32"),
+        ]
+
+        with patch("backend.services.encoding_worker_manager.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 5, 5, 9, 0, 0, tzinfo=UTC)
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            manager.ensure_any_running(candidates)
+
+        doc_ref = mock_db.collection.return_value.document.return_value
+        # A merge-set recorded the c4d stockout under its type@zone key.
+        set_calls = [c for c in doc_ref.set.call_args_list
+                     if "capacity_state" in (c.args[0] if c.args else {})]
+        recorded = {}
+        for c in set_calls:
+            recorded.update(c.args[0]["capacity_state"])
+        assert recorded.get("c4d-highcpu-32@us-central1-c") == "2026-05-05T09:00:00+00:00"
+
+    def test_clears_stockout_for_type_on_clean_start(self, manager, mock_db, mock_compute):
+        mock_instance = MagicMock()
+        mock_instance.status = "TERMINATED"
+        mock_compute.get.return_value = mock_instance
+        mock_compute.start.return_value = _ok_op()
+
+        candidates = [
+            EncodingWorkerCandidate(vm_name="encoding-worker-a", zone="us-central1-c",
+                                    ip="10.0.0.1", machine_type="c4d-highcpu-32", is_primary=True),
+        ]
+
+        with patch("backend.services.encoding_worker_manager.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 5, 5, 9, 0, 0, tzinfo=UTC)
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            manager.ensure_any_running(candidates)
+
+        doc_ref = mock_db.collection.return_value.document.return_value
+        cleared = {}
+        for c in doc_ref.set.call_args_list:
+            payload = c.args[0] if c.args else {}
+            if "capacity_state" in payload:
+                cleared.update(payload["capacity_state"])
+        assert cleared.get("c4d-highcpu-32@us-central1-c") is None
+
+    def test_stockout_write_failure_does_not_break_start(self, manager, mock_db, mock_compute):
+        """A Firestore error while recording a stockout must not abort failover."""
+        mock_instance = MagicMock()
+        mock_instance.status = "TERMINATED"
+        mock_compute.get.return_value = mock_instance
+        mock_compute.start.side_effect = [_capacity_op(), _ok_op()]
+
+        doc_ref = mock_db.collection.return_value.document.return_value
+        doc_ref.set.side_effect = RuntimeError("firestore down")
+
+        candidates = [
+            EncodingWorkerCandidate(vm_name="encoding-worker-a", zone="us-central1-c",
+                                    ip="10.0.0.1", machine_type="c4d-highcpu-32", is_primary=True),
+            EncodingWorkerCandidate(vm_name="encoding-worker-fallback-n2f", zone="us-central1-f",
+                                    ip="10.0.0.2", machine_type="n2-highcpu-32"),
+        ]
+
+        with patch("backend.services.encoding_worker_manager.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 5, 5, 9, 0, 0, tzinfo=UTC)
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = manager.ensure_any_running(candidates)
+
+        assert result["vm_name"] == "encoding-worker-fallback-n2f"
+        assert result["fell_back"] is True
+
+    def test_is_primary_flag_routes_override_regardless_of_position(self, manager, mock_db, mock_compute):
+        """A fallback ranked FIRST (is_primary=False) must still set active_override.
+
+        When the preference logic demotes a stocked-out primary, the fallback can be
+        candidate index 0 — the override must key off is_primary, not position.
+        """
+        mock_instance = MagicMock()
+        mock_instance.status = "TERMINATED"
+        mock_compute.get.return_value = mock_instance
+        mock_compute.start.return_value = _ok_op()
+
+        # Fallback is first (primary demoted), primary flagged but ranked second.
+        candidates = [
+            EncodingWorkerCandidate(vm_name="encoding-worker-fallback-c2df", zone="us-central1-f",
+                                    ip="10.0.0.9", machine_type="c2d-highcpu-32", is_primary=False),
+            EncodingWorkerCandidate(vm_name="encoding-worker-a", zone="us-central1-c",
+                                    ip="10.0.0.1", machine_type="c4d-highcpu-32", is_primary=True),
+        ]
+
+        with patch("backend.services.encoding_worker_manager.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 5, 5, 9, 0, 0, tzinfo=UTC)
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = manager.ensure_any_running(candidates)
+
+        assert result["vm_name"] == "encoding-worker-fallback-c2df"
+        assert result["fell_back"] is True
+        doc_ref = mock_db.collection.return_value.document.return_value
+        override_calls = [c for c in doc_ref.update.call_args_list
+                          if "active_override_vm" in c.args[0]]
+        assert override_calls, "Fallback at index 0 must still set the override"
+        assert override_calls[0].args[0]["active_override_vm"] == "encoding-worker-fallback-c2df"
+
+    def test_legacy_candidates_without_flag_use_position(self, manager, mock_db, mock_compute):
+        """No is_primary flag anywhere → first candidate is treated as primary (legacy)."""
+        mock_instance = MagicMock()
+        mock_instance.status = "TERMINATED"
+        mock_compute.get.return_value = mock_instance
+        mock_compute.start.return_value = _ok_op()
+
+        candidates = [
+            EncodingWorkerCandidate(vm_name="encoding-worker-blue", zone="us-central1-c", ip="10.0.0.1"),
+            EncodingWorkerCandidate(vm_name="encoding-worker-fb-a", zone="us-central1-a", ip="10.0.0.2"),
+        ]
+
+        with patch("backend.services.encoding_worker_manager.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 5, 5, 9, 0, 0, tzinfo=UTC)
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = manager.ensure_any_running(candidates)
+
+        assert result["fell_back"] is False
+        assert result["vm_name"] == "encoding-worker-blue"

--- a/backend/tests/test_encoding_worker_preference.py
+++ b/backend/tests/test_encoding_worker_preference.py
@@ -1,0 +1,172 @@
+"""Unit tests for the shared encoding-worker candidate preference logic.
+
+This pure module drives BOTH runtime selection and deploy green selection, so its
+ordering guarantees (fastest-first, cooldown demotion, machine_type inference) are
+the contract both call-sites rely on.
+"""
+from datetime import datetime, timedelta, timezone
+
+from backend.services.encoding_worker_preference import (
+    COOLDOWN_SECONDS,
+    SPEED_RANK,
+    UNKNOWN_RANK,
+    cooldown_key,
+    infer_machine_type,
+    ordered_candidates,
+)
+
+NOW = datetime(2026, 8, 15, 19, 0, 0, tzinfo=timezone.utc)
+
+
+def _c(vm, zone, machine_type=None, **extra):
+    d = {"vm": vm, "zone": zone, "ip": f"10.0.0.{hash(vm) % 250 + 1}"}
+    if machine_type is not None:
+        d["machine_type"] = machine_type
+    d.update(extra)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# machine_type inference
+# ---------------------------------------------------------------------------
+
+def test_explicit_machine_type_wins():
+    assert infer_machine_type(_c("whatever", "z", "c2d-highcpu-32")) == "c2d-highcpu-32"
+
+
+def test_infer_from_vm_name_specific_before_generic():
+    # "n2d"/"c4d" must not be shadowed by "n2"/"c4".
+    assert infer_machine_type(_c("encoding-worker-fallback-n2da", "z")) == "n2d-highcpu-32"
+    assert infer_machine_type(_c("encoding-worker-fallback-n2f", "z")) == "n2-highcpu-32"
+    assert infer_machine_type(_c("encoding-worker-fallback-c4x", "z")) == "c4-highcpu-32"
+
+
+def test_infer_unknown_returns_none():
+    # Bare a/b c4d fallbacks (no family token) can't be inferred from the name.
+    assert infer_machine_type(_c("encoding-worker-fallback-a", "z")) is None
+
+
+def test_runtime_dict_shape_uses_vm_name_key():
+    assert infer_machine_type({"vm_name": "x-n2d-y", "zone": "z"}) == "n2d-highcpu-32"
+
+
+# ---------------------------------------------------------------------------
+# fastest-first ordering
+# ---------------------------------------------------------------------------
+
+def test_orders_fastest_first():
+    pool = [
+        _c("n2", "us-central1-c", "n2-highcpu-32"),
+        _c("c4d", "us-central1-c", "c4d-highcpu-32"),
+        _c("c2d", "us-central1-f", "c2d-highcpu-32"),
+        _c("c4", "us-central1-a", "c4-highcpu-32"),
+    ]
+    got = [c["vm"] for c in ordered_candidates(pool, now=NOW)]
+    assert got == ["c4d", "c4", "c2d", "n2"]
+
+
+def test_unknown_type_sorts_last_but_kept():
+    pool = [
+        _c("mystery", "z"),  # no machine_type, unknown name
+        _c("c4d", "z", "c4d-highcpu-32"),
+    ]
+    got = [c["vm"] for c in ordered_candidates(pool, now=NOW)]
+    assert got == ["c4d", "mystery"]
+    assert SPEED_RANK["c4d-highcpu-32"] < UNKNOWN_RANK
+
+
+def test_stable_within_equal_rank_preserves_zone_spread():
+    # Two n2 in different zones keep input order (caller's secondary preference).
+    pool = [
+        _c("n2f", "us-central1-f", "n2-highcpu-32"),
+        _c("n2c", "us-central1-c", "n2-highcpu-32"),
+    ]
+    got = [c["vm"] for c in ordered_candidates(pool, now=NOW)]
+    assert got == ["n2f", "n2c"]
+
+
+# ---------------------------------------------------------------------------
+# cooldown / availability awareness
+# ---------------------------------------------------------------------------
+
+def test_recent_stockout_demotes_type_to_back():
+    pool = [
+        _c("c4d", "us-central1-c", "c4d-highcpu-32"),
+        _c("c4", "us-central1-a", "c4-highcpu-32"),
+        _c("n2", "us-central1-c", "n2-highcpu-32"),
+    ]
+    # c4d stocked out 1 minute ago → demoted behind the still-healthy types.
+    capacity_state = {"c4d-highcpu-32@us-central1-c": (NOW - timedelta(minutes=1)).isoformat()}
+    got = [c["vm"] for c in ordered_candidates(pool, capacity_state, now=NOW)]
+    assert got == ["c4", "n2", "c4d"]
+
+
+def test_cooldown_expires_and_snaps_back_to_fastest():
+    pool = [
+        _c("c4d", "us-central1-c", "c4d-highcpu-32"),
+        _c("c4", "us-central1-a", "c4-highcpu-32"),
+    ]
+    # Stockout older than COOLDOWN → c4d is hot again and returns to the top.
+    old = (NOW - timedelta(seconds=COOLDOWN_SECONDS + 60)).isoformat()
+    capacity_state = {"c4d-highcpu-32@us-central1-c": old}
+    got = [c["vm"] for c in ordered_candidates(pool, capacity_state, now=NOW)]
+    assert got == ["c4d", "c4"]
+
+
+def test_two_types_stocked_out_still_serves_from_deep_pool():
+    # Both newest-gen types (c4d, c4) exhausted; deep pools keep serving in order.
+    pool = [
+        _c("c4d", "us-central1-c", "c4d-highcpu-32"),
+        _c("c4", "us-central1-a", "c4-highcpu-32"),
+        _c("c2d", "us-central1-f", "c2d-highcpu-32"),
+        _c("n2d", "us-central1-a", "n2d-highcpu-32"),
+    ]
+    recent = (NOW - timedelta(minutes=2)).isoformat()
+    capacity_state = {
+        "c4d-highcpu-32@us-central1-c": recent,
+        "c4-highcpu-32@us-central1-a": recent,
+    }
+    got = [c["vm"] for c in ordered_candidates(pool, capacity_state, now=NOW)]
+    # Hot deep pools first (fastest-first among them), then the two cold types.
+    assert got == ["c2d", "n2d", "c4d", "c4"]
+
+
+def test_type_only_capacity_key_demotes_all_zones():
+    pool = [
+        _c("c4d-c", "us-central1-c", "c4d-highcpu-32"),
+        _c("n2", "us-central1-c", "n2-highcpu-32"),
+    ]
+    capacity_state = {"c4d-highcpu-32": (NOW - timedelta(minutes=1)).isoformat()}
+    got = [c["vm"] for c in ordered_candidates(pool, capacity_state, now=NOW)]
+    assert got == ["n2", "c4d-c"]
+
+
+def test_empty_capacity_state_is_pure_speed_order():
+    pool = [_c("n2", "z", "n2-highcpu-32"), _c("c4d", "z", "c4d-highcpu-32")]
+    assert [c["vm"] for c in ordered_candidates(pool, {}, now=NOW)] == ["c4d", "n2"]
+    assert [c["vm"] for c in ordered_candidates(pool, None, now=NOW)] == ["c4d", "n2"]
+
+
+def test_naive_timestamp_tolerated():
+    pool = [_c("c4d", "us-central1-c", "c4d-highcpu-32"), _c("n2", "z", "n2-highcpu-32")]
+    naive = (NOW - timedelta(minutes=1)).replace(tzinfo=None).isoformat()
+    capacity_state = {"c4d-highcpu-32@us-central1-c": naive}
+    got = [c["vm"] for c in ordered_candidates(pool, capacity_state, now=NOW)]
+    assert got == ["n2", "c4d"]
+
+
+def test_malformed_timestamp_ignored():
+    pool = [_c("c4d", "us-central1-c", "c4d-highcpu-32"), _c("n2", "z", "n2-highcpu-32")]
+    capacity_state = {"c4d-highcpu-32@us-central1-c": "not-a-date"}
+    got = [c["vm"] for c in ordered_candidates(pool, capacity_state, now=NOW)]
+    assert got == ["c4d", "n2"]  # unparseable → not in cooldown
+
+
+def test_empty_pool():
+    assert ordered_candidates([], now=NOW) == []
+
+
+def test_cooldown_key_shape():
+    assert cooldown_key(_c("x", "us-central1-c", "c4d-highcpu-32")) == "c4d-highcpu-32@us-central1-c"
+    assert cooldown_key(_c("x", None, "n2-highcpu-32")) == "n2-highcpu-32"
+    assert cooldown_key(_c("no-token", "z")) is None

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -6,6 +6,41 @@ Key insights for future AI agents working on this codebase.
 
 ---
 
+## Multi-instance-type encode pool: one shared speed-rank, availability-aware (Aug 2026, v0.195.0)
+
+"c4d primary + a single n2 fallback family" is not resilient — a stockout is per
+**(machine family × region)** and can exhaust every zone of a family at once. The
+fix is a **ranked pool of ≥5 x86_64, 32-vCPU, ≥32 GB highcpu types across ≥3
+independent silicon lineages** (c4d/c4/n4d + c2d/n2d/n2), tried fastest-first.
+
+Three things that made this clean:
+- **One pure preference module is the single source of truth.** Runtime selection
+  (`encoding_service._build_worker_candidates` → `ensure_any_running`) and deploy
+  green selection (`deploy_promote.select_green_candidates`) both call
+  `backend/services/encoding_worker_preference.ordered_candidates`. Two call-sites
+  computing "candidate order" independently WILL drift (they already had — runtime
+  used secret order, deploy used "n2-first"). `deploy_promote` is loaded by path in
+  CI, so it imports the module with a **by-path fallback** (an installed `backend`
+  package can otherwise shadow the repo working tree).
+- **Prefer fastest, but be availability-aware.** Base order is speed-rank (c4d
+  stays top when it can start). A type that raises `ZONE_RESOURCE_POOL_EXHAUSTED`
+  is recorded in Firestore `capacity_state` and **demoted for a 15-min cooldown,
+  not dropped** — stops wasting ~2 min/attempt probing a known-dead type, then
+  re-probes so we snap back to c4d the moment capacity returns.
+- **Override routing must key off an explicit `is_primary` flag, not list
+  position.** Once the ranker can put a fallback ahead of a stocked-out primary,
+  "candidate index 0 == primary" is false and the active-override set/clear logic
+  breaks silently (routes to the primary IP while a fallback is actually running).
+- **Disk-type is family-specific:** next-gen Titanium families (c4/c4d/n4/n4d)
+  support **hyperdisk-balanced only**; older families (c2d/n2/n2d) use
+  **pd-balanced**. Wrong disk type = GCE rejects the instance at create.
+- **Bake the full dep tree (CPU-only torch) into the image.** Each new fresh type
+  VM otherwise hits the fragile first-render `ensure_latest_wheel` full-tree
+  install; baking it (CPU torch via `--index-url` the PyTorch CPU index) makes all
+  types boot self-sufficient. CPU torch avoids multi-GB CUDA wheels the encode path
+  never uses. Verify `torch.version.cuda is None` — NOT `cuda.is_available()`,
+  which is False on the GPU-less builder even for a CUDA build.
+
 ## Concurrent encodes OOM-killed the worker → lost renders (Aug 2026, v0.194.0)
 
 Three renders submitted at once ran as **3 concurrent 4K ffmpeg encodes** on the
@@ -238,6 +273,8 @@ When a metadata key is missing, don't set it to "now" and skip the action — th
 ### Encoding Worker Blue-Green: Named VMs Beat MIG for Small Scale (Mar 2026)
 
 **Why not a Managed Instance Group?** MIG rolling updates don't support deep health checks — you can verify HTTP liveness but not "did a real encode actually work?". PR #587 showed that the service can respond to `/health` while failing all encode jobs (pip resolution error had broken the wheel). A real encode test catches this; a simple HTTP check does not. At two VMs, the operational complexity of a MIG (instance template management, rolling update policies, drain configuration) adds no value over two named VMs with a Firestore pointer.
+
+**Still true after the multi-type pool (Aug 2026, v0.195.0).** Broadening to a 6-type fallback pool (see the v0.195.0 lesson above) is a stockout-resilience play and stays on the named-VM model: static IPs, IP-addressed blue-green, on-demand start/stop, deep encode-test-before-swap. A regional MIG with instance flexibility is GCP's textbook answer to stockouts, but it would replace IP addressing with service discovery / an internal LB and turn blue-green into rolling recreate — high blast radius for a system just hardened. **Revisit MIG only when we need horizontal autoscaling (>1 concurrent worker per burst) or VM sprawl becomes unmanageable (>~10 types).**
 
 **Deep health check pattern**: After deploying to the secondary VM, CI runs a real encode job end-to-end before swapping traffic. This has caught broken deploys that passed all unit tests and liveness probes.
 

--- a/docs/archive/2026-08-15-encoding-instance-type-diversity-plan.md
+++ b/docs/archive/2026-08-15-encoding-instance-type-diversity-plan.md
@@ -1,0 +1,254 @@
+# Encoding Worker — Mature Multi-Instance-Type Strategy (Plan)
+
+**Date:** 2026-08-15
+**Branch:** `feat/sess-20260815-1915-encoding-instance-type-diversity`
+**Status:** IMPLEMENTED (v0.195.0) — code + IaC + Packer landed; operator rollout steps below still pending.
+**Context:** memory `project_gen_encoding_instance_type_diversity` + `_worker_serialization` + `_machine_family_diversity` + `_wheel_deps_missing`
+
+## Goal
+
+Replace "c4d primary + single n2 fallback family" with a **ranked pool of ≥5 encode-capable
+x86_64 instance types** and **availability-aware selection**, so a render never stalls even
+when 2+ instance types are fully stocked out in us-central1 — while still **preferring the
+fastest type (c4d) whenever it's available**. Resilience, not abandoning c4d.
+
+---
+
+## Current system (verified against code, 2026-08-15)
+
+| Piece | File | Behaviour |
+|---|---|---|
+| Runtime candidate order | `backend/services/encoding_service.py::_build_worker_candidates` | `[primary] + ENCODING_WORKER_FALLBACK_VMS (secret order)` |
+| Runtime fall-through | `backend/services/encoding_worker_manager.py::ensure_any_running` / `_ensure_any_running_once` | Iterates candidates; capacity/transient error → next; sets `active_override_*` on fallback success |
+| Deploy green pick | `infrastructure/encoding-worker/deploy_promote.py::select_green_candidates` | secondary first, then fallbacks, **n2-before-c4d**, excluding current override |
+| Idle shutdown | `infrastructure/functions/encoding_worker_idle/main.py::_parse_fallback_vms` | Stops idle primary/secondary/fallbacks (secret-driven) |
+| IaC pool | `infrastructure/config.py::EncodingWorkerConfig.FALLBACKS` + `compute/encoding_worker_vm.py` | 2× c4d (a/b) + 2× n2 (n2c/n2f) fallbacks, each `{machine_type, disk_type}` |
+| Secret | `encoding-worker-fallback-vms` | `[{vm,zone,ip}×4]` — **no machine_type today** |
+| ffmpeg | `infrastructure/packer/scripts/provision.sh:59` | johnvansickle **amd64-static** → x86_64 only |
+
+**Live state now:** primary `encoding-worker-a` (c4d, us-central1-c) @0.194.2 serving; no override
+(c4d capacity currently back). Fallback fleet = c4d a/b (zones a,b) + n2 n2c/n2f (zones c,f).
+2 machine families, 6 VMs total.
+
+**Two order heuristics exist independently** (runtime = secret order; deploy = n2-first) — the
+plan unifies them behind one pure, scored module.
+
+---
+
+## Ground-truth SKU menu (us-central1 a/b/c/f, all present)
+
+x86_64, 32 vCPU, ≥32 GB, highcpu — verified via `gcloud compute machine-types list`:
+
+| Type | vCPU | RAM | Silicon | Disk support | Pool notes |
+|---|---|---|---|---|---|
+| **c4d-highcpu-32** | 32 | 60 | AMD EPYC Turin (Zen5) | hyperdisk-balanced only | **current primary, fastest**; in the crunch |
+| **c4-highcpu-32** | 32 | 64 | Intel Emerald Rapids | hyperdisk-balanced only | newest Intel perf tier, also in-demand |
+| **n4-highcpu-32** | 32 | 64 | Intel Emerald Rapids (Titanium) | hyperdisk-balanced only | flexible/deep Intel |
+| **n4d-highcpu-32** | 32 | 64 | AMD (Titanium) | hyperdisk-balanced only | flexible/deep AMD |
+| **c2d-highcpu-32** | 32 | 64 | AMD Milan (Zen3) | pd-balanced | mature, **deep** |
+| **n2d-highcpu-32** | 32 | 32 | AMD Rome/Milan | pd-balanced | **deep**, 32 GB floor |
+| **n2-highcpu-32** | 32 | 32 | Intel Cascade/Ice Lake | pd-balanced | **current fallback**, floor |
+
+Excluded:
+- `n1-highcpu-32` = **28.8 GB** → below the 32 GB serialized-4K floor.
+- `e2-highcpu-32` = 32 GB but E2 is cost/shared-tier, variable perf → not for fast finalization.
+- `c4a-/n4a-highcpu-32` (Arm Axion, 64 GB) → **needs a separate Arm static ffmpeg** (provision.sh
+  bakes amd64 only). Documented as a future pool-doubler, NOT in this phase.
+- `c3-highcpu-44` (44/88) / `c3d-highcpu-30` (30/59) — no exact 32-vCPU SKU; optional extra pools
+  if we want more breadth later (both support pd + hyperdisk).
+
+### Chosen pool (≥5, spanning ≥3 independent silicon pools)
+
+Two tiers by intent:
+
+- **Tier A — fast, newest-gen (may stock out together in a crunch):** `c4d` (keep primary), `c4`, `n4d`
+- **Tier B — deep, mature, independent pools (the insurance):** `c2d`, `n2d`, `n2` (already deployed)
+
+= **6 types across 4 zones and 4 distinct silicon lineages** (AMD Turin, Intel Emerald, AMD
+Milan, Intel Cascade, AMD Rome). Even if ALL of Tier A (all newest-gen, the crunch cohort) is
+exhausted at once, three independent mature pools keep serving. Meets "no disruption if 2+ types
+stocked out."
+
+Zone spread (one type per zone where possible to avoid same-type-same-zone correlation):
+c4d→c (primary, keep) · c4→a · n4d→b · c2d→f · n2d→a · n2→c/f (keep n2c/n2f).
+
+---
+
+## Design
+
+### 1. Shared, scored preference module (single source of truth)
+
+New pure module `backend/services/encoding_worker_preference.py` (importable by BOTH backend and
+`infrastructure/encoding-worker/deploy_promote.py` — deploy already `sys.path`-inserts that dir;
+we vendor/import the pure function so runtime + deploy can never drift).
+
+```python
+SPEED_RANK = {          # lower = faster; seed from arch, refine with benchmark (§2)
+  "c4d-highcpu-32": 10,
+  "c4-highcpu-32":  20,
+  "n4d-highcpu-32": 30,
+  "c2d-highcpu-32": 50,
+  "n2d-highcpu-32": 60,
+  "n2-highcpu-32":  70,
+}
+COOLDOWN_SECONDS = 900  # a type that just stocked out is demoted for 15 min, then re-probed
+
+def ordered_candidates(pool, capacity_state, now):
+    """pool: [{vm,zone,ip,machine_type,kind}]. capacity_state: {type|type@zone: last_stockout_iso}.
+    Returns pool ranked fastest-first, but any candidate whose (type[,zone]) stocked out within
+    COOLDOWN is stable-partitioned to the back (keeping speed order within each group)."""
+    def speed(c): return SPEED_RANK.get(c["machine_type"], _infer_rank(c))
+    base = sorted(pool, key=speed)                       # fastest first — c4d stays top
+    cooled = lambda c: _recently_out(capacity_state, c, now, COOLDOWN_SECONDS)
+    return [c for c in base if not cooled(c)] + [c for c in base if cooled(c)]
+```
+
+Why this shape:
+- **Fastest-first base order** → keeps preferring c4d/c4 whenever they're up (the whole reason c4d
+  was chosen). No behavioural change on a healthy day.
+- **Cooldown demotion** → the "availability-aware" layer. When c4d throws
+  `ZONE_RESOURCE_POOL_EXHAUSTED`, we record it and stop paying the ~2 min-per-deploy /
+  per-render probe cost on a known-dead type — but we DON'T remove it, we re-probe after 15 min so
+  we snap back to c4d the moment capacity returns.
+- **Deterministic + pure** → fully unit-testable; identical logic drives runtime and deploy.
+
+Consumers:
+- Runtime: `_build_worker_candidates` builds the pool (primary + all fallbacks, each carrying
+  `machine_type`) and calls `ordered_candidates`. `ensure_any_running` iterates unchanged.
+- Deploy: `select_green_candidates` builds the pool minus the current `active_override_vm`
+  (guarantees a fresh green) and calls the SAME `ordered_candidates`. Drops the ad-hoc "n2-first"
+  rule — the cooldown state now handles "don't waste time on the stocked-out fast type."
+
+### 2. Capacity-state feedback (availability awareness)
+
+- New Firestore map on `config/encoding-worker`: `capacity_state = { "<type>@<zone>": "<iso>" }`.
+- Write `<iso>=now` in `_ensure_any_running_once` when a candidate raises
+  `EncodingWorkerCapacityError`; clear a type's entry on a successful start of that type.
+- Read in both consumers. Stale entries self-expire via COOLDOWN (no GC needed).
+- Deploy's `Select & start green` step reads it too (already reads config), so CI stops probing a
+  dead fast type first during a sustained stockout.
+- Backward-compatible: absent map ⇒ pure speed order (today's behaviour).
+
+### 3. Benchmark to build the real ranking
+
+Seed `SPEED_RANK` from architecture now; replace with measured wall-time. Harness:
+
+- `infrastructure/encoding-worker/benchmark_types.py` (manual, not CI — it starts real VMs):
+  1. For each type: ensure its fallback VM is RUNNING + `/health` 200.
+  2. POST an identical **canonical 4K encode** (pin one real production render's inputs in GCS;
+     reuse the CI `test-assets` encode input but at full 4K/length for representativeness).
+  3. Poll `/status`; record ffmpeg wall-time (worker already times jobs). Median of 3.
+  4. Emit `ranking.json` → hand-copy medians into `SPEED_RANK` (as relative-to-c4d if preferred).
+  5. Stop all started VMs.
+- Re-run occasionally / after a new type is added. Document expected order: Turin ≳ Emerald ≈
+  Genoa > Milan > Rome > Cascade (verify — don't assume).
+
+### 4. IaC changes (Pulumi, purely additive)
+
+- Extend `EncodingWorkerConfig.FALLBACKS` with the new entries, each `{suffix, zone_suffix,
+  machine_type, disk_type}`:
+  - `c4` → `{suffix:"c4a", zone:"a", machine:"c4-highcpu-32", disk:"hyperdisk-balanced"}`
+  - `n4d`→ `{suffix:"n4db", zone:"b", machine:"n4d-highcpu-32", disk:"hyperdisk-balanced"}`
+  - `c2d`→ `{suffix:"c2df", zone:"f", machine:"c2d-highcpu-32", disk:"pd-balanced"}`
+  - `n2d`→ `{suffix:"n2da", zone:"a", machine:"n2d-highcpu-32", disk:"pd-balanced"}`
+  (suffix names avoid collision; disk_type matches each family's capability — **c4/c4d/n4/n4d =
+  hyperdisk-balanced ONLY; c2d/n2/n2d = pd-balanced**. Getting this wrong = pulumi error.)
+- **Do NOT touch** existing a/b/n2c/n2f entries or the c4d a/b Address `description` strings
+  (changing them forces an Address replace → cascades to replacing the c4d VM, which needs the
+  exact scarce capacity — see `_machine_family_diversity`). Verify `pulumi preview` shows only
+  `+N to create` (new IPs + new stopped VMs), zero replace.
+- `create_encoding_worker_fallback_vms` already reads `machine_type`/`disk_type` per entry and
+  provisions `desired_status=TERMINATED` — no code change beyond the config list.
+
+### 5. Secret schema: add `machine_type`
+
+- `encoding-worker-fallback-vms` entries become `{vm,zone,ip,machine_type}` (append the 4 new
+  VMs' entries too). `machine_type` lets the preference module score without a name lookup.
+- Backward-compatible reads: `_build_worker_candidates`, `_parse_fallback_vms`,
+  `select_green_candidates` treat `machine_type` as optional; when absent, `_infer_rank` derives
+  it from the vm-name/type substring (c4d/c4/n4d/c2d/n2d/n2). Primary/secondary machine_type
+  (c4d) is known from config.
+- Carry `machine_type` through `EncodingWorkerCandidate` (add field, default None).
+
+### 6. Wheel-deps + ffmpeg companion checks
+
+- **ffmpeg:** all chosen types are x86_64 → baked amd64 static ffmpeg works unchanged. Arm
+  excluded precisely because it wouldn't. (No image change needed for this phase.)
+- **Wheel deps** (`_wheel_deps_missing`): every fresh type VM hits first-render full-tree install;
+  already covered by `ensure_latest_wheel` (single-wheel + `verify_wheel_imports` + 900s×3). But
+  adding 4 fresh types multiplies first-render exposure → **strongly recommend the durable
+  follow-up: bake the full dep tree (CPU-only torch) into the Packer image** so every type boots
+  self-sufficient. One image-family rebuild covers all types (all share the `encoding-worker`
+  image). Track as a fast-follow; not strictly blocking because the runtime guard exists.
+
+---
+
+## Architecture assessment: per-VM start/stop vs MIG vs reservations
+
+| Option | Verdict |
+|---|---|
+| **Per-VM start/stop (today) + broadened ranked pool** | **RECOMMENDED for this phase.** Low-risk incremental extension of the system just hardened in #908–#910. Reuses `ensure_any_running`, `deploy_promote`, idle-shutdown, the secret, static IPs, IP-addressed blue-green. Delivers the resilience goal. Cost when idle ≈ boot disk only (~$10/mo/VM × ~4 new = ~$40/mo). |
+| **Regional MIG + instance flexibility** | **Right long-term shape per GCP guidance, but DEFER.** A MIG lists ranked machine types and lets GCP find capacity across type×zone natively (add-a-type = one policy line, no VM sprawl). BUT it invalidates the just-stabilized model: MIG instances have ephemeral names/IPs → the entire Firestore primary/secondary/override addressing (routes by IP) breaks → needs an internal LB / service discovery (extra hop, cost); blue-green deploy (IP swap) becomes rolling-update; on-demand scale-to-zero isn't native (keep a warm instance = cost, or bolt on a scaler); the 1-heavy-encode serialization + in-memory queue + client-resubmit assume a stable addressable worker. High blast radius days after stabilizing. **Trigger to revisit:** we need horizontal autoscaling (>1 concurrent worker per burst) OR per-VM sprawl becomes unmanageable (>~10 types). |
+| **Reservation / CUD for a fast baseline** | **Optional lever — user's cost call.** A 1× `c4d-highcpu-32` reservation in us-central1-c *guarantees* the primary can always start, eliminating the exact stockout behind #908/#910. Purely additive (attach to the primary), no code change, instantly removable when demand subsides. Cost ≈ full on-demand of one c4d-highcpu-32 (~$650–800/mo) whether running or not; 1yr CUD lowers rate but commits spend. Given demand is "expected to subside," a *temporary* reservation during the crunch is the pragmatic middle. |
+
+**Recommendation:** ship the broadened ranked pool + adaptive selection now (per-VM model);
+offer a temporary c4d reservation as an independent toggle; keep MIG documented as the future
+path with explicit triggers.
+
+---
+
+## Testing strategy (per `docs/TESTING.md`)
+
+- **Unit (pure, highest value):** `encoding_worker_preference` — fastest-first ordering, cooldown
+  demotion + stable-partition, re-probe after COOLDOWN, missing-`machine_type` inference,
+  empty/degenerate pools. `test_deploy_promote.py` — updated to assert new ordering + fresh-green
+  exclusion + machine_type carry-through.
+- **Unit:** `test_encoding_worker_manager.py` — multi-type fall-through, capacity_state
+  write-on-stockout / clear-on-success.
+- **Infra:** `test_encoding_worker_config.py` — every FALLBACK entry has a disk_type valid for its
+  family (hyperdisk-only vs pd), unique VM/IP names, expected zone spread.
+- **Emulator/integration:** capacity_state Firestore round-trip; idle-shutdown parses new entries.
+- **Prod E2E (post-deploy, once):** start each new type, `/health` 200, run canonical encode,
+  confirm output — codifies that each type actually encodes. (Doubles as the benchmark seed run.)
+
+## Rollout (operator, needs WRITE creds — my ADC is read-only)
+
+1. Merge code (preference module + consumers + tests) — no infra yet, behaviour identical (pool
+   still 2 families until secret grows).
+2. `cd infrastructure && pulumi up` (stack prod) → creates 4 new IPs + 4 stopped VMs. **Verify
+   `+8 to create`, zero replace** before applying.
+3. Add a new `encoding-worker-fallback-vms` secret version = existing 4 + 4 new entries, each with
+   `machine_type`. Cloud Run svc + `video-encoding-job` + idle fn read `:latest` (cycle/redeploy to
+   pick up).
+4. Run `benchmark_types.py` → fill real `SPEED_RANK` medians → small follow-up PR.
+5. (Optional) `bake full deps into Packer` fast-follow. (Optional) create c4d reservation.
+
+## Decisions (locked 2026-08-15)
+
+1. **Pool size — 6 types** (c4d, c4, n4d, c2d, n2d, n2). 4 silicon lineages × 4 zones.
+2. **Reservation — NO.** Rely on the broadened pool; no guaranteed c4d baseline (revisit only if
+   stockouts persist). No reservation/CUD in this effort.
+3. **MIG — DEFER.** Ship per-VM start/stop; MIG documented as future path with triggers above.
+4. **Packer dep-bake — INCLUDE IN THIS EFFORT.** Bake the full CPU-only-torch dep tree into the
+   `encoding-worker` image so all 4 new type VMs (and existing ones) boot self-sufficient, instead
+   of relying on first-render `ensure_latest_wheel`. See scope note below.
+
+### Scope note: Packer dep-bake (now in-scope)
+
+- `infrastructure/packer/scripts/provision.sh` currently bakes only
+  `fastapi uvicorn google-cloud-storage aiofiles aiohttp packaging` (per `_wheel_deps_missing`).
+  Extend it to `pip install` the full karaoke-gen dependency set with **CPU-only torch**
+  (`--index-url https://download.pytorch.org/whl/cpu` for torch) into `/opt/encoding-worker/venv`
+  at build time — the encode/render path needs the generator→correction/langchain chain
+  (tenacity etc.) but NOT CUDA, so CPU torch keeps the image far smaller than the ~6.4 GB GPU tree.
+- Keep `ensure_latest_wheel` as the runtime code-update path (it still upgrades the karaoke-gen
+  wheel itself on each new version), but a fresh VM will now already have the whole dep tree →
+  first render no longer risks a partial/timed-out full-tree install.
+- Requires: image rebuild (`build-runner-images.yml`/Packer) + a Pulumi apply that repoints the
+  `encoding-worker` image family. Re-apply the `gcloud compute disks update` IOPS tune after any
+  rebuild that recreates disks (per `encoding_worker_vm.py` comments).
+- **Sequencing:** rebuild the image FIRST (all types boot self-sufficient), then `pulumi up` the
+  new VMs against the new image family, then grow the secret. This way the 4 new types never hit
+  the fragile first-render install path at all.
+- Verify amd64 CPU-torch wheels resolve for Python 3.13 during the Packer build (fail the build if
+  `verify_wheel_imports`-equivalent import check fails, so a broken image never ships).

--- a/infrastructure/config.py
+++ b/infrastructure/config.py
@@ -53,7 +53,17 @@ class MachineTypes:
     # us-central1-a/-b/-c simultaneously (2026-08-12) which took out every same-family lane.
     # n2-highcpu-32 (Intel Cascade/Ice Lake) draws from a much deeper, independent pool, so a
     # c4d shortage cannot exhaust it. n2 does NOT support hyperdisk-balanced → uses pd-balanced.
-    ENCODING_WORKER_ALT = "n2-highcpu-32"  # 32 vCPU, Intel - deep-capacity fallback pool
+    ENCODING_WORKER_ALT = "n2-highcpu-32"  # 32 vCPU, Intel Cascade/Ice Lake - deep-capacity fallback pool
+    # Broadened ranked pool (2026-08-15) — ≥5 x86_64, 32-vCPU, ≥32 GB highcpu types
+    # across 4 distinct silicon lineages, so a stockout of the newest-gen cohort
+    # (c4d/c4, the crunch) cannot exhaust every lane. Encode-speed ranking lives in
+    # backend/services/encoding_worker_preference.py::SPEED_RANK. Disk-type rule:
+    # next-gen Titanium families (c4/c4d/n4/n4d) support hyperdisk-balanced ONLY;
+    # older families (c2d/n2/n2d) use pd-balanced. Getting this wrong = pulumi error.
+    ENCODING_WORKER_C4 = "c4-highcpu-32"    # 32 vCPU / 64 GB, Intel Emerald Rapids (hyperdisk-only)
+    ENCODING_WORKER_N4D = "n4d-highcpu-32"  # 32 vCPU / 64 GB, AMD Titanium (hyperdisk-only)
+    ENCODING_WORKER_C2D = "c2d-highcpu-32"  # 32 vCPU / 64 GB, AMD Milan (Zen3), deep pool (pd-balanced)
+    ENCODING_WORKER_N2D = "n2d-highcpu-32"  # 32 vCPU / 32 GB, AMD Rome/Milan, deep pool (pd-balanced)
     FLACFETCH = "e2-small"  # 0.5 vCPU, 2GB RAM
 
 
@@ -300,8 +310,17 @@ class EncodingWorkerConfig:
     #
     # Each entry: name/IP suffix, zone suffix ({REGION}-{zone_suffix}),
     # machine_type, boot disk_type. ORDER MATTERS — IPs and VMs are zipped by
-    # position, and it defines candidate priority. Keep the c4d a/b entries
-    # first and byte-identical so Pulumi does not recreate the existing VMs.
+    # position. (Candidate PRIORITY is no longer positional: it is decided at
+    # runtime/deploy by the shared speed-rank + cooldown in
+    # backend/services/encoding_worker_preference.py.) Keep the existing a/b/n2c/n2f
+    # entries first and byte-identical so Pulumi does not recreate those VMs; the
+    # broadened-pool entries are APPENDED so the change is purely additive
+    # (verify `pulumi preview` shows only new IPs+VMs, zero replace).
+    #
+    # Zone spread: one machine type per zone where possible so a single
+    # (type × zone) stockout can't correlate across the pool. c4d primary lives in
+    # zone c (the primary pair), so the c4 fallback goes to a, n4d to b, c2d to f,
+    # n2d to a — 4 lineages across 4 zones.
     FALLBACKS = [
         {"suffix": "a", "zone_suffix": "a",
          "machine_type": MachineTypes.ENCODING_WORKER, "disk_type": "hyperdisk-balanced"},
@@ -311,6 +330,15 @@ class EncodingWorkerConfig:
          "machine_type": MachineTypes.ENCODING_WORKER_ALT, "disk_type": "pd-balanced"},
         {"suffix": "n2f", "zone_suffix": "f",
          "machine_type": MachineTypes.ENCODING_WORKER_ALT, "disk_type": "pd-balanced"},
+        # --- Broadened pool (2026-08-15), appended (additive-only) ---
+        {"suffix": "c4a", "zone_suffix": "a",
+         "machine_type": MachineTypes.ENCODING_WORKER_C4, "disk_type": "hyperdisk-balanced"},
+        {"suffix": "n4db", "zone_suffix": "b",
+         "machine_type": MachineTypes.ENCODING_WORKER_N4D, "disk_type": "hyperdisk-balanced"},
+        {"suffix": "c2df", "zone_suffix": "f",
+         "machine_type": MachineTypes.ENCODING_WORKER_C2D, "disk_type": "pd-balanced"},
+        {"suffix": "n2da", "zone_suffix": "a",
+         "machine_type": MachineTypes.ENCODING_WORKER_N2D, "disk_type": "pd-balanced"},
     ]
 
     # Derived name lists (kept for readability / any external reference).

--- a/infrastructure/encoding-worker/benchmark_types.py
+++ b/infrastructure/encoding-worker/benchmark_types.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Benchmark encode wall-time per instance type to build the speed ranking.
+
+The runtime + deploy candidate ordering is driven by
+``backend/services/encoding_worker_preference.SPEED_RANK`` — a fastest-first
+preference. That table is SEEDED from CPU architecture; this script replaces the
+seed with MEASURED medians so the ranking reflects reality on our actual encode
+workload (fast finalization is the whole reason c4d was chosen).
+
+This is an OPERATOR tool, not part of CI: it starts real (billed) VMs, runs a
+canonical encode on each, and stops them again. Run it occasionally and after
+adding a new type.
+
+Usage:
+    python infrastructure/encoding-worker/benchmark_types.py \\
+        --ass-gcs   gs://karaoke-gen-storage-nomadkaraoke/bench/canonical.ass \\
+        --audio-gcs gs://karaoke-gen-storage-nomadkaraoke/bench/canonical.flac \\
+        --out-prefix gs://karaoke-gen-storage-nomadkaraoke/bench/out \\
+        [--repeats 3] [--types c4-highcpu-32,n2-highcpu-32] [--json ranking.json]
+
+The canonical input should be a representative FULL 4K render (not the tiny CI
+preview asset) so the medians reflect production finalization time. Pin one real
+job's `.ass` + audio in a stable GCS location once and reuse it.
+
+Requires: gcloud/gsutil authenticated with compute + secret access. The fallback
+VM inventory (vm/zone/ip/machine_type) is read from the
+``encoding-worker-fallback-vms`` secret; the c4d primary is added from Firestore.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+PROJECT = "nomadkaraoke"
+PORT = 8080
+DEFAULT_C4D_ZONE = "us-central1-c"
+
+
+def _gcloud(*args: str, check: bool = True) -> str:
+    r = subprocess.run(
+        ["gcloud", *args, f"--project={PROJECT}"],
+        capture_output=True, text=True,
+    )
+    if check and r.returncode != 0:
+        raise RuntimeError(f"gcloud {' '.join(args)} failed: {r.stderr.strip()}")
+    return r.stdout.strip()
+
+
+def _api_key() -> str:
+    return _gcloud("secrets", "versions", "access", "latest",
+                   "--secret=encoding-worker-api-key")
+
+
+def _inventory(only_types: Optional[set]) -> List[Dict[str, Any]]:
+    """Assemble the {vm,zone,ip,machine_type} list to benchmark.
+
+    Primary c4d (from Firestore) + every fallback (from the secret). machine_type
+    is required here — legacy entries without it are skipped with a warning.
+    """
+    workers: List[Dict[str, Any]] = []
+
+    # Primary c4d from Firestore config.
+    cfg_raw = _gcloud("firestore", "documents", "get",
+                      "projects/nomadkaraoke/databases/(default)/documents/config/encoding-worker",
+                      "--format=json", check=False)
+    try:
+        # Fall back to the python client if the CLI shape isn't available.
+        from google.cloud import firestore  # type: ignore
+        doc = firestore.Client(project=PROJECT).collection("config").document("encoding-worker").get()
+        data = doc.to_dict() or {}
+        if data.get("primary_vm"):
+            workers.append({
+                "vm": data["primary_vm"], "zone": DEFAULT_C4D_ZONE,
+                "ip": data.get("primary_ip"), "machine_type": "c4d-highcpu-32",
+            })
+    except Exception as e:  # noqa: BLE001
+        print(f"WARN: could not read primary from Firestore ({e}); benchmarking fallbacks only")
+
+    secret = _gcloud("secrets", "versions", "access", "latest",
+                     "--secret=encoding-worker-fallback-vms", check=False)
+    try:
+        for f in json.loads(secret or "[]"):
+            mt = f.get("machine_type")
+            if not mt:
+                print(f"WARN: fallback {f.get('vm')} has no machine_type; skipping")
+                continue
+            workers.append({"vm": f["vm"], "zone": f["zone"], "ip": f.get("ip"), "machine_type": mt})
+    except Exception as e:  # noqa: BLE001
+        print(f"WARN: could not parse fallback secret ({e})")
+
+    # De-dup by machine_type (one representative VM per type) and optional filter.
+    seen, result = set(), []
+    for w in workers:
+        if only_types and w["machine_type"] not in only_types:
+            continue
+        if w["machine_type"] in seen:
+            continue
+        seen.add(w["machine_type"])
+        result.append(w)
+    return result
+
+
+def _vm_status(vm: str, zone: str) -> str:
+    return _gcloud("compute", "instances", "describe", vm, f"--zone={zone}",
+                   "--format=value(status)", check=False)
+
+
+def _start(vm: str, zone: str) -> None:
+    _gcloud("compute", "instances", "start", vm, f"--zone={zone}", check=False)
+
+
+def _stop(vm: str, zone: str) -> None:
+    _gcloud("compute", "instances", "stop", vm, f"--zone={zone}", check=False)
+
+
+def _http(method: str, url: str, api_key: str, body: Optional[dict] = None,
+          timeout: float = 30.0) -> Dict[str, Any]:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("X-API-Key", api_key)
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode() or "{}")
+
+
+def _wait_health(ip: str, api_key: str, timeout: float = 240.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            _http("GET", f"http://{ip}:{PORT}/health", api_key, timeout=5.0)
+            return True
+        except (urllib.error.URLError, OSError, ValueError):
+            time.sleep(5)
+    return False
+
+
+def _one_encode(ip: str, api_key: str, job_id: str, ass: str, audio: str,
+                out: str, poll_timeout: float = 1800.0) -> float:
+    """Submit one full /encode and return client-side wall-time (seconds)."""
+    start = time.monotonic()
+    _http("POST", f"http://{ip}:{PORT}/encode", api_key, body={
+        "job_id": job_id,
+        "ass_gcs_path": ass,
+        "audio_gcs_path": audio,
+        "output_gcs_path": out,
+    })
+    deadline = time.monotonic() + poll_timeout
+    while time.monotonic() < deadline:
+        time.sleep(5)
+        try:
+            st = _http("GET", f"http://{ip}:{PORT}/status/{job_id}", api_key, timeout=10.0)
+        except (urllib.error.URLError, OSError, ValueError):
+            continue
+        status = st.get("status")
+        if status == "complete":
+            return time.monotonic() - start
+        if status == "failed":
+            raise RuntimeError(f"encode {job_id} failed: {st.get('error')}")
+    raise TimeoutError(f"encode {job_id} did not complete within {poll_timeout}s")
+
+
+def benchmark(args) -> Dict[str, float]:
+    api_key = _api_key()
+    only = set(args.types.split(",")) if args.types else None
+    workers = _inventory(only)
+    if not workers:
+        print("No workers to benchmark (check --types / secret).")
+        return {}
+
+    print(f"Benchmarking {len(workers)} types × {args.repeats} repeats each:")
+    for w in workers:
+        print(f"  - {w['machine_type']:>16}  {w['vm']} ({w['zone']})")
+
+    medians: Dict[str, float] = {}
+    for w in workers:
+        vm, zone, ip, mt = w["vm"], w["zone"], w.get("ip"), w["machine_type"]
+        print(f"\n=== {mt} — {vm} ({zone}) ===")
+        try:
+            if _vm_status(vm, zone) != "RUNNING":
+                print("  starting VM...")
+                _start(vm, zone)
+            if not ip:
+                ip = _gcloud("compute", "instances", "describe", vm, f"--zone={zone}",
+                             "--format=value(networkInterfaces[0].accessConfigs[0].natIP)")
+            if not _wait_health(ip, api_key):
+                print(f"  SKIP: {vm} never became healthy")
+                continue
+            samples: List[float] = []
+            for i in range(args.repeats):
+                job_id = f"bench-{mt}-{i}"
+                out = f"{args.out_prefix}/{mt}-{i}.mp4"
+                secs = _one_encode(ip, api_key, job_id, args.ass_gcs, args.audio_gcs, out)
+                print(f"  run {i + 1}/{args.repeats}: {secs:.1f}s")
+                samples.append(secs)
+            medians[mt] = round(statistics.median(samples), 1)
+        except Exception as e:  # noqa: BLE001 — keep benchmarking the rest
+            print(f"  ERROR benchmarking {mt}: {e}")
+        finally:
+            if not args.no_stop:
+                print("  stopping VM...")
+                _stop(vm, zone)
+
+    return medians
+
+
+def _suggest_ranks(medians: Dict[str, float]) -> Dict[str, int]:
+    """Map medians → SPEED_RANK ints (fastest = smallest), spaced by 10."""
+    ordered = sorted(medians.items(), key=lambda kv: kv[1])
+    return {mt: (idx + 1) * 10 for idx, (mt, _) in enumerate(ordered)}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--ass-gcs", dest="ass_gcs", required=True)
+    p.add_argument("--audio-gcs", dest="audio_gcs", required=True)
+    p.add_argument("--out-prefix", dest="out_prefix", required=True)
+    p.add_argument("--repeats", type=int, default=3)
+    p.add_argument("--types", default=None, help="comma-separated machine types to limit to")
+    p.add_argument("--json", dest="json_out", default=None, help="write ranking JSON here")
+    p.add_argument("--no-stop", action="store_true", help="leave VMs running after benchmarking")
+    args = p.parse_args()
+
+    medians = benchmark(args)
+    if not medians:
+        return 1
+
+    ranks = _suggest_ranks(medians)
+    print("\n=== RESULTS (median encode seconds, fastest first) ===")
+    for mt, secs in sorted(medians.items(), key=lambda kv: kv[1]):
+        print(f"  {mt:>16}: {secs:>7.1f}s   → suggested SPEED_RANK {ranks[mt]}")
+
+    payload = {"medians_seconds": medians, "suggested_speed_rank": ranks}
+    if args.json_out:
+        with open(args.json_out, "w") as f:
+            json.dump(payload, f, indent=2)
+        print(f"\nWrote {args.json_out}")
+    print("\nCopy suggested_speed_rank into "
+          "backend/services/encoding_worker_preference.py::SPEED_RANK "
+          "(keep c4d lowest/first unless measurements say otherwise).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infrastructure/encoding-worker/benchmark_types.py
+++ b/infrastructure/encoding-worker/benchmark_types.py
@@ -13,14 +13,20 @@ adding a new type.
 
 Usage:
     python infrastructure/encoding-worker/benchmark_types.py \\
-        --ass-gcs   gs://karaoke-gen-storage-nomadkaraoke/bench/canonical.ass \\
-        --audio-gcs gs://karaoke-gen-storage-nomadkaraoke/bench/canonical.flac \\
-        --out-prefix gs://karaoke-gen-storage-nomadkaraoke/bench/out \\
-        [--repeats 3] [--types c4-highcpu-32,n2-highcpu-32] [--json ranking.json]
+        --input-gcs       gs://karaoke-gen-storage-nomadkaraoke/bench/inputs/ \\
+        --encoding-config @bench/encoding_config.json \\
+        --out-prefix      gs://karaoke-gen-storage-nomadkaraoke/bench/out \\
+        [--repeats 3] [--types c4-highcpu-32,n2-highcpu-32] [--json ranking.json] \\
+        [--include-running] [--no-stop]
 
-The canonical input should be a representative FULL 4K render (not the tiny CI
-preview asset) so the medians reflect production finalization time. Pin one real
-job's `.ass` + audio in a stable GCS location once and reuse it.
+The payload matches the real /encode contract (input_gcs_path + output_gcs_path +
+encoding_config), i.e. the production FULL finalization path — not the lighter
+/encode-preview. Pin one real job's inputs dir + its encoding_config in a stable
+GCS location once and reuse it so the medians reflect production 4K finalization
+time. `--encoding-config` takes inline JSON or `@path/to/file.json`.
+
+SAFETY: VMs already RUNNING (likely serving production) are skipped by default and
+never stopped; only VMs this run starts are benchmarked and stopped afterwards.
 
 Requires: gcloud/gsutil authenticated with compute + secret access. The fallback
 VM inventory (vm/zone/ip/machine_type) is read from the
@@ -142,15 +148,20 @@ def _wait_health(ip: str, api_key: str, timeout: float = 240.0) -> bool:
     return False
 
 
-def _one_encode(ip: str, api_key: str, job_id: str, ass: str, audio: str,
-                out: str, poll_timeout: float = 1800.0) -> float:
-    """Submit one full /encode and return client-side wall-time (seconds)."""
+def _one_encode(ip: str, api_key: str, job_id: str, input_gcs: str,
+                encoding_config: dict, out: str, poll_timeout: float = 1800.0) -> float:
+    """Submit one full /encode and return client-side wall-time (seconds).
+
+    Payload matches the real /encode contract (EncodeRequest:
+    input_gcs_path + output_gcs_path + encoding_config) — the production
+    finalization path we want to benchmark, NOT the lighter /encode-preview.
+    """
     start = time.monotonic()
     _http("POST", f"http://{ip}:{PORT}/encode", api_key, body={
         "job_id": job_id,
-        "ass_gcs_path": ass,
-        "audio_gcs_path": audio,
+        "input_gcs_path": input_gcs,
         "output_gcs_path": out,
+        "encoding_config": encoding_config,
     })
     deadline = time.monotonic() + poll_timeout
     while time.monotonic() < deadline:
@@ -183,10 +194,21 @@ def benchmark(args) -> Dict[str, float]:
     for w in workers:
         vm, zone, ip, mt = w["vm"], w["zone"], w.get("ip"), w["machine_type"]
         print(f"\n=== {mt} — {vm} ({zone}) ===")
+        initial_status = _vm_status(vm, zone)
+        # SAFETY: never touch a VM that is already RUNNING — it may be the serving
+        # primary/override, and injecting bench jobs (or stopping it) would disrupt
+        # production and wipe its in-memory job registry. Only benchmark VMs we
+        # start ourselves, and only stop those. `--include-running` overrides the
+        # skip but STILL never stops a VM this run didn't start.
+        started_by_us = False
+        if initial_status == "RUNNING" and not args.include_running:
+            print(f"  SKIP: {vm} is already RUNNING (likely serving); pass --include-running to bench it")
+            continue
         try:
-            if _vm_status(vm, zone) != "RUNNING":
+            if initial_status != "RUNNING":
                 print("  starting VM...")
                 _start(vm, zone)
+                started_by_us = True
             if not ip:
                 ip = _gcloud("compute", "instances", "describe", vm, f"--zone={zone}",
                              "--format=value(networkInterfaces[0].accessConfigs[0].natIP)")
@@ -196,17 +218,21 @@ def benchmark(args) -> Dict[str, float]:
             samples: List[float] = []
             for i in range(args.repeats):
                 job_id = f"bench-{mt}-{i}"
-                out = f"{args.out_prefix}/{mt}-{i}.mp4"
-                secs = _one_encode(ip, api_key, job_id, args.ass_gcs, args.audio_gcs, out)
+                out = f"{args.out_prefix}/{mt}-{i}/"
+                secs = _one_encode(ip, api_key, job_id, args.input_gcs,
+                                   args.encoding_config, out)
                 print(f"  run {i + 1}/{args.repeats}: {secs:.1f}s")
                 samples.append(secs)
             medians[mt] = round(statistics.median(samples), 1)
         except Exception as e:  # noqa: BLE001 — keep benchmarking the rest
             print(f"  ERROR benchmarking {mt}: {e}")
         finally:
-            if not args.no_stop:
+            # Only stop a VM this invocation actually started (never a serving one).
+            if started_by_us and not args.no_stop:
                 print("  stopping VM...")
                 _stop(vm, zone)
+            elif not started_by_us:
+                print("  leaving VM as found (was already running before this benchmark)")
 
     return medians
 
@@ -219,14 +245,33 @@ def _suggest_ranks(medians: Dict[str, float]) -> Dict[str, int]:
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--ass-gcs", dest="ass_gcs", required=True)
-    p.add_argument("--audio-gcs", dest="audio_gcs", required=True)
+    p.add_argument("--input-gcs", dest="input_gcs", required=True,
+                   help="gs:// path to the canonical /encode inputs dir")
+    p.add_argument("--encoding-config", dest="encoding_config_raw", required=True,
+                   help="encoding_config as inline JSON or @path/to/file.json")
     p.add_argument("--out-prefix", dest="out_prefix", required=True)
     p.add_argument("--repeats", type=int, default=3)
     p.add_argument("--types", default=None, help="comma-separated machine types to limit to")
     p.add_argument("--json", dest="json_out", default=None, help="write ranking JSON here")
     p.add_argument("--no-stop", action="store_true", help="leave VMs running after benchmarking")
+    p.add_argument("--include-running", action="store_true",
+                   help="also benchmark VMs already RUNNING (never stops them)")
     args = p.parse_args()
+
+    # Resolve --encoding-config (inline JSON or @file) into a dict once.
+    raw = args.encoding_config_raw
+    try:
+        if raw.startswith("@"):
+            with open(raw[1:]) as f:
+                args.encoding_config = json.load(f)
+        else:
+            args.encoding_config = json.loads(raw)
+    except (OSError, ValueError) as e:
+        print(f"ERROR: --encoding-config is not valid JSON / readable file: {e}")
+        return 2
+    if not isinstance(args.encoding_config, dict):
+        print("ERROR: --encoding-config must be a JSON object")
+        return 2
 
     medians = benchmark(args)
     if not medians:

--- a/infrastructure/encoding-worker/deploy_promote.py
+++ b/infrastructure/encoding-worker/deploy_promote.py
@@ -21,42 +21,62 @@ from typing import Any, Dict, List, Optional
 # c4d/n2 primary+secondary live here; the worker manager uses the same zone.
 DEFAULT_C4D_ZONE = "us-central1-c"
 
+# Shared, pure candidate-ranking logic — the SINGLE SOURCE OF TRUTH also used by
+# the runtime worker manager, so deploy green selection and runtime selection can
+# never drift. Preferred import is the normal package path; when that isn't
+# importable (this file is loaded by path in CI/tests, and an installed `backend`
+# package can even shadow the repo working tree), fall back to loading the module
+# straight from its file. It is stdlib-only, so by-path exec has no side effects.
+try:
+    from backend.services.encoding_worker_preference import (
+        PRIMARY_MACHINE_TYPE,
+        ordered_candidates,
+    )
+except ImportError:  # pragma: no cover - exercised in the bare CI heredoc / shadowed env
+    import importlib.util
+    import pathlib
 
-def _is_n2(vm_name: str) -> bool:
-    """True for the non-Spot n2 fallbacks (e.g. encoding-worker-fallback-n2c/-n2f).
-
-    n2 fallbacks are on-demand (reliable to start); c4d fallbacks are Spot and
-    share the stockout, so we prefer n2 as a green target.
-    """
-    return "n2" in (vm_name or "")
+    _pref_path = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "backend" / "services" / "encoding_worker_preference.py"
+    )
+    _spec = importlib.util.spec_from_file_location("encoding_worker_preference", _pref_path)
+    _pref = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_pref)
+    PRIMARY_MACHINE_TYPE = _pref.PRIMARY_MACHINE_TYPE
+    ordered_candidates = _pref.ordered_candidates
 
 
 def select_green_candidates(
     config: Dict[str, Any],
     fallback_vms: List[Dict[str, Any]],
 ) -> List[Dict[str, Optional[str]]]:
-    """Ordered list of candidate green (staging) targets for the workflow to try.
+    """Ranked list of candidate green (staging) targets for the workflow to try.
 
-    Order:
-      1. the c4d `secondary_vm` (kind="secondary") — keeps the normal blue-green
-         behaviour when c4d capacity is available;
-      2. fallback VMs (kind="fallback"), EXCLUDING the current `active_override_vm`,
-         with n2 fallbacks before c4d fallbacks.
+    Pool = the c4d ``secondary_vm`` (kind="secondary") + all fallback VMs
+    (kind="fallback"), EXCLUDING the current ``active_override_vm``. The pool is
+    ranked by the shared preference logic — fastest-first, demoting any type that
+    recently stocked out (per ``config["capacity_state"]``). So:
+      * when c4d has capacity, the c4d secondary sorts first → normal blue-green;
+      * during a c4d stockout, the secondary is demoted and a deep-pool fallback
+        (n2d/n2/c2d) leads, instead of wasting ~2 min probing a c4d that won't boot.
 
     Excluding the current override is what makes the deploy zero-downtime: the
     green is always a *different*, freshly-booted worker, so the override keeps
     serving until the workflow atomically switches to the validated green.
 
-    Each candidate: {"vm", "ip", "zone", "kind"}.
+    Each candidate: {"vm", "ip", "zone", "machine_type", "kind"}.
     """
-    candidates: List[Dict[str, Optional[str]]] = []
+    pool: List[Dict[str, Optional[str]]] = []
 
     secondary_vm = config.get("secondary_vm")
     if secondary_vm:
-        candidates.append({
+        pool.append({
             "vm": secondary_vm,
             "ip": config.get("secondary_ip"),
             "zone": config.get("secondary_zone") or DEFAULT_C4D_ZONE,
+            # secondary is always the c4d pair unless the config says otherwise.
+            "machine_type": config.get("secondary_machine_type") or PRIMARY_MACHINE_TYPE,
             "kind": "secondary",
         })
 
@@ -68,17 +88,16 @@ def select_green_candidates(
         f for f in (fallback_vms or [])
         if f.get("vm") and f.get("zone") and f.get("ip") and f.get("vm") != override_vm
     ]
-    # n2 (non-Spot) first, then stable name order for determinism.
-    usable.sort(key=lambda f: (0 if _is_n2(f["vm"]) else 1, f["vm"]))
     for f in usable:
-        candidates.append({
+        pool.append({
             "vm": f["vm"],
             "ip": f.get("ip"),
             "zone": f.get("zone"),
+            "machine_type": f.get("machine_type"),  # inferred from vm name if absent
             "kind": "fallback",
         })
 
-    return candidates
+    return ordered_candidates(pool, capacity_state=config.get("capacity_state"))
 
 
 def promote_plan(

--- a/infrastructure/encoding-worker/startup.sh
+++ b/infrastructure/encoding-worker/startup.sh
@@ -114,11 +114,12 @@ echo "Downloaded wheel as: ${WHEEL_NAME}"
 # graph (langchain, CUDA, etc.) can hit pip's "resolution-too-deep" error and
 # crash-loop the service before it can serve health checks (see #587).
 #
-# The karaoke-gen dependency tree (torch, langchain, tenacity, ...) is therefore
-# NOT installed here. It is installed lazily at the first job by
-# ensure_latest_wheel() in backend/services/gce_encoding/main.py (which installs
-# WITH deps, retries, and verifies the import chain). Do not assume deps are
-# present just because this step succeeded.
+# The full karaoke-gen dependency tree (torch [CPU-only], langchain, tenacity,
+# ...) is now BAKED INTO THE IMAGE at build time (provision.sh), so this --no-deps
+# code upgrade just fast-forwards the app to the newest wheel on an already-
+# complete venv. ensure_latest_wheel() in backend/services/gce_encoding/main.py
+# remains as a runtime backstop (installs WITH deps + verifies imports) for the
+# rare case of an image predating the dep-bake or a partial venv.
 echo "[4/5] Installing wheel..."
 "${VENV}/bin/pip" install --upgrade --quiet --force-reinstall --no-deps "${WHEEL_PATH}"
 

--- a/infrastructure/modules/secrets.py
+++ b/infrastructure/modules/secrets.py
@@ -40,10 +40,12 @@ def create_secrets() -> dict[str, secretmanager.Secret]:
         "flacfetch-api-key",
         "flacfetch-api-url",
         "encoding-worker-api-key",
-        # Capacity-fallback VMs config (JSON list of {vm,zone,ip}). Stored as
-        # a secret because --set-env-vars on Cloud Run is comma-delimited and
-        # the JSON value contains commas; the value itself is non-secret
-        # (just public IPs of fallback VMs).
+        # Capacity-fallback VMs config (JSON list of {vm,zone,ip,machine_type?}).
+        # machine_type (e.g. "c4-highcpu-32") drives the shared speed-rank
+        # ordering; optional for legacy entries (inferred from the vm name).
+        # Stored as a secret because --set-env-vars on Cloud Run is
+        # comma-delimited and the JSON value contains commas; the value itself is
+        # non-secret (just public IPs of fallback VMs).
         "encoding-worker-fallback-vms",
 
         # Notifications

--- a/infrastructure/packer/scripts/provision.sh
+++ b/infrastructure/packer/scripts/provision.sh
@@ -119,10 +119,28 @@ pip install fastapi uvicorn google-cloud-storage aiofiles aiohttp packaging
 # fallback uses). gsutil ships in the debian-cloud base image and the Packer
 # builder SA has GCS read on this bucket.
 BUCKET="gs://karaoke-gen-storage-nomadkaraoke"
-echo "Baking full dependency tree (CPU-only torch) from ${BUCKET}/wheels/karaoke_gen-current.whl ..."
-if ! gsutil cp "${BUCKET}/wheels/karaoke_gen-current.whl" /tmp/karaoke_gen.whl; then
-    echo "FATAL: could not download karaoke_gen-current.whl to bake deps into the image"
-    exit 1
+# pip requires a PEP 427-valid wheel filename; the GCS alias
+# `karaoke_gen-current.whl` is NOT valid, so copy it to a properly-versioned
+# name (mirrors startup.sh). Prefer version.txt for the version tag.
+BAKE_VERSION=$(gsutil cat "${BUCKET}/encoding-worker/version.txt" 2>/dev/null | tr -d '[:space:]')
+if [ -n "${BAKE_VERSION}" ]; then
+    WHEEL_NAME="karaoke_gen-${BAKE_VERSION}-py3-none-any.whl"
+else
+    WHEEL_NAME="karaoke_gen-0.0.0-py3-none-any.whl"
+fi
+WHEEL_PATH="/tmp/${WHEEL_NAME}"
+echo "Baking full dependency tree (CPU-only torch) from ${BUCKET}/wheels/karaoke_gen-current.whl → ${WHEEL_NAME} ..."
+if ! gsutil cp "${BUCKET}/wheels/karaoke_gen-current.whl" "${WHEEL_PATH}"; then
+    # Fall back to the latest properly-named versioned wheel.
+    LATEST_WHEEL=$(gsutil ls "${BUCKET}/wheels/karaoke_gen-*.whl" 2>/dev/null | grep -v 'current' | sort -V | tail -1 || echo "")
+    if [ -n "${LATEST_WHEEL}" ]; then
+        WHEEL_NAME=$(basename "${LATEST_WHEEL}")
+        WHEEL_PATH="/tmp/${WHEEL_NAME}"
+        gsutil cp "${LATEST_WHEEL}" "${WHEEL_PATH}"
+    else
+        echo "FATAL: could not download a wheel to bake deps into the image"
+        exit 1
+    fi
 fi
 
 # --index-url = PyTorch CPU index (primary, so torch resolves to the CPU build),
@@ -132,7 +150,7 @@ for attempt in 1 2 3; do
     if pip install \
         --index-url https://download.pytorch.org/whl/cpu \
         --extra-index-url https://pypi.org/simple \
-        /tmp/karaoke_gen.whl; then
+        "${WHEEL_PATH}"; then
         break
     fi
     echo "pip install of full dep tree failed (attempt ${attempt}/3); retrying..."
@@ -142,7 +160,7 @@ for attempt in 1 2 3; do
         exit 1
     fi
 done
-rm -f /tmp/karaoke_gen.whl
+rm -f "${WHEEL_PATH}"
 
 # Verify the import chain that actually broke before (tenacity is pulled
 # transitively via the generator→correction/langchain chain). Fail the BUILD if

--- a/infrastructure/packer/scripts/provision.sh
+++ b/infrastructure/packer/scripts/provision.sh
@@ -93,18 +93,91 @@ cd /opt/encoding-worker
 echo "Creating Python virtual environment..."
 /opt/python313/bin/python3.13 -m venv venv
 
-# Install ONLY the packages the worker needs to boot and serve HTTP. The full
-# karaoke-gen dependency tree (torch, langchain, tenacity, ...) is NOT baked
-# here — it is installed at the first job by ensure_latest_wheel() in
-# backend/services/gce_encoding/main.py, because startup.sh installs the wheel
-# with --no-deps (see #587: full resolution at boot crash-loops the service).
+# Bake the FULL karaoke-gen dependency tree into the image (2026-08-15) so every
+# fresh worker VM — including the broadened multi-instance-type fallback pool — is
+# self-sufficient at boot instead of relying on a first-job ensure_latest_wheel()
+# install of the whole tree (torch + CUDA, langchain, tenacity, ...). That lazy
+# path repeatedly bit fresh fallback VMs (see #903 / "No module named 'tenacity'"):
+# a partial/timed-out install left a broken venv and every retry hit the same VM.
 #
-# Consequence: a freshly-provisioned worker's first job pays a one-time cost to
-# install the whole tree, and depends on that install succeeding. ensure_latest_wheel()
-# retries and verifies the import chain to keep that reliable.
+# HOW: install the current published wheel WITH deps, but resolve torch from the
+# PyTorch CPU index (primary) with PyPI as the fallback index (everything else).
+# CPU-only torch avoids the multi-GB CUDA/nvidia wheels the encode/finalize path
+# never needs, keeping the image small. The wheel's CODE is intentionally kept
+# installed too — startup.sh still runs `pip install --no-deps <latest wheel>` at
+# boot to fast-forward the code to the newest version (deps already satisfied), so
+# there's no crash-loop from full resolution at boot (the #587 reason for --no-deps)
+# AND no missing-dep failure on the first job.
 source venv/bin/activate
 pip install --upgrade pip
+
+# Boot/serve packages first (guarantees the service can start even if the heavy
+# install below is ever trimmed).
 pip install fastapi uvicorn google-cloud-storage aiofiles aiohttp packaging
+
+# Pull the current wheel from the fixed GCS path (same artifact the runtime
+# fallback uses). gsutil ships in the debian-cloud base image and the Packer
+# builder SA has GCS read on this bucket.
+BUCKET="gs://karaoke-gen-storage-nomadkaraoke"
+echo "Baking full dependency tree (CPU-only torch) from ${BUCKET}/wheels/karaoke_gen-current.whl ..."
+if ! gsutil cp "${BUCKET}/wheels/karaoke_gen-current.whl" /tmp/karaoke_gen.whl; then
+    echo "FATAL: could not download karaoke_gen-current.whl to bake deps into the image"
+    exit 1
+fi
+
+# --index-url = PyTorch CPU index (primary, so torch resolves to the CPU build),
+# --extra-index-url = PyPI (everything else). Retry a couple of times to ride out
+# transient index blips during the build.
+for attempt in 1 2 3; do
+    if pip install \
+        --index-url https://download.pytorch.org/whl/cpu \
+        --extra-index-url https://pypi.org/simple \
+        /tmp/karaoke_gen.whl; then
+        break
+    fi
+    echo "pip install of full dep tree failed (attempt ${attempt}/3); retrying..."
+    sleep 15
+    if [ "${attempt}" = "3" ]; then
+        echo "FATAL: could not install the full karaoke-gen dependency tree"
+        exit 1
+    fi
+done
+rm -f /tmp/karaoke_gen.whl
+
+# Verify the import chain that actually broke before (tenacity is pulled
+# transitively via the generator→correction/langchain chain). Fail the BUILD if
+# any import fails, so a half-baked image that claims to be self-sufficient can
+# never ship.
+echo "Verifying baked dependency imports..."
+python - << 'PYVERIFY'
+import importlib
+import sys
+
+# torch must be the CPU build. NOTE: torch.cuda.is_available() is False even for a
+# CUDA build on this GPU-less builder, so it can't tell CPU from CUDA — check the
+# build's compiled CUDA version instead (None only for a true CPU-only wheel).
+import torch
+assert torch.version.cuda is None, (
+    f"baked torch is a CUDA build (torch.version.cuda={torch.version.cuda!r}) — "
+    "expected CPU-only; check the --index-url resolves torch from the CPU index"
+)
+
+# Importing the worker app module transitively exercises the generator/correction
+# chain that pulls tenacity (the dep that was missing on fresh fallback VMs).
+modules = ["tenacity", "backend.services.gce_encoding.main"]
+failed = []
+for name in modules:
+    try:
+        importlib.import_module(name)
+    except Exception as exc:  # noqa: BLE001
+        failed.append(f"{name}: {exc}")
+if failed:
+    print("FATAL: baked dependency import check failed:")
+    for f in failed:
+        print(f"  - {f}")
+    sys.exit(1)
+print("Baked dependency imports OK (CPU-only torch).")
+PYVERIFY
 
 # Create bootstrap script (runs via ExecStartPre before service starts)
 # This minimal script downloads the REAL startup script from GCS.
@@ -226,6 +299,7 @@ echo "  - Python ${PYTHON_VERSION} at /opt/python313"
 echo "  - FFmpeg at /usr/local/bin/ffmpeg"
 echo "  - Noto fonts (including CJK)"
 echo "  - Virtual environment at /opt/encoding-worker/venv"
+echo "  - Full karaoke-gen dependency tree baked (CPU-only torch)"
 echo "  - Systemd service: encoding-worker.service"
 echo ""
 echo "Immutable deployment pattern:"

--- a/infrastructure/test_encoding_worker_config.py
+++ b/infrastructure/test_encoding_worker_config.py
@@ -33,6 +33,59 @@ def test_n2_fallbacks_use_pd_balanced_disk():
             assert fb["disk_type"] == "pd-balanced", fb
 
 
+# Machine families and the ONLY boot-disk type each supports for these VMs.
+# Next-gen Titanium families (c4/c4d/n4/n4d) support hyperdisk-balanced only;
+# older families (c2d/n2/n2d) use pd-balanced. Mismatched disk_type = GCE rejects
+# the instance at create time (the exact failure the fallback fleet must avoid).
+_FAMILY_DISK_TYPE = {
+    "c4d": "hyperdisk-balanced",
+    "c4": "hyperdisk-balanced",
+    "n4d": "hyperdisk-balanced",
+    "n4": "hyperdisk-balanced",
+    "c2d": "pd-balanced",
+    "n2d": "pd-balanced",
+    "n2": "pd-balanced",
+}
+
+
+def _family(machine_type: str) -> str:
+    # Longest prefix wins so "n2d"/"c4d" aren't shadowed by "n2"/"c4".
+    return max(
+        (fam for fam in _FAMILY_DISK_TYPE if machine_type.startswith(fam)),
+        key=len,
+        default="",
+    )
+
+
+def test_every_fallback_disk_type_matches_its_family_capability():
+    """Each fallback's disk_type must be the one its machine family supports."""
+    for fb in EncodingWorkerConfig.FALLBACKS:
+        fam = _family(fb["machine_type"])
+        assert fam, f"unknown family for {fb['machine_type']}"
+        assert fb["disk_type"] == _FAMILY_DISK_TYPE[fam], fb
+
+
+def test_pool_has_at_least_five_types_across_multiple_lineages():
+    """The broadened pool must be ≥5 distinct machine types spanning ≥3 lineages
+    (AMD Turin / Intel Emerald / AMD Milan / Intel Cascade / AMD Rome) so a
+    newest-gen stockout can't exhaust every lane."""
+    types = {fb["machine_type"] for fb in EncodingWorkerConfig.FALLBACKS}
+    # primary (c4d) + the fallback types.
+    types.add(MachineTypes.ENCODING_WORKER)
+    assert len(types) >= 5, f"pool has only {len(types)} types: {types}"
+    families = {_family(mt) for mt in types}
+    assert len(families) >= 3, f"pool spans only {families}"
+
+
+def test_zone_spread_avoids_same_type_same_zone():
+    """No machine type should sit twice in the same zone (correlated stockout)."""
+    seen = set()
+    for fb in EncodingWorkerConfig.FALLBACKS:
+        key = (fb["machine_type"], fb["zone_suffix"])
+        assert key not in seen, f"duplicate (type,zone): {key}"
+        seen.add(key)
+
+
 def test_fallback_names_and_ips_are_unique_and_aligned():
     """Names/IPs are zipped by position with FALLBACKS — they must stay aligned
     and unique so no two VMs collide on a resource name or static IP."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.194.2"
+version = "0.195.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Replaces "c4d primary + single n2 fallback family" with a **ranked pool of 6 x86_64 / 32-vCPU / ≥32 GB highcpu types** across 4 silicon lineages (c4d, c4, n4d, c2d, n2d, n2), selected **fastest-first** but **availability-aware** — a type that stocks out is demoted for a 15-min cooldown then re-probed. c4d stays the top pick whenever it can start; a render no longer stalls even if 2+ types are fully stocked out in us-central1.
- One **pure preference module** (`encoding_worker_preference.ordered_candidates`) is now the single source of truth for candidate ranking, driving **both** runtime selection and deploy green selection so they can't drift.
- Keeps the per-VM start/stop model (MIG deferred with documented triggers; no reservation). Full plan + rollout in `docs/archive/2026-08-15-encoding-instance-type-diversity-plan.md`.

## Changes
- **New** `backend/services/encoding_worker_preference.py` — speed-rank + Firestore `capacity_state` cooldown; stdlib-only so `deploy_promote` imports it (with a shadow-proof by-path fallback).
- **Runtime** (`encoding_service`, `encoding_worker_manager`): builder ranks primary + fallbacks; manager records/clears per-(type,zone) stockout; override routing now keys off an explicit `is_primary` flag instead of list position.
- **Deploy** (`deploy_promote`, `ci.yml`): green selection uses the shared ranker + threads `capacity_state`.
- **IaC** (`config.py`, tests): `FALLBACKS` broadened to 6 types (additive-only) with family-correct disk types (Titanium c4/c4d/n4/n4d = hyperdisk-balanced; c2d/n2/n2d = pd-balanced); secret schema gains optional `machine_type`.
- **Packer** (`provision.sh`, `startup.sh`): bake full dep tree with **CPU-only torch** so fresh type VMs boot self-sufficient; build-time import verify.
- **New** `benchmark_types.py` to measure per-type encode wall-time and refine the seeded `SPEED_RANK`.

## Testing
- [x] Full backend unit suite: **3871 passed, 36 skipped** (emulator tests need external services)
- [x] New/updated tests: preference module (16), capacity_state + `is_primary` manager tests, builder-ordering + non-list-JSON service tests, deploy ranking tests, infra disk-capability + pool-breadth invariants
- [ ] Operator rollout (needs write creds): `pulumi up` (verify +8 create, 0 replace) → rebuild image (dep-bake) → grow fallback secret with `machine_type` → run `benchmark_types.py`

## Review
- [x] Local CodeRabbit review completed (4 major findings fixed; cycle 2 clean)
- [x] Review feedback addressed

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)