### PR TITLE
perf(encoding): remove dead ffmpeg_threads config; confirm finalization not CPU-capped

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,10 @@ See `docs/TESTING.md` § "Ad-Hoc Production Debugging" for full details.
 - Never modify GCP resources directly via console or `gcloud` CLI
 - `gcloud` CLI for reading/debugging only (e.g., checking logs, SSH to VMs)
 - Stop and notify user on auth issues
+- **GCS ops on macOS: never use `gsutil -m`** — its fork-based multiprocessing segfaults
+  on macOS (crash-report popups + the parent process hangs forever). Use `gcloud storage`
+  instead (`gcloud storage cp/rm/rsync …`) — no fork, and faster. Plain `gsutil` (no `-m`)
+  is safe but slower. `~/.boto` pins `parallel_process_count=1` as a safety net; don't remove it.
 
 ### Internationalization (i18n)
 

--- a/backend/workers/video_worker.py
+++ b/backend/workers/video_worker.py
@@ -128,7 +128,10 @@ async def _encode_via_gce(
         "base_name": base_name,
         "instrumental_selection": instrumental_selection,
         "existing_instrumental": existing_instrumental,
-        "ffmpeg_threads": 8,  # c4-standard-8 has 8 vCPUs
+        # NOTE: intentionally no "ffmpeg_threads" — finalization ffmpeg commands in
+        # LocalEncodingService carry no -threads flag, so x264 uses its all-core auto
+        # default (measured ~66-78% of a 32-vCPU worker busy during the heavy libx264
+        # stages — not capped). See docs/archive/2026-08-16-finalization-cpu-efficiency-handoff.md.
     }
 
     job_log.info(f"Submitting encoding job to GCE worker")

--- a/docs/archive/2026-08-16-finalization-cpu-efficiency-handoff.md
+++ b/docs/archive/2026-08-16-finalization-cpu-efficiency-handoff.md
@@ -153,9 +153,11 @@ ship it. Bump `pyproject.toml` version; if the fix is in the wheel's
 worker's 32 vCPUs during every heavy libx264 stage. No threading fix warranted.**
 
 ### 1. `ffmpeg_threads` is dead config — confirmed statically AND empirically
-- `grep -rn ffmpeg_threads backend/` → exactly one hit (the setter at
-  `video_worker.py:131`), zero consumers. `EncodingConfig(...)` at
-  `gce_encoding/main.py:1111` never passes it.
+- Before this change, `grep -rn ffmpeg_threads backend/` returned exactly one hit —
+  the setter `"ffmpeg_threads": 8` in the `encoding_config` dict at
+  `video_worker.py:131` — with zero consumers; `EncodingConfig(...)` at
+  `gce_encoding/main.py:1111` never passes it. This change removes that setter
+  (line 131 is now the explanatory NOTE comment), so grep now returns no setter.
 - **Empirically**, the deployed ffmpeg argv captured mid-encode (`ps`/probe on the
   worker) carry **no `-threads` flag** on any finalization command — x264 runs its
   all-core auto default. Sample argv observed:

--- a/docs/archive/2026-08-16-finalization-cpu-efficiency-handoff.md
+++ b/docs/archive/2026-08-16-finalization-cpu-efficiency-handoff.md
@@ -1,6 +1,11 @@
 # Handoff: Investigate prod finalization CPU efficiency / utilization — 2026-08-16
 
