### PR TITLE
fix(made-for-you): isolate order emails from audio-acquisition failures

### DIFF
--- a/backend/api/routes/users.py
+++ b/backend/api/routes/users.py
@@ -866,13 +866,19 @@ def _send_mfy_failure_alert(
     safe_error = html.escape(str(error))
     job_line_html = f"<li><strong>Job ID:</strong> {html.escape(job_id)}</li>" if job_id else ""
     job_line_text = f"Job ID: {job_id}\n" if job_id else ""
+    remediation = (
+        "The customer's order-confirmation email is sent separately and up-front, so it "
+        "is unaffected by failures during processing. Please review this order and take "
+        "any needed manual action — e.g. provide/repair the audio source, or resend the "
+        "customer confirmation."
+    )
     try:
-        email_service.send_email(
+        sent = email_service.send_email(
             to_email=ADMIN_EMAIL,
             subject=f"[FAILED] Made For You Order: {artist} - {title}",
             html_content=f"""
-                <h2>Made-For-You Order Failed</h2>
-                <p>An error occurred processing this order:</p>
+                <h2>Made-For-You Order — Action Needed</h2>
+                <p>A problem occurred while processing this order:</p>
                 <ul>
                     <li><strong>Customer:</strong> {safe_customer}</li>
                     <li><strong>Artist:</strong> {safe_artist}</li>
@@ -880,25 +886,24 @@ def _send_mfy_failure_alert(
                     {job_line_html}
                     <li><strong>Error:</strong> {safe_error}</li>
                 </ul>
-                <p>The customer's order-confirmation email was still sent (if the job
-                was created), so no immediate customer action is needed. Please manually
-                complete this job — e.g. provide/repair the audio source — and it will be
-                delivered as normal.</p>
+                <p>{remediation}</p>
             """,
             text_content=(
-                "Made-For-You Order Failed\n\n"
+                "Made-For-You Order — Action Needed\n\n"
                 f"Customer: {customer_email}\n"
                 f"Artist: {artist}\n"
                 f"Title: {title}\n"
                 f"{job_line_text}"
                 f"Error: {error}\n\n"
-                "The customer's order-confirmation email was still sent (if the job was "
-                "created), so no immediate customer action is needed. Please manually "
-                "complete this job (e.g. provide/repair the audio source) and it will be "
-                "delivered as normal."
+                f"{remediation}"
             ),
         )
-        logger.info(f"Sent made-for-you failure alert to admin for job {job_id}")
+        if sent:
+            logger.info(f"Sent made-for-you failure alert to admin for job {job_id}")
+        else:
+            logger.error(
+                f"Made-for-you failure alert to admin was rejected by the email provider (job {job_id})"
+            )
     except Exception as email_error:
         logger.error(
             f"Failed to send made-for-you failure alert (job {job_id}): {email_error}",
@@ -1047,20 +1052,42 @@ async def _handle_made_for_you_order(
         # acquisition. The order is paid and confirmed regardless of whether the
         # (fallible) YouTube download / audio search succeeds, so a failure there must
         # never rob the customer of their confirmation email. Resilient: a delivery
-        # error is logged but does not abort order processing.
+        # failure is logged but does not abort order processing.
+        confirmation_ok = False
         try:
-            email_service.send_made_for_you_order_confirmation(
+            # Providers return False (not an exception) when the send is rejected, so
+            # check the result rather than assuming success.
+            confirmation_ok = bool(email_service.send_made_for_you_order_confirmation(
                 to_email=customer_email,
                 artist=artist,
                 title=title,
                 job_id=job_id,
                 notes=notes,
-            )
-            logger.info(f"Sent made-for-you customer confirmation for job {job_id}")
+            ))
+            if confirmation_ok:
+                logger.info(f"Sent made-for-you customer confirmation for job {job_id}")
+            else:
+                logger.error(
+                    f"Job {job_id}: customer order-confirmation email was rejected by the email provider"
+                )
         except Exception as confirm_error:
             logger.error(
                 f"Job {job_id}: Failed to send customer order-confirmation email: {confirm_error}",
                 exc_info=True,
+            )
+
+        if not confirmation_ok:
+            # A paid customer must never silently miss their confirmation. Escalate to
+            # the admin so it can be resent manually. Order processing still continues.
+            _send_mfy_failure_alert(
+                email_service,
+                customer_email=customer_email,
+                artist=artist,
+                title=title,
+                job_id=job_id,
+                error=RuntimeError(
+                    "Customer order-confirmation email failed to send — please resend it manually"
+                ),
             )
 
         # Handle based on whether we have a YouTube URL or need to search
@@ -1194,7 +1221,7 @@ async def _handle_made_for_you_order(
                 email=ADMIN_EMAIL,
                 expiry_hours=24,
             )
-            email_service.send_made_for_you_admin_notification(
+            admin_notified = bool(email_service.send_made_for_you_admin_notification(
                 to_email=ADMIN_EMAIL,
                 customer_email=customer_email,
                 artist=artist,
@@ -1203,8 +1230,13 @@ async def _handle_made_for_you_order(
                 admin_login_token=admin_login.token,
                 notes=notes,
                 audio_source_count=audio_source_count,
-            )
-            logger.info(f"Sent made-for-you admin notification for job {job_id}")
+            ))
+            if admin_notified:
+                logger.info(f"Sent made-for-you admin notification for job {job_id}")
+            else:
+                logger.error(
+                    f"Job {job_id}: admin order notification was rejected by the email provider"
+                )
         except Exception as admin_email_error:
             logger.error(
                 f"Job {job_id}: Failed to send admin order notification: {admin_email_error}",
@@ -1225,6 +1257,14 @@ async def _handle_made_for_you_order(
             job_id=job_id,
             error=e,
         )
+        # If we failed before the job was even created, no job exists and the Stripe
+        # session was never marked processed — re-raise so the webhook returns non-2xx
+        # and Stripe retries the (likely transient) failure rather than silently
+        # dropping a paid order. Post-creation failures keep job_id set: those return
+        # normally (job exists, session marked processed, admin already alerted), so a
+        # retry would be a no-op / risk a duplicate job.
+        if job_id is None:
+            raise
 
 
 @router.post("/webhooks/stripe")

--- a/backend/api/routes/users.py
+++ b/backend/api/routes/users.py
@@ -9,6 +9,7 @@ Handles:
 - Admin user management
 """
 import hashlib
+import html
 import logging
 import threading
 from datetime import datetime
@@ -844,6 +845,67 @@ async def create_made_for_you_checkout(
 ADMIN_EMAIL = "madeforyou@nomadkaraoke.com"
 
 
+def _send_mfy_failure_alert(
+    email_service: EmailService,
+    *,
+    customer_email: str,
+    artist: str,
+    title: str,
+    job_id: Optional[str],
+    error: Exception,
+) -> None:
+    """Best-effort admin alert when a made-for-you order can't be fully processed.
+
+    This never raises: a failure to send the alert must not mask the original
+    error, nor interfere with the customer-facing order-confirmation email
+    (which is sent independently, before audio acquisition is attempted).
+    """
+    safe_customer = html.escape(customer_email or "")
+    safe_artist = html.escape(artist or "")
+    safe_title = html.escape(title or "")
+    safe_error = html.escape(str(error))
+    job_line_html = f"<li><strong>Job ID:</strong> {html.escape(job_id)}</li>" if job_id else ""
+    job_line_text = f"Job ID: {job_id}\n" if job_id else ""
+    try:
+        email_service.send_email(
+            to_email=ADMIN_EMAIL,
+            subject=f"[FAILED] Made For You Order: {artist} - {title}",
+            html_content=f"""
+                <h2>Made-For-You Order Failed</h2>
+                <p>An error occurred processing this order:</p>
+                <ul>
+                    <li><strong>Customer:</strong> {safe_customer}</li>
+                    <li><strong>Artist:</strong> {safe_artist}</li>
+                    <li><strong>Title:</strong> {safe_title}</li>
+                    {job_line_html}
+                    <li><strong>Error:</strong> {safe_error}</li>
+                </ul>
+                <p>The customer's order-confirmation email was still sent (if the job
+                was created), so no immediate customer action is needed. Please manually
+                complete this job — e.g. provide/repair the audio source — and it will be
+                delivered as normal.</p>
+            """,
+            text_content=(
+                "Made-For-You Order Failed\n\n"
+                f"Customer: {customer_email}\n"
+                f"Artist: {artist}\n"
+                f"Title: {title}\n"
+                f"{job_line_text}"
+                f"Error: {error}\n\n"
+                "The customer's order-confirmation email was still sent (if the job was "
+                "created), so no immediate customer action is needed. Please manually "
+                "complete this job (e.g. provide/repair the audio source) and it will be "
+                "delivered as normal."
+            ),
+        )
+        logger.info(f"Sent made-for-you failure alert to admin for job {job_id}")
+    except Exception as email_error:
+        logger.error(
+            f"Failed to send made-for-you failure alert (job {job_id}): {email_error}",
+            exc_info=True,
+        )
+
+
 async def _handle_made_for_you_order(
     session_id: str,
     metadata: dict,
@@ -891,6 +953,10 @@ async def _handle_made_for_you_order(
         f"Processing made-for-you order: {artist} - {title} for {customer_email} "
         f"(session: {session_id}, source_type: {source_type})"
     )
+
+    # Defined up-front so the outer failure handler can reference it even if job
+    # creation is what failed (job_id stays None until the job actually exists).
+    job_id = None
 
     try:
         job_manager = JobManager()
@@ -976,6 +1042,26 @@ async def _handle_made_for_you_order(
 
         # Initialize search_results for later use in email notification
         search_results = None
+
+        # Send the customer's order-confirmation email NOW, before attempting audio
+        # acquisition. The order is paid and confirmed regardless of whether the
+        # (fallible) YouTube download / audio search succeeds, so a failure there must
+        # never rob the customer of their confirmation email. Resilient: a delivery
+        # error is logged but does not abort order processing.
+        try:
+            email_service.send_made_for_you_order_confirmation(
+                to_email=customer_email,
+                artist=artist,
+                title=title,
+                job_id=job_id,
+                notes=notes,
+            )
+            logger.info(f"Sent made-for-you customer confirmation for job {job_id}")
+        except Exception as confirm_error:
+            logger.error(
+                f"Job {job_id}: Failed to send customer order-confirmation email: {confirm_error}",
+                exc_info=True,
+            )
 
         # Handle based on whether we have a YouTube URL or need to search
         if youtube_url:
@@ -1099,66 +1185,46 @@ async def _handle_made_for_you_order(
         # (search_results may be set from the search flow above, or None for YouTube URL orders)
         audio_source_count = len(search_results) if search_results else 0
 
-        # Generate admin login token for one-click email access (24hr expiry)
-        admin_login = user_service.create_admin_login_token(
-            email=ADMIN_EMAIL,
-            expiry_hours=24,
-        )
+        # Send notification email to admin using professional template.
+        # Resilient: an email delivery error here must not turn a successfully-created
+        # order into a "[FAILED]" alert — it's logged and swallowed instead.
+        try:
+            # Generate admin login token for one-click email access (24hr expiry)
+            admin_login = user_service.create_admin_login_token(
+                email=ADMIN_EMAIL,
+                expiry_hours=24,
+            )
+            email_service.send_made_for_you_admin_notification(
+                to_email=ADMIN_EMAIL,
+                customer_email=customer_email,
+                artist=artist,
+                title=title,
+                job_id=job_id,
+                admin_login_token=admin_login.token,
+                notes=notes,
+                audio_source_count=audio_source_count,
+            )
+            logger.info(f"Sent made-for-you admin notification for job {job_id}")
+        except Exception as admin_email_error:
+            logger.error(
+                f"Job {job_id}: Failed to send admin order notification: {admin_email_error}",
+                exc_info=True,
+            )
 
-        # Send confirmation email to customer using professional template
-        email_service.send_made_for_you_order_confirmation(
-            to_email=customer_email,
-            artist=artist,
-            title=title,
-            job_id=job_id,
-            notes=notes,
-        )
-
-        # Send notification email to admin using professional template
-        email_service.send_made_for_you_admin_notification(
-            to_email=ADMIN_EMAIL,
+    except Exception as e:
+        # A hard failure in order processing (e.g. job creation, or audio acquisition
+        # raising after transitioning the job to FAILED). The customer confirmation is
+        # sent earlier and independently, so it is unaffected by failures here. Alert
+        # the admin so they can intervene manually.
+        logger.error(f"Error processing made-for-you order: {e}", exc_info=True)
+        _send_mfy_failure_alert(
+            email_service,
             customer_email=customer_email,
             artist=artist,
             title=title,
             job_id=job_id,
-            admin_login_token=admin_login.token,
-            notes=notes,
-            audio_source_count=audio_source_count,
+            error=e,
         )
-
-        logger.info(f"Sent made-for-you order notifications for job {job_id}")
-
-    except Exception as e:
-        logger.error(f"Error processing made-for-you order: {e}", exc_info=True)
-        # Still try to notify Andrew of the failure
-        try:
-            email_service.send_email(
-                to_email=ADMIN_EMAIL,
-                subject=f"[FAILED] Made For You Order: {artist} - {title}",
-                html_content=f"""
-                <h2>Made-For-You Order Failed</h2>
-                <p>An error occurred processing this order:</p>
-                <ul>
-                    <li><strong>Customer:</strong> {customer_email}</li>
-                    <li><strong>Artist:</strong> {artist}</li>
-                    <li><strong>Title:</strong> {title}</li>
-                    <li><strong>Error:</strong> {str(e)}</li>
-                </ul>
-                <p>Please manually create this job and notify the customer.</p>
-                """,
-                text_content=f"""
-Made-For-You Order Failed
-
-Customer: {customer_email}
-Artist: {artist}
-Title: {title}
-Error: {str(e)}
-
-Please manually create this job and notify the customer.
-                """.strip(),
-            )
-        except Exception as email_error:
-            logger.error(f"Failed to send error notification: {email_error}")
 
 
 @router.post("/webhooks/stripe")

--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -259,6 +259,32 @@ class EmailService:
         """Check if a real email provider is configured (not just console logging)."""
         return isinstance(self.provider, PostmarkEmailProvider)
 
+    def send_email(
+        self,
+        to_email: str,
+        subject: str,
+        html_content: str,
+        text_content: Optional[str] = None,
+        cc_emails: Optional[List[str]] = None,
+        bcc_emails: Optional[List[str]] = None,
+        from_email_override: Optional[str] = None,
+    ) -> bool:
+        """Send a raw email via the configured provider.
+
+        Thin passthrough for callers that need to send an ad-hoc/plain email
+        (e.g. internal failure alerts) without a dedicated template method.
+        Prefer a dedicated ``send_*`` template method for customer-facing mail.
+        """
+        return self.provider.send_email(
+            to_email=to_email,
+            subject=subject,
+            html_content=html_content,
+            text_content=text_content,
+            cc_emails=cc_emails,
+            bcc_emails=bcc_emails,
+            from_email_override=from_email_override,
+        )
+
     def send_magic_link(
         self,
         email: str,

--- a/backend/tests/emulator/test_made_for_you_youtube_integration.py
+++ b/backend/tests/emulator/test_made_for_you_youtube_integration.py
@@ -502,8 +502,12 @@ class TestMadeForYouYouTubeErrorHandling:
         youtube_order_metadata
     ):
         """
-        Test that exceptions during processing send failure notification to admin.
+        Test that a job-creation failure sends a failure notification to admin AND
+        re-raises so the Stripe webhook returns non-2xx and Stripe retries the (likely
+        transient) failure — a paid order must not be silently dropped when no job was
+        ever created.
         """
+        import pytest
         from backend.api.routes.users import _handle_made_for_you_order, ADMIN_EMAIL
 
         # Make job creation fail
@@ -516,15 +520,16 @@ class TestMadeForYouYouTubeErrorHandling:
              patch('backend.api.routes.users.get_effective_distribution_settings', return_value=mock_distribution_settings), \
              patch('backend.api.routes.users.resolve_cdg_txt_defaults', return_value=(False, False)):
 
-            # Should not raise - error is handled internally
-            await _handle_made_for_you_order(
-                session_id="sess_test_error",
-                metadata=youtube_order_metadata,
-                user_service=mock_user_service_for_webhook,
-                email_service=mock_email_service,
-            )
+            # Re-raises (job never created) so the webhook returns non-2xx -> Stripe retries
+            with pytest.raises(Exception, match="Database error"):
+                await _handle_made_for_you_order(
+                    session_id="sess_test_error",
+                    metadata=youtube_order_metadata,
+                    user_service=mock_user_service_for_webhook,
+                    email_service=mock_email_service,
+                )
 
-            # Verify failure email was sent to admin
+            # Verify failure email was sent to admin before re-raising
             mock_email_service.send_email.assert_called()
             call_args = mock_email_service.send_email.call_args
             assert call_args.kwargs['to_email'] == ADMIN_EMAIL

--- a/backend/tests/test_made_for_you.py
+++ b/backend/tests/test_made_for_you.py
@@ -1848,10 +1848,11 @@ class TestMadeForYouYouTubeDownloadContract:
     ):
         """
         Resilience: if the customer confirmation email itself fails to send, order
-        processing (audio acquisition + admin notification) must still proceed. An
+        processing (audio acquisition + admin notification) must still proceed, and the
+        failed confirmation must be escalated to the admin (never silently lost). An
         email-provider hiccup should never block the actual work.
         """
-        from backend.api.routes.users import _handle_made_for_you_order
+        from backend.api.routes.users import _handle_made_for_you_order, ADMIN_EMAIL
 
         # Confirmation email raises, but the order must still be processed
         mock_email_service.send_made_for_you_order_confirmation.side_effect = \
@@ -1882,8 +1883,83 @@ class TestMadeForYouYouTubeDownloadContract:
         # Download still happened and admin notification still sent
         mock_youtube_service.download.assert_called_once()
         mock_email_service.send_made_for_you_admin_notification.assert_called_once()
-        # No [FAILED] alert - the order itself succeeded
-        mock_email_service.send_email.assert_not_called()
+        # The failed customer confirmation is escalated to the admin so it can be
+        # resent manually — a paid confirmation must never be silently lost.
+        mock_email_service.send_email.assert_called_once()
+        alert_kwargs = mock_email_service.send_email.call_args.kwargs
+        assert alert_kwargs['to_email'] == ADMIN_EMAIL
+        assert "[FAILED]" in alert_kwargs['subject']
+
+    @pytest.mark.asyncio
+    async def test_confirmation_provider_rejection_is_escalated(
+        self, mock_job_manager, mock_email_service, mock_user_service,
+        mock_theme_service, youtube_order_metadata
+    ):
+        """
+        Providers return False (not an exception) when a send is rejected. A rejected
+        customer confirmation must be escalated to the admin, not silently logged as
+        sent. Regression guard for the "log success even on False" bug.
+        """
+        from backend.api.routes.users import _handle_made_for_you_order, ADMIN_EMAIL
+
+        # Provider rejects the confirmation (returns False, does not raise)
+        mock_email_service.send_made_for_you_order_confirmation.return_value = False
+        mock_job_manager.start_job_processing = AsyncMock()
+
+        mock_youtube_service = MagicMock()
+        mock_youtube_service.download = AsyncMock(
+            return_value="uploads/test-job-123/audio/test.webm"
+        )
+
+        with patch('backend.services.job_manager.JobManager', return_value=mock_job_manager), \
+             patch('backend.services.worker_service.get_worker_service', return_value=MagicMock()), \
+             patch('backend.services.storage_service.StorageService'), \
+             patch('backend.api.routes.users.get_theme_service', return_value=mock_theme_service), \
+             patch('backend.api.routes.users.get_youtube_download_service', return_value=mock_youtube_service):
+
+            await _handle_made_for_you_order(
+                session_id="sess_123",
+                metadata=youtube_order_metadata,
+                user_service=mock_user_service,
+                email_service=mock_email_service,
+            )
+
+        # Rejected confirmation escalated to admin; order still processed
+        mock_email_service.send_email.assert_called_once()
+        assert mock_email_service.send_email.call_args.kwargs['to_email'] == ADMIN_EMAIL
+        mock_email_service.send_made_for_you_admin_notification.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_job_creation_failure_reraises_for_stripe_retry(
+        self, mock_email_service, mock_user_service, mock_theme_service,
+        youtube_order_metadata
+    ):
+        """
+        If job creation fails (no job_id, session never marked processed), the handler
+        must re-raise so the Stripe webhook returns non-2xx and Stripe retries — a paid
+        order must not be silently dropped. The admin is still alerted first.
+        """
+        from backend.api.routes.users import _handle_made_for_you_order, ADMIN_EMAIL
+
+        mock_job_manager = MagicMock()
+        mock_job_manager.create_job.side_effect = RuntimeError("Firestore unavailable")
+
+        with patch('backend.services.job_manager.JobManager', return_value=mock_job_manager), \
+             patch('backend.services.storage_service.StorageService'), \
+             patch('backend.api.routes.users.get_theme_service', return_value=mock_theme_service):
+
+            with pytest.raises(RuntimeError, match="Firestore unavailable"):
+                await _handle_made_for_you_order(
+                    session_id="sess_123",
+                    metadata=youtube_order_metadata,
+                    user_service=mock_user_service,
+                    email_service=mock_email_service,
+                )
+
+        # Admin alerted before the re-raise; no confirmation (job never created)
+        mock_email_service.send_email.assert_called_once()
+        assert mock_email_service.send_email.call_args.kwargs['to_email'] == ADMIN_EMAIL
+        mock_email_service.send_made_for_you_order_confirmation.assert_not_called()
 
 
 class TestMadeForYouYouTubeImports:

--- a/backend/tests/test_made_for_you.py
+++ b/backend/tests/test_made_for_you.py
@@ -266,6 +266,37 @@ class TestMadeForYouOrderConfirmationEmail:
         assert call_kwargs.get('cc_emails') is None
 
 
+class TestEmailServiceSendEmailPassthrough:
+    """Tests for the generic EmailService.send_email passthrough.
+
+    Regression (2026-08-22): the made-for-you failure handler called
+    ``email_service.send_email(...)`` but EmailService had no such method (only the
+    provider did), so the failure alert itself crashed with
+    ``'EmailService' object has no attribute 'send_email'`` — masking the original
+    error and losing the admin alert entirely.
+    """
+
+    def test_send_email_delegates_to_provider(self):
+        service = EmailService()
+        service.provider = Mock()
+        service.provider.send_email.return_value = True
+
+        result = service.send_email(
+            to_email="admin@example.com",
+            subject="[FAILED] Test",
+            html_content="<p>oops</p>",
+            text_content="oops",
+        )
+
+        assert result is True
+        service.provider.send_email.assert_called_once()
+        call_kwargs = service.provider.send_email.call_args.kwargs
+        assert call_kwargs["to_email"] == "admin@example.com"
+        assert call_kwargs["subject"] == "[FAILED] Test"
+        assert call_kwargs["html_content"] == "<p>oops</p>"
+        assert call_kwargs["text_content"] == "oops"
+
+
 class TestMadeForYouAdminNotificationEmail:
     """Tests for send_made_for_you_admin_notification method."""
 
@@ -1756,6 +1787,103 @@ class TestMadeForYouYouTubeDownloadContract:
         email_call = mock_email_service.send_email.call_args
         assert "[FAILED]" in email_call.kwargs.get('subject', ''), \
             "Error notification email should have [FAILED] in subject"
+
+    @pytest.mark.asyncio
+    async def test_youtube_download_failure_still_sends_customer_confirmation(
+        self, mock_job_manager, mock_email_service, mock_user_service,
+        mock_theme_service, youtube_order_metadata
+    ):
+        """
+        Regression: a YouTube download failure must NOT prevent the paid customer
+        from receiving their order-confirmation email, nor prevent the admin from
+        being alerted.
+
+        Bug context (2026-08-22): Job 17dc6f48 failed on a YouTube bot-check
+        download error. Because the confirmation + admin emails were only sent
+        *after* audio acquisition, the download failure skipped both — Andrew never
+        received the "New Made-For-You Order Received!" notification and there was no
+        guarantee the customer got their confirmation. The confirmation email is now
+        sent up-front, independently of the (fallible) audio acquisition step.
+        """
+        from backend.api.routes.users import _handle_made_for_you_order, ADMIN_EMAIL
+        from backend.services.youtube_download_service import YouTubeDownloadError
+
+        mock_youtube_service = MagicMock()
+        mock_youtube_service.download = AsyncMock(
+            side_effect=YouTubeDownloadError(
+                "Sign in to confirm you're not a bot"
+            )
+        )
+
+        with patch('backend.services.job_manager.JobManager', return_value=mock_job_manager), \
+             patch('backend.services.worker_service.get_worker_service', return_value=MagicMock()), \
+             patch('backend.services.storage_service.StorageService'), \
+             patch('backend.api.routes.users.get_theme_service', return_value=mock_theme_service), \
+             patch('backend.api.routes.users.get_youtube_download_service', return_value=mock_youtube_service):
+
+            # Must not raise - order intake is resilient to audio-acquisition failures
+            await _handle_made_for_you_order(
+                session_id="sess_123",
+                metadata=youtube_order_metadata,
+                user_service=mock_user_service,
+                email_service=mock_email_service,
+            )
+
+        # CRITICAL: customer still receives their order confirmation despite the failure
+        mock_email_service.send_made_for_you_order_confirmation.assert_called_once()
+        confirm_kwargs = mock_email_service.send_made_for_you_order_confirmation.call_args.kwargs
+        assert confirm_kwargs['to_email'] == youtube_order_metadata['customer_email']
+        assert confirm_kwargs['job_id'] == "test-job-123"
+
+        # CRITICAL: admin is alerted to the failure so they can intervene manually
+        mock_email_service.send_email.assert_called_once()
+        failure_kwargs = mock_email_service.send_email.call_args.kwargs
+        assert failure_kwargs['to_email'] == ADMIN_EMAIL
+        assert "[FAILED]" in failure_kwargs['subject']
+
+    @pytest.mark.asyncio
+    async def test_customer_confirmation_email_failure_does_not_abort_order(
+        self, mock_job_manager, mock_email_service, mock_user_service,
+        mock_theme_service, youtube_order_metadata
+    ):
+        """
+        Resilience: if the customer confirmation email itself fails to send, order
+        processing (audio acquisition + admin notification) must still proceed. An
+        email-provider hiccup should never block the actual work.
+        """
+        from backend.api.routes.users import _handle_made_for_you_order
+
+        # Confirmation email raises, but the order must still be processed
+        mock_email_service.send_made_for_you_order_confirmation.side_effect = \
+            RuntimeError("Postmark timeout")
+
+        # start_job_processing is async - mock it so the success path completes
+        mock_job_manager.start_job_processing = AsyncMock()
+
+        mock_youtube_service = MagicMock()
+        mock_youtube_service.download = AsyncMock(
+            return_value="uploads/test-job-123/audio/test.webm"
+        )
+
+        with patch('backend.services.job_manager.JobManager', return_value=mock_job_manager), \
+             patch('backend.services.worker_service.get_worker_service', return_value=MagicMock()), \
+             patch('backend.services.storage_service.StorageService'), \
+             patch('backend.api.routes.users.get_theme_service', return_value=mock_theme_service), \
+             patch('backend.api.routes.users.get_youtube_download_service', return_value=mock_youtube_service):
+
+            # Must not raise despite the confirmation email failure
+            await _handle_made_for_you_order(
+                session_id="sess_123",
+                metadata=youtube_order_metadata,
+                user_service=mock_user_service,
+                email_service=mock_email_service,
+            )
+
+        # Download still happened and admin notification still sent
+        mock_youtube_service.download.assert_called_once()
+        mock_email_service.send_made_for_you_admin_notification.assert_called_once()
+        # No [FAILED] alert - the order itself succeeded
+        mock_email_service.send_email.assert_not_called()
 
 
 class TestMadeForYouYouTubeImports:

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -1025,6 +1025,41 @@ All status transitions after workers complete fail silently because they're inva
 - `test_youtube_url_calls_start_job_processing_after_download` - verifies proper sequence
 - `TestInvalidStateTransitionError`, `TestValidateStateTransitionRaisesBehavior`, `TestStartJobProcessing` in `test_job_manager.py`
 
+### Made-For-You Order Emails Must Be Isolated From Audio Acquisition (Aug 2026)
+
+**Problem**: Job 17dc6f48 (made_for_you order) failed on a YouTube "confirm you're
+not a bot" download error, and the admin never received the "New Made-For-You Order
+Received!" email. The error-fallback then crashed with
+`'EmailService' object has no attribute 'send_email'`, so even the failure alert was lost.
+
+**Root cause**: In `_handle_made_for_you_order`, both the customer order-confirmation
+and the admin notification were sent *after* the fallible audio-acquisition step
+(YouTube download / audio search). When acquisition raised, execution jumped straight
+to the outer `except`, skipping BOTH emails. Separately, the fallback called
+`email_service.send_email(...)` — a method that only existed on the *provider*
+(`self.provider.send_email`), never on `EmailService` itself.
+
+**Fix**:
+1. Send the customer order-confirmation email **up-front**, right after job creation and
+   *before* audio acquisition — the order is paid/confirmed regardless of whether the
+   download or search succeeds. Wrapped so an email error is logged, not fatal.
+2. Wrap the admin notification so an email hiccup on a successful order can't fake a
+   `[FAILED]` alert.
+3. Route the outer failure handler through `_send_mfy_failure_alert()` (never raises,
+   HTML-escapes user input, tolerates `job_id=None`): success → normal admin
+   notification; acquisition failure → `[FAILED]` admin alert while the customer is
+   still confirmed.
+4. Add a thin `EmailService.send_email()` passthrough to the provider so ad-hoc/plain
+   emails (like the failure alert) work.
+
+**Why tests didn't catch it**: `email_service` was a `MagicMock` in the handler tests,
+so `mock.send_email(...)` auto-created the attribute and never surfaced the real
+`AttributeError`. **Pattern**: for critical fallbacks, add at least one test that
+exercises the real `EmailService` (only mocking `.provider`), and assert that a failure
+in a *later* step (audio) does not suppress *earlier* side effects (the confirmation
+email). Idempotency note: mark the Stripe session processed *before* sending the
+confirmation so a webhook retry can't double-send.
+
 ### Use data-testid for E2E
 Prefer `data-testid` over label/text selectors. They're immune to label changes and won't break when similar fields are added.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.196.8"
+version = "0.196.9"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Problem

Job `17dc6f48` (a Made-For-You order) failed on a YouTube "confirm you're not a bot" download error, and the admin **never received the "New Made-For-You Order Received!" email** — leaving no signal that a paid order needed attention, and no certainty the customer got their confirmation. The Discord error monitor also fired `'EmailService' object has no attribute 'send_email'`.

Two root causes in `_handle_made_for_you_order` (`backend/api/routes/users.py`):

1. **Emails were sent *after* audio acquisition.** Both the customer confirmation and the admin notification ran only after the fallible YouTube download / audio search. When acquisition raised, execution jumped to the error handler, **skipping both emails.**
2. **The error fallback itself crashed.** It called `email_service.send_email(...)`, but that method existed only on the *provider* (`self.provider.send_email`), never on `EmailService` — so even the failure alert was lost.

## Changes

- **Send the customer order-confirmation email up-front**, right after job creation and *before* audio acquisition. The order is paid/confirmed regardless of the download/search outcome. Resilient: a delivery failure is logged, not fatal.
- **Wrap the admin notification** so an email hiccup on a successful order can't fake a `[FAILED]` alert.
- **Route the outer failure handler through `_send_mfy_failure_alert()`** — never raises, HTML-escapes user input, tolerates `job_id=None`. Success → normal admin notification; audio-acquisition failure → `[FAILED]` admin alert while the customer stays confirmed.
- **Add a thin `EmailService.send_email()` passthrough** to the provider (fixes the `AttributeError`).
- **Handle `False` provider results** (providers signal rejection by returning `False`, not raising): log accurately instead of always "Sent"; a rejected *customer* confirmation is escalated to the admin so it can be resent manually.
- **Retry dropped paid orders:** if job creation fails (no `job_id`, session never marked processed), re-raise after alerting so the Stripe webhook returns non-2xx and Stripe retries. Post-creation failures keep `job_id` set and return 200 to avoid duplicate jobs on retry.
- Idempotency preserved: the Stripe session is marked processed before the confirmation send, so a webhook retry can't double-send.

## Out of scope

The YouTube "confirm you're not a bot" download error itself is a separate flacfetch/yt-dlp cookies issue (credential keeper) — this PR only makes the order emails resilient to it.

## Testing

- `make`-level backend suites for made-for-you, tenant/email, admin-feedback, internal-webhook all green (138 passed locally).
- New/updated regression tests:
  - customer confirmation survives a YouTube download failure
  - confirmation-email failure doesn't abort order processing (and is escalated)
  - provider-returns-`False` confirmation is escalated
  - job-creation failure re-raises (Stripe retry) after alerting
  - `EmailService.send_email` passthrough delegates to the provider
- Local CodeRabbit review: 2 findings addressed, re-run clean (no new findings).

@coderabbitai ignore