### PR TITLE
fix(audio-download): wire POSTMARK_SERVER_TOKEN into audio-download-job + resilient email construct

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -107,11 +107,13 @@ class Settings(BaseSettings):
     # Models used by the multi-model "compare" mode (semicolon-separated —
     # Cloud Run --set-env-vars is comma-delimited). Empty = single-model only.
     auto_correct_compare_models: str = os.getenv("AUTO_CORRECT_COMPARE_MODELS", "")
-    # Proactively generate (and cache) auto-correct suggestions in the lyrics
-    # worker once transcription + references are ready, so the review UI has
-    # them instantly. Best-effort: failures never block or fail the job. Only
-    # meaningful where ANTHROPIC_API_KEY + AUTO_CORRECT_COMPARE_MODELS are set
-    # (the lyrics-transcription-job, via ci.yml). Default off.
+    # Proactively generate (and cache) auto-correct suggestions once
+    # transcription + references are ready, so the review UI has them instantly.
+    # This flag gates whether the lyrics worker fires the trigger; the actual
+    # multi-model LLM call + caching runs on the API service (auto_correct_worker),
+    # which holds the model credentials — the lyrics-transcription-job itself does
+    # NOT need ANTHROPIC_API_KEY / AUTO_CORRECT_COMPARE_MODELS. Best-effort:
+    # failures never block or fail the job. Default off.
     auto_correct_proactive_enabled: bool = os.getenv(
         "AUTO_CORRECT_PROACTIVE_ENABLED", "false"
     ).lower() in ("true", "1", "yes")

--- a/backend/services/duration_reconciliation.py
+++ b/backend/services/duration_reconciliation.py
@@ -138,7 +138,24 @@ async def reconcile_and_maybe_pause(job_id: str) -> bool:
     user_service = get_user_service()
     storage = StorageService()
     # JobManager/StorageService have no singleton accessor; instantiate directly (matches audio_download_worker).
-    email_service = get_email_service()
+    #
+    # Email is only actually sent on the rare over-limit *cancel* branch. Building
+    # the service must never crash an otherwise-successful download: EmailService()
+    # raises in production when POSTMARK_SERVER_TOKEN is unset (the "fail loudly"
+    # guard from the 2026-06-09 fallback audit), and this worker runs as the
+    # audio-download-job Cloud Run Job. If the provider can't be built, reconcile
+    # still proceeds (reconcile_duration tolerates email_service=None); we log
+    # loudly so a config regression is visible rather than silently dropping a
+    # customer notification. (Job a453d1d5: token missing on the job crashed the
+    # download entirely.)
+    try:
+        email_service = get_email_service()
+    except Exception as e:
+        logger.error(
+            "Job %s: could not construct email service for duration reconcile "
+            "(%s); proceeding without customer email notifications", job_id, e,
+        )
+        email_service = None
 
     result = await asyncio.get_running_loop().run_in_executor(
         None,

--- a/backend/tests/services/test_duration_reconciliation.py
+++ b/backend/tests/services/test_duration_reconciliation.py
@@ -258,3 +258,58 @@ def test_stale_48h_expiry_sends_email_with_timeout_reason():
         assert "48" not in sent['subject'] and "not confirmed" not in sent['subject'], (
             f"over_limit email should not say '48 hours'. subject={sent.get('subject')!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression (job a453d1d5): a failing email-service construction must NOT
+# crash an otherwise-successful audio download. reconcile_and_maybe_pause runs
+# in the audio-download-job Cloud Run Job; EmailService() raises in production
+# when POSTMARK_SERVER_TOKEN is unset. Reconcile must degrade to no-email.
+# ---------------------------------------------------------------------------
+
+def _patch_reconcile_singletons(monkeypatch, jm, us, actual_seconds):
+    """Patch the function-scoped imports reconcile_and_maybe_pause pulls in.
+
+    These are imported inside the function (to avoid circular imports), so they
+    must be patched at their source modules, not on duration_reconciliation.
+    """
+    from backend.services import duration_reconciliation as dr
+    monkeypatch.setattr("backend.services.job_manager.JobManager", lambda: jm)
+    monkeypatch.setattr("backend.services.user_service.get_user_service", lambda: us)
+    monkeypatch.setattr("backend.services.storage_service.StorageService", lambda: MagicMock())
+    monkeypatch.setattr(
+        "backend.services.email_service.get_email_service",
+        MagicMock(side_effect=RuntimeError("POSTMARK_SERVER_TOKEN is not set in production")),
+    )
+    monkeypatch.setattr(dr, "_ffprobe_seconds", lambda job, storage: actual_seconds)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_and_maybe_pause_survives_email_service_failure(monkeypatch):
+    from backend.services import duration_reconciliation as dr
+
+    jm = MagicMock()
+    jm.get_job.return_value = _job(credits_charged=2)
+    # Duration matches estimate → proceed, no email needed anyway.
+    _patch_reconcile_singletons(monkeypatch, jm, MagicMock(), actual_seconds=900.0)  # 15min -> 2 credits
+
+    # Must not raise despite email service construction failing.
+    blocked = await dr.reconcile_and_maybe_pause("job1")
+    assert blocked is False  # proceeds normally
+
+
+@pytest.mark.asyncio
+async def test_reconcile_and_maybe_pause_over_limit_still_cancels_without_email(monkeypatch):
+    """Over-limit cancel must still refund+cancel even if email can't be built."""
+    from backend.services import duration_reconciliation as dr
+
+    jm = MagicMock()
+    jm.get_job.return_value = _job(credits_charged=2)
+    us = MagicMock()
+    us.add_credits.return_value = (True, 99, "ok")
+    _patch_reconcile_singletons(monkeypatch, jm, us, actual_seconds=4000.0)  # >60min
+
+    blocked = await dr.reconcile_and_maybe_pause("job1")
+    assert blocked is True  # cancelled
+    jm.cancel_job.assert_called_once()
+    us.add_credits.assert_called_once()  # full refund still happens

--- a/infrastructure/modules/cloud_run.py
+++ b/infrastructure/modules/cloud_run.py
@@ -373,6 +373,20 @@ def create_audio_download_job(
                                 name="GOOGLE_CLOUD_PROJECT",
                                 value=PROJECT_ID,
                             ),
+                            # Email provider (Postmark). The worker's duration
+                            # reconcile can send an over-limit cancellation email
+                            # to the customer; without this the EmailService "fail
+                            # loudly" guard raised in production and crashed the
+                            # whole download (job a453d1d5).
+                            cloudrunv2.JobTemplateTemplateContainerEnvArgs(
+                                name="POSTMARK_SERVER_TOKEN",
+                                value_source=cloudrunv2.JobTemplateTemplateContainerEnvValueSourceArgs(
+                                    secret_key_ref=cloudrunv2.JobTemplateTemplateContainerEnvValueSourceSecretKeyRefArgs(
+                                        secret=f"projects/{PROJECT_ID}/secrets/postmark-server-token",
+                                        version="latest",
+                                    ),
+                                ),
+                            ),
                         ],
                     )
                 ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.196.9"