-**Status:** OPEN investigation (not started). Written for a fresh Claude session —
+**Status:** ✅ RESOLVED 2026-08-16 — outcome (a): CPU already well-utilized (NOT
+capped at 8 cores); removed dead `ffmpeg_threads` config. Empirical measurement +
+resolution appended at the bottom under "RESOLUTION". The original investigation
+brief follows unchanged for context.
+
+**Status (original):** OPEN investigation (not started). Written for a fresh Claude session —
 self-contained; all facts you need are inlined below or in the linked repo docs.
 **Origin:** surfaced by the encode-worker multi-instance-type benchmark
 (`docs/archive/2026-08-15-encoding-instance-type-diversity-plan.md`; benchmark
@@ -139,3 +144,69 @@ close this out and just fix the stale comment; or (b) confirm an ~2–4× idle-c
 gap → raise threads / parallelize formats, validate the speedup and RAM headroom,
 ship it. Bump `pyproject.toml` version; if the fix is in the wheel's
 `LocalEncodingService`, it ships via the normal wheel → `ensure_latest_wheel` path.
+
+---
+
+## RESOLUTION (2026-08-16) — outcome (a): already efficient; dead config removed
+
+**Verdict: the "leaving 75% idle" fear is unfounded. Finalization uses ~21–25 of a
+worker's 32 vCPUs during every heavy libx264 stage. No threading fix warranted.**
+
+### 1. `ffmpeg_threads` is dead config — confirmed statically AND empirically
+- `grep -rn ffmpeg_threads backend/` → exactly one hit (the setter at
+  `video_worker.py:131`), zero consumers. `EncodingConfig(...)` at
+  `gce_encoding/main.py:1111` never passes it.
+- **Empirically**, the deployed ffmpeg argv captured mid-encode (`ps`/probe on the
+  worker) carry **no `-threads` flag** on any finalization command — x264 runs its
+  all-core auto default. Sample argv observed:
+  - `… -i with_vocals.mkv -c:v libx264 -c:a copy … (With Vocals).mp4`
+  - `… concat=n=3… -c:v libx264 -c:a pcm_s16le … (Final Karaoke Lossless 4k).mp4`
+  - `… -i …Lossless 4k.mp4 -c:v copy -c:a aac … (Lossy 4k).mp4`
+  - `… -c:v libx264 -vf scale=1280:720 -preset medium -tune animation … (Lossy 720p).mp4`
+
+### 2. Process-level CPU measurement (the point of this task)
+Method: started `encoding-worker-fallback-c4a` (c4-highcpu-32, 32 vCPU / 62 GB),
+recreated the bench input, POSTed `/encode` **directly to the VM IP**, and sampled
+`top -bH -d 2` on that same VM for the whole run. The authoritative signal is the
+system-wide `%Cpu(s)` summary line (0–100% across all 32 cores):
+
+| Stage (serial)            | ffmpeg cmd                         | `%Cpu us` (of 32) | ≈cores busy | peak RSS | ~duration |
+|---------------------------|------------------------------------|-------------------|-------------|----------|-----------|
+| "With Vocals" mp4 convert | `libx264 -c:a copy` (mkv→mp4)      | 64–70%            | ~21         | ~11 GB   | ~59 s     |
+| **Lossless 4K concat**    | `libx264 -c:a pcm_s16le`           | 72–75%            | ~23         | ~9 GB    | ~45 s     |
+| Lossy 4K                  | `-c:v copy -c:a aac` (stream copy) | 3–5%              | I/O-bound   | <0.1 GB  | ~4 s      |
+| MKV (YouTube)             | `-c:v copy -c:a flac` (copy)       | low               | I/O-bound   | —        | ~2 s      |
+| 720p                      | `libx264 scale=1280:720 -preset medium` | 76–78%       | ~25         | ~1.2 GB  | ~12 s     |
+
+Full run: ~122 s of encoding + ~35 s GCS download/upload = **~158 s wall** (matches
+the ~139 s c4 baseline plus I/O). An 8-core cap would show `us≈25%, idle≈75%`; we
+observed the **opposite** (`us≈66–78%, idle≈22–34%`). Not capped.
+
+### 3. Why the residual ~25–30% idle is NOT recoverable by more threads
+The heavy processes already spawn 90–162 OS threads (`nlwp`); x264's auto default is
+~1.5×cores. The idle is the structural ceiling of x264 **frame-threading**
+(inter-frame dependencies + a partially-serial lookahead), not a thread cap. Forcing
+`-threads 32`/`-x264-params threads=N` above auto gives negligible speed and can hurt
+quality. **Formats are serial and dependency-chained** (`encode_all_formats` steps
+3→{4,5,6}; lossy/mkv/720p all consume the lossless output), and the only overlap-able
+work after lossless is two near-free stream copies (lossy, mkv) — so parallelizing
+formats buys ~nothing and would raise peak RAM against the 32 GB fallback floor +
+the `ENCODING_HEAVY_CONCURRENCY=1` OOM constraint. Not worth it.
+
+### 4. What shipped
+- Removed the dead `"ffmpeg_threads": 8` field + stale `c4-standard-8` comment at
+  `video_worker.py:131`, replaced with a NOTE explaining the measured all-core
+  behaviour (so nobody re-opens this). No behaviour change. Version bump only.
+
+### 5. Follow-up worth its own task (NOT done here — out of scope, needs verification)
+The single biggest CPU cost is the **"With Vocals" preview** — a full 4K libx264
+re-encode (~59 s, longer than the lossless master itself). The source
+`with_vocals.mkv` is **already H.264** (High 4:4:4 Predictive, 3840×2160, `yuv444p`).
+If nothing downstream needs a re-encode / a different `pix_fmt`, this could become a
+container remux (`-c:v copy`) and save ~40–50 s/job — a far bigger win than any
+threading tweak. Requires confirming: (a) do players/consumers need `yuv420p` (4:4:4
+mp4 is poorly supported), and (b) does `convert_mov_to_mp4` intentionally normalize
+pix_fmt? Left for a dedicated investigation.
+
+### Operational note
+Bench VM stopped, `gs://…/bench/**` deleted after the run, per hygiene.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.195.1"
+version = "0.195.2"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Investigated whether prod video **finalization** (`/encode` → 4K lossless/lossy + 720p) uses the 32-vCPU `*-highcpu-32` workers efficiently. **It does** — ~21–25 of 32 cores busy during every heavy libx264 stage. Not capped at 8.
- `"ffmpeg_threads": 8` in `video_worker.py` was **dead config** (zero consumers; no finalization ffmpeg command carries `-threads`). Removed it + the stale `c4-standard-8` comment.
- No behaviour change — cleanup + documentation of the empirical finding.

## Evidence (process-level measurement)
Drove a real finalization on a live `c4-highcpu-32` worker and sampled `top -bH` on that same VM. System-wide `%Cpu(s)` during the heavy stages:

| Stage | ffmpeg | `%Cpu us` (of 32) | ≈cores | peak RSS |
|---|---|---|---|---|
| "With Vocals" convert | `libx264 -c:a copy` | 64–70% | ~21 | ~11 GB |
| Lossless 4K concat | `libx264 -c:a pcm_s16le` | 72–75% | ~23 | ~9 GB |
| 720p | `libx264 scale=1280:720` | 76–78% | ~25 | ~1.2 GB |
| Lossy 4K / MKV | stream copies | low (I/O) | — | <0.1 GB |

An 8-core cap would show `us≈25%, idle≈75%`; observed the opposite. The residual ~25–30% idle is x264's structural frame-threading ceiling, not a recoverable cap. Full write-up in `docs/archive/2026-08-16-finalization-cpu-efficiency-handoff.md` (RESOLUTION section).

## Changes
- `backend/workers/video_worker.py` — remove dead `"ffmpeg_threads": 8` field + stale comment; replace with explanatory NOTE.
- `docs/archive/2026-08-16-finalization-cpu-efficiency-handoff.md` — append RESOLUTION with measurement, argv, stage timings, and a follow-up note.
- `pyproject.toml` — bump `0.195.1` → `0.195.2`.
- `CLAUDE.md` — note to avoid `gsutil -m` on macOS (fork segfaults → crash popups/hangs); use `gcloud storage`.

## Testing
- [x] Targeted encoding/worker tests pass (110: `test_video_worker_orchestrator`, `test_workers_extended`, `test_encoding_interface_contract`)
- [x] `grep` confirms no remaining `ffmpeg_threads` code/test references
- [x] Change is a no-op removal of an already-ignored dict field

## Review
- [x] Local CodeRabbit review completed
- [x] Review feedback addressed (1 minor doc-accuracy fix)

## Follow-up (separate task)
The "With Vocals" preview is a full 4K libx264 re-encode (~59s) of an **already-H.264** source (`yuv444p`). If nothing downstream needs a re-encode / different pix_fmt, a `-c:v copy` remux could save ~40–50s/job — bigger than any threading tweak. Needs its own investigation.

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)