### PR TITLE
fix(infra): allow GET/HEAD CORS on storage bucket for vocals waveform

### DIFF
--- a/infrastructure/modules/storage.py
+++ b/infrastructure/modules/storage.py
@@ -32,7 +32,12 @@ def create_bucket() -> storage.Bucket:
                     "https://singa.nomadkaraoke.com",
                     "http://localhost:3000",
                 ],
-                methods=["PUT"],
+                # PUT: direct-to-GCS uploads. GET/HEAD: the lyrics-review vocals
+                # waveform fetch()es the signed stem URL and reads its bytes via
+                # decodeAudioData — unlike <audio> playback, that's a cross-origin
+                # read and needs CORS. Without GET the browser blocks it with
+                # "Access-Control-Allow-Origin missing".
+                methods=["GET", "HEAD", "PUT"],
                 response_headers=["Content-Type"],
                 max_age_seconds=3600,
             ),


### PR DESCRIPTION
## Problem
The vocals waveform shipped in #927 doesn't render in prod. The `/audio/vocals` endpoint works (302 → signed GCS URL, 200), but the browser **blocks the fetch**:

```
Cross-Origin Request Blocked ... storage.googleapis.com/.../vocals_clean.ogg
(Reason: CORS header 'Access-Control-Allow-Origin' missing). Status code: 200.
Failed to load vocals audio data TypeError: NetworkError
```

The waveform uses `fetch()` + `decodeAudioData` to read the stem's **raw bytes** cross-origin. Unlike the existing `<audio>` playback (media elements don't need CORS to *play*), reading bytes **does** need CORS. The bucket's CORS config only allowed **`PUT`** (for uploads), so cross-origin **`GET`** was blocked.

## Fix
Add `GET` + `HEAD` to the `karaoke-gen-storage` bucket CORS methods (same gen/tenant/localhost origins). One line.

## Verification
`pulumi preview`:
```
~ gcp:storage/bucket:Bucket: (update) karaoke-storage
  ~ cors[0].methods: + "GET" + "HEAD"
~ 1 to update. 295 unchanged.
```
`curl` already returns the audio (200, `audio/ogg`, 3.6 MB) — only the browser's CORS check was failing.

## Apply
Per repo convention, apply `pulumi up` before merge (CI re-applies as no-op). Trivial CORS metadata update — no resource replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled browser-based playback of audio from signed URLs.
  * Preserved support for audio uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->