### PR TITLE
fix: connectivity banner only on real read stall (not slowness)

### DIFF
--- a/docs/archive/2026-08-22-health-check-alert-noise-and-graceful-degradation.md
+++ b/docs/archive/2026-08-22-health-check-alert-noise-and-graceful-degradation.md
@@ -49,16 +49,24 @@ Goal: during a blip, retry transparently and show one reassuring app-wide messag
 instead of every screen throwing a generic error.
 
 - **`lib/backend-status.ts`** — framework-agnostic connectivity store
-  (`online | reconnecting | unavailable`) + `useBackendStatus()`. Escalates to
-  `unavailable` after `UNAVAILABLE_AFTER_MS` (10s) of unbroken trouble; any
-  success returns to `online`.
+  (`online | reconnecting | unavailable`) + `useBackendStatus()`. **Status is
+  derived purely from how long the OLDEST in-flight tracked read has been
+  outstanding** (`beginRequest`/`endRequest`): `reconnecting` at
+  `STALL_RECONNECTING_MS` (10s), `unavailable` at `STALL_UNAVAILABLE_MS` (20s),
+  back to `online` the instant the stalled read settles.
 - **`lib/api.ts` — `apiFetch`** wraps every backend call (drop-in for `fetch`;
   internals use `globalThis.fetch`). Design decisions:
-  - **Decoupled** the non-aborting "reconnecting" hint (2.5s) from the hard
-    backstop (45s) + transient-status/network detection — so a legitimately slow
-    GET shows the hint then clears on success and is **never falsely failed**.
+  - **The banner keys on a genuine STALL, not slowness.** A read that completes —
+    even a normal-slow 3–5s one — surfaces nothing; only a read still outstanding
+    past 10s shows the hint. (The original 2.5s "slow-request" hint was too
+    trigger-happy — it fired during normal lyrics-review loads.)
+  - **Only GETs are tracked, and only GETs get a hard-timeout (45s) backstop.**
+    Long-running POSTs (preview video, generate, search, auto-correct) are
+    legitimately slow: they must never trip the banner nor be aborted mid-encode.
+    Callers can opt a slow read out with `opts.trackConnectivity: false`, or
+    time-box any request with `opts.timeoutMs`.
   - **Retries GET only** (idempotent); **never auto-retries non-GET** (a replayed
-    create/submit/payment could double-charge). GETs retry within a ~10s budget,
+    create/submit/payment could double-charge). GETs retry within a ~2s budget,
     then throw `BackendUnavailableError`.
   - Transient = 502/503/504 + Cloudflare 520–524. Third-party hosts (GCS
     signed-URL uploads) pass straight through untouched.

--- a/frontend/__tests__/api-fetch.test.ts
+++ b/frontend/__tests__/api-fetch.test.ts
@@ -9,8 +9,8 @@
 import { apiFetch, BackendUnavailableError } from '@/lib/api'
 import {
   getBackendStatus,
-  reportBackendOnline,
-  UNAVAILABLE_AFTER_MS,
+  STALL_RECONNECTING_MS,
+  STALL_UNAVAILABLE_MS,
 } from '@/lib/backend-status'
 
 function mockResponse(status: number, body: unknown = {}): Response {
@@ -21,34 +21,44 @@ function mockResponse(status: number, body: unknown = {}): Response {
   } as unknown as Response
 }
 
