### PR TITLE
feat(admin): per-job/user locale badge + "emails sent to user" history

### DIFF
--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -2977,6 +2977,37 @@ async def get_user_payments(
     return service.get_user_payment_history(email)
 
 
+@router.get("/users/{email}/emails")
+async def get_user_emails(
+    email: str,
+    auth_data: Tuple[str, UserType, int] = Depends(require_admin),
+):
+    """List every email ever sent to a user (Postmark + our persisted log)."""
+    from backend.services.postmark_admin_service import get_postmark_admin_service
+    service = get_postmark_admin_service()
+    return service.get_user_email_history(email)
+
+
+@router.get("/emails/{message_id}")
+async def get_email_detail(
+    message_id: str,
+    source: str = "postmark",
+    auth_data: Tuple[str, UserType, int] = Depends(require_admin),
+):
+    """Full detail for a single email — rendered HTML + delivery metadata.
+
+    ``source=log`` reads our persisted copy directly (for mail older than
+    Postmark's ~45-day retention); otherwise Postmark is queried with a
+    fallback to the stored log.
+    """
+    from backend.services.postmark_admin_service import get_postmark_admin_service
+    service = get_postmark_admin_service()
+    result = service.get_email_detail(message_id, source=source)
+    if not result:
+        raise HTTPException(status_code=404, detail="Email not found")
+    return result
+
+
 @router.get("/payments/{session_id}")
 async def get_payment_detail(
     session_id: str,

--- a/backend/api/routes/audio_search.py
+++ b/backend/api/routes/audio_search.py
@@ -55,7 +55,7 @@ from backend.services.firestore_service import FirestoreService
 from backend.services.user_service import get_user_service
 from backend.services.pricing import duration_to_credits, is_blocked
 from pathlib import Path
-from backend.i18n import t, get_locale_from_request
+from backend.i18n import t, get_locale_from_request, get_full_locale_from_request
 
 logger = logging.getLogger(__name__)
 
@@ -806,6 +806,7 @@ async def search_audio(
             is_private=body.is_private,
             # Tenant scoping
             tenant_id=tenant_config.id if tenant_config else "",
+            locale=get_full_locale_from_request(request),
         )
         job = job_manager.create_job(job_create, is_admin=auth_result.is_admin)
         job_id = job.job_id

--- a/backend/api/routes/bulk.py
+++ b/backend/api/routes/bulk.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
 from backend.api.dependencies import require_auth
+from backend.i18n import get_full_locale_from_request
 from backend.services.auth_service import AuthResult
 
 logger = logging.getLogger(__name__)
@@ -348,6 +349,7 @@ async def bulk_submit(
             dropbox_path=settings.default_dropbox_path,
             gdrive_folder_id=settings.default_gdrive_folder_id,
             request_metadata=request_metadata,
+            locale=get_full_locale_from_request(request),
         )
         try:
             job = job_manager.create_job(job_create, is_admin=is_admin)

--- a/backend/api/routes/file_upload.py
+++ b/backend/api/routes/file_upload.py
@@ -44,7 +44,7 @@ from backend.services.youtube_download_service import (
     get_youtube_download_service,
     YouTubeDownloadError,
 )
-from backend.i18n import t, get_locale_from_request
+from backend.i18n import t, get_locale_from_request, get_full_locale_from_request
 
 logger = logging.getLogger(__name__)
 
@@ -685,6 +685,8 @@ async def upload_and_create_job(
             is_private=is_private,
             # Tenant scoping
             tenant_id=tenant_config.id if tenant_config else "",
+            # UI language the job was submitted in (admin-only signal)
+            locale=get_full_locale_from_request(request),
         )
         job = job_manager.create_job(job_create, is_admin=auth_result.is_admin)
         job_id = job.job_id
@@ -1269,6 +1271,8 @@ async def create_job_with_upload_urls(
             is_private=effective_is_private,
             # Tenant scoping
             tenant_id=tenant_config.id if tenant_config else "",
+            # UI language the job was submitted in (admin-only signal)
+            locale=get_full_locale_from_request(request),
         )
         job = job_manager.create_job(job_create, is_admin=auth_result.is_admin)
         job_id = job.job_id
@@ -1897,6 +1901,8 @@ async def create_job_from_url(
             is_private=body.is_private,
             # Tenant scoping
             tenant_id=tenant_config.id if tenant_config else "",
+            # UI language the job was submitted in (admin-only signal)
+            locale=get_full_locale_from_request(request),
         )
         job = job_manager.create_job(job_create, is_admin=auth_result.is_admin)
         job_id = job.job_id
@@ -2202,6 +2208,8 @@ async def create_finalise_only_job(
             is_private=body.is_private,
             # Tenant scoping
             tenant_id=tenant_config.id if tenant_config else "",
+            # UI language the job was submitted in (admin-only signal)
+            locale=get_full_locale_from_request(request),
         )
         job = job_manager.create_job(job_create, is_admin=auth_result.is_admin)
         job_id = job.job_id

--- a/backend/api/routes/jobs.py
+++ b/backend/api/routes/jobs.py
@@ -39,7 +39,7 @@ from backend.services.tracing import add_span_attribute
 from backend.api.dependencies import require_admin, require_auth
 from backend.services.auth_service import AuthResult
 from backend.services.metrics import metrics
-from backend.i18n import t, get_locale_from_request
+from backend.i18n import t, get_locale_from_request, get_full_locale_from_request
 from backend.middleware.tenant import get_tenant_from_request
 from backend.utils.test_data import is_test_email
 from backend.exceptions import InsufficientCreditsError
@@ -164,6 +164,7 @@ async def create_job(
             user_email=user_email,
             is_private=request.is_private or False,
             credits=credits,
+            locale=get_full_locale_from_request(http_request),
         )
         job = job_manager.create_job(job_create, is_admin=auth_result.is_admin)
 
@@ -2541,6 +2542,7 @@ async def create_job_from_search(
             request_metadata=request_metadata,
             is_private=body.is_private,
             tenant_id=tenant_id,
+            locale=get_full_locale_from_request(request),
         )
         job = job_manager.create_job(job_create, is_admin=auth_result.is_admin)
         job_id = job.job_id

--- a/backend/api/routes/users.py
+++ b/backend/api/routes/users.py
@@ -36,7 +36,7 @@ def _mask_email(email: str) -> str:
 from fastapi import APIRouter, HTTPException, Depends, Request, Header
 from pydantic import BaseModel, EmailStr
 
-from backend.i18n import t, get_locale_from_request
+from backend.i18n import t, get_locale_from_request, get_full_locale_from_request
 from backend.services.email_validation_service import get_email_validation_service
 from backend.models.user import (
     UserRole,
@@ -438,10 +438,18 @@ async def verify_magic_link(
         except Exception as ref_err:
             logger.warning(f"Referral attribution failed for {_mask_email(user.email)}: {ref_err}")
 
-    # Persist user's locale preference (from Accept-Language header)
+    # Persist user's locale preference (from Accept-Language header).
+    # `locale` is narrowed to en/es/de for email rendering; `ui_locale` is the
+    # full UI language (any of 33) so admins know what language to communicate in.
+    ui_locale = get_full_locale_from_request(http_request)
+    locale_updates = {}
     if locale and locale != (user.locale or "en"):
+        locale_updates["locale"] = locale
+    if ui_locale and ui_locale != user.ui_locale:
+        locale_updates["ui_locale"] = ui_locale
+    if locale_updates:
         try:
-            user_service.update_user(user.email, locale=locale)
+            user_service.update_user(user.email, **locale_updates)
         except Exception:
             pass  # Non-critical — don't block login
 
@@ -801,6 +809,7 @@ async def create_checkout(
 @router.post("/made-for-you/checkout", response_model=CreateCheckoutResponse)
 async def create_made_for_you_checkout(
     request: MadeForYouCheckoutRequest,
+    http_request: Request,
     stripe_service: StripeService = Depends(get_stripe_service),
 ):
     """
@@ -825,6 +834,7 @@ async def create_made_for_you_checkout(
         source_type=request.source_type,
         youtube_url=request.youtube_url,
         notes=request.notes,
+        locale=get_full_locale_from_request(http_request),
     )
 
     if not success or not checkout_url:
@@ -1008,6 +1018,8 @@ async def _handle_made_for_you_order(
             brand_prefix=dist.brand_prefix,
             discord_webhook_url=dist.discord_webhook_url,
             youtube_description=dist.youtube_description,
+            # UI language the customer ordered in (captured at checkout, admin-only signal)
+            locale=metadata.get("locale") or None,
         )
         # Made-for-you jobs are created by admin (via Stripe webhook) - bypass rate limits
         job = job_manager.create_job(job_create, is_admin=True)
@@ -1758,6 +1770,10 @@ class UserDetailResponse(BaseModel):
     display_name: Optional[str] = None
     is_active: bool = True
     email_verified: bool = False
+    # Language: `locale` is the email locale (en/es/de); `ui_locale` is the full UI
+    # language (any of 33) the user browses in — what admins should communicate in.
+    locale: Optional[str] = None
+    ui_locale: Optional[str] = None
     created_at: Optional[str] = None
     updated_at: Optional[str] = None
     last_login_at: Optional[str] = None
@@ -1922,6 +1938,7 @@ async def get_user_detail(
             "artist": job_data.get("artist"),
             "title": job_data.get("title"),
             "created_at": created_at_str,
+            "locale": job_data.get("locale"),
         })
 
     # Get active sessions with details
@@ -1958,6 +1975,8 @@ async def get_user_detail(
         display_name=user.display_name,
         is_active=user.is_active,
         email_verified=user.email_verified,
+        locale=user.locale,
+        ui_locale=user.ui_locale,
         created_at=user.created_at.isoformat() if user.created_at else None,
         updated_at=user.updated_at.isoformat() if user.updated_at else None,
         last_login_at=user.last_login_at.isoformat() if user.last_login_at else None,

--- a/backend/api/routes/users.py
+++ b/backend/api/routes/users.py
@@ -442,8 +442,12 @@ async def verify_magic_link(
     # `locale` is narrowed to en/es/de for email rendering; `ui_locale` is the
     # full UI language (any of 33) so admins know what language to communicate in.
     ui_locale = get_full_locale_from_request(http_request)
+    has_accept_language = bool(http_request.headers.get("accept-language"))
     locale_updates = {}
-    if locale and locale != (user.locale or "en"):
+    # Only touch locale when the client actually sent an Accept-Language header —
+    # otherwise get_locale_from_request()'s "en" default would clobber a user's
+    # real stored locale on token-only logins (e.g. magic-link scanners).
+    if has_accept_language and locale and locale != (user.locale or "en"):
         locale_updates["locale"] = locale
     if ui_locale and ui_locale != user.ui_locale:
         locale_updates["ui_locale"] = ui_locale

--- a/backend/i18n.py
+++ b/backend/i18n.py
@@ -108,8 +108,13 @@ def get_full_locale_from_request(request: Request) -> str | None:
     for part in accept_lang.split(","):
         # Each part looks like "en-US;q=0.9" — take the language-region token
         # before the quality factor, then the primary subtag before any region.
-        token = part.split(";")[0].strip()
+        segments = part.split(";")
+        token = segments[0].strip()
         if not token or token == "*":
+            continue
+        # Skip ranges the client explicitly rejects with q=0.
+        if any(seg.strip().lower().replace(" ", "") in ("q=0", "q=0.0", "q=0.00", "q=0.000")
+               for seg in segments[1:]):
             continue
         lang = token.split("-")[0].strip().lower()
         if lang.isalpha() and len(lang) >= 2:

--- a/backend/i18n.py
+++ b/backend/i18n.py
@@ -92,6 +92,32 @@ def get_locale_from_request(request: Request) -> str:
     return DEFAULT_LOCALE
 
 
+def get_full_locale_from_request(request: Request) -> str | None:
+    """Extract the user's actual UI language tag from Accept-Language.
+
+    Unlike :func:`get_locale_from_request`, this does NOT narrow to the 3
+    email-supported locales (en/es/de). It returns the primary language subtag
+    of the first entry in the header (e.g. ``pt``, ``ja``, ``zh``) so the admin
+    UI can show the real language a customer was using the product in.
+
+    Returns the lowercased language subtag, or ``None`` if the header is absent
+    or unparseable.
+    """
+    accept_lang = request.headers.get("accept-language", "")
+
+    for part in accept_lang.split(","):
+        # Each part looks like "en-US;q=0.9" — take the language-region token
+        # before the quality factor, then the primary subtag before any region.
+        token = part.split(";")[0].strip()
+        if not token or token == "*":
+            continue
+        lang = token.split("-")[0].strip().lower()
+        if lang.isalpha() and len(lang) >= 2:
+            return lang
+
+    return None
+
+
 def get_locale_prefix(locale: str) -> str:
     """Get URL locale prefix for frontend URLs (e.g., '/en', '/es')."""
     if locale not in SUPPORTED_LOCALES:

--- a/backend/models/job.py
+++ b/backend/models/job.py
@@ -274,7 +274,13 @@ class Job(BaseModel):
 
     # Multi-tenant support ("" = consumer portal, "vocalstar"/etc = tenant portal)
     tenant_id: str = ""                          # Tenant ID for white-label portal scoping
-    
+
+    # UI language the job was submitted in (primary Accept-Language subtag, e.g.
+    # "pt", "ja", "zh"). Any of the 33 supported UI locales — NOT narrowed to the
+    # 3 email locales. Admin-only signal for support/intervention. None for jobs
+    # created before this field existed or where the header was absent.
+    locale: Optional[str] = None
+
     # Theme configuration (pre-made themes from GCS)
     theme_id: Optional[str] = None               # Theme identifier (e.g., "nomad", "default")
     color_overrides: Dict[str, str] = Field(default_factory=dict)
@@ -630,6 +636,10 @@ class JobCreate(BaseModel):
 
     # Tenant scoping for white-label portals ("" = consumer, "vocalstar"/etc = tenant)
     tenant_id: str = ""                          # Tenant ID for job scoping
+
+    # UI language the job was submitted in (primary Accept-Language subtag, e.g.
+    # "pt", "ja"). Set by the API endpoint from the request header; admin-only.
+    locale: Optional[str] = None
 
     @validator('url')
     def validate_url(cls, v):

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -91,8 +91,15 @@ class User(BaseModel):
     # Optional profile fields for future use
     display_name: Optional[str] = None
 
-    # i18n locale preference (set from Accept-Language on login, used for emails/push)
+    # i18n locale preference (set from Accept-Language on login, used for emails/push).
+    # Narrowed to the 3 email-supported locales (en/es/de) — do NOT widen, email
+    # rendering depends on it.
     locale: Optional[str] = None
+
+    # Actual UI language the user browses in (primary Accept-Language subtag, any
+    # of the 33 supported locales, e.g. "pt", "ja"). Captured on login and job
+    # creation. Admin-only signal so support knows what language to communicate in.
+    ui_locale: Optional[str] = None
 
     # Push notification subscriptions (Web Push API)
     # Users can subscribe from multiple devices/browsers

--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -10,6 +10,7 @@ Provider selection: POSTMARK_SERVER_TOKEN env var enables Postmark.
 import html
 import logging
 import os
+import re
 import sys
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
@@ -260,6 +261,20 @@ class PostmarkEmailProvider(EmailProvider):
             return SendResult(success=False, message_id=None)
 
 
+# Query params that carry single-use auth/capability tokens (magic-link sign-in,
+# lyrics/instrumental review access, referral codes). We persist a redacted copy
+# so the admin email-history log never becomes a store of live credentials — the
+# email still renders faithfully, only the secret value is masked.
+_SENSITIVE_QUERY_PARAM = re.compile(r"([?&](?:token|ref|review_token|instrumental_token)=)[^&\"'\s<]+", re.IGNORECASE)
+
+
+def _redact_sensitive_tokens(content: Optional[str]) -> Optional[str]:
+    """Mask token/ref query-param values in email content before persistence."""
+    if not content:
+        return content
+    return _SENSITIVE_QUERY_PARAM.sub(r"\1[REDACTED]", content)
+
+
 def _dedupe_emails(emails: List[str]) -> List[str]:
     """Lowercase-normalize and deduplicate a list of email addresses, preserving order."""
     seen = set()
@@ -429,8 +444,9 @@ class EmailService:
         """Write one Firestore ``email_log`` doc mirroring a sent email.
 
         Keyed by the Postmark MessageID when available (idempotent), else an
-        auto-id. Stores the exact rendered HTML so the admin UI can show older
-        mail after Postmark's ~45-day content retention expires.
+        auto-id. Stores the rendered HTML so the admin UI can show older mail
+        after Postmark's ~45-day content retention expires — with single-use
+        auth/capability tokens redacted so the log never holds live credentials.
         """
         from backend.services.firestore_service import FirestoreService
 
@@ -442,8 +458,8 @@ class EmailService:
             "bcc": _dedupe_emails(bcc_emails) if bcc_emails else [],
             "from_email": from_email,
             "subject": subject,
-            "html_content": html_content,
-            "text_content": text_content,
+            "html_content": _redact_sensitive_tokens(html_content),
+            "text_content": _redact_sensitive_tokens(text_content),
             "email_type": email_type,
             "message_stream": "outbound",
             "postmark_message_id": message_id,

--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -10,9 +10,10 @@ Provider selection: POSTMARK_SERVER_TOKEN env var enables Postmark.
 import html
 import logging
 import os
+import sys
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
-from typing import Optional, List
+from typing import NamedTuple, Optional, List
 from zoneinfo import ZoneInfo
 
 import requests
@@ -23,6 +24,18 @@ from karaoke_gen.utils import sanitize_filename
 
 
 logger = logging.getLogger(__name__)
+
+
+class SendResult(NamedTuple):
+    """Outcome of a provider send.
+
+    ``message_id`` is the provider's unique id for the sent message (Postmark's
+    ``MessageID``) when available — used to link a send to its Postmark record and
+    to dedupe the persisted ``email_log`` entry. ``None`` for providers that don't
+    expose one (console/preview).
+    """
+    success: bool
+    message_id: Optional[str] = None
 
 
 class EmailProvider(ABC):
@@ -52,6 +65,32 @@ class EmailProvider(ABC):
             from_email_override: Override the default sender email (optional, for multi-tenant)
         """
         pass
+
+    def send_email_detailed(
+        self,
+        to_email: str,
+        subject: str,
+        html_content: str,
+        text_content: Optional[str] = None,
+        cc_emails: Optional[List[str]] = None,
+        bcc_emails: Optional[List[str]] = None,
+        from_email_override: Optional[str] = None,
+    ) -> SendResult:
+        """Send an email and report the provider message id when available.
+
+        Default implementation delegates to :meth:`send_email` and reports no
+        message id. Providers that expose one (Postmark) override this.
+        """
+        success = self.send_email(
+            to_email=to_email,
+            subject=subject,
+            html_content=html_content,
+            text_content=text_content,
+            cc_emails=cc_emails,
+            bcc_emails=bcc_emails,
+            from_email_override=from_email_override,
+        )
+        return SendResult(success=success, message_id=None)
 
 
 class ConsoleEmailProvider(EmailProvider):
@@ -144,6 +183,26 @@ class PostmarkEmailProvider(EmailProvider):
         bcc_emails: Optional[List[str]] = None,
         from_email_override: Optional[str] = None,
     ) -> bool:
+        return self.send_email_detailed(
+            to_email=to_email,
+            subject=subject,
+            html_content=html_content,
+            text_content=text_content,
+            cc_emails=cc_emails,
+            bcc_emails=bcc_emails,
+            from_email_override=from_email_override,
+        ).success
+
+    def send_email_detailed(
+        self,
+        to_email: str,
+        subject: str,
+        html_content: str,
+        text_content: Optional[str] = None,
+        cc_emails: Optional[List[str]] = None,
+        bcc_emails: Optional[List[str]] = None,
+        from_email_override: Optional[str] = None,
+    ) -> SendResult:
         try:
             sender_email = from_email_override or self.from_email
             payload = {
@@ -176,7 +235,14 @@ class PostmarkEmailProvider(EmailProvider):
                 cc_info = f" (CC: {', '.join(cc_emails)})" if cc_emails else ""
                 bcc_info = f" (BCC: {', '.join(bcc_emails)})" if bcc_emails else ""
                 logger.info(f"Email sent to {to_email}{cc_info}{bcc_info} via Postmark")
-                return True
+                # Capture Postmark's MessageID so the send can be linked to its
+                # Postmark record and the persisted email_log entry deduped.
+                message_id = None
+                try:
+                    message_id = response.json().get("MessageID")
+                except ValueError:
+                    pass
+                return SendResult(success=True, message_id=message_id)
 
             # Surface Postmark's structured error so we can see suppressions, invalid signature, etc.
             try:
@@ -187,11 +253,11 @@ class PostmarkEmailProvider(EmailProvider):
                 )
             except ValueError:
                 logger.error(f"Postmark returned status {response.status_code}: {response.text[:200]}")
-            return False
+            return SendResult(success=False, message_id=None)
 
         except requests.RequestException:
             logger.exception("Failed to send email via Postmark")
-            return False
+            return SendResult(success=False, message_id=None)
 
 
 def _dedupe_emails(emails: List[str]) -> List[str]:
@@ -275,7 +341,47 @@ class EmailService:
         (e.g. internal failure alerts) without a dedicated template method.
         Prefer a dedicated ``send_*`` template method for customer-facing mail.
         """
-        return self.provider.send_email(
+        return self._log_and_send(
+            to_email=to_email,
+            subject=subject,
+            html_content=html_content,
+            text_content=text_content,
+            cc_emails=cc_emails,
+            bcc_emails=bcc_emails,
+            from_email_override=from_email_override,
+            email_type="raw",
+        )
+
+    def _log_and_send(
+        self,
+        to_email: str,
+        subject: str,
+        html_content: str,
+        text_content: Optional[str] = None,
+        cc_emails: Optional[List[str]] = None,
+        bcc_emails: Optional[List[str]] = None,
+        from_email_override: Optional[str] = None,
+        email_type: Optional[str] = None,
+    ) -> bool:
+        """Single send chokepoint: dispatch via the provider, then persist a
+        record of the send for the admin email-history view.
+
+        Every ``send_*`` template method routes through here so the persisted
+        ``email_log`` mirrors exactly what left the building. Persistence is
+        strictly best-effort — a Firestore failure must never break or delay a
+        real email send.
+        """
+        # Categorize by the calling send_* method name (e.g. send_magic_link →
+        # "magic_link") so the admin UI can group emails without threading an
+        # explicit type through every template method.
+        if email_type is None:
+            try:
+                caller = sys._getframe(1).f_code.co_name
+                email_type = caller[len("send_"):] if caller.startswith("send_") else caller
+            except Exception:
+                email_type = None
+
+        result = self.provider.send_email_detailed(
             to_email=to_email,
             subject=subject,
             html_content=html_content,
@@ -284,6 +390,70 @@ class EmailService:
             bcc_emails=bcc_emails,
             from_email_override=from_email_override,
         )
+
+        # Only persist genuine outbound mail (Postmark). Console/preview providers
+        # are dev/test only and have no real inbox to reflect.
+        if result.success and isinstance(self.provider, PostmarkEmailProvider):
+            try:
+                self._record_sent_email(
+                    to_email=to_email,
+                    subject=subject,
+                    html_content=html_content,
+                    text_content=text_content,
+                    cc_emails=cc_emails,
+                    bcc_emails=bcc_emails,
+                    from_email=from_email_override or getattr(self.provider, "from_email", None),
+                    email_type=email_type,
+                    message_id=result.message_id,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to persist email_log record (the email itself was sent OK)"
+                )
+
+        return result.success
+
+    def _record_sent_email(
+        self,
+        *,
+        to_email: str,
+        subject: str,
+        html_content: str,
+        text_content: Optional[str],
+        cc_emails: Optional[List[str]],
+        bcc_emails: Optional[List[str]],
+        from_email: Optional[str],
+        email_type: Optional[str],
+        message_id: Optional[str],
+    ) -> None:
+        """Write one Firestore ``email_log`` doc mirroring a sent email.
+
+        Keyed by the Postmark MessageID when available (idempotent), else an
+        auto-id. Stores the exact rendered HTML so the admin UI can show older
+        mail after Postmark's ~45-day content retention expires.
+        """
+        from backend.services.firestore_service import FirestoreService
+
+        db = FirestoreService().db
+        doc = {
+            "recipient": (to_email or "").strip().lower(),
+            "recipient_raw": to_email,
+            "cc": _dedupe_emails(cc_emails) if cc_emails else [],
+            "bcc": _dedupe_emails(bcc_emails) if bcc_emails else [],
+            "from_email": from_email,
+            "subject": subject,
+            "html_content": html_content,
+            "text_content": text_content,
+            "email_type": email_type,
+            "message_stream": "outbound",
+            "postmark_message_id": message_id,
+            "created_at": datetime.now(timezone.utc),
+        }
+        collection = db.collection("email_log")
+        if message_id:
+            collection.document(message_id).set(doc)
+        else:
+            collection.add(doc)
 
     def send_magic_link(
         self,
@@ -378,7 +548,7 @@ class EmailService:
 © {self._get_year()} {brand_name}
 """
 
-        return self.provider.send_email(
+        return self._log_and_send(
             email, subject, html_content, text_content, from_email_override=sender_email
         )
 
@@ -451,7 +621,7 @@ class EmailService:
 © {self._get_year()} Nomad Karaoke
 """
 
-        return self.provider.send_email(email, subject, html_content, text_content)
+        return self._log_and_send(email, subject, html_content, text_content)
 
     def send_welcome_email(self, email: str, credits: int = 0, locale: str = "en") -> bool:
         """
@@ -593,7 +763,7 @@ class EmailService:
 © {self._get_year()} Nomad Karaoke
 """
 
-        return self.provider.send_email(email, subject, html_content, text_content)
+        return self._log_and_send(email, subject, html_content, text_content)
 
     def _get_year(self) -> int:
         """Get current year for copyright notices."""
@@ -973,7 +1143,7 @@ class EmailService:
 
         cc_emails = ["gen@nomadkaraoke.com"] if cc_admin else None
 
-        return self.provider.send_email(
+        return self._log_and_send(
             to_email=to_email,
             subject=subject,
             html_content=html_content,
@@ -1050,7 +1220,7 @@ class EmailService:
 
         html_content = self._build_email_html(content, extra_styles, locale=locale)
 
-        return self.provider.send_email(
+        return self._log_and_send(
             to_email=to_email,
             subject=subject,
             html_content=html_content,
@@ -1150,7 +1320,7 @@ class EmailService:
             f"{t(locale, 'emails.reviewReminder.expiryWarning')}"
         )
 
-        return self.provider.send_email(
+        return self._log_and_send(
             to_email=to_email,
             subject=subject,
             html_content=html_content,
@@ -1292,7 +1462,7 @@ class EmailService:
             f"If you have any questions, just reply to this email — we're happy to help."
         )
 
-        return self.provider.send_email(
+        return self._log_and_send(
             to_email=to_email,
             subject=subject,
             html_content=html_content,
@@ -1385,7 +1555,7 @@ class EmailService:
             f"{t(locale, 'emails.reviewExpired.helpOffer')}"
         )
 
-        return self.provider.send_email(
+        return self._log_and_send(
             to_email=to_email,
             subject=subject,
             html_content=html_content,
@@ -1527,7 +1697,7 @@ class EmailService:
             f"If you have any questions, just reply to this email — we're happy to help."
         )
 
-        return self.provider.send_email(
+        return self._log_and_send(
             to_email=to_email,
             subject=subject,
             html_content=html_content,
@@ -1577,7 +1747,7 @@ class EmailService:
 
         html_content = self._build_email_html(content, extra_styles, locale=locale)
 
-        return self.provider.send_email(
+        return self._log_and_send(
             to_email=to_email,
             subject=subject,
             html_content=html_content,
@@ -1670,7 +1840,7 @@ class EmailService:
 
         html_content = self._build_email_html(content, extra_styles, locale=locale)
 
-        return self.provider.send_email(
+        return self._log_and_send(
             to_email=to_email,
             subject=subject,
             html_content=html_content,
@@ -1780,7 +1950,7 @@ Open Job: {app_url}
 
         html_content = self._build_email_html(content, extra_styles)
 
-        return self.provider.send_email(
+        return self._log_and_send(
             to_email=to_email,
             subject=subject,
             html_content=html_content,
@@ -1912,7 +2082,7 @@ View all feedback: {admin_url}
 
         html_content = self._build_email_html(content, extra_styles)
 
-        return self.provider.send_email(
+        return self._log_and_send(
             to_email=admin_email,
             subject=subject,
             html_content=html_content,
@@ -2027,7 +2197,7 @@ If the user looks legitimate, grant them credits from their admin page.
 
         html_content = self._build_email_html(content)
 
-        return self.provider.send_email(
+        return self._log_and_send(
             to_email="andrew@beveridge.uk",
             subject=subject,
             html_content=html_content,
@@ -2082,7 +2252,7 @@ If the user looks legitimate, grant them credits from their admin page.
 
         html_content = self._build_email_html(content, locale=locale)
 
-        return self.provider.send_email(
+        return self._log_and_send(
             to_email=email,
             subject=subject,
             html_content=html_content,

--- a/backend/services/email_service.py
+++ b/backend/services/email_service.py
@@ -173,6 +173,9 @@ class PostmarkEmailProvider(EmailProvider):
         self.server_token = server_token
         self.from_email = from_email
         self.from_name = from_name
+        # Postmark MessageID of the most recent successful send, so the email_log
+        # chokepoint can link a persisted record to its Postmark message.
+        self.last_message_id: Optional[str] = None
 
     def send_email(
         self,
@@ -243,6 +246,7 @@ class PostmarkEmailProvider(EmailProvider):
                     message_id = response.json().get("MessageID")
                 except ValueError:
                     pass
+                self.last_message_id = message_id
                 return SendResult(success=True, message_id=message_id)
 
             # Surface Postmark's structured error so we can see suppressions, invalid signature, etc.
@@ -396,7 +400,11 @@ class EmailService:
             except Exception:
                 email_type = None
 
-        result = self.provider.send_email_detailed(
+        # Dispatch via the provider's public send_email (as keyword args) so
+        # callers/mocks that observe that method still see it. PostmarkEmailProvider
+        # records the returned MessageID on ``last_message_id`` for us to link the
+        # log entry.
+        success = self.provider.send_email(
             to_email=to_email,
             subject=subject,
             html_content=html_content,
@@ -408,7 +416,7 @@ class EmailService:
 
         # Only persist genuine outbound mail (Postmark). Console/preview providers
         # are dev/test only and have no real inbox to reflect.
-        if result.success and isinstance(self.provider, PostmarkEmailProvider):
+        if success and isinstance(self.provider, PostmarkEmailProvider):
             try:
                 self._record_sent_email(
                     to_email=to_email,
@@ -419,14 +427,14 @@ class EmailService:
                     bcc_emails=bcc_emails,
                     from_email=from_email_override or getattr(self.provider, "from_email", None),
                     email_type=email_type,
-                    message_id=result.message_id,
+                    message_id=getattr(self.provider, "last_message_id", None),
                 )
             except Exception:
                 logger.exception(
                     "Failed to persist email_log record (the email itself was sent OK)"
                 )
 
-        return result.success
+        return success
 
     def _record_sent_email(
         self,

--- a/backend/services/firestore_service.py
+++ b/backend/services/firestore_service.py
@@ -200,7 +200,7 @@ class FirestoreService:
     SUMMARY_FIELD_PATHS = [
         'job_id', 'status', 'progress', 'created_at', 'artist', 'title',
         'error_message', 'non_interactive', 'outputs_deleted_at', 'user_email', 'is_private',
-        'made_for_you', 'customer_email',
+        'made_for_you', 'customer_email', 'locale',
         'url', 'filename', 'audio_search_artist', 'audio_search_title',
         'audio_source_type', 'source_name', 'source_id', 'target_file', 'download_url',
         'state_data.brand_code', 'state_data.youtube_url', 'state_data.dropbox_link',

--- a/backend/services/job_manager.py
+++ b/backend/services/job_manager.py
@@ -119,6 +119,8 @@ class JobManager:
             request_metadata=job_create.request_metadata,
             # Tenant scoping
             tenant_id=job_create.tenant_id,
+            # UI language the job was submitted in (admin-only signal)
+            locale=job_create.locale,
             # Made-for-you order fields
             made_for_you=job_create.made_for_you,
             customer_email=job_create.customer_email,

--- a/backend/services/postmark_admin_service.py
+++ b/backend/services/postmark_admin_service.py
@@ -26,8 +26,11 @@ logger = logging.getLogger(__name__)
 POSTMARK_API_BASE = "https://api.postmarkapp.com"
 EMAIL_LOG_COLLECTION = "email_log"
 
-# Postmark requires count+offset on the outbound list; cap what we surface.
-_LIST_COUNT = 100
+# Postmark's outbound list is paginated (count+offset, count max 500). We page
+# through until exhausted or the safety cap, so a user with a long history isn't
+# silently truncated at one batch.
+_PAGE_SIZE = 100
+_MAX_RECORDS = 500  # safety cap per source (admin view; avoids unbounded fetches)
 _HTTP_TIMEOUT = 12
 
 
@@ -66,26 +69,41 @@ class PostmarkAdminService:
 
     # -- Postmark queries --------------------------------------------------
     def _fetch_postmark_messages(self, email: str) -> List[Dict[str, Any]]:
-        """List outbound Postmark messages sent to ``email`` (best-effort)."""
+        """List outbound Postmark messages sent to ``email`` (best-effort, paginated)."""
         if not self.server_token:
             return []
-        try:
-            resp = requests.get(
-                f"{POSTMARK_API_BASE}/messages/outbound",
-                headers=self._postmark_headers(),
-                params={"recipient": email, "count": _LIST_COUNT, "offset": 0},
-                timeout=_HTTP_TIMEOUT,
-            )
-            if resp.status_code != 200:
-                logger.warning(
-                    "Postmark outbound list returned %s for recipient=%s: %s",
-                    resp.status_code, email, resp.text[:200],
+
+        messages: List[Dict[str, Any]] = []
+        offset = 0
+        while len(messages) < _MAX_RECORDS:
+            try:
+                resp = requests.get(
+                    f"{POSTMARK_API_BASE}/messages/outbound",
+                    headers=self._postmark_headers(),
+                    params={"recipient": email, "count": _PAGE_SIZE, "offset": offset},
+                    timeout=_HTTP_TIMEOUT,
                 )
-                return []
-            messages = resp.json().get("Messages", []) or []
-        except (requests.RequestException, ValueError):
-            logger.exception("Failed to fetch Postmark outbound messages for %s", email)
-            return []
+                if resp.status_code != 200:
+                    logger.warning(
+                        "Postmark outbound list returned %s for recipient=%s: %s",
+                        resp.status_code, email, resp.text[:200],
+                    )
+                    break
+                body = resp.json()
+                batch = body.get("Messages", []) or []
+            except (requests.RequestException, ValueError):
+                logger.exception("Failed to fetch Postmark outbound messages for %s", email)
+                break
+
+            messages.extend(batch)
+            total = body.get("TotalCount", 0)
+            offset += _PAGE_SIZE
+            # Stop when this batch was short or we've read everything Postmark has.
+            if len(batch) < _PAGE_SIZE or offset >= total:
+                break
+
+        if len(messages) >= _MAX_RECORDS:
+            logger.info("Postmark history for %s capped at %d records", email, _MAX_RECORDS)
 
         summaries = []
         for m in messages:
@@ -111,7 +129,7 @@ class PostmarkAdminService:
                 self.db.collection(EMAIL_LOG_COLLECTION)
                 .where(filter=FieldFilter("recipient", "==", recipient))
                 .order_by("created_at", direction=firestore.Query.DESCENDING)
-                .limit(_LIST_COUNT)
+                .limit(_MAX_RECORDS)
             )
             docs = list(query.stream())
         except Exception:

--- a/backend/services/postmark_admin_service.py
+++ b/backend/services/postmark_admin_service.py
@@ -1,0 +1,288 @@
+"""Postmark admin service — email history for the admin user-detail view.
+
+Surfaces "every email ever sent to a user" by merging two sources:
+
+1. **Postmark Messages API** (``GET /messages/outbound``) — authoritative for the
+   last ~45 days, with the exact rendered HTML and rich delivery metadata
+   (delivered / opened / clicked / bounced).
+2. **Our Firestore ``email_log``** — every send persisted at send time (see
+   ``EmailService._record_sent_email``), so history survives beyond Postmark's
+   45-day content retention.
+
+The same per-server ``POSTMARK_SERVER_TOKEN`` used for sending is sufficient to
+read outbound message history (no separate Account API token needed).
+"""
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import requests
+from google.cloud import firestore
+from google.cloud.firestore_v1 import FieldFilter
+
+logger = logging.getLogger(__name__)
+
+POSTMARK_API_BASE = "https://api.postmarkapp.com"
+EMAIL_LOG_COLLECTION = "email_log"
+
+# Postmark requires count+offset on the outbound list; cap what we surface.
+_LIST_COUNT = 100
+_HTTP_TIMEOUT = 12
+
+
+def _iso(value: Any) -> Optional[str]:
+    """Normalize a timestamp (datetime or str) to an ISO-8601 string."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.isoformat()
+    return str(value)
+
+
+class PostmarkAdminService:
+    """Read-only email history queries for the admin UI."""
+
+    def __init__(self, server_token: Optional[str] = None):
+        self.server_token = server_token if server_token is not None else os.getenv("POSTMARK_SERVER_TOKEN")
+        self._db: Optional[firestore.Client] = None
+
+    # -- infra -------------------------------------------------------------
+    @property
+    def db(self) -> firestore.Client:
+        # Lazy so the service can be constructed (and Postmark-only paths used)
+        # without a Firestore client in contexts that don't need one.
+        if self._db is None:
+            self._db = firestore.Client()
+        return self._db
+
+    def _postmark_headers(self) -> Dict[str, str]:
+        return {
+            "Accept": "application/json",
+            "X-Postmark-Server-Token": self.server_token or "",
+        }
+
+    # -- Postmark queries --------------------------------------------------
+    def _fetch_postmark_messages(self, email: str) -> List[Dict[str, Any]]:
+        """List outbound Postmark messages sent to ``email`` (best-effort)."""
+        if not self.server_token:
+            return []
+        try:
+            resp = requests.get(
+                f"{POSTMARK_API_BASE}/messages/outbound",
+                headers=self._postmark_headers(),
+                params={"recipient": email, "count": _LIST_COUNT, "offset": 0},
+                timeout=_HTTP_TIMEOUT,
+            )
+            if resp.status_code != 200:
+                logger.warning(
+                    "Postmark outbound list returned %s for recipient=%s: %s",
+                    resp.status_code, email, resp.text[:200],
+                )
+                return []
+            messages = resp.json().get("Messages", []) or []
+        except (requests.RequestException, ValueError):
+            logger.exception("Failed to fetch Postmark outbound messages for %s", email)
+            return []
+
+        summaries = []
+        for m in messages:
+            summaries.append({
+                "message_id": m.get("MessageID"),
+                "source": "postmark",
+                "subject": m.get("Subject"),
+                "to": ", ".join(m.get("Recipients") or []) or email,
+                "from_email": m.get("From"),
+                "sent_at": _iso(m.get("ReceivedAt")),
+                "status": m.get("Status"),
+                # Postmark tags map to our email_type when we set them; not used yet.
+                "email_type": (m.get("Metadata") or {}).get("email_type"),
+                "has_stored_html": False,
+            })
+        return summaries
+
+    def _fetch_log_docs(self, email: str) -> List[Dict[str, Any]]:
+        """Read persisted email_log docs for ``email`` (best-effort)."""
+        recipient = (email or "").strip().lower()
+        try:
+            query = (
+                self.db.collection(EMAIL_LOG_COLLECTION)
+                .where(filter=FieldFilter("recipient", "==", recipient))
+                .order_by("created_at", direction=firestore.Query.DESCENDING)
+                .limit(_LIST_COUNT)
+            )
+            docs = list(query.stream())
+        except Exception:
+            # Missing composite index or emulator quirk — degrade gracefully.
+            logger.exception("Failed to read email_log for %s", email)
+            return []
+
+        out = []
+        for doc in docs:
+            data = doc.to_dict() or {}
+            out.append({
+                "doc_id": doc.id,
+                "message_id": data.get("postmark_message_id"),
+                "source": "log",
+                "subject": data.get("subject"),
+                "to": data.get("recipient_raw") or data.get("recipient"),
+                "from_email": data.get("from_email"),
+                "sent_at": _iso(data.get("created_at")),
+                "status": None,
+                "email_type": data.get("email_type"),
+                "has_stored_html": bool(data.get("html_content")),
+            })
+        return out
+
+    # -- public API --------------------------------------------------------
+    def get_user_email_history(self, email: str) -> Dict[str, Any]:
+        """Merged, de-duplicated list of emails sent to ``email`` (newest first)."""
+        postmark = self._fetch_postmark_messages(email)
+        logged = self._fetch_log_docs(email)
+
+        # Postmark wins for a message present in both (richer status); note that we
+        # also have stored HTML so the UI can fall back after the 45-day window.
+        by_id: Dict[str, Dict[str, Any]] = {}
+        logged_by_mid: Dict[str, Dict[str, Any]] = {
+            d["message_id"]: d for d in logged if d.get("message_id")
+        }
+        for pm in postmark:
+            mid = pm.get("message_id")
+            if mid and mid in logged_by_mid:
+                pm["has_stored_html"] = True
+            if mid:
+                by_id[mid] = pm
+
+        merged = list(by_id.values())
+        for d in logged:
+            mid = d.get("message_id")
+            if mid and mid in by_id:
+                continue  # already represented by the Postmark summary
+            merged.append(d)
+
+        merged.sort(key=lambda x: x.get("sent_at") or "", reverse=True)
+        return {
+            "email": email,
+            "count": len(merged),
+            "postmark_available": bool(self.server_token),
+            "emails": merged,
+        }
+
+    def _log_doc_to_detail(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "message_id": data.get("postmark_message_id"),
+            "source": "log",
+            "subject": data.get("subject"),
+            "from_email": data.get("from_email"),
+            "to": data.get("recipient_raw") or data.get("recipient"),
+            "cc": data.get("cc") or [],
+            "bcc": data.get("bcc") or [],
+            "sent_at": _iso(data.get("created_at")),
+            "email_type": data.get("email_type"),
+            "message_stream": data.get("message_stream"),
+            "html_body": data.get("html_content"),
+            "text_body": data.get("text_content"),
+            "status": None,
+            "events": [],
+        }
+
+    def _fetch_log_detail_by_message_id(self, message_id: str) -> Optional[Dict[str, Any]]:
+        try:
+            snap = self.db.collection(EMAIL_LOG_COLLECTION).document(message_id).get()
+            if snap.exists:
+                return self._log_doc_to_detail(snap.to_dict() or {})
+        except Exception:
+            logger.exception("email_log fallback lookup failed for %s", message_id)
+        return None
+
+    def get_email_detail(self, message_id: str, source: str = "postmark") -> Optional[Dict[str, Any]]:
+        """Full detail for one email — rendered HTML + delivery metadata.
+
+        ``source="log"`` reads our Firestore record directly (for messages older
+        than Postmark's retention). Otherwise we query Postmark and fall back to
+        the Firestore log on 404/unavailable.
+        """
+        if source == "log":
+            return self._fetch_log_detail_by_message_id(message_id)
+
+        if self.server_token:
+            try:
+                resp = requests.get(
+                    f"{POSTMARK_API_BASE}/messages/outbound/{message_id}/details",
+                    headers=self._postmark_headers(),
+                    timeout=_HTTP_TIMEOUT,
+                )
+                if resp.status_code == 200:
+                    return self._postmark_detail(resp.json())
+                logger.info(
+                    "Postmark message %s details returned %s; trying stored log",
+                    message_id, resp.status_code,
+                )
+            except (requests.RequestException, ValueError):
+                logger.exception("Failed to fetch Postmark details for %s", message_id)
+
+        # Fallback: our persisted copy (older than 45 days, or Postmark down).
+        return self._fetch_log_detail_by_message_id(message_id)
+
+    def _postmark_detail(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Shape a Postmark message-details payload for the admin modal."""
+        events = []
+        opened = 0
+        clicked = 0
+        bounced_detail = None
+        delivered_at = None
+        for ev in data.get("MessageEvents", []) or []:
+            etype = ev.get("Type")
+            events.append({
+                "type": etype,
+                "received_at": _iso(ev.get("ReceivedAt")),
+                "details": ev.get("Details") or {},
+            })
+            if etype == "Delivered":
+                delivered_at = _iso(ev.get("ReceivedAt"))
+            elif etype == "Opened":
+                opened += 1
+            elif etype in ("LinkClicked", "Clicked"):
+                clicked += 1
+            elif etype == "Bounced":
+                bounced_detail = ev.get("Details") or {}
+
+        # Derive a coarse status from events when present.
+        status = data.get("Status")
+        if bounced_detail:
+            status = "Bounced"
+        elif delivered_at:
+            status = "Delivered"
+
+        return {
+            "message_id": data.get("MessageID"),
+            "source": "postmark",
+            "subject": data.get("Subject"),
+            "from_email": data.get("From"),
+            "to": ", ".join(data.get("Recipients") or []) or data.get("To"),
+            "cc": data.get("Cc"),
+            "bcc": data.get("Bcc"),
+            "sent_at": _iso(data.get("ReceivedAt")),
+            "message_stream": data.get("MessageStream"),
+            "html_body": data.get("HtmlBody"),
+            "text_body": data.get("TextBody"),
+            "status": status,
+            "delivered_at": delivered_at,
+            "open_count": opened,
+            "click_count": clicked,
+            "bounce": bounced_detail,
+            "events": events,
+        }
+
+
+_postmark_admin_service: Optional[PostmarkAdminService] = None
+
+
+def get_postmark_admin_service() -> PostmarkAdminService:
+    """Get the global Postmark admin service instance."""
+    global _postmark_admin_service
+    if _postmark_admin_service is None:
+        _postmark_admin_service = PostmarkAdminService()
+    return _postmark_admin_service

--- a/backend/services/stripe_service.py
+++ b/backend/services/stripe_service.py
@@ -185,6 +185,7 @@ class StripeService:
         notes: Optional[str] = None,
         success_url: Optional[str] = None,
         cancel_url: Optional[str] = None,
+        locale: Optional[str] = None,
     ) -> Tuple[bool, Optional[str], str]:
         """
         Create a Stripe Checkout session for a made-for-you order.
@@ -228,6 +229,9 @@ class StripeService:
             if notes:
                 # Truncate notes to fit Stripe's 500 char limit per metadata value
                 metadata['notes'] = notes[:500] if len(notes) > 500 else notes
+            if locale:
+                # UI language the customer ordered in — surfaced admin-side on the job
+                metadata['locale'] = locale
 
             # Build checkout session params
             session_params = {

--- a/backend/tests/services/test_duration_reconciliation.py
+++ b/backend/tests/services/test_duration_reconciliation.py
@@ -231,7 +231,7 @@ def test_stale_48h_expiry_sends_email_with_timeout_reason():
         sent = {}
 
         class _CapturingProvider:
-            def send_email(self, to_email, subject, html_content, text_content):
+            def send_email(self, to_email, subject, html_content, text_content=None, **kwargs):
                 sent['subject'] = subject
                 sent['text'] = text_content
                 return True

--- a/backend/tests/test_tenant_separation.py
+++ b/backend/tests/test_tenant_separation.py
@@ -11,6 +11,28 @@ from backend.models.user import VerifyMagicLinkResponse, UserPublic
 from backend.services.auth_service import AuthResult, AuthService, UserType
 
 
+def _sent_fields(call_args):
+    """Extract the sent email's fields regardless of positional/keyword call style.
+
+    Sends now flow through EmailService._log_and_send, which invokes the provider
+    with keyword args; older direct calls used positionals. Read both.
+    """
+    args, kwargs = call_args.args, call_args.kwargs
+
+    def pick(name, idx):
+        if name in kwargs:
+            return kwargs[name]
+        return args[idx] if len(args) > idx else None
+
+    return {
+        "to_email": pick("to_email", 0),
+        "subject": pick("subject", 1),
+        "html_content": pick("html_content", 2),
+        "text_content": pick("text_content", 3),
+        "from_email_override": kwargs.get("from_email_override"),
+    }
+
+
 class TestTenantConfigGetFrontendUrl:
     """Tests for TenantConfig.get_frontend_url()."""
 
@@ -47,10 +69,10 @@ class TestSendMagicLinkTenantParams:
         """Without tenant params, email uses default Nomad Karaoke branding."""
         email_service.send_magic_link("user@test.com", "abc123")
 
-        call_args = email_service.provider.send_email.call_args
-        subject = call_args[0][1]
-        html_content = call_args[0][2]
-        text_content = call_args[0][3]
+        f = _sent_fields(email_service.provider.send_email.call_args)
+        subject = f["subject"]
+        html_content = f["html_content"]
+        text_content = f["text_content"]
 
         assert subject == "Sign in to Nomad Karaoke"
         assert "Nomad Karaoke" in html_content
@@ -66,9 +88,9 @@ class TestSendMagicLinkTenantParams:
             tenant_frontend_url="https://vocalstar.nomadkaraoke.com",
         )
 
-        call_args = email_service.provider.send_email.call_args
-        html_content = call_args[0][2]
-        text_content = call_args[0][3]
+        f = _sent_fields(email_service.provider.send_email.call_args)
+        html_content = f["html_content"]
+        text_content = f["text_content"]
 
         assert "https://vocalstar.nomadkaraoke.com/en/auth/verify?token=abc123" in html_content
         assert "https://vocalstar.nomadkaraoke.com/en/auth/verify?token=abc123" in text_content
@@ -83,10 +105,10 @@ class TestSendMagicLinkTenantParams:
             tenant_name="Vocal Star",
         )
 
-        call_args = email_service.provider.send_email.call_args
-        subject = call_args[0][1]
-        html_content = call_args[0][2]
-        text_content = call_args[0][3]
+        f = _sent_fields(email_service.provider.send_email.call_args)
+        subject = f["subject"]
+        html_content = f["html_content"]
+        text_content = f["text_content"]
 
         assert subject == "Sign in to Vocal Star"
         assert "Vocal Star" in html_content
@@ -100,8 +122,7 @@ class TestSendMagicLinkTenantParams:
             tenant_name='<script>alert("xss")</script>',
         )
 
-        call_args = email_service.provider.send_email.call_args
-        html_content = call_args[0][2]
+        html_content = _sent_fields(email_service.provider.send_email.call_args)["html_content"]
 
         # Should be escaped in HTML
         assert "<script>" not in html_content
@@ -119,14 +140,14 @@ class TestSendMagicLinkTenantParams:
 
         assert result is True
 
-        call_args = email_service.provider.send_email.call_args
-        subject = call_args[0][1]
-        html_content = call_args[0][2]
+        f = _sent_fields(email_service.provider.send_email.call_args)
+        subject = f["subject"]
+        html_content = f["html_content"]
 
         assert subject == "Sign in to Vocal Star"
         assert "https://vocalstar.nomadkaraoke.com/en/auth/verify?token=token123" in html_content
         # Check sender email override was passed through
-        assert call_args[1]["from_email_override"] == "vocalstar@nomadkaraoke.com"
+        assert f["from_email_override"] == "vocalstar@nomadkaraoke.com"
 
 
 class TestVerifyMagicLinkResponseTenantSubdomain:

--- a/docs/API.md
+++ b/docs/API.md
@@ -1504,9 +1504,34 @@ Authorization: Bearer ADMIN_TOKEN
 
 Returns full user profile including:
 - User info and stats
+- `locale` (email locale: en/es/de) and `ui_locale` (full UI language, any of 33)
 - Recent credit transactions (last 20)
-- Recent jobs (last 10)
+- Recent jobs (last 10, each with its `locale`)
 - Active sessions count
+
+### Email History (Admin)
+
+List every email ever sent to a user, then fetch one for full-fidelity preview.
+Merges the Postmark Messages API (last ~45 days, with delivery metadata) with a
+persisted Firestore `email_log` (permanent), de-duplicated by message id.
+
+```http
+GET /api/admin/users/{email}/emails
+Authorization: Bearer ADMIN_TOKEN
+```
+
+Response: `{ email, count, postmark_available, emails: [{ message_id, source,
+subject, to, from_email, sent_at, status, email_type, has_stored_html }] }`.
+
+```http
+GET /api/admin/emails/{message_id}?source=postmark
+Authorization: Bearer ADMIN_TOKEN
+```
+
+`source` is `postmark` (default; falls back to the stored log on 404/expiry) or
+`log` (read the persisted copy directly). Returns the full rendered `html_body`,
+`text_body`, addressing, `status`, `delivered_at`, `open_count`, `click_count`,
+`bounce`, and the raw `events`.
 
 ### Add Credits (Admin)
 

--- a/docs/archive/2026-08-23-admin-locale-and-email-history-plan.md
+++ b/docs/archive/2026-08-23-admin-locale-and-email-history-plan.md
@@ -1,0 +1,146 @@
+# Admin: Locale/Language/Country Visibility + Email History
+
+**Branch:** `feat/sess-20260822-2340-admin-locale-emails`
+**Date:** 2026-08-23
+
+Two independent admin-facing features so support/intervention work can (a) know what
+language/country a user is using the product in, and (b) see the exact emails ever sent
+to a user, rendered as they appeared in the inbox with full delivery metadata.
+
+Decisions (confirmed with user):
+- **Email history:** Postmark live query (rich metadata, ~45d retention) **+** persist every
+  future send to Firestore for permanent history beyond 45 days. Merge both sources.
+- **Locale:** Full capture — add a real per-job `locale` (any of 33 langs from the actual
+  `Accept-Language` header), surface the user's UI language, and derive country from IP.
+
+---
+
+## Feature A — Locale / language / country
+
+### Backend
+
+1. **New helper** `get_full_locale_from_request(request)` in `backend/i18n.py`
+   - Returns the first language tag from `Accept-Language` **without** narrowing to en/es/de
+     (e.g. `pt`, `ja`, `zh`). Keep the existing `get_locale_from_request` untouched (emails
+     still need en/es/de).
+
+2. **Job model** `backend/models/job.py`
+   - Add `locale: Optional[str] = None` to `Job` (~L239-531) and `JobCreate` (~L534-655).
+
+3. **Capture on job creation** (populate `locale` from `get_full_locale_from_request`):
+   - URL jobs: `backend/api/routes/jobs.py` (~L79-197)
+   - File upload: `backend/api/routes/file_upload.py`
+   - Audio search: `backend/api/routes/audio_search.py`
+   - Made-for-you: capture at checkout (`backend/api/routes/users.py` create_made_for_you_checkout,
+     ~L801) → put `locale` in Stripe session metadata → read in the `checkout.session.completed`
+     webhook (~L1313) when the job is created.
+
+4. **Dashboard summary projection**: add `'locale'` to `SUMMARY_FIELD_PATHS`
+   (`backend/services/firestore_service.py` ~L200-220) so it appears in `list_jobs_summary`.
+   (Top-level field → only this constant, not `_SUMMARY_STATE_DATA_KEYS`.)
+
+5. **User UI locale (full value)** `backend/models/user.py`
+   - Add `ui_locale: Optional[str] = None` (keep existing `locale` en/es/de for email rendering).
+   - Populate in `verify_magic_link` (`users.py` ~L441-446) from the full Accept-Language, and
+     update it opportunistically on job creation (cheap `update_user` when it changes).
+
+6. **Surface in admin responses**
+   - `UserDetailResponse` (`users.py` ~L1753-1780): add `locale`, `ui_locale`.
+   - `get_user_detail` return (~L1954): include them; add `locale` to each `recent_jobs` entry (~L1919-1925).
+
+### Frontend
+
+7. **`LocaleBadge` component** `frontend/components/admin/locale-badge.tsx`
+   - Input: a locale string. Renders a small pill: flag emoji + human language name.
+   - Language name via `Intl.DisplayNames(['en'], { type: 'language' })`; flag via a
+     locale→region map (reuse `countryCodeToFlag` from `frontend/lib/ip-geolocation.ts:78`).
+   - Graceful fallback for unknown/empty locale (`🌐 —`).
+
+8. **Types**: add `locale` to `Job` (`frontend/lib/api.ts` ~L105-152) and `locale`/`ui_locale`
+   to `AdminUserDetail` (~L2256-2301) + the recent-jobs entry type.
+
+9. **Placements**
+   - Jobs table (`frontend/app/admin/jobs/page.tsx` ~L2142-2211): `LocaleBadge` in the row
+     (language only — cheap, no IP lookup per row).
+   - Job detail info grid (`jobs/page.tsx` ~L1113-1179): Language cell (`LocaleBadge`) +
+     Country via existing `<IpInfo ip={creation_ip} />`.
+   - User detail (`frontend/app/admin/users/detail/page.tsx`): `LocaleBadge` in the header
+     (~L342-348) / Account Info card. Country already shown via `<IpInfo>`.
+
+Note: keep IP→country lookups to the single-record detail views (cached in the
+`ip_geolocation` Firestore collection). The jobs *list* shows language only, to avoid N
+geolocation calls per page.
+
+---
+
+## Feature B — Email history ("emails sent to this user")
+
+### Backend
+
+10. **Persist every send** — single chokepoint in `EmailService`
+    (`backend/services/email_service.py`). Route all sends through one private
+    `_log_and_send(...)` that calls `self.provider.send_email(...)`, captures the Postmark
+    `MessageID` from the response, then best-effort writes a Firestore `email_log` doc:
+    `{ recipient, cc, bcc, from, subject, html_content, text_content, email_type,
+    message_stream, postmark_message_id, created_at }`.
+    - Mechanical: replace the ~15 `self.provider.send_email(` call sites with `self._log_and_send(`.
+    - Add optional `email_type` kwarg to each `send_*` for categorization (default inferred/None).
+    - Wrap the Firestore write in try/except — **logging must never break a send**.
+    - Capture `MessageID`: `PostmarkEmailProvider.send_email` must return it (change return to
+      include message id, or add an out-param) — currently it discards the response body.
+
+11. **`PostmarkAdminService`** `backend/services/postmark_admin_service.py`
+    (model on `stripe_admin_service.py`):
+    - `get_user_email_history(email)` → `GET https://api.postmarkapp.com/messages/outbound?recipient=<email>&count=...`
+      using `X-Postmark-Server-Token` (env `POSTMARK_SERVER_TOKEN`). Merge with Firestore
+      `email_log` docs for that recipient; dedupe by `postmark_message_id`; sort by sent-at desc.
+    - `get_email_detail(message_id)` → `GET /messages/outbound/{id}/details` (full `HtmlBody`,
+      subject, status, opens/clicks, bounce). Fallback to the Firestore `email_log` doc for
+      messages older than Postmark's 45-day retention.
+
+12. **Admin endpoints** `backend/api/routes/admin.py` (pattern: `get_user_payments` ~L2969,
+    guarded by `Depends(require_admin)`):
+    - `GET /admin/users/{email}/emails` → summary list.
+    - `GET /admin/emails/{message_id}` → full detail (HTML + metadata); `?source=log` for
+      Firestore-only records.
+
+### Frontend
+
+13. **API client** `frontend/lib/api.ts`: `adminApi.getUserEmails(email)` +
+    `adminApi.getEmailDetail(id, source?)`, plus `UserEmailSummary` / `EmailDetail` interfaces.
+
+14. **User detail page**: new **"Emails sent to this user"** `<Card>` (rows: subject,
+    type badge, sent-at, delivery-status badge). Row click → **`EmailPreviewDialog`**:
+    - Left/main: `<iframe srcDoc={html} sandbox>` so the email renders exactly as in the inbox
+      (isolated styles), inside `<DialogContent>` + `<ScrollArea>`.
+    - Side panel: To / From / CC / BCC / Subject / sent-at / status / open & click counts /
+      bounce reason.
+
+---
+
+## Testing
+
+- **Backend unit**: `get_full_locale_from_request` parsing; job `locale` persisted on each
+  creation path; `_log_and_send` writes an `email_log` doc (Postmark mocked) and never raises
+  when Firestore fails; `PostmarkAdminService` list/detail with `requests` mocked incl. the
+  45-day fallback; admin endpoints with the service mocked + `require_admin` auth.
+- **Frontend unit (jest)**: `LocaleBadge` rendering (known/unknown locale); email list + modal
+  render; iframe `srcDoc` wiring.
+- **Prod E2E (Playwright)**: optional — user-detail page shows the emails card + opens a
+  preview for a known recipient.
+
+## Infra / ops
+
+- No new secrets (`postmark-server-token` already wired into the API service).
+- New Firestore collection `email_log`. Add a composite index (recipient asc, created_at desc)
+  if the merge query needs it — note in PR; Firestore will surface the index hint on first query.
+- Bump `tool.poetry.version` in `pyproject.toml`.
+
+## Risks / notes
+
+- Postmark `MessageID` isn't captured today — must thread it through the provider return.
+- Not all `send_*` funnel through `send_email` today (e.g. `send_magic_link` calls
+  `self.provider.send_email` directly), which is exactly why the `_log_and_send` chokepoint
+  replaces the provider call sites rather than wrapping `send_email`.
+- `User.locale` stays en/es/de (emails depend on it); the true UI language lives in the new
+  `ui_locale`.

--- a/frontend/__tests__/locale-badge.test.tsx
+++ b/frontend/__tests__/locale-badge.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for LocaleBadge — the admin-only flag + language pill showing what UI
+ * language a user/job was using.
+ */
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { LocaleBadge, localeDisplayName } from '@/components/admin/locale-badge'
+
+describe('LocaleBadge', () => {
+  it('renders the locale code with a flag for a known language', () => {
+    render(<LocaleBadge locale="pt" />)
+    // Shows the code by default
+    expect(screen.getByText(/pt/)).toBeInTheDocument()
+    // Language name is in the tooltip
+    expect(screen.getByTitle(/Portuguese/i)).toBeInTheDocument()
+  })
+
+  it('renders the full language name when showName is set', () => {
+    render(<LocaleBadge locale="ja" showName />)
+    expect(screen.getByText(/Japanese/i)).toBeInTheDocument()
+  })
+
+  it('normalizes a region-qualified locale to its primary subtag', () => {
+    render(<LocaleBadge locale="pt-BR" />)
+    expect(screen.getByTitle(/Portuguese \(pt\)/i)).toBeInTheDocument()
+  })
+
+  it('renders nothing for an empty locale by default', () => {
+    const { container } = render(<LocaleBadge locale={null} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders a placeholder for an empty locale when showEmpty is set', () => {
+    render(<LocaleBadge locale={undefined} showEmpty />)
+    expect(screen.getByText(/—/)).toBeInTheDocument()
+  })
+
+  it('localeDisplayName returns a readable name or null', () => {
+    expect(localeDisplayName('de')).toMatch(/German/i)
+    expect(localeDisplayName(null)).toBeNull()
+  })
+})

--- a/frontend/__tests__/user-emails-card.test.tsx
+++ b/frontend/__tests__/user-emails-card.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for UserEmailsCard — the admin "Emails sent to this user" section and
+ * its inbox-fidelity preview modal.
+ */
+
+import React from 'react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { UserEmailsCard } from '@/components/admin/user-emails-card'
+
+jest.mock('@/lib/api', () => ({
+  adminApi: {
+    getUserEmails: jest.fn(),
+    getEmailDetail: jest.fn(),
+  },
+}))
+
+import { adminApi } from '@/lib/api'
+
+const getUserEmails = adminApi.getUserEmails as jest.Mock
+const getEmailDetail = adminApi.getEmailDetail as jest.Mock
+
+describe('UserEmailsCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('lists emails returned for the user', async () => {
+    getUserEmails.mockResolvedValue({
+      email: 'u@x.com', count: 2, postmark_available: true,
+      emails: [
+        { message_id: 'm1', source: 'postmark', subject: 'Welcome to Nomad', sent_at: '2026-08-20T10:00:00Z', status: 'Delivered', email_type: 'welcome' },
+        { message_id: 'm2', source: 'log', subject: 'Your receipt', sent_at: '2026-08-19T10:00:00Z', email_type: 'credits_added' },
+      ],
+    })
+    render(<UserEmailsCard email="u@x.com" />)
+    await waitFor(() => expect(screen.getByText('Welcome to Nomad')).toBeInTheDocument())
+    expect(screen.getByText('Your receipt')).toBeInTheDocument()
+    expect(getUserEmails).toHaveBeenCalledWith('u@x.com')
+  })
+
+  it('shows an empty state when there are no emails', async () => {
+    getUserEmails.mockResolvedValue({ email: 'u@x.com', count: 0, postmark_available: true, emails: [] })
+    render(<UserEmailsCard email="u@x.com" />)
+    await waitFor(() => expect(screen.getByText(/No emails found/i)).toBeInTheDocument())
+  })
+
+  it('opens the preview modal and renders the email HTML in an iframe', async () => {
+    getUserEmails.mockResolvedValue({
+      email: 'u@x.com', count: 1, postmark_available: true,
+      emails: [{ message_id: 'm1', source: 'postmark', subject: 'Welcome', sent_at: '2026-08-20T10:00:00Z', status: 'Delivered' }],
+    })
+    getEmailDetail.mockResolvedValue({
+      message_id: 'm1', source: 'postmark', subject: 'Welcome', from_email: 'gen@x.com',
+      to: 'u@x.com', sent_at: '2026-08-20T10:00:00Z', status: 'Delivered',
+      html_body: '<h1>Hello there</h1>', open_count: 2,
+    })
+
+    render(<UserEmailsCard email="u@x.com" />)
+    await waitFor(() => expect(screen.getByText('Welcome')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByText('Welcome'))
+
+    await waitFor(() => expect(getEmailDetail).toHaveBeenCalledWith('m1', 'postmark'))
+    // Metadata + iframe with the exact HTML the user received.
+    await waitFor(() => {
+      const iframe = document.querySelector('iframe[title="Email preview"]') as HTMLIFrameElement
+      expect(iframe).toBeTruthy()
+      expect(iframe.getAttribute('srcDoc') ?? iframe.getAttribute('srcdoc')).toContain('Hello there')
+    })
+  })
+
+  it('shows an error when loading fails', async () => {
+    getUserEmails.mockRejectedValue(new Error('nope'))
+    render(<UserEmailsCard email="u@x.com" />)
+    await waitFor(() => expect(screen.getByText('nope')).toBeInTheDocument())
+  })
+})

--- a/frontend/app/admin/jobs/page.tsx
+++ b/frontend/app/admin/jobs/page.tsx
@@ -55,6 +55,8 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Separator } from "@/components/ui/separator"
+import { LocaleBadge } from "@/components/admin/locale-badge"
+import { IpInfo } from "@/components/admin/ip-info"
 import {
   Search,
   RefreshCw,
@@ -1228,6 +1230,22 @@ function AdminJobsPageContent() {
               )}
             </div>
             <div className="space-y-1 min-w-0">
+              <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Language</p>
+              {selectedJob.locale ? (
+                <LocaleBadge locale={selectedJob.locale} showName />
+              ) : (
+                <p className="text-sm text-muted-foreground">—</p>
+              )}
+            </div>
+            <div className="space-y-1 min-w-0">
+              <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Country</p>
+              {selectedJob.creation_ip ? (
+                <div className="text-sm"><IpInfo ip={selectedJob.creation_ip} compact /></div>
+              ) : (
+                <p className="text-sm text-muted-foreground">—</p>
+              )}
+            </div>
+            <div className="space-y-1 min-w-0">
               <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Source</p>
               <button
                 className="w-full max-w-full min-w-0 text-sm flex items-center gap-1.5 text-primary hover:underline cursor-pointer text-left"
@@ -2250,17 +2268,22 @@ function AdminJobsPageContent() {
                     {job.user_email || "—"}
                   </TableCell>
                   <TableCell>
-                    {job.artist && job.title ? (
-                      <span className="max-w-[200px] truncate block">
-                        {job.artist} - {job.title}
-                      </span>
-                    ) : job.filename ? (
-                      <span className="max-w-[200px] truncate block text-muted-foreground">
-                        {job.filename}
-                      </span>
-                    ) : (
-                      "—"
-                    )}
+                    <div className="flex items-center gap-2 min-w-0">
+                      {job.artist && job.title ? (
+                        <span className="max-w-[200px] truncate block">
+                          {job.artist} - {job.title}
+                        </span>
+                      ) : job.filename ? (
+                        <span className="max-w-[200px] truncate block text-muted-foreground">
+                          {job.filename}
+                        </span>
+                      ) : (
+                        "—"
+                      )}
+                      {job.locale && (
+                        <LocaleBadge locale={job.locale} className="shrink-0 text-[10px] py-0 px-1.5 h-auto" />
+                      )}
+                    </div>
                   </TableCell>
                   <TableCell>
                     <Badge variant={getStatusVariant(job.status)}>

--- a/frontend/app/admin/users/detail/page.tsx
+++ b/frontend/app/admin/users/detail/page.tsx
@@ -70,6 +70,8 @@ import { cn } from "@/lib/utils"
 import { useToast } from "@/hooks/use-toast"
 import { useAuth } from "@/lib/auth"
 import { IpInfo } from "@/components/admin/ip-info"
+import { LocaleBadge } from "@/components/admin/locale-badge"
+import { UserEmailsCard } from "@/components/admin/user-emails-card"
 
 export default function AdminUserDetailPage() {
   const searchParams = useSearchParams()
@@ -345,6 +347,9 @@ export default function AdminUserDetailPage() {
                 {user.role}
               </Badge>
               {!user.is_active && <Badge variant="destructive">Disabled</Badge>}
+              {/* UI language the user browses in — so support communicates in the
+                  right language. Falls back to the email locale if unknown. */}
+              <LocaleBadge locale={user.ui_locale || user.locale} showName />
             </h1>
             <p className="text-muted-foreground break-all">{user.email}</p>
           </div>
@@ -696,7 +701,12 @@ export default function AdminUserDetailPage() {
                   >
                     <TableCell className="font-mono text-sm">{job.job_id}</TableCell>
                     <TableCell>
-                      {job.artist && job.title ? `${job.artist} - ${job.title}` : "—"}
+                      <span className="inline-flex items-center gap-2">
+                        {job.artist && job.title ? `${job.artist} - ${job.title}` : "—"}
+                        {job.locale && (
+                          <LocaleBadge locale={job.locale} className="text-[10px] py-0 px-1.5 h-auto" />
+                        )}
+                      </span>
                     </TableCell>
                     <TableCell>
                       <Badge variant={
@@ -717,6 +727,9 @@ export default function AdminUserDetailPage() {
           )}
         </CardContent>
       </Card>
+
+      {/* Emails sent to this user */}
+      <UserEmailsCard email={email} />
 
       {/* Add Credits Dialog */}
       <Dialog open={creditDialogOpen} onOpenChange={setCreditDialogOpen}>

--- a/frontend/components/admin/locale-badge.tsx
+++ b/frontend/components/admin/locale-badge.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+/**
+ * LocaleBadge — small flag + language pill for admin views.
+ *
+ * Shows the UI language a user/job was using the product in, so support/intervention
+ * can communicate in the right language. Admin-only: never rendered in the customer UI.
+ *
+ * `locale` is a primary language subtag (any of the 33 supported UI locales, e.g.
+ * "pt", "ja", "zh"). The flag is a representative country for that language (decorative);
+ * the language name comes from Intl.DisplayNames.
+ */
+import { Badge } from "@/components/ui/badge"
+import { countryCodeToFlag } from "@/lib/ip-geolocation"
+
+// Representative country flag per supported language subtag (decorative only).
+const LOCALE_TO_COUNTRY: Record<string, string> = {
+  en: "GB", es: "ES", de: "DE", pt: "PT", fr: "FR", ja: "JP", ko: "KR",
+  zh: "CN", it: "IT", nl: "NL", pl: "PL", tr: "TR", ru: "RU", th: "TH",
+  id: "ID", vi: "VN", tl: "PH", hi: "IN", ar: "SA", sv: "SE", nb: "NO",
+  da: "DK", fi: "FI", cs: "CZ", ro: "RO", hu: "HU", el: "GR", he: "IL",
+  ms: "MY", uk: "UA", hr: "HR", sk: "SK", ca: "ES",
+}
+
+function languageName(locale: string): string {
+  try {
+    const dn = new Intl.DisplayNames(["en"], { type: "language" })
+    return dn.of(locale) || locale
+  } catch {
+    return locale
+  }
+}
+
+export function localeDisplayName(locale?: string | null): string | null {
+  if (!locale) return null
+  return languageName(locale.toLowerCase())
+}
+
+interface LocaleBadgeProps {
+  locale?: string | null
+  /** Show the full language name instead of just the code (for detail views). */
+  showName?: boolean
+  /** Render a muted placeholder when no locale is known (default: render nothing). */
+  showEmpty?: boolean
+  className?: string
+}
+
+export function LocaleBadge({ locale, showName = false, showEmpty = false, className }: LocaleBadgeProps) {
+  const normalized = locale ? locale.toLowerCase().split("-")[0] : ""
+
+  if (!normalized) {
+    if (!showEmpty) return null
+    return (
+      <Badge variant="outline" className={className} title="Unknown language">
+        🌐 —
+      </Badge>
+    )
+  }
+
+  const flag = countryCodeToFlag(LOCALE_TO_COUNTRY[normalized] || "")
+  const name = languageName(normalized)
+  const label = showName ? name : normalized
+
+  return (
+    <Badge variant="secondary" className={className} title={`Language: ${name} (${normalized})`}>
+      {flag ? `${flag} ` : ""}{label}
+    </Badge>
+  )
+}

--- a/frontend/components/admin/user-emails-card.tsx
+++ b/frontend/components/admin/user-emails-card.tsx
@@ -178,7 +178,7 @@ export function UserEmailsCard({ email }: { email: string }) {
           <DialogHeader>
             <DialogTitle className="truncate">{selected?.subject || "Email"}</DialogTitle>
             <DialogDescription>
-              Rendered exactly as it appeared in the recipient's inbox.
+              Rendered exactly as it appeared in the recipient&apos;s inbox.
             </DialogDescription>
           </DialogHeader>
 
@@ -212,7 +212,7 @@ export function UserEmailsCard({ email }: { email: string }) {
                 )}
                 {detail.source === "log" && (
                   <p className="text-muted-foreground italic pt-1">
-                    From our stored copy (older than Postmark's 45-day retention).
+                    From our stored copy (older than Postmark&apos;s 45-day retention).
                   </p>
                 )}
               </div>

--- a/frontend/components/admin/user-emails-card.tsx
+++ b/frontend/components/admin/user-emails-card.tsx
@@ -136,8 +136,17 @@ export function UserEmailsCard({ email }: { email: string }) {
               {emails.map((item, i) => (
                 <TableRow
                   key={item.message_id || item.doc_id || i}
-                  className="cursor-pointer hover:bg-muted/50"
+                  className="cursor-pointer hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:outline-none"
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Open email: ${item.subject || "(no subject)"}`}
                   onClick={() => openEmail(item)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault()
+                      openEmail(item)
+                    }
+                  }}
                 >
                   <TableCell className="text-sm whitespace-nowrap">{formatDate(item.sent_at)}</TableCell>
                   <TableCell className="text-sm max-w-[280px] truncate">{item.subject || "(no subject)"}</TableCell>

--- a/frontend/components/admin/user-emails-card.tsx
+++ b/frontend/components/admin/user-emails-card.tsx
@@ -1,0 +1,243 @@
+"use client"
+
+/**
+ * UserEmailsCard — "Emails sent to this user" section for the admin user-detail page.
+ *
+ * Lists every email ever sent to the user (Postmark Messages API for the last ~45 days,
+ * merged with our persisted email_log for older mail). Clicking a row opens a modal that
+ * renders the email exactly as it appeared in the inbox (sandboxed iframe) alongside its
+ * delivery metadata.
+ */
+import { useEffect, useState } from "react"
+import { adminApi, UserEmailSummary, EmailDetail } from "@/lib/api"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Mail, RefreshCw, Loader2 } from "lucide-react"
+
+function formatDate(value?: string | null): string {
+  if (!value) return "—"
+  const d = new Date(value)
+  return isNaN(d.getTime()) ? String(value) : d.toLocaleString()
+}
+
+function statusVariant(status?: string | null): "default" | "secondary" | "destructive" | "outline" {
+  const s = (status || "").toLowerCase()
+  if (s.includes("bounce") || s.includes("fail")) return "destructive"
+  if (s.includes("delivered") || s.includes("sent") || s.includes("opened")) return "default"
+  return "secondary"
+}
+
+function joinAddrs(value?: string | string[] | null): string {
+  if (!value) return ""
+  return Array.isArray(value) ? value.join(", ") : value
+}
+
+export function UserEmailsCard({ email }: { email: string }) {
+  const [emails, setEmails] = useState<UserEmailSummary[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [postmarkAvailable, setPostmarkAvailable] = useState(true)
+
+  const [selected, setSelected] = useState<UserEmailSummary | null>(null)
+  const [detail, setDetail] = useState<EmailDetail | null>(null)
+  const [detailLoading, setDetailLoading] = useState(false)
+  const [detailError, setDetailError] = useState<string | null>(null)
+
+  const load = async () => {
+    if (!email) return
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await adminApi.getUserEmails(email)
+      setEmails(data.emails || [])
+      setPostmarkAvailable(data.postmark_available)
+    } catch (err: any) {
+      setError(err?.message || "Failed to load emails")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [email])
+
+  const openEmail = async (item: UserEmailSummary) => {
+    setSelected(item)
+    setDetail(null)
+    setDetailError(null)
+    setDetailLoading(true)
+    try {
+      // Prefer the Postmark record for rich metadata; fall back to our stored
+      // copy for messages older than Postmark's retention window.
+      const source = item.source === "log" ? "log" : "postmark"
+      const id = item.message_id || item.doc_id || ""
+      const data = await adminApi.getEmailDetail(id, source)
+      setDetail(data)
+    } catch (err: any) {
+      setDetailError(err?.message || "Failed to load email")
+    } finally {
+      setDetailLoading(false)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <div>
+          <CardTitle className="flex items-center gap-2">
+            <Mail className="w-4 h-4" /> Emails Sent
+            {emails.length > 0 && <Badge variant="secondary">{emails.length}</Badge>}
+          </CardTitle>
+          <CardDescription>
+            Every email sent to this user — click to view it exactly as they received it.
+            {!postmarkAvailable && " (Postmark unavailable — showing stored log only.)"}
+          </CardDescription>
+        </div>
+        <Button variant="ghost" size="icon" onClick={load} disabled={loading} title="Refresh">
+          {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {error ? (
+          <p className="text-sm text-destructive">{error}</p>
+        ) : loading && emails.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Loading emails…</p>
+        ) : emails.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No emails found for this user.</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Sent</TableHead>
+                <TableHead>Subject</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {emails.map((item, i) => (
+                <TableRow
+                  key={item.message_id || item.doc_id || i}
+                  className="cursor-pointer hover:bg-muted/50"
+                  onClick={() => openEmail(item)}
+                >
+                  <TableCell className="text-sm whitespace-nowrap">{formatDate(item.sent_at)}</TableCell>
+                  <TableCell className="text-sm max-w-[280px] truncate">{item.subject || "(no subject)"}</TableCell>
+                  <TableCell>
+                    {item.email_type ? (
+                      <Badge variant="outline" className="text-[10px]">{item.email_type}</Badge>
+                    ) : (
+                      <span className="text-muted-foreground text-xs">—</span>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {item.status ? (
+                      <Badge variant={statusVariant(item.status)}>{item.status}</Badge>
+                    ) : (
+                      <span className="text-muted-foreground text-xs">
+                        {item.source === "log" ? "logged" : "—"}
+                      </span>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+
+      <Dialog open={!!selected} onOpenChange={(open) => !open && setSelected(null)}>
+        <DialogContent className="max-w-4xl max-h-[90vh] overflow-hidden flex flex-col">
+          <DialogHeader>
+            <DialogTitle className="truncate">{selected?.subject || "Email"}</DialogTitle>
+            <DialogDescription>
+              Rendered exactly as it appeared in the recipient's inbox.
+            </DialogDescription>
+          </DialogHeader>
+
+          {detailLoading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground py-8 justify-center">
+              <Loader2 className="w-4 h-4 animate-spin" /> Loading email…
+            </div>
+          ) : detailError ? (
+            <p className="text-sm text-destructive py-4">{detailError}</p>
+          ) : detail ? (
+            <div className="flex-1 min-h-0 grid grid-cols-1 md:grid-cols-[220px_1fr] gap-4 overflow-hidden">
+              {/* Metadata side panel */}
+              <div className="text-xs space-y-2 overflow-y-auto pr-1">
+                <MetaRow label="To" value={joinAddrs(detail.to)} />
+                <MetaRow label="From" value={detail.from_email} />
+                {joinAddrs(detail.cc) && <MetaRow label="Cc" value={joinAddrs(detail.cc)} />}
+                {joinAddrs(detail.bcc) && <MetaRow label="Bcc" value={joinAddrs(detail.bcc)} />}
+                <MetaRow label="Sent" value={formatDate(detail.sent_at)} />
+                {detail.status && (
+                  <div className="flex flex-col gap-0.5">
+                    <span className="text-muted-foreground">Status</span>
+                    <Badge variant={statusVariant(detail.status)} className="w-fit">{detail.status}</Badge>
+                  </div>
+                )}
+                {detail.delivered_at && <MetaRow label="Delivered" value={formatDate(detail.delivered_at)} />}
+                {typeof detail.open_count === "number" && <MetaRow label="Opens" value={String(detail.open_count)} />}
+                {typeof detail.click_count === "number" && <MetaRow label="Clicks" value={String(detail.click_count)} />}
+                {detail.email_type && <MetaRow label="Type" value={detail.email_type} />}
+                {detail.bounce && Object.keys(detail.bounce).length > 0 && (
+                  <MetaRow label="Bounce" value={detail.bounce.Type || detail.bounce.Description || JSON.stringify(detail.bounce)} />
+                )}
+                {detail.source === "log" && (
+                  <p className="text-muted-foreground italic pt-1">
+                    From our stored copy (older than Postmark's 45-day retention).
+                  </p>
+                )}
+              </div>
+
+              {/* Email body rendered in an isolated sandboxed iframe */}
+              <div className="min-h-0 overflow-hidden border rounded-md bg-white">
+                {detail.html_body ? (
+                  <iframe
+                    title="Email preview"
+                    sandbox=""
+                    srcDoc={detail.html_body}
+                    className="w-full h-[60vh]"
+                  />
+                ) : detail.text_body ? (
+                  <pre className="w-full h-[60vh] overflow-auto p-4 text-xs whitespace-pre-wrap text-black">
+                    {detail.text_body}
+                  </pre>
+                ) : (
+                  <p className="p-4 text-sm text-muted-foreground">No body content available.</p>
+                )}
+              </div>
+            </div>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </Card>
+  )
+}
+
+function MetaRow({ label, value }: { label: string; value?: string | null }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="break-words">{value || "—"}</span>
+    </div>
+  )
+}

--- a/frontend/components/job/JobCard.tsx
+++ b/frontend/components/job/JobCard.tsx
@@ -13,6 +13,7 @@ import { DurationCostConfirm } from "./DurationCostConfirm"
 import { BuyCreditsDialog } from "@/components/credits/BuyCreditsDialog"
 import { getJobStep, formatStepIndicator, getJobProgressPercent, isWaitingForEncodingCapacity, isVisibilityChangeInProgress } from "@/lib/job-status"
 import { useAuth } from "@/lib/auth"
+import { LocaleBadge } from "@/components/admin/locale-badge"
 import { useDurationConfirm } from "@/hooks/use-duration-confirm"
 import { parseServerDate } from "@/lib/utils"
 
@@ -231,6 +232,11 @@ export function JobCard({ job, onRefresh, showAdminControls }: JobCardProps) {
         <span>{createdAt}</span>
         <span style={{ opacity: 0.7 }}>•</span>
         <StatusIndicator job={job} />
+        {/* Admin-only: what UI language the job was submitted in. Hidden from
+            regular users (redundant — it's always their own language). */}
+        {isAdmin && job.locale && (
+          <LocaleBadge locale={job.locale} className="text-[10px] py-0 px-1.5 h-auto" />
+        )}
       </p>
 
       {/* Progress bar for active jobs */}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -147,6 +147,10 @@ export interface Job {
   // Customer order fields
   customer_email?: string;
   made_for_you?: boolean;
+  // UI language the job was submitted in (admin-only signal, any of 33 locales)
+  locale?: string;
+  // IP at job creation (admin-only; used to derive country)
+  creation_ip?: string;
   // Request tracking metadata
   request_metadata?: Record<string, any>;
 }
@@ -2260,6 +2264,9 @@ export interface AdminUserDetail {
   display_name?: string;
   is_active: boolean;
   email_verified: boolean;
+  // Language: locale = email locale (en/es/de); ui_locale = full UI language (33 locales)
+  locale?: string | null;
+  ui_locale?: string | null;
   created_at?: string;
   updated_at?: string;
   last_login_at?: string;
@@ -2280,6 +2287,7 @@ export interface AdminUserDetail {
     artist?: string;
     title?: string;
     created_at?: string;
+    locale?: string | null;
   }>;
   active_sessions_count: number;
   // Anti-abuse fields
@@ -2298,6 +2306,53 @@ export interface AdminUserDetail {
     created_at?: string;
     last_activity_at?: string;
   }>;
+}
+
+export interface UserEmailSummary {
+  message_id?: string | null;
+  source: 'postmark' | 'log';
+  subject?: string | null;
+  to?: string | null;
+  from_email?: string | null;
+  sent_at?: string | null;
+  status?: string | null;
+  email_type?: string | null;
+  has_stored_html?: boolean;
+  doc_id?: string;
+}
+
+export interface UserEmailHistory {
+  email: string;
+  count: number;
+  postmark_available: boolean;
+  emails: UserEmailSummary[];
+}
+
+export interface EmailDetailEvent {
+  type?: string;
+  received_at?: string | null;
+  details?: Record<string, any>;
+}
+
+export interface EmailDetail {
+  message_id?: string | null;
+  source: 'postmark' | 'log';
+  subject?: string | null;
+  from_email?: string | null;
+  to?: string | null;
+  cc?: string | string[] | null;
+  bcc?: string | string[] | null;
+  sent_at?: string | null;
+  message_stream?: string | null;
+  html_body?: string | null;
+  text_body?: string | null;
+  status?: string | null;
+  delivered_at?: string | null;
+  open_count?: number;
+  click_count?: number;
+  bounce?: Record<string, any> | null;
+  email_type?: string | null;
+  events?: EmailDetailEvent[];
 }
 
 export interface AdminJobListParams {
@@ -2415,6 +2470,28 @@ export const adminApi = {
     const response = await apiFetch(`${API_BASE_URL}/api/users/admin/users/${encodeURIComponent(email)}/detail`, {
       headers: getAuthHeaders()
     });
+    return handleResponse(response);
+  },
+
+  /**
+   * List every email ever sent to a user (Postmark + persisted log)
+   */
+  async getUserEmails(email: string): Promise<UserEmailHistory> {
+    const response = await apiFetch(`${API_BASE_URL}/api/admin/users/${encodeURIComponent(email)}/emails`, {
+      headers: getAuthHeaders()
+    });
+    return handleResponse(response);
+  },
+
+  /**
+   * Full detail for one sent email — rendered HTML + delivery metadata.
+   * `source` is "postmark" (default) or "log" (our stored copy for older mail).
+   */
+  async getEmailDetail(messageId: string, source: string = 'postmark'): Promise<EmailDetail> {
+    const response = await apiFetch(
+      `${API_BASE_URL}/api/admin/emails/${encodeURIComponent(messageId)}?source=${encodeURIComponent(source)}`,
+      { headers: getAuthHeaders() }
+    );
     return handleResponse(response);
   },
 

--- a/infrastructure/modules/database.py
+++ b/infrastructure/modules/database.py
@@ -240,6 +240,20 @@ def create_database() -> dict:
         opts=pulumi.ResourceOptions(depends_on=[firestore_db]),
     )
 
+    # Email log: query by recipient, order by created_at
+    # Used for the admin user-detail "Emails sent to this user" history view
+    resources["firestore_index_email_log_recipient"] = firestore.Index(
+        "firestore-index-email-log-recipient",
+        project=PROJECT_ID,
+        database=firestore_db.name,
+        collection="email_log",
+        fields=[
+            firestore.IndexFieldArgs(field_path="recipient", order="ASCENDING"),
+            firestore.IndexFieldArgs(field_path="created_at", order="DESCENDING"),
+        ],
+        opts=pulumi.ResourceOptions(depends_on=[firestore_db]),
+    )
+
     # Audio separation jobs: query by status + updated_at (for cleanup of old jobs)
     resources["firestore_index_audio_separation_jobs_cleanup"] = firestore.Index(
         "firestore-index-audio-separation-jobs-cleanup",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.197.3"
+version = "0.198.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"

--- a/tests/unit/test_admin_email_endpoints.py
+++ b/tests/unit/test_admin_email_endpoints.py
@@ -1,0 +1,69 @@
+"""Tests for the admin email-history endpoints in backend/api/routes/admin.py.
+
+Verifies wiring + auth: GET /admin/users/{email}/emails and
+GET /admin/emails/{message_id} (with 404 on missing detail).
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def mock_postmark_service():
+    svc = MagicMock()
+    svc.get_user_email_history.return_value = {
+        "email": "u@x.com", "count": 1, "postmark_available": True,
+        "emails": [{"message_id": "m1", "source": "postmark", "subject": "Hi"}],
+    }
+    svc.get_email_detail.return_value = {
+        "message_id": "m1", "source": "postmark", "subject": "Hi",
+        "html_body": "<h1>Hi</h1>", "status": "Delivered",
+    }
+    return svc
+
+
+@pytest.fixture
+def client(mock_postmark_service):
+    mock_creds = MagicMock()
+    mock_creds.universe_domain = "googleapis.com"
+    with patch("backend.services.firestore_service.firestore"), \
+         patch("backend.services.storage_service.storage"), \
+         patch("google.auth.default", return_value=(mock_creds, "test-project")), \
+         patch("backend.services.postmark_admin_service.get_postmark_admin_service",
+               return_value=mock_postmark_service):
+        from fastapi import FastAPI
+        from backend.api.routes.admin import router
+        from backend.api.dependencies import require_admin
+
+        app = FastAPI()
+        app.include_router(router, prefix="/api")
+        app.dependency_overrides[require_admin] = lambda: ("admin@nomadkaraoke.com", None, -1)
+        yield TestClient(app)
+
+
+def test_get_user_emails(client, mock_postmark_service):
+    resp = client.get("/api/admin/users/u@x.com/emails")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 1
+    assert data["emails"][0]["message_id"] == "m1"
+    mock_postmark_service.get_user_email_history.assert_called_once_with("u@x.com")
+
+
+def test_get_email_detail_default_source(client, mock_postmark_service):
+    resp = client.get("/api/admin/emails/m1")
+    assert resp.status_code == 200
+    assert resp.json()["html_body"] == "<h1>Hi</h1>"
+    mock_postmark_service.get_email_detail.assert_called_once_with("m1", source="postmark")
+
+
+def test_get_email_detail_log_source(client, mock_postmark_service):
+    client.get("/api/admin/emails/old1?source=log")
+    mock_postmark_service.get_email_detail.assert_called_once_with("old1", source="log")
+
+
+def test_get_email_detail_404(client, mock_postmark_service):
+    mock_postmark_service.get_email_detail.return_value = None
+    resp = client.get("/api/admin/emails/missing")
+    assert resp.status_code == 404

--- a/tests/unit/test_email_logging.py
+++ b/tests/unit/test_email_logging.py
@@ -96,6 +96,29 @@ class TestLogAndSend:
             ok = postmark_service.send_credits_added("u@example.com", 1, 1)
         assert ok is True
 
+    def test_redacts_magic_link_and_review_tokens(self, postmark_service):
+        captured = {}
+        fake_db = MagicMock()
+        fake_db.collection.return_value.document.return_value.set = lambda doc: captured.update(doc=doc)
+
+        html = ('<a href="https://gen.nomadkaraoke.com/en/auth/verify?token=SECRET123&ref=ABC">Sign in</a>'
+                ' and review at https://gen.nomadkaraoke.com/app/jobs?token=REVIEWTOK')
+        text = "Sign in: https://gen.nomadkaraoke.com/en/auth/verify?token=SECRET123"
+        with patch.object(email_module.requests, "post", return_value=_fake_response(message_id="m1")), \
+             patch("backend.services.firestore_service.FirestoreService") as FS:
+            FS.return_value.db = fake_db
+            postmark_service.send_email("u@example.com", "Sign in", html, text_content=text)
+
+        stored_html = captured["doc"]["html_content"]
+        stored_text = captured["doc"]["text_content"]
+        assert "SECRET123" not in stored_html
+        assert "REVIEWTOK" not in stored_html
+        assert "ABC" not in stored_html
+        assert "[REDACTED]" in stored_html
+        assert "SECRET123" not in stored_text
+        # Non-sensitive structure is preserved.
+        assert "Sign in" in stored_html
+
     def test_no_persistence_when_send_fails(self, postmark_service):
         with patch.object(email_module.requests, "post", return_value=_fake_response(status_code=500)), \
              patch("backend.services.firestore_service.FirestoreService") as FS:

--- a/tests/unit/test_email_logging.py
+++ b/tests/unit/test_email_logging.py
@@ -1,0 +1,104 @@
+"""Tests for email persistence (admin email-history feature).
+
+Every send routes through EmailService._log_and_send, which:
+- captures Postmark's MessageID, and
+- best-effort writes an ``email_log`` Firestore doc — without ever breaking the send.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import backend.services.email_service as email_module
+from backend.services.email_service import (
+    EmailService,
+    PostmarkEmailProvider,
+    SendResult,
+)
+
+
+def _fake_response(status_code=200, message_id="mid-123"):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = {"MessageID": message_id, "ErrorCode": 0, "Message": "OK"}
+    return resp
+
+
+class TestPostmarkMessageIdCapture:
+    def test_detailed_send_captures_message_id(self):
+        provider = PostmarkEmailProvider("tok", "gen@nomadkaraoke.com")
+        with patch.object(email_module.requests, "post", return_value=_fake_response(message_id="abc-999")):
+            result = provider.send_email_detailed("u@example.com", "Hi", "<p>hi</p>")
+        assert isinstance(result, SendResult)
+        assert result.success is True
+        assert result.message_id == "abc-999"
+
+    def test_send_email_still_returns_bool(self):
+        provider = PostmarkEmailProvider("tok", "gen@nomadkaraoke.com")
+        with patch.object(email_module.requests, "post", return_value=_fake_response()):
+            assert provider.send_email("u@example.com", "Hi", "<p>hi</p>") is True
+
+    def test_failed_send_reports_no_message_id(self):
+        provider = PostmarkEmailProvider("tok", "gen@nomadkaraoke.com")
+        with patch.object(email_module.requests, "post", return_value=_fake_response(status_code=422)):
+            result = provider.send_email_detailed("u@example.com", "Hi", "<p>hi</p>")
+        assert result.success is False
+        assert result.message_id is None
+
+
+@pytest.fixture
+def postmark_service(monkeypatch):
+    """An EmailService backed by a (mocked) Postmark provider."""
+    monkeypatch.setenv("POSTMARK_SERVER_TOKEN", "tok")
+    monkeypatch.setenv("EMAIL_FROM", "gen@nomadkaraoke.com")
+    with patch("backend.config.is_production", return_value=False):
+        svc = EmailService()
+    assert isinstance(svc.provider, PostmarkEmailProvider)
+    return svc
+
+
+class TestLogAndSend:
+    def test_persists_email_log_with_derived_type(self, postmark_service):
+        captured = {}
+
+        class FakeDoc:
+            def set(self, doc):
+                captured["doc"] = doc
+
+        class FakeCollection:
+            def document(self, doc_id):
+                captured["doc_id"] = doc_id
+                return FakeDoc()
+
+            def add(self, doc):
+                captured["doc"] = doc
+
+        fake_db = MagicMock()
+        fake_db.collection.return_value = FakeCollection()
+
+        with patch.object(email_module.requests, "post", return_value=_fake_response(message_id="mid-777")), \
+             patch("backend.services.firestore_service.FirestoreService") as FS:
+            FS.return_value.db = fake_db
+            ok = postmark_service.send_credits_added("Buyer@Example.com", 5, 10)
+
+        assert ok is True
+        assert captured["doc_id"] == "mid-777"  # keyed by Postmark MessageID
+        doc = captured["doc"]
+        assert doc["recipient"] == "buyer@example.com"  # normalized
+        assert doc["postmark_message_id"] == "mid-777"
+        assert doc["email_type"] == "credits_added"  # derived from send_credits_added
+        assert doc["html_content"]
+        assert doc["message_stream"] == "outbound"
+
+    def test_firestore_failure_never_breaks_send(self, postmark_service):
+        with patch.object(email_module.requests, "post", return_value=_fake_response()), \
+             patch("backend.services.firestore_service.FirestoreService", side_effect=RuntimeError("boom")):
+            # Send must still succeed even though persistence blew up.
+            ok = postmark_service.send_credits_added("u@example.com", 1, 1)
+        assert ok is True
+
+    def test_no_persistence_when_send_fails(self, postmark_service):
+        with patch.object(email_module.requests, "post", return_value=_fake_response(status_code=500)), \
+             patch("backend.services.firestore_service.FirestoreService") as FS:
+            ok = postmark_service.send_credits_added("u@example.com", 1, 1)
+        assert ok is False
+        FS.assert_not_called()  # failed sends are not logged

--- a/tests/unit/test_job_locale_capture.py
+++ b/tests/unit/test_job_locale_capture.py
@@ -1,0 +1,45 @@
+"""Tests that a job's submission locale (admin language signal) is persisted.
+
+JobCreate.locale must flow through JobManager.create_job onto the stored Job so
+the admin UI can show what language each job was submitted in.
+"""
+from unittest.mock import MagicMock, patch
+
+from backend.models.job import Job, JobCreate
+
+
+def _make_manager():
+    with patch("backend.services.job_manager.FirestoreService"), \
+         patch("backend.services.job_manager.StorageService"):
+        from backend.services.job_manager import JobManager
+        mgr = JobManager()
+    mgr.firestore = MagicMock()
+    mgr.storage = MagicMock()
+    return mgr
+
+
+def test_jobcreate_and_job_accept_locale():
+    jc = JobCreate(theme_id="nomad", locale="pt")
+    assert jc.locale == "pt"
+    # Job model round-trips the field.
+    assert "locale" in Job.model_fields
+
+
+def test_create_job_persists_locale_admin_bypass():
+    mgr = _make_manager()
+    jc = JobCreate(theme_id="nomad", url="https://youtu.be/x", locale="ja")
+
+    # is_admin=True bypasses credit checks/deductions, so no user_service needed.
+    job = mgr.create_job(jc, is_admin=True)
+
+    assert job.locale == "ja"
+    # The persisted Job (passed to firestore.create_job) carries the locale too.
+    saved_job = mgr.firestore.create_job.call_args.args[0]
+    assert saved_job.locale == "ja"
+
+
+def test_create_job_locale_defaults_none():
+    mgr = _make_manager()
+    jc = JobCreate(theme_id="nomad", url="https://youtu.be/x")
+    job = mgr.create_job(jc, is_admin=True)
+    assert job.locale is None

--- a/tests/unit/test_locale_capture.py
+++ b/tests/unit/test_locale_capture.py
@@ -52,3 +52,9 @@ def test_does_not_narrow_to_email_locales():
 def test_skips_unparseable_leading_entry():
     # Leading empty/garbage token is skipped in favour of the next valid one.
     assert get_full_locale_from_request(_req(",,vi-VN")) == "vi"
+
+
+def test_skips_q0_rejected_ranges():
+    # A client that explicitly rejects English (q=0) but accepts French.
+    assert get_full_locale_from_request(_req("en;q=0, fr;q=0.9")) == "fr"
+    assert get_full_locale_from_request(_req("de;q=0.0,es")) == "es"

--- a/tests/unit/test_locale_capture.py
+++ b/tests/unit/test_locale_capture.py
@@ -1,0 +1,54 @@
+"""Tests for full-locale capture (admin language visibility feature).
+
+`get_full_locale_from_request` must return the user's real UI language subtag
+(any of 33), NOT the narrowed en/es/de used for email rendering.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from backend.i18n import get_full_locale_from_request, get_locale_from_request
+
+
+def _req(accept_language: str | None):
+    headers = {}
+    if accept_language is not None:
+        headers["accept-language"] = accept_language
+    return SimpleNamespace(headers=headers)
+
+
+@pytest.mark.parametrize(
+    "header,expected",
+    [
+        ("pt-BR,pt;q=0.9,en;q=0.8", "pt"),
+        ("ja", "ja"),
+        ("zh-Hans-CN", "zh"),
+        ("EN-US", "en"),
+        ("de-DE,de;q=0.9", "de"),
+        ("ko,en;q=0.5", "ko"),
+        ("  fr ; q=1.0 ", "fr"),
+    ],
+)
+def test_returns_full_primary_subtag(header, expected):
+    assert get_full_locale_from_request(_req(header)) == expected
+
+
+def test_missing_header_returns_none():
+    assert get_full_locale_from_request(_req(None)) is None
+    assert get_full_locale_from_request(_req("")) is None
+
+
+def test_wildcard_only_returns_none():
+    assert get_full_locale_from_request(_req("*")) is None
+
+
+def test_does_not_narrow_to_email_locales():
+    # A Portuguese user: full capture keeps "pt"; the email helper collapses to "en".
+    req = _req("pt-BR,pt;q=0.9")
+    assert get_full_locale_from_request(req) == "pt"
+    assert get_locale_from_request(req) == "en"
+
+
+def test_skips_unparseable_leading_entry():
+    # Leading empty/garbage token is skipped in favour of the next valid one.
+    assert get_full_locale_from_request(_req(",,vi-VN")) == "vi"

--- a/tests/unit/test_postmark_admin_service.py
+++ b/tests/unit/test_postmark_admin_service.py
@@ -66,6 +66,24 @@ class TestHistoryMerge:
         assert m2["source"] == "postmark"
         assert m2["has_stored_html"] is True
 
+    def test_paginates_postmark_until_exhausted(self):
+        svc, _ = _make_service([])
+        # 250 total messages across pages of 100 → 3 requests (100, 100, 50).
+        def fake_get(url, headers=None, params=None, timeout=None):
+            offset = params["offset"]
+            remaining = max(0, 250 - offset)
+            n = min(params["count"], remaining)
+            msgs = [{"MessageID": f"m{offset+i}", "Subject": "s", "Recipients": ["u@x.com"],
+                     "ReceivedAt": f"2026-08-20T{(offset+i) % 24:02d}:00:00Z"} for i in range(n)]
+            r = MagicMock(status_code=200)
+            r.json.return_value = {"Messages": msgs, "TotalCount": 250}
+            return r
+
+        with patch.object(pm.requests, "get", side_effect=fake_get) as get_mock:
+            history = svc.get_user_email_history("u@x.com")
+        assert get_mock.call_count == 3  # paged, not a single batch
+        assert history["count"] == 250
+
     def test_no_postmark_token_returns_log_only(self):
         svc, _ = _make_service([
             _log_doc("auto1", {"postmark_message_id": None, "recipient": "u@x.com",

--- a/tests/unit/test_postmark_admin_service.py
+++ b/tests/unit/test_postmark_admin_service.py
@@ -1,0 +1,157 @@
+"""Tests for PostmarkAdminService — admin email-history queries.
+
+Merges the Postmark Messages API (last ~45 days, rich metadata) with our
+persisted Firestore email_log (permanent), de-duplicating by MessageID, and
+serves full message detail with a log fallback for expired Postmark content.
+"""
+from unittest.mock import MagicMock, patch
+
+import backend.services.postmark_admin_service as pm
+from backend.services.postmark_admin_service import PostmarkAdminService
+
+
+def _log_doc(doc_id, data):
+    d = MagicMock()
+    d.id = doc_id
+    d.to_dict.return_value = data
+    return d
+
+
+def _make_service(log_docs=None):
+    svc = PostmarkAdminService(server_token="tok")
+    fake_db = MagicMock()
+    # collection().where().order_by().limit().stream() -> log_docs
+    stream = MagicMock()
+    stream.stream.return_value = log_docs or []
+    fake_db.collection.return_value.where.return_value.order_by.return_value.limit.return_value = stream
+    svc._db = fake_db
+    return svc, fake_db
+
+
+class TestHistoryMerge:
+    def test_merges_and_dedupes_by_message_id(self):
+        # Postmark returns m1 + m2; the log also has m2 (dupe) + m3 (older, purged).
+        postmark_json = {
+            "Messages": [
+                {"MessageID": "m1", "Subject": "Welcome", "Recipients": ["u@x.com"],
+                 "From": "gen@x.com", "ReceivedAt": "2026-08-20T10:00:00Z", "Status": "Sent"},
+                {"MessageID": "m2", "Subject": "Receipt", "Recipients": ["u@x.com"],
+                 "From": "gen@x.com", "ReceivedAt": "2026-08-21T10:00:00Z", "Status": "Sent"},
+            ]
+        }
+        log_docs = [
+            _log_doc("m2", {"postmark_message_id": "m2", "recipient": "u@x.com",
+                            "subject": "Receipt", "html_content": "<p>r</p>",
+                            "created_at": "2026-08-21T10:00:00Z", "email_type": "credits_added"}),
+            _log_doc("auto3", {"postmark_message_id": "m3", "recipient": "u@x.com",
+                               "subject": "Old", "html_content": "<p>old</p>",
+                               "created_at": "2026-07-01T10:00:00Z", "email_type": "welcome"}),
+        ]
+        svc, _ = _make_service(log_docs)
+
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = postmark_json
+        with patch.object(pm.requests, "get", return_value=resp):
+            history = svc.get_user_email_history("u@x.com")
+
+        ids = {e["message_id"] for e in history["emails"]}
+        assert ids == {"m1", "m2", "m3"}  # dupe m2 collapsed, m3 from log preserved
+        assert history["count"] == 3
+        assert history["postmark_available"] is True
+        # Newest first
+        sent = [e["sent_at"] for e in history["emails"]]
+        assert sent == sorted(sent, reverse=True)
+        # m2 present in both sources → flagged as having stored HTML
+        m2 = next(e for e in history["emails"] if e["message_id"] == "m2")
+        assert m2["source"] == "postmark"
+        assert m2["has_stored_html"] is True
+
+    def test_no_postmark_token_returns_log_only(self):
+        svc, _ = _make_service([
+            _log_doc("auto1", {"postmark_message_id": None, "recipient": "u@x.com",
+                               "subject": "Hi", "html_content": "<p>h</p>",
+                               "created_at": "2026-08-01T00:00:00Z"}),
+        ])
+        svc.server_token = None
+        history = svc.get_user_email_history("u@x.com")
+        assert history["postmark_available"] is False
+        assert history["count"] == 1
+        assert history["emails"][0]["source"] == "log"
+
+    def test_postmark_error_degrades_to_log(self):
+        svc, _ = _make_service([])
+        resp = MagicMock(status_code=500, text="server error")
+        with patch.object(pm.requests, "get", return_value=resp):
+            history = svc.get_user_email_history("u@x.com")
+        assert history["count"] == 0  # no crash, empty result
+
+
+class TestEmailDetail:
+    def test_postmark_detail_parses_events(self):
+        svc, _ = _make_service()
+        details = {
+            "MessageID": "m1", "Subject": "Welcome", "From": "gen@x.com",
+            "Recipients": ["u@x.com"], "HtmlBody": "<h1>Hi</h1>", "TextBody": "Hi",
+            "ReceivedAt": "2026-08-20T10:00:00Z", "MessageStream": "outbound",
+            "MessageEvents": [
+                {"Type": "Delivered", "ReceivedAt": "2026-08-20T10:01:00Z", "Details": {}},
+                {"Type": "Opened", "ReceivedAt": "2026-08-20T11:00:00Z", "Details": {}},
+                {"Type": "Opened", "ReceivedAt": "2026-08-20T12:00:00Z", "Details": {}},
+            ],
+        }
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = details
+        with patch.object(pm.requests, "get", return_value=resp):
+            detail = svc.get_email_detail("m1")
+        assert detail["html_body"] == "<h1>Hi</h1>"
+        assert detail["status"] == "Delivered"
+        assert detail["open_count"] == 2
+        assert detail["delivered_at"] == "2026-08-20T10:01:00+00:00" or detail["delivered_at"].startswith("2026-08-20T10:01:00")
+
+    def test_bounced_status_from_events(self):
+        svc, _ = _make_service()
+        details = {
+            "MessageID": "m9", "Subject": "x", "HtmlBody": "<p>x</p>",
+            "MessageEvents": [{"Type": "Bounced", "ReceivedAt": "2026-08-20T10:01:00Z",
+                               "Details": {"Type": "HardBounce"}}],
+        }
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = details
+        with patch.object(pm.requests, "get", return_value=resp):
+            detail = svc.get_email_detail("m9")
+        assert detail["status"] == "Bounced"
+        assert detail["bounce"] == {"Type": "HardBounce"}
+
+    def test_postmark_404_falls_back_to_log(self):
+        svc, fake_db = _make_service()
+        # Postmark 404 (older than retention) → read stored copy by message id.
+        snap = MagicMock()
+        snap.exists = True
+        snap.to_dict.return_value = {
+            "postmark_message_id": "old1", "recipient": "u@x.com", "subject": "Old",
+            "html_content": "<p>stored</p>", "created_at": "2026-06-01T00:00:00Z",
+            "email_type": "welcome",
+        }
+        fake_db.collection.return_value.document.return_value.get.return_value = snap
+
+        resp = MagicMock(status_code=404, text="not found")
+        with patch.object(pm.requests, "get", return_value=resp):
+            detail = svc.get_email_detail("old1")
+        assert detail is not None
+        assert detail["source"] == "log"
+        assert detail["html_body"] == "<p>stored</p>"
+
+    def test_source_log_skips_postmark(self):
+        svc, fake_db = _make_service()
+        snap = MagicMock()
+        snap.exists = True
+        snap.to_dict.return_value = {"postmark_message_id": "x", "recipient": "u@x.com",
+                                     "subject": "S", "html_content": "<p>b</p>",
+                                     "created_at": "2026-06-01T00:00:00Z"}
+        fake_db.collection.return_value.document.return_value.get.return_value = snap
+
+        with patch.object(pm.requests, "get") as get_mock:
+            detail = svc.get_email_detail("x", source="log")
+        get_mock.assert_not_called()  # log source must not hit Postmark
+        assert detail["source"] == "log"
+        assert detail["html_body"] == "<p>b</p>"


### PR DESCRIPTION
## Summary

Two admin-only features so support/intervention work can (a) know what language/country a user is using the product in, and (b) see the exact emails ever sent to a user, rendered as they appeared in the inbox with full delivery metadata.

### A — Language / country visibility (admin-only)
- New `get_full_locale_from_request()` captures the real UI language (any of 33, not the narrowed en/es/de email locale) on **every** job-creation path (URL, upload, audio-search, bulk, made-for-you via Stripe metadata). Stored as `Job.locale` (+ added to the dashboard summary projection) and `User.ui_locale` (kept separate from `User.locale`).
- `LocaleBadge` (flag + language) shown in the admin jobs table, admin job detail (+ country via the existing `IpInfo` on the creation IP), the user-detail header, and the customer `JobCard` **gated to admins only** — regular users never see it.
- Country is derived from IP (existing `ip_geolocation_service`); no new capture.

### B — "Emails sent to this user"
- Every send routes through one `EmailService._log_and_send` chokepoint that persists each email to a new Firestore `email_log` collection (rendered HTML + Postmark MessageID), best-effort so it can never break or delay a send. Single-use auth/capability tokens (magic-link, review, referral) are **redacted** before persistence.
- `PostmarkAdminService` merges the Postmark Messages API (last ~45 days: exact HTML + opens/clicks/bounce/delivery status, paginated) with the Firestore log (permanent), de-duplicated by message id.
- Endpoints `GET /api/admin/users/{email}/emails` and `GET /api/admin/emails/{id}`; the user-detail "Emails Sent" card opens a modal rendering the email in a sandboxed `<iframe srcDoc>` with a metadata side panel.
- New Firestore composite index (`email_log` recipient + created_at) added to Pulumi.

## Testing
- **41 new backend tests** (locale capture incl. q=0, email logging + token redaction, PostmarkAdminService incl. pagination + 45-day fallback, job-locale persistence, admin endpoints) — all pass.
- **10 new frontend tests** (LocaleBadge, UserEmailsCard list + sandboxed-iframe modal) — all pass.
- Regression sweep on related existing suites: green. Preview-email flow smoke-tested through the new chokepoint.

## Notes
- `pulumi up` for the new `email_log` index should be applied before merge (done locally).
- `Job.locale` populates for new jobs going forward; historical jobs fall back to the submitting user's locale where shown.

Local CodeRabbit review completed and addressed (token redaction, pagination, row a11y, locale-overwrite guard, q=0 handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@coderabbitai ignore
