### PR TITLE
infra: Firestore composite index for jobs by request_metadata.client_id

### DIFF
--- a/infrastructure/modules/database.py
+++ b/infrastructure/modules/database.py
@@ -104,6 +104,23 @@ def create_database() -> dict:
         opts=pulumi.ResourceOptions(depends_on=[firestore_db]),
     )
 
+    # Jobs: query by request_metadata.client_id + tenant_id, order by created_at.
+    # Powers GET /api/jobs?client_id= — the idempotency lookup for externally
+    # created jobs (the Fiverr agent tags jobs client_id="fiverr:{order_id}").
+    # Without it that query 400s ("The query requires an index").
+    resources["firestore_index_jobs_client_id"] = firestore.Index(
+        "firestore-index-jobs-client-id",
+        project=PROJECT_ID,
+        database=firestore_db.name,
+        collection="jobs",
+        fields=[
+            firestore.IndexFieldArgs(field_path="request_metadata.client_id", order="ASCENDING"),
+            firestore.IndexFieldArgs(field_path="tenant_id", order="ASCENDING"),
+            firestore.IndexFieldArgs(field_path="created_at", order="DESCENDING"),
+        ],
+        opts=pulumi.ResourceOptions(depends_on=[firestore_db]),
+    )
+
     # Sessions: query by user_email + is_active, order by created_at
     resources["firestore_index_sessions_active"] = firestore.Index(
         "firestore-index-sessions-active",


### PR DESCRIPTION
## Problem

`karaoke-backend` started logging `400 The query requires an index` for `GET /api/jobs?client_id=` (both "Error listing jobs" and "Error listing jobs summary" patterns — one prod error alert). The query filters `request_metadata.client_id` + `tenant_id` and orders by `created_at`, with no composite index.

This surfaced because the **fiverr-agent** now tags the jobs it creates with `client_id="fiverr:{order_id}"` and calls that endpoint for idempotency (finding an existing job before creating one).

## Fix

Adds `firestore-index-jobs-client-id` to the IaC:
- `request_metadata.client_id` ASC
- `tenant_id` ASC
- `created_at` DESC

(matches the index Firestore's error link requested).

## Applied

Already applied to prod via `pulumi up` (`+1 created, 294 unchanged` — clean preview, no other drift). Verified: `GET /api/jobs?client_id=fiverr:…` now returns **200** (was 500/400). This PR codifies the change to prevent IaC drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database query support for filtering jobs by client and tenant while sorting by newest first.
  * Helps ensure relevant job results load reliably and efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->