+/** A fetch mock that returns a promise you resolve/reject by hand, so a request can
+ *  be held "in flight" under fake timers and then settled to clean up. */
+function deferredFetch() {
+  let settle!: (r: Response) => void
+  let fail!: (e: unknown) => void
+  const fn = jest.fn(
+    () =>
+      new Promise<Response>((res, rej) => {
+        settle = res
+        fail = rej
+      }),
+  )
+  return { fn, settle: (r: Response) => settle(r), fail: (e: unknown) => fail(e) }
+}
+
 describe('apiFetch', () => {
   const fetchMock = jest.fn()
 
   beforeEach(() => {
     fetchMock.mockReset()
     ;(globalThis as unknown as { fetch: unknown }).fetch = fetchMock
-    reportBackendOnline()
   })
 
   afterEach(() => {
     jest.useRealTimers()
   })
 
-  it('returns the response and marks the backend online on a successful GET', async () => {
+  it('returns the response and stays online on a fast successful GET', async () => {
     fetchMock.mockResolvedValue(mockResponse(200, { ok: true }))
-
     const res = await apiFetch('/api/jobs/abc')
-
     expect(res.status).toBe(200)
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(getBackendStatus()).toBe('online')
   })
 
-  it('does NOT retry a deterministic 404 and stays online (backend was reached)', async () => {
+  it('does NOT retry a deterministic 404 and stays online', async () => {
     fetchMock.mockResolvedValue(mockResponse(404))
-
     const res = await apiFetch('/api/jobs/missing')
-
     expect(res.status).toBe(404)
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(getBackendStatus()).toBe('online')
@@ -60,18 +70,13 @@ describe('apiFetch', () => {
 
     const p = apiFetch('/api/jobs/abc')
     const assertion = expect(p).rejects.toBeInstanceOf(BackendUnavailableError)
-
-    // Drive the two backoff sleeps (600ms, then 1500ms) between the 3 attempts.
     await jest.advanceTimersByTimeAsync(600)
     await jest.advanceTimersByTimeAsync(1500)
-
     await assertion
+
     expect(fetchMock).toHaveBeenCalledTimes(3)
-    // A fast-failing retry budget (~2s) still only shows the subtle "reconnecting"
-    // hint — the full banner is gated on the UNAVAILABLE_AFTER_MS (10s) clock.
-    expect(getBackendStatus()).toBe('reconnecting')
-    await jest.advanceTimersByTimeAsync(UNAVAILABLE_AFTER_MS)
-    expect(getBackendStatus()).toBe('unavailable')
+    // A fast total failure (~2s) is NOT a stall, so the banner never appears.
+    expect(getBackendStatus()).toBe('online')
   })
 
   it('retries a GET that keeps returning a transient 503, then throws', async () => {
@@ -80,15 +85,90 @@ describe('apiFetch', () => {
 
     const p = apiFetch('/api/jobs/abc')
     const assertion = expect(p).rejects.toBeInstanceOf(BackendUnavailableError)
-
     await jest.advanceTimersByTimeAsync(600)
     await jest.advanceTimersByTimeAsync(1500)
-
     await assertion
+
     expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(getBackendStatus()).toBe('online')
+  })
+
+  it('recovers transparently when a retried GET succeeds on a later attempt', async () => {
+    jest.useFakeTimers()
+    fetchMock
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(mockResponse(200, { ok: true }))
+
+    const p = apiFetch('/api/jobs/abc')
+    await jest.advanceTimersByTimeAsync(600)
+    const res = await p
+
+    expect(res.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(getBackendStatus()).toBe('online')
+  })
+
+  it('surfaces the banner only once a GET has STALLED past the thresholds, then clears', async () => {
+    jest.useFakeTimers()
+    const d = deferredFetch()
+    fetchMock.mockImplementation(d.fn)
+
+    const p = apiFetch('/api/jobs/abc')
+    p.catch(() => {}) // avoid unhandled rejection if it ever fails
+
+    expect(getBackendStatus()).toBe('online')
+    await jest.advanceTimersByTimeAsync(STALL_RECONNECTING_MS)
     expect(getBackendStatus()).toBe('reconnecting')
-    await jest.advanceTimersByTimeAsync(UNAVAILABLE_AFTER_MS)
+    await jest.advanceTimersByTimeAsync(STALL_UNAVAILABLE_MS - STALL_RECONNECTING_MS)
     expect(getBackendStatus()).toBe('unavailable')
+
+    d.settle(mockResponse(200, { ok: true }))
+    await p
+    expect(getBackendStatus()).toBe('online')
+  })
+
+  it('never surfaces the banner for a slow POST (mutations are not tracked)', async () => {
+    jest.useFakeTimers()
+    const d = deferredFetch()
+    fetchMock.mockImplementation(d.fn)
+
+    const p = apiFetch('/api/jobs/create-from-url', { method: 'POST', body: '{}' })
+    p.catch(() => {})
+
+    await jest.advanceTimersByTimeAsync(STALL_UNAVAILABLE_MS + 5000)
+    expect(getBackendStatus()).toBe('online')
+
+    d.settle(mockResponse(200, { ok: true }))
+    await p
+  })
+
+  it('does NOT impose a hard timeout on a long-running POST (e.g. preview render)', async () => {
+    jest.useFakeTimers()
+    let capturedSignal: AbortSignal | undefined
+    const d = deferredFetch()
+    fetchMock.mockImplementation((_url: unknown, init: RequestInit) => {
+      capturedSignal = init.signal ?? undefined
+      return d.fn()
+    })
+
+    const p = apiFetch('/api/review/abc/preview-video', { method: 'POST', body: '{}' })
+    p.catch(() => {})
+
+    // Well past the GET hard-timeout (45s): a POST must still be running, unaborted.
+    await jest.advanceTimersByTimeAsync(60_000)
+    expect(capturedSignal?.aborted).toBe(false)
+
+    d.settle(mockResponse(200, { ok: true }))
+    await expect(p).resolves.toBeDefined()
+  })
+
+  it('never auto-retries a non-GET, even on network failure', async () => {
+    fetchMock.mockRejectedValue(new TypeError('Failed to fetch'))
+    await expect(
+      apiFetch('/api/jobs/create-from-url', { method: 'POST', body: '{}' }),
+    ).rejects.toBeInstanceOf(BackendUnavailableError)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(getBackendStatus()).toBe('online')
   })
 
   it('reads method + signal from a Request input (a POST Request is not retried)', async () => {
@@ -108,73 +188,36 @@ describe('apiFetch', () => {
 
     try {
       fetchMock.mockRejectedValue(new TypeError('Failed to fetch'))
-
-      // A Request carrying method=POST must be treated as a non-idempotent mutation:
-      // one attempt only, never replayed (which could double-submit).
       const req = new FakeRequest('http://localhost/api/jobs/create-from-url', {
         method: 'POST',
       })
-
       await expect(apiFetch(req as unknown as Request)).rejects.toBeInstanceOf(
         BackendUnavailableError,
       )
       expect(fetchMock).toHaveBeenCalledTimes(1)
-      expect(getBackendStatus()).toBe('reconnecting')
     } finally {
       delete (globalThis as unknown as { Request?: unknown }).Request
     }
   })
 
-  it('recovers transparently when a retried GET succeeds on a later attempt', async () => {
-    jest.useFakeTimers()
-    fetchMock
-      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
-      .mockResolvedValueOnce(mockResponse(200, { ok: true }))
-
-    const p = apiFetch('/api/jobs/abc')
-    await jest.advanceTimersByTimeAsync(600)
-    const res = await p
-
-    expect(res.status).toBe(200)
-    expect(fetchMock).toHaveBeenCalledTimes(2)
-    expect(getBackendStatus()).toBe('online')
-  })
-
-  it('never auto-retries a non-GET (avoids duplicate submits) and does not hard-fail to "unavailable"', async () => {
-    fetchMock.mockRejectedValue(new TypeError('Failed to fetch'))
-
-    await expect(
-      apiFetch('/api/jobs/create-from-url', { method: 'POST', body: '{}' }),
-    ).rejects.toBeInstanceOf(BackendUnavailableError)
-
-    expect(fetchMock).toHaveBeenCalledTimes(1)
-    // A single mutation blip shows the subtle hint, not the full "unavailable" banner.
-    expect(getBackendStatus()).toBe('reconnecting')
-  })
-
   it('passes non-backend URLs (e.g. GCS uploads) straight through with the original error', async () => {
     const gcsError = new TypeError('gcs unreachable')
     fetchMock.mockRejectedValue(gcsError)
-
     await expect(
       apiFetch('https://storage.googleapis.com/bucket/obj', { method: 'PUT', body: 'x' }),
     ).rejects.toBe(gcsError)
-
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    // Third-party hosts must not drive our backend-status banner.
     expect(getBackendStatus()).toBe('online')
   })
 
-  it('propagates a caller-initiated abort without reporting backend trouble', async () => {
+  it('propagates a caller-initiated abort without surfacing the banner', async () => {
     const abortErr = new DOMException('Aborted', 'AbortError')
     fetchMock.mockRejectedValue(abortErr)
     const controller = new AbortController()
     controller.abort()
-
     await expect(
       apiFetch('/api/jobs/abc', { signal: controller.signal }),
     ).rejects.toBe(abortErr)
-
     expect(getBackendStatus()).toBe('online')
   })
 })

--- a/frontend/__tests__/backend-status.test.ts
+++ b/frontend/__tests__/backend-status.test.ts
@@ -2,24 +2,29 @@
  * @jest-environment jsdom
  *
  * Tests for the backend-connectivity status store (lib/backend-status.ts).
+ * Status is derived from how long the OLDEST in-flight tracked read has been
+ * outstanding — a read that completes promptly never surfaces the banner.
  */
 
 import {
   getBackendStatus,
-  reportBackendOnline,
-  reportBackendTrouble,
-  reportBackendUnavailable,
-  UNAVAILABLE_AFTER_MS,
+  beginRequest,
+  endRequest,
+  STALL_RECONNECTING_MS,
+  STALL_UNAVAILABLE_MS,
 } from '@/lib/backend-status'
 
-describe('backend-status store', () => {
+describe('backend-status store (stall-based)', () => {
+  let open: number[] = []
+
   beforeEach(() => {
-    // Reset the module singleton to a known-good baseline before each test.
-    reportBackendOnline()
     jest.useFakeTimers()
+    open = []
   })
 
   afterEach(() => {
+    // Settle anything still in flight so the module singleton resets to online.
+    open.forEach((id) => endRequest(id))
     jest.clearAllTimers()
     jest.useRealTimers()
   })
@@ -28,51 +33,58 @@ describe('backend-status store', () => {
     expect(getBackendStatus()).toBe('online')
   })
 
-  it('moves to "reconnecting" on first trouble, then escalates to "unavailable" after the threshold', async () => {
-    reportBackendTrouble()
-    expect(getBackendStatus()).toBe('reconnecting')
-
-    // Just before the threshold it should still be reconnecting...
-    await jest.advanceTimersByTimeAsync(UNAVAILABLE_AFTER_MS - 1)
-    expect(getBackendStatus()).toBe('reconnecting')
-
-    // ...and cross it to become unavailable.
-    await jest.advanceTimersByTimeAsync(2)
-    expect(getBackendStatus()).toBe('unavailable')
-  })
-
-  it('does not reset the escalation clock on repeated trouble reports', async () => {
-    reportBackendTrouble()
-    await jest.advanceTimersByTimeAsync(UNAVAILABLE_AFTER_MS - 2000)
-    // A second failure partway through must NOT push the deadline out.
-    reportBackendTrouble()
-    expect(getBackendStatus()).toBe('reconnecting')
-    await jest.advanceTimersByTimeAsync(2001)
-    expect(getBackendStatus()).toBe('unavailable')
-  })
-
-  it('reportBackendUnavailable escalates immediately without waiting', () => {
-    reportBackendTrouble()
-    reportBackendUnavailable()
-    expect(getBackendStatus()).toBe('unavailable')
-  })
-
-  it('reportBackendOnline clears trouble and cancels a pending escalation', async () => {
-    reportBackendTrouble()
-    expect(getBackendStatus()).toBe('reconnecting')
-
-    reportBackendOnline()
+  it('stays online while a read is young, then escalates as it stalls', async () => {
+    open.push(beginRequest())
     expect(getBackendStatus()).toBe('online')
 
-    // The previously-armed escalation timer must have been cancelled.
-    await jest.advanceTimersByTimeAsync(UNAVAILABLE_AFTER_MS + 1000)
+    await jest.advanceTimersByTimeAsync(STALL_RECONNECTING_MS - 1000)
+    expect(getBackendStatus()).toBe('online')
+
+    await jest.advanceTimersByTimeAsync(1000) // cross the reconnecting threshold
+    expect(getBackendStatus()).toBe('reconnecting')
+
+    await jest.advanceTimersByTimeAsync(STALL_UNAVAILABLE_MS - STALL_RECONNECTING_MS)
+    expect(getBackendStatus()).toBe('unavailable')
+  })
+
+  it('returns to online the moment the stalled read settles', async () => {
+    const id = beginRequest()
+    open.push(id)
+    await jest.advanceTimersByTimeAsync(STALL_UNAVAILABLE_MS + 100)
+    expect(getBackendStatus()).toBe('unavailable')
+
+    endRequest(id)
+    open = []
     expect(getBackendStatus()).toBe('online')
   })
 
-  it('recovers to online from the unavailable state', () => {
-    reportBackendUnavailable()
-    expect(getBackendStatus()).toBe('unavailable')
-    reportBackendOnline()
+  it('a read that completes quickly never surfaces the banner', async () => {
+    const id = beginRequest()
+    await jest.advanceTimersByTimeAsync(3000) // 3s — normal-slow, not a stall
+    endRequest(id)
+    expect(getBackendStatus()).toBe('online')
+
+    // ...and nothing appears later either (nothing is in flight).
+    await jest.advanceTimersByTimeAsync(STALL_UNAVAILABLE_MS)
+    expect(getBackendStatus()).toBe('online')
+  })
+
+  it('tracks the OLDEST outstanding read, not the newest', async () => {
+    const a = beginRequest()
+    open.push(a)
+    await jest.advanceTimersByTimeAsync(STALL_RECONNECTING_MS)
+    expect(getBackendStatus()).toBe('reconnecting')
+
+    const b = beginRequest() // fresh read starts while `a` is still stalled
+    open.push(b)
+    expect(getBackendStatus()).toBe('reconnecting')
+
+    endRequest(b) // settling the young one doesn't clear the old stall
+    open = [a]
+    expect(getBackendStatus()).toBe('reconnecting')
+
+    endRequest(a)
+    open = []
     expect(getBackendStatus()).toBe('online')
   })
 })

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -5,7 +5,7 @@
 import type { VideoThemeSummary, VideoThemeDetail, ThemesListResponse, ThemeDetailResponse, ColorOverrides } from './video-themes';
 import type { MagicLinkResponse, VerifyMagicLinkResponse, UserProfileResponse, ReferralInterstitial, ReferralDashboard, ReferralLink } from './types';
 import type { CorrectionData, CorrectionAnnotation, EditLog, SearchLyricsResponse } from './lyrics-review/types';
-import { reportBackendOnline, reportBackendTrouble } from './backend-status';
+import { beginRequest, endRequest } from './backend-status';
 
 // In development, use relative URLs to go through Next.js proxy (avoids CORS)
 // In production (static export), use the full backend URL
@@ -465,15 +465,12 @@ export class BackendUnavailableError extends ApiError {
 // ===== Backend connectivity: timeout + safe retry wrapper =====
 //
 // Every `api.*` call goes through apiFetch instead of raw fetch so that a transient
-// backend blip (e.g. Cloud Run recycling its single min-instance) degrades
-// gracefully — a subtle "reconnecting" hint, transparent retries for idempotent
-// reads, and an app-wide "temporarily unavailable" banner — instead of every screen
-// throwing its own generic error. See lib/backend-status.ts for the UX states.
+// backend blip (e.g. Cloud Run recycling its single min-instance) degrades gracefully:
+// transparent retries for idempotent reads, and — via the backend-status store — a
+// single app-wide banner that only appears once a read has genuinely STALLED (been
+// outstanding past the store's threshold), never merely because a request was slow.
+// See lib/backend-status.ts for how the banner is derived from in-flight GETs.
 
-/** Show the subtle "reconnecting…" hint if a request is still outstanding after this
- *  long. Non-aborting: a slow-but-healthy response still completes and clears it, so
- *  legitimately slow endpoints are never falsely failed. */
-const RECONNECTING_HINT_MS = 2500;
 /** Hard backstop: abort a request that has hung this long (Cloud Run holds requests
  *  during a cold start, but not forever). Generous so genuine cold-starts can ride
  *  out and still succeed rather than erroring the user. */
@@ -518,17 +515,22 @@ function isManagedBackendUrl(input: RequestInfo | URL): boolean {
 }
 
 export interface ApiFetchOptions {
-  /** Override the per-attempt hard-timeout (ms). */
+  /** Override the per-attempt hard-timeout (ms). By default only GETs get a timeout
+   *  (a backstop for hung reads); non-GETs run untimed. Set explicitly to time-box a
+   *  POST, or pass a larger value for a slow read. */
   timeoutMs?: number;
   /** Force-disable retry even for GET (e.g. a GET with side effects). */
   retry?: boolean;
+  /** Opt a GET out of connectivity-banner tracking — for reads that are inherently
+   *  slow (large payloads, server-side work) and should never surface the banner. */
+  trackConnectivity?: boolean;
 }
 
 /**
- * Drop-in replacement for `fetch` for backend calls: adds a non-aborting
- * "reconnecting" hint, a hard-timeout backstop, safe retries for GETs, and reports
- * connectivity to the backend-status store. Signature matches fetch so call sites
- * only change the function name.
+ * Drop-in replacement for `fetch` for backend calls: a hard-timeout backstop, safe
+ * retries for GETs, and — for GETs only — connectivity tracking so the app-wide
+ * banner can surface when a read STALLS (see lib/backend-status.ts). Signature matches
+ * fetch so call sites only change the function name.
  */
 export async function apiFetch(
   input: RequestInfo | URL,
@@ -550,71 +552,78 @@ export async function apiFetch(
   // Never auto-retry non-GET: replaying a create/submit/payment could double-charge
   // or duplicate a job. Reads are idempotent and safe to retry.
   const allowRetry = isGet && (opts?.retry ?? true);
-  const hardTimeout = opts?.timeoutMs ?? HARD_TIMEOUT_MS;
+  // Only reads get an artificial hard-timeout backstop; long-running POSTs (preview
+  // video, generate, search) must run as long as they need or they'd fail mid-encode.
+  // A caller can still explicitly time-box any request via opts.timeoutMs.
+  const hardTimeout = opts?.timeoutMs ?? (isGet ? HARD_TIMEOUT_MS : undefined);
   const maxAttempts = allowRetry ? GET_MAX_ATTEMPTS : 1;
   const callerSignal = init?.signal ?? request?.signal ?? undefined;
 
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    const controller = new AbortController();
-    const hintTimer = setTimeout(reportBackendTrouble, RECONNECTING_HINT_MS);
-    const hardTimer = setTimeout(
-      () => controller.abort(new DOMException('Request timed out', 'AbortError')),
-      hardTimeout,
-    );
-    const onCallerAbort = () =>
-      controller.abort((callerSignal as AbortSignal | undefined)?.reason);
-    if (callerSignal) {
-      if (callerSignal.aborted) controller.abort(callerSignal.reason);
-      else callerSignal.addEventListener('abort', onCallerAbort, { once: true });
-    }
-    const cleanup = () => {
-      clearTimeout(hintTimer);
-      clearTimeout(hardTimer);
-      callerSignal?.removeEventListener('abort', onCallerAbort);
-    };
+  // Only reads feed the connectivity banner: a page waits on GETs during a recycle,
+  // whereas long POSTs (search, generate, auto-correct) are legitimately slow and
+  // must never trip it. Tracking spans the whole call (across retries) and settles in
+  // `finally`, so the banner reflects how long the read has actually been stalled.
+  const track = isGet && (opts?.trackConnectivity ?? true);
+  const trackingId = track ? beginRequest() : null;
+  try {
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const controller = new AbortController();
+      const hardTimer =
+        hardTimeout != null
+          ? setTimeout(
+              () => controller.abort(new DOMException('Request timed out', 'AbortError')),
+              hardTimeout,
+            )
+          : null;
+      const onCallerAbort = () =>
+        controller.abort((callerSignal as AbortSignal | undefined)?.reason);
+      if (callerSignal) {
+        if (callerSignal.aborted) controller.abort(callerSignal.reason);
+        else callerSignal.addEventListener('abort', onCallerAbort, { once: true });
+      }
+      const cleanup = () => {
+        if (hardTimer) clearTimeout(hardTimer);
+        callerSignal?.removeEventListener('abort', onCallerAbort);
+      };
 
-    let response: Response;
-    try {
-      response = await globalThis.fetch(input, { ...init, signal: controller.signal });
-    } catch (err) {
+      let response: Response;
+      try {
+        response = await globalThis.fetch(input, { ...init, signal: controller.signal });
+      } catch (err) {
+        cleanup();
+        // The CALLER aborted (navigation, their own timeout) — not a backend problem.
+        if (callerSignal?.aborted) throw err;
+        lastError = err;
+        if (attempt < maxAttempts) {
+          await sleep(RETRY_BACKOFF_MS[Math.min(attempt - 1, RETRY_BACKOFF_MS.length - 1)]);
+          continue;
+        }
+        throw new BackendUnavailableError(err);
+      }
       cleanup();
-      // The CALLER aborted (navigation, their own timeout) — not a backend problem.
-      if (callerSignal?.aborted) throw err;
-      lastError = err;
-      // reportBackendTrouble() (above) armed the escalation timer, so the banner
-      // still escalates to "unavailable" strictly on the UNAVAILABLE_AFTER_MS clock
-      // rather than the instant a fast-failing retry budget (~2s) runs out.
-      reportBackendTrouble();
-      if (attempt < maxAttempts) {
-        await sleep(RETRY_BACKOFF_MS[Math.min(attempt - 1, RETRY_BACKOFF_MS.length - 1)]);
-        continue;
-      }
-      throw new BackendUnavailableError(err);
-    }
-    cleanup();
 
-    if (TRANSIENT_STATUS.has(response.status)) {
-      reportBackendTrouble();
-      if (allowRetry && attempt < maxAttempts) {
-        await sleep(RETRY_BACKOFF_MS[Math.min(attempt - 1, RETRY_BACKOFF_MS.length - 1)]);
-        continue;
+      if (TRANSIENT_STATUS.has(response.status)) {
+        if (allowRetry && attempt < maxAttempts) {
+          await sleep(RETRY_BACKOFF_MS[Math.min(attempt - 1, RETRY_BACKOFF_MS.length - 1)]);
+          continue;
+        }
+        if (isGet) {
+          throw new BackendUnavailableError(undefined, response.status);
+        }
+        // Non-GET: hand the real transient response back so the caller's handleResponse
+        // surfaces it.
+        return response;
       }
-      if (isGet) {
-        throw new BackendUnavailableError(undefined, response.status);
-      }
-      // Non-GET: hand the real transient response back so the caller's handleResponse
-      // surfaces it; the banner is already showing via reportBackendTrouble().
+
       return response;
     }
 
-    // A real reply from the backend (2xx, or a deterministic 4xx/5xx) → we're online.
-    reportBackendOnline();
-    return response;
+    // Unreachable (loop always returns or throws) — satisfies the compiler.
+    throw new BackendUnavailableError(lastError);
+  } finally {
+    if (trackingId !== null) endRequest(trackingId);
   }
-
-  // Unreachable (loop always returns or throws) — satisfies the compiler.
-  throw new BackendUnavailableError(lastError);
 }
 
 // Exported for testing

--- a/frontend/lib/backend-status.ts
+++ b/frontend/lib/backend-status.ts
@@ -5,38 +5,47 @@
  *
  * The backend runs on Cloud Run with `--min-instances 1`. When Cloud Run recycles
  * that single instance (routine host maintenance / instance max-lifetime), there is
- * a brief (~1-2 min worst case, usually well under) window where the origin is
- * unreachable and API calls fail even though nothing is actually broken — and any
- * karaoke jobs already rendering (Cloud Run Jobs / GCE encoding VMs) keep running
- * untouched. See infrastructure/modules/monitoring.py for the server-side story.
+ * a brief window where the origin is unreachable and requests HANG (Cloud Run holds
+ * them during the cold start) even though nothing is actually broken — and any
+ * karaoke jobs already rendering keep running untouched.
  *
- * `apiFetch` (lib/api.ts) reports request outcomes here so a single app-wide banner
- * can reassure the user during those blips instead of every screen showing its own
- * scary generic error. This is a tiny framework-agnostic store (module singleton +
- * listeners) consumed via the `useBackendStatus` hook.
+ * We want ONE reassuring app-wide banner during those blips, but only when there's
+ * real evidence of a problem — NOT merely because a request was a little slow. So
+ * status is derived purely from **how long the oldest in-flight backend GET has been
+ * outstanding**: a read that completes (even a slowish 3–5s one) shows nothing; only
+ * a read stalled past STALL_RECONNECTING_MS surfaces the hint, escalating past
+ * STALL_UNAVAILABLE_MS to the full message. This matches "only tell the user once
+ * something has genuinely been trying to load for >10s / timed out."
+ *
+ * Only GETs are tracked: reads are what a page waits on during a recycle, and long
+ * POSTs (search, generate, auto-correct) are legitimately slow and must never trip
+ * the banner. See lib/api.ts (apiFetch) for the begin/endRequest wiring.
  */
 
 import { useSyncExternalStore } from 'react'
 
 export type BackendStatus =
-  /** Requests are succeeding (or we have no evidence of trouble). */
+  /** No stalled reads — everything is completing in a reasonable time. */
   | 'online'
-  /** A request just failed and we're transparently retrying — show a subtle hint. */
+  /** A read has been outstanding a while; show a subtle "reconnecting" hint. */
   | 'reconnecting'
-  /** Trouble has persisted past the threshold — show the gentle full message. */
+  /** A read has been stalled long enough to show the full "temporarily unavailable". */
   | 'unavailable'
 
-/**
- * How long connectivity trouble must persist before we escalate from the subtle
- * "reconnecting" hint to the full "temporarily unavailable" message. Kept in sync
- * with the read-retry budget in lib/api.ts so a request that exhausts its retries
- * lands right around the same time this escalates.
- */
-export const UNAVAILABLE_AFTER_MS = 10_000
+/** A tracked read must be outstanding at least this long before we show ANYTHING —
+ *  so a normal slow-but-successful load never surfaces the banner. */
+export const STALL_RECONNECTING_MS = 10_000
+/** ...and this long before we escalate to the full assertive message. */
+export const STALL_UNAVAILABLE_MS = 20_000
+
+let nextId = 1
+/** id -> startedAt (ms) for every tracked backend GET currently in flight. */
+const inFlight = new Map<number, number>()
+/** Dev/preview override: when non-null, forces the reported status. */
+let devOverride: BackendStatus | null = null
 
 let status: BackendStatus = 'online'
-let firstTroubleAt: number | null = null
-let escalationTimer: ReturnType<typeof setTimeout> | null = null
+let ticker: ReturnType<typeof setInterval> | null = null
 
 const listeners = new Set<() => void>()
 
@@ -50,54 +59,48 @@ function setStatus(next: BackendStatus) {
   emit()
 }
 
-function clearEscalationTimer() {
-  if (escalationTimer) {
-    clearTimeout(escalationTimer)
-    escalationTimer = null
+function computeFromStalls(): BackendStatus {
+  if (inFlight.size === 0) return 'online'
+  let oldest = Infinity
+  for (const startedAt of inFlight.values()) {
+    if (startedAt < oldest) oldest = startedAt
+  }
+  const age = Date.now() - oldest
+  if (age >= STALL_UNAVAILABLE_MS) return 'unavailable'
+  if (age >= STALL_RECONNECTING_MS) return 'reconnecting'
+  return 'online'
+}
+
+function recompute() {
+  setStatus(devOverride ?? computeFromStalls())
+  // Stop the clock once nothing is outstanding (and no dev override needs it).
+  if (inFlight.size === 0 && devOverride === null && ticker) {
+    clearInterval(ticker)
+    ticker = null
   }
 }
 
-/**
- * Report that a backend request attempt failed and we're about to retry (or it
- * ultimately failed but might just be a transient blip). Moves us to "reconnecting"
- * immediately and arms a timer that escalates to "unavailable" if trouble persists.
- */
-export function reportBackendTrouble() {
-  if (firstTroubleAt === null) {
-    firstTroubleAt = Date.now()
-  }
-  if (status === 'online') {
-    setStatus('reconnecting')
-  }
-  if (status !== 'unavailable' && escalationTimer === null) {
-    const elapsed = Date.now() - (firstTroubleAt ?? Date.now())
-    const remaining = Math.max(0, UNAVAILABLE_AFTER_MS - elapsed)
-    escalationTimer = setTimeout(() => {
-      escalationTimer = null
-      // Still no success by now → this is more than a momentary blip.
-      if (firstTroubleAt !== null) setStatus('unavailable')
-    }, remaining)
-  }
+function ensureTicker() {
+  if (ticker) return
+  // Re-evaluate every second so a request that keeps hanging escalates over time.
+  ticker = setInterval(recompute, 1000)
 }
 
 /**
- * Report that trouble is confirmed sustained (e.g. a read exhausted its full retry
- * budget). Escalates to "unavailable" right away without waiting on the timer.
+ * Mark a tracked backend read as started. Returns an id to pass to `endRequest` when
+ * it settles (success OR failure — either way it's no longer outstanding).
  */
-export function reportBackendUnavailable() {
-  if (firstTroubleAt === null) firstTroubleAt = Date.now()
-  clearEscalationTimer()
-  setStatus('unavailable')
+export function beginRequest(): number {
+  const id = nextId++
+  inFlight.set(id, Date.now())
+  ensureTicker()
+  recompute()
+  return id
 }
 
-/**
- * Report a successful backend request. Clears any trouble state and returns us to
- * "online" — the banner disappears the moment connectivity is restored.
- */
-export function reportBackendOnline() {
-  firstTroubleAt = null
-  clearEscalationTimer()
-  setStatus('online')
+/** Mark a tracked read as settled. */
+export function endRequest(id: number): void {
+  if (inFlight.delete(id)) recompute()
 }
 
 export function getBackendStatus(): BackendStatus {
@@ -120,19 +123,22 @@ export function useBackendStatus(): BackendStatus {
 }
 
 /**
- * Dev/preview-only escape hatch so the outage UX can be demoed without actually
- * taking the backend down. Exposed on `window.__nkBackendStatus` and no-ops on the
- * production consumer build. Not referenced by app code paths.
+ * Dev/preview-only escape hatch so the outage UX can be demoed without waiting on a
+ * real stall. Exposed on `window.__nkBackendStatus` and no-ops on the production
+ * consumer host. Not referenced by app code paths.
  */
 export function __installBackendStatusDevHook() {
   if (typeof window === 'undefined') return
-  const host = window.location.hostname
-  const isProd = host === 'gen.nomadkaraoke.com'
-  if (isProd) return
+  if (window.location.hostname === 'gen.nomadkaraoke.com') return
+  const simulate = (s: BackendStatus | null) => {
+    devOverride = s
+    if (s !== null) ensureTicker()
+    recompute()
+  }
   ;(window as unknown as { __nkBackendStatus?: unknown }).__nkBackendStatus = {
-    reconnecting: () => reportBackendTrouble(),
-    unavailable: () => reportBackendUnavailable(),
-    online: () => reportBackendOnline(),
+    reconnecting: () => simulate('reconnecting'),
+    unavailable: () => simulate('unavailable'),
+    online: () => simulate(null),
     get: () => getBackendStatus(),
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.196.4"
+version = "0.196.5"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Why

Follow-up to #921. In prod the connectivity banner was **too sensitive**:
1. It fired during a normal lyrics-review load — the 2.5s "slow request" hint tripped on any request taking >2.5s, even successful ones.
2. The "Preview Video" modal showed **"The server is temporarily unavailable"** — the long-running preview-generation POST (video encode, often >45s) hit apiFetch's blanket 45s hard-timeout and failed, even though the backend was fine.

## What

- **`backend-status.ts` — status now derives purely from a real STALL.** It tracks how long the *oldest in-flight tracked read* has been outstanding: `reconnecting` at 10s, `unavailable` at 20s, back to `online` the instant it settles. A read that completes — even a normal-slow 3–5s one — surfaces **nothing**.
- **`apiFetch` — GET-only tracking + GET-only hard-timeout.**
  - Only GETs feed the banner (a page waits on reads during a recycle; long POSTs are legitimately slow).
  - The 45s hard-timeout backstop applies to **GETs only** — preview/generate/search POSTs run **untimed** to completion, fixing the false "unavailable" error.
  - New `opts.trackConnectivity: false` lets a known-slow read opt out; `opts.timeoutMs` still time-boxes any call.

Retry semantics unchanged (GET-only, never replays a mutation).

## Testing
- Rewrote store + apiFetch unit tests for the stall model: POST untracked, POST not hard-timed-out (signal not aborted after 60s), a stalled GET → reconnecting→unavailable→clear, fast failures stay `online`.
- Full suite green: **1132 passing**.
- Banner rendering re-verified locally.
- Local CodeRabbit review: **no findings**.

No infra changes in this PR.

@coderabbitai ignore