+version = "0.196.10"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Fixes production job `a453d1d5` (Regina Spektor – Laughing With), which failed with:

> Audio download failed: POSTMARK_SERVER_TOKEN is not set in production. Refusing to silently drop emails via the console provider — set the Postmark token secret.

### Root cause
The audio download worker runs as its **own Cloud Run Job** (`audio-download-job`) — a thin orchestrator that calls the flacfetch VM over the VPC and waits, then triggers separation + lyrics. Each Cloud Run Job has an **independent env block**, and `audio-download-job`'s block omitted `POSTMARK_SERVER_TOKEN` (it was wired only into `karaoke-backend` and `video-encoding-job`).

`audio_download_worker` → `reconcile_and_maybe_pause()` **eagerly** builds `get_email_service()` on every no-edit download, even though email is only sent in the rare over‑60‑min cancel branch. `EmailService()` deliberately raises in production when the token is absent (2026‑06‑09 fallback‑audit "fail loudly" guard), so the whole download failed.

Blast radius was small (1 job in Firestore) because jobs that stop at `AWAITING_AUDIO_EDIT` never reach reconcile — but it recurs for every automated/no‑edit download.

## Changes
- **infra** (`infrastructure/modules/cloud_run.py`): add `POSTMARK_SERVER_TOKEN` secret env to `audio-download-job` so the over‑limit cancellation email works. *(Needs `pulumi up` — applied locally before merge.)*
- **`backend/services/duration_reconciliation.py`**: wrap `get_email_service()` in try/except → log and proceed with `email_service=None`. A construct‑time email failure can no longer crash an otherwise‑successful paid download (`reconcile_duration` already tolerates `None`; over‑limit still cancels + refunds).
- **tests**: `survives-email-service-failure` (proceeds) and `over-limit-still-cancels-without-email`.
- **`backend/config.py`**: corrected a stale comment claiming `lyrics-transcription-job` needs `ANTHROPIC_API_KEY` — the LLM work actually runs on the API service (`auto_correct_worker`), not the lyrics job.
- version bump 0.196.9 → 0.196.10.

## Env audit
Audited **all** Cloud Run Jobs' env vs. their worker code paths. The only production hard‑fail pattern is the `EmailService` guard; the POSTMARK gap was **unique to `audio-download-job`**. `bulk-search-job` and `lyrics-transcription-job` never construct `EmailService` on their path; `video-encoding-job` already has the token and is doubly defended. No other env vars need adding.

## Testing
- `test_duration_reconciliation.py` 14/14, `test_audio_download_worker.py` 37/37, `test_email_service.py` included — 94 passed.
- CodeRabbit local review: no findings.

@coderabbitai ignore
