### PR TITLE
perf(encoding): faster, smaller, portable "With Vocals" mp4 (yuv420p + veryfast + AAC)

### DIFF
--- a/backend/services/local_encoding_service.py
+++ b/backend/services/local_encoding_service.py
@@ -325,10 +325,24 @@ class LocalEncodingService:
         output_file: str,
     ) -> bool:
         """
-        Convert MOV to MP4 format.
+        Convert the source "With Vocals" video (MOV/MKV) to a standard, portable MP4.
+
+        This produces the "(With Vocals).mp4" sing-along deliverable. It is a leaf
+        output — no later encode reads it — so the encode is chosen purely for the
+        deliverable itself:
+          - ``-pix_fmt yuv420p``: the renderer emits High 4:4:4 (yuv444p), which many
+            browsers/TVs/phones cannot decode. Normalize to 4:2:0 so it plays
+            everywhere and matches every other output. (Also ~halves this stage's CPU
+            time vs. re-encoding 4:4:4, and yields a slightly smaller file.)
+          - ``-preset veryfast``: this is the single longest finalization stage; a fast
+            preset roughly halves it (~56s → ~28s on a 32-vCPU worker) with negligible
+            quality difference for karaoke content (static background + text).
+          - ``-c:a aac``: the source audio is FLAC; FLAC-in-MP4 is non-standard. Encode
+            AAC 320k so the file is fully portable. Matches the documented spec
+            ("4k H264/AAC with original vocals", see template_service.py).
 
         Args:
-            input_file: Path to input MOV file
+            input_file: Path to input MOV/MKV file (source "With Vocals" video)
             output_file: Path for output MP4 file
 
         Returns:
@@ -336,11 +350,13 @@ class LocalEncodingService:
         """
         gpu_command = (
             f'{self._ffmpeg_base_command} {self.hwaccel_decode_flags} -i "{input_file}" '
-            f'-c:v {self.video_encoder} -c:a copy {self.MP4_FLAGS} "{output_file}"'
+            f'-c:v {self.video_encoder} -c:a {self.aac_codec} -ar 48000 -b:a 320k '
+            f'{self.MP4_FLAGS} "{output_file}"'
         )
         cpu_command = (
             f'{self._ffmpeg_base_command} -i "{input_file}" '
-            f'-c:v libx264 -c:a copy {self.MP4_FLAGS} "{output_file}"'
+            f'-c:v libx264 -pix_fmt yuv420p -preset veryfast '
+            f'-c:a {self.aac_codec} -ar 48000 -b:a 320k {self.MP4_FLAGS} "{output_file}"'
         )
         return self._execute_command_with_fallback(
             gpu_command, cpu_command, "Converting MOV to MP4"

--- a/backend/services/local_encoding_service.py
+++ b/backend/services/local_encoding_service.py
@@ -341,6 +341,11 @@ class LocalEncodingService:
             AAC 320k so the file is fully portable. Matches the documented spec
             ("4k H264/AAC with original vocals", see template_service.py).
 
+        Both commands force ``-pix_fmt yuv420p`` (h264_nvenc can otherwise *preserve* a
+        yuv444p input). Prod encoding workers are CPU-only, so ``cpu_command`` is the
+        real path; if the NVENC command ever errors, ``_execute_command_with_fallback``
+        drops to the (correct) CPU command.
+
         Args:
             input_file: Path to input MOV/MKV file (source "With Vocals" video)
             output_file: Path for output MP4 file
@@ -350,7 +355,7 @@ class LocalEncodingService:
         """
         gpu_command = (
             f'{self._ffmpeg_base_command} {self.hwaccel_decode_flags} -i "{input_file}" '
-            f'-c:v {self.video_encoder} -c:a {self.aac_codec} -ar 48000 -b:a 320k '
+            f'-c:v {self.video_encoder} -pix_fmt yuv420p -c:a {self.aac_codec} -ar 48000 -b:a 320k '
             f'{self.MP4_FLAGS} "{output_file}"'
         )
         cpu_command = (

--- a/backend/tests/test_local_encoding_service.py
+++ b/backend/tests/test_local_encoding_service.py
@@ -171,7 +171,7 @@ class TestLocalEncodingServiceEncodingMethods:
 
     @patch.object(LocalEncodingService, "_execute_command_with_fallback")
     def test_convert_mov_to_mp4(self, mock_execute):
-        """Test MOV to MP4 conversion."""
+        """Test MOV to MP4 conversion produces a standard, portable "With Vocals" mp4."""
         mock_execute.return_value = True
 
         service = LocalEncodingService()
@@ -182,6 +182,18 @@ class TestLocalEncodingServiceEncodingMethods:
 
         assert result is True
         mock_execute.assert_called_once()
+        gpu_command, cpu_command = mock_execute.call_args[0][0], mock_execute.call_args[0][1]
+        # The CPU (software) command is what runs on prod encoding workers (no NVENC).
+        # It must normalize 4:4:4 -> 4:2:0 for playback compatibility, use a fast preset
+        # (this is the longest finalization stage), and emit portable AAC (not FLAC-in-mp4).
+        assert "-pix_fmt yuv420p" in cpu_command
+        assert "-preset veryfast" in cpu_command
+        assert "-c:a aac" in cpu_command
+        assert "-b:a 320k" in cpu_command
+        assert "-c:a copy" not in cpu_command  # regression guard: no FLAC-in-mp4
+        # GPU path also emits portable AAC; NVENC h264 encodes 4:2:0 natively.
+        assert "-c:a aac" in gpu_command
+        assert "-b:a 320k" in gpu_command
 
     @patch.object(LocalEncodingService, "_execute_command_with_fallback")
     def test_encode_lossless_mp4_without_end(self, mock_execute):

--- a/backend/tests/test_local_encoding_service.py
+++ b/backend/tests/test_local_encoding_service.py
@@ -191,7 +191,8 @@ class TestLocalEncodingServiceEncodingMethods:
         assert "-c:a aac" in cpu_command
         assert "-b:a 320k" in cpu_command
         assert "-c:a copy" not in cpu_command  # regression guard: no FLAC-in-mp4
-        # GPU path also emits portable AAC; NVENC h264 encodes 4:2:0 natively.
+        # GPU path also forces 4:2:0 (h264_nvenc can preserve yuv444p) and emits AAC.
+        assert "-pix_fmt yuv420p" in gpu_command
         assert "-c:a aac" in gpu_command
         assert "-b:a 320k" in gpu_command
 

--- a/docs/archive/2026-08-16-with-vocals-encode-optimization.md
+++ b/docs/archive/2026-08-16-with-vocals-encode-optimization.md
@@ -1,0 +1,71 @@
+# "With Vocals" preview encode — faster, smaller, more portable (2026-08-16)
+
+**Status:** ✅ SHIPPED (v0.196.0). Follow-up from the finalization-CPU investigation
+(`2026-08-16-finalization-cpu-efficiency-handoff.md`), which identified the "With
+Vocals" conversion as the single longest finalization stage.
+
+## Problem
+
+`convert_mov_to_mp4` produces the **"(With Vocals).mp4"** sing-along deliverable from
+the renderer's source video. Process-level measurement on a live c4-highcpu-32 worker
+showed this was the **longest single finalization stage (~59s)** — longer than the
+lossless master itself.
+
+Probing a real prod job (`faafd5ad`) revealed the encode was *accidentally* bad:
+- **No `-pix_fmt`** → inherited the renderer's `High 4:4:4 Predictive / yuv444p`. This
+  is the **only** 4:4:4 file in the deliverable set (every other output is `yuv420p`),
+  and 4:4:4 H.264 is rejected by many browsers/TVs/phones.
+- **Default `medium` preset** → slow.
+- **`-c:a copy`** (LocalEncodingService path) → **FLAC-in-MP4**, which is non-standard,
+  despite the customer-facing spec (`template_service.py`) documenting the file as
+  "4k H264/**AAC**".
+
+## Safety check — is the "With Vocals" mp4 used downstream?
+
+**No.** Confirmed in both encode paths (cloud `encode_all_formats` and local
+`KaraokeFinalise.remux_and_encode_output_video_files`): every later output (Karaoke.mp4,
+Lossless/Lossy/720p, MKV) derives from the **source** `with_vocals` file (via
+`remux_with_instrumental` → `Karaoke.mp4` → concat) and carries the **instrumental**
+audio. YouTube upload uses `final_karaoke_lossless_mkv`. The "(With Vocals).mp4" is
+written once and only uploaded/delivered — a leaf. So its encode can be chosen purely
+for the deliverable.
+
+## Fix
+
+`convert_mov_to_mp4` software (CPU) command — the path that runs on prod workers
+(no NVENC) — changed to:
+
+```
+-c:v libx264 -pix_fmt yuv420p -preset veryfast -c:a aac -ar 48000 -b:a 320k -movflags +faststart
+```
+
+Applied to **both** implementations (kept in sync):
+- `backend/services/local_encoding_service.py::LocalEncodingService.convert_mov_to_mp4`
+  (cloud worker — prod)
+- `karaoke_gen/karaoke_finalise/karaoke_finalise.py::KaraokeFinalise.convert_mov_to_mp4`
+  (local CLI; already emitted AAC, now also 4:2:0 + veryfast + 320k)
+
+GPU/NVENC command: emits AAC 320k; `h264_nvenc` encodes 4:2:0 natively so no `-pix_fmt`
+needed. (Prod workers are CPU-only; NVENC is a local/GPU path.)
+
+## Measured result (real source: Arctic Monkeys – Riot Van, 138s 4K)
+
+| Metric | Before (prod) | After |
+|---|---|---|
+| Encode time | 56 s | **29 s** (~2×) |
+| File size | 22 MB | **14 MB** (~36% smaller) |
+| Video | h264 High 4:4:4 / yuv444p | **h264 High / yuv420p** |
+| Audio | FLAC-in-mp4 (~639 kbps) | **AAC-LC 48 kHz / 320 kbps** |
+
+This is the longest finalization stage, so ~halving it cuts **~20-25% off total
+finalization wall-time**. The file gets **smaller** (AAC 320k ≪ FLAC ~639k, and 4:2:0
+< 4:4:4), so there is no size/CPU tradeoff — every axis improves, plus universal
+playback and spec-alignment.
+
+## Notes / non-goals
+- Quality: for karaoke content (static background + text) `veryfast` vs `medium` is
+  visually negligible; CRF-based, comparable bitrate.
+- The finalise-only **user-upload** path (a user's own `.mov`/`.mkv`, arbitrary codec)
+  still re-encodes correctly — the command is codec-agnostic (no stream-copy assumption).
+- Not touched: whether a "reference" file needs to be 4K at all (a 1080p variant would
+  be smaller still) — a product decision, left for later.

--- a/karaoke_gen/karaoke_finalise/karaoke_finalise.py
+++ b/karaoke_gen/karaoke_finalise/karaoke_finalise.py
@@ -889,13 +889,14 @@ class KaraokeFinalise:
         """Convert the source "With Vocals" video (MOV/MKV) to a standard, portable MP4.
 
         Produces the "(With Vocals).mp4" sing-along deliverable — a leaf output (no
-        later encode reads it). ``-pix_fmt yuv420p`` normalizes the renderer's High
-        4:4:4 (yuv444p) output to 4:2:0 so it plays everywhere and matches every other
-        deliverable; ``-preset veryfast`` roughly halves this stage (the longest one)
-        with negligible quality impact for karaoke content; AAC 320k keeps it fully
-        portable. Kept in sync with LocalEncodingService.convert_mov_to_mp4.
+        later encode reads it). ``-preset veryfast`` roughly halves this stage (the
+        longest finalization stage) with negligible quality impact for karaoke content;
+        AAC 320k keeps the audio portable. yuv420p (playback compatibility) comes from
+        ``self.mp4_flags``, which already carries ``-pix_fmt yuv420p``. Kept in sync
+        with LocalEncodingService.convert_mov_to_mp4 (whose MP4_FLAGS lacks pix_fmt, so
+        that variant sets ``-pix_fmt yuv420p`` explicitly).
         """
-        # Hardware-accelerated version
+        # Hardware-accelerated version (pix_fmt yuv420p supplied via self.mp4_flags)
         gpu_command = (
             f'{self.ffmpeg_base_command} {self.hwaccel_decode_flags} -i "{input_file}" '
             f'-c:v {self.video_encoder} {self.get_nvenc_quality_settings("high")} -c:a {self.aac_codec} -ar 48000 -b:a 320k {self.mp4_flags} "{output_file}"'
@@ -904,7 +905,7 @@ class KaraokeFinalise:
         # Software fallback version
         cpu_command = (
             f'{self.ffmpeg_base_command} -i "{input_file}" '
-            f'-c:v libx264 -pix_fmt yuv420p -preset veryfast -c:a {self.aac_codec} -ar 48000 -b:a 320k {self.mp4_flags} "{output_file}"'
+            f'-c:v libx264 -preset veryfast -c:a {self.aac_codec} -ar 48000 -b:a 320k {self.mp4_flags} "{output_file}"'
         )
 
         self.execute_command_with_fallback(gpu_command, cpu_command, "Converting MOV video to MP4")

--- a/karaoke_gen/karaoke_finalise/karaoke_finalise.py
+++ b/karaoke_gen/karaoke_finalise/karaoke_finalise.py
@@ -886,19 +886,27 @@ class KaraokeFinalise:
         self.execute_command(ffmpeg_command, "Remuxing video with instrumental audio")
 
     def convert_mov_to_mp4(self, input_file, output_file):
-        """Convert MOV file to MP4 format with hardware acceleration support"""
+        """Convert the source "With Vocals" video (MOV/MKV) to a standard, portable MP4.
+
+        Produces the "(With Vocals).mp4" sing-along deliverable — a leaf output (no
+        later encode reads it). ``-pix_fmt yuv420p`` normalizes the renderer's High
+        4:4:4 (yuv444p) output to 4:2:0 so it plays everywhere and matches every other
+        deliverable; ``-preset veryfast`` roughly halves this stage (the longest one)
+        with negligible quality impact for karaoke content; AAC 320k keeps it fully
+        portable. Kept in sync with LocalEncodingService.convert_mov_to_mp4.
+        """
         # Hardware-accelerated version
         gpu_command = (
             f'{self.ffmpeg_base_command} {self.hwaccel_decode_flags} -i "{input_file}" '
-            f'-c:v {self.video_encoder} {self.get_nvenc_quality_settings("high")} -c:a {self.aac_codec} -ar 48000 {self.mp4_flags} "{output_file}"'
+            f'-c:v {self.video_encoder} {self.get_nvenc_quality_settings("high")} -c:a {self.aac_codec} -ar 48000 -b:a 320k {self.mp4_flags} "{output_file}"'
         )
-        
+
         # Software fallback version
         cpu_command = (
             f'{self.ffmpeg_base_command} -i "{input_file}" '
-            f'-c:v libx264 -c:a {self.aac_codec} -ar 48000 {self.mp4_flags} "{output_file}"'
+            f'-c:v libx264 -pix_fmt yuv420p -preset veryfast -c:a {self.aac_codec} -ar 48000 -b:a 320k {self.mp4_flags} "{output_file}"'
         )
-        
+
         self.execute_command_with_fallback(gpu_command, cpu_command, "Converting MOV video to MP4")
 
     def encode_lossless_mp4(self, title_mov_file, karaoke_mp4_file, env_mov_input, ffmpeg_filter, output_file):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.195.2"
+version = "0.196.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"

--- a/tests/unit/test_karaoke_finalise/test_ffmpeg_commands.py
+++ b/tests/unit/test_karaoke_finalise/test_ffmpeg_commands.py
@@ -138,11 +138,11 @@ def test_convert_mov_to_mp4_aac(mock_execute_fallback, finaliser_with_aac):
     
     expected_gpu_cmd = (
         f'{finaliser_with_aac.ffmpeg_base_command}  -i "{WITH_VOCALS_MOV}" '
-        f'-c:v libx264 -preset p4 -tune hq -cq 18 -c:a aac -ar 48000 {finaliser_with_aac.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
+        f'-c:v libx264 -preset p4 -tune hq -cq 18 -c:a aac -ar 48000 -b:a 320k {finaliser_with_aac.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
     )
     expected_cpu_cmd = (
         f'{finaliser_with_aac.ffmpeg_base_command} -i "{WITH_VOCALS_MOV}" '
-        f'-c:v libx264 -c:a aac -ar 48000 {finaliser_with_aac.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
+        f'-c:v libx264 -pix_fmt yuv420p -preset veryfast -c:a aac -ar 48000 -b:a 320k {finaliser_with_aac.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
     )
     mock_execute_fallback.assert_called_once_with(expected_gpu_cmd, expected_cpu_cmd, "Converting MOV video to MP4")
 
@@ -153,11 +153,11 @@ def test_convert_mov_to_mp4_aac_at(mock_execute_fallback, finaliser_with_aac_at)
     
     expected_gpu_cmd = (
         f'{finaliser_with_aac_at.ffmpeg_base_command}  -i "{WITH_VOCALS_MOV}" '
-        f'-c:v libx264 -preset p4 -tune hq -cq 18 -c:a aac_at -ar 48000 {finaliser_with_aac_at.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
+        f'-c:v libx264 -preset p4 -tune hq -cq 18 -c:a aac_at -ar 48000 -b:a 320k {finaliser_with_aac_at.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
     )
     expected_cpu_cmd = (
         f'{finaliser_with_aac_at.ffmpeg_base_command} -i "{WITH_VOCALS_MOV}" '
-        f'-c:v libx264 -c:a aac_at -ar 48000 {finaliser_with_aac_at.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
+        f'-c:v libx264 -pix_fmt yuv420p -preset veryfast -c:a aac_at -ar 48000 -b:a 320k {finaliser_with_aac_at.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
     )
     mock_execute_fallback.assert_called_once_with(expected_gpu_cmd, expected_cpu_cmd, "Converting MOV video to MP4")
 
@@ -398,11 +398,11 @@ def test_convert_mov_to_mp4_aac_nvenc(mock_execute_fallback, finaliser_with_nven
     
     expected_gpu_cmd = (
         f'{finaliser_with_nvenc_aac.ffmpeg_base_command} {finaliser_with_nvenc_aac.hwaccel_decode_flags} -i "{WITH_VOCALS_MOV}" '
-        f'-c:v h264_nvenc -preset p4 -tune hq -cq 18 -c:a aac {finaliser_with_nvenc_aac.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
+        f'-c:v h264_nvenc -preset p4 -tune hq -cq 18 -c:a aac -ar 48000 -b:a 320k {finaliser_with_nvenc_aac.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
     )
     expected_cpu_cmd = (
         f'{finaliser_with_nvenc_aac.ffmpeg_base_command} -i "{WITH_VOCALS_MOV}" '
-        f'-c:v libx264 -c:a aac {finaliser_with_nvenc_aac.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
+        f'-c:v libx264 -pix_fmt yuv420p -preset veryfast -c:a aac -ar 48000 -b:a 320k {finaliser_with_nvenc_aac.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
     )
     mock_execute_fallback.assert_called_once_with(expected_gpu_cmd, expected_cpu_cmd, "Converting MOV video to MP4")
 
@@ -414,11 +414,11 @@ def test_convert_mov_to_mp4_aac_at_nvenc(mock_execute_fallback, finaliser_with_n
     
     expected_gpu_cmd = (
         f'{finaliser_with_nvenc_aac_at.ffmpeg_base_command} {finaliser_with_nvenc_aac_at.hwaccel_decode_flags} -i "{WITH_VOCALS_MOV}" '
-        f'-c:v h264_nvenc -preset p4 -tune hq -cq 18 -c:a aac_at {finaliser_with_nvenc_aac_at.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
+        f'-c:v h264_nvenc -preset p4 -tune hq -cq 18 -c:a aac_at -ar 48000 -b:a 320k {finaliser_with_nvenc_aac_at.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
     )
     expected_cpu_cmd = (
         f'{finaliser_with_nvenc_aac_at.ffmpeg_base_command} -i "{WITH_VOCALS_MOV}" '
-        f'-c:v libx264 -c:a aac_at {finaliser_with_nvenc_aac_at.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
+        f'-c:v libx264 -pix_fmt yuv420p -preset veryfast -c:a aac_at -ar 48000 -b:a 320k {finaliser_with_nvenc_aac_at.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
     )
     mock_execute_fallback.assert_called_once_with(expected_gpu_cmd, expected_cpu_cmd, "Converting MOV video to MP4")
 

--- a/tests/unit/test_karaoke_finalise/test_ffmpeg_commands.py
+++ b/tests/unit/test_karaoke_finalise/test_ffmpeg_commands.py
@@ -142,7 +142,7 @@ def test_convert_mov_to_mp4_aac(mock_execute_fallback, finaliser_with_aac):
     )
     expected_cpu_cmd = (
         f'{finaliser_with_aac.ffmpeg_base_command} -i "{WITH_VOCALS_MOV}" '
-        f'-c:v libx264 -pix_fmt yuv420p -preset veryfast -c:a aac -ar 48000 -b:a 320k {finaliser_with_aac.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
+        f'-c:v libx264 -preset veryfast -c:a aac -ar 48000 -b:a 320k {finaliser_with_aac.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
     )
     mock_execute_fallback.assert_called_once_with(expected_gpu_cmd, expected_cpu_cmd, "Converting MOV video to MP4")
 
@@ -157,7 +157,7 @@ def test_convert_mov_to_mp4_aac_at(mock_execute_fallback, finaliser_with_aac_at)
     )
     expected_cpu_cmd = (
         f'{finaliser_with_aac_at.ffmpeg_base_command} -i "{WITH_VOCALS_MOV}" '
-        f'-c:v libx264 -pix_fmt yuv420p -preset veryfast -c:a aac_at -ar 48000 -b:a 320k {finaliser_with_aac_at.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
+        f'-c:v libx264 -preset veryfast -c:a aac_at -ar 48000 -b:a 320k {finaliser_with_aac_at.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
     )
     mock_execute_fallback.assert_called_once_with(expected_gpu_cmd, expected_cpu_cmd, "Converting MOV video to MP4")
 
@@ -402,7 +402,7 @@ def test_convert_mov_to_mp4_aac_nvenc(mock_execute_fallback, finaliser_with_nven
     )
     expected_cpu_cmd = (
         f'{finaliser_with_nvenc_aac.ffmpeg_base_command} -i "{WITH_VOCALS_MOV}" '
-        f'-c:v libx264 -pix_fmt yuv420p -preset veryfast -c:a aac -ar 48000 -b:a 320k {finaliser_with_nvenc_aac.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
+        f'-c:v libx264 -preset veryfast -c:a aac -ar 48000 -b:a 320k {finaliser_with_nvenc_aac.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
     )
     mock_execute_fallback.assert_called_once_with(expected_gpu_cmd, expected_cpu_cmd, "Converting MOV video to MP4")
 
@@ -418,7 +418,7 @@ def test_convert_mov_to_mp4_aac_at_nvenc(mock_execute_fallback, finaliser_with_n
     )
     expected_cpu_cmd = (
         f'{finaliser_with_nvenc_aac_at.ffmpeg_base_command} -i "{WITH_VOCALS_MOV}" '
-        f'-c:v libx264 -pix_fmt yuv420p -preset veryfast -c:a aac_at -ar 48000 -b:a 320k {finaliser_with_nvenc_aac_at.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
+        f'-c:v libx264 -preset veryfast -c:a aac_at -ar 48000 -b:a 320k {finaliser_with_nvenc_aac_at.mp4_flags} "{OUTPUT_FILES["with_vocals_mp4"]}"'
     )
     mock_execute_fallback.assert_called_once_with(expected_gpu_cmd, expected_cpu_cmd, "Converting MOV video to MP4")
 


### PR DESCRIPTION
## Summary
- The **"(With Vocals).mp4"** sing-along deliverable was the *single longest finalization stage* (~59s on a 32-vCPU worker). `convert_mov_to_mp4` encoded it accidentally-badly: no `-pix_fmt` (inherited the renderer's `High 4:4:4`/`yuv444p` — the only 4:4:4 file in the set, poorly supported by browsers/TVs/phones), default `medium` preset (slow), and `-c:a copy` → **FLAC-in-mp4** (non-standard) despite the documented spec ("4k H264/**AAC**").
- Verified the file is a **pure leaf** — nothing downstream reads its video or audio. Every later output (Karaoke.mp4, Lossless/Lossy/720p, MKV) derives from the *source* `with_vocals` file + the *instrumental* audio; YouTube uploads the lossless MKV. So the encode is chosen purely for the deliverable.

## Change
`convert_mov_to_mp4` (software/CPU path — what runs on prod workers):
```
-c:v libx264 -pix_fmt yuv420p -preset veryfast -c:a aac -ar 48000 -b:a 320k -movflags +faststart
```
Applied to both implementations, kept in sync:
- `LocalEncodingService.convert_mov_to_mp4` (cloud worker — prod). Its `MP4_FLAGS` has no pix_fmt, so `-pix_fmt yuv420p` is explicit on both GPU and CPU commands.
- `KaraokeFinalise.convert_mov_to_mp4` (local CLI). Already emitted AAC and already forces yuv420p via its `mp4_flags`; adds the `-preset veryfast` speed win + `-b:a 320k`.

## Measured result (real 138s 4K source: Arctic Monkeys – Riot Van)
| Metric | Before (prod) | After |
|---|---|---|
| Encode time | 56 s | **29 s** (~2×) |
| File size | 22 MB | **14 MB** (~36% smaller) |
| Video | h264 High 4:4:4 / yuv444p | **h264 High / yuv420p** |
| Audio | FLAC-in-mp4 (~639 kbps) | **AAC-LC 48 kHz / 320 kbps** |

This is the longest finalization stage, so ~halving it cuts **~20-25% off total finalization wall-time**. The file also gets **smaller** (AAC 320k ≪ FLAC ~639k, 4:2:0 < 4:4:4) — no size/CPU tradeoff; every axis improves, plus universal playback + spec alignment. Verified end-to-end by running the exact shipped command on the source and re-probing the output.

## Testing
- [x] `backend/tests/test_local_encoding_service.py` + `tests/unit/test_karaoke_finalise/test_ffmpeg_commands.py` updated to assert the new flags (pix_fmt/preset/AAC/320k + regression guard: no `-c:a copy`)
- [x] 236 passed / 8 skipped across encoding + karaoke_finalise suites
- [x] End-to-end: exact command on real source → 29s, 14MB, yuv420p, AAC 320k

## Review
- [x] Local CodeRabbit review completed (2 cycles); findings addressed (forced yuv420p on NVENC path; removed duplicate pix_fmt on CLI path). Pre-existing skipped-NVENC-test fixture gap noted, out of scope.

## Non-goals
User-uploaded (finalise-only) non-H.264 videos still re-encode correctly (codec-agnostic). Whether a "reference" file needs to be 4K at all is a separate product decision.

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)