### PR TITLE
fix(review): proxy vocals audio through the API (fixes waveform CORS)

### DIFF
--- a/backend/api/routes/review.py
+++ b/backend/api/routes/review.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Dict, Any, List, Literal, Optional, Set, Tuple
 
 from fastapi import APIRouter, HTTPException, Request, Depends, Form, File, UploadFile
-from fastapi.responses import RedirectResponse
+from fastapi.responses import RedirectResponse, Response
 
 from backend.models.job import JobStatus
 from backend.models.review_session import ReviewSession, ReviewSessionSummary
@@ -437,6 +437,19 @@ async def _stream_audio(job_id: str, stem: Literal["input"] | Literal["vocals"] 
 
     try:
         transcoding = AudioTranscodingService()
+
+        if stem == "vocals":
+            # Proxy the vocals bytes through the API rather than 302-redirecting to
+            # a signed GCS URL. The waveform visualizer fetch()es + decodeAudioData()s
+            # this (a cross-origin READ), and a cross-origin redirect makes the
+            # browser send `Origin: null`, which the bucket CORS rejects. Serving
+            # the (~3 MB) bytes from the API keeps it same-origin to api.* whose
+            # CORS already allows the frontend. <audio> playback (stem="input")
+            # doesn't need CORS, so it keeps the lighter redirect below.
+            audio_bytes, content_type = await transcoding.get_review_audio_bytes_async(audio_gcs_path)
+            logger.info(f"Job {job_id}: Proxying {len(audio_bytes)}B vocals audio for waveform")
+            return Response(content=audio_bytes, media_type=content_type)
+
         signed_url = await transcoding.get_review_audio_url_async(audio_gcs_path, expiration_minutes=120)
         logger.info(f"Job {job_id}: Redirecting to signed URL for audio review")
         return RedirectResponse(url=signed_url, status_code=302)

--- a/backend/services/audio_transcoding_service.py
+++ b/backend/services/audio_transcoding_service.py
@@ -137,6 +137,24 @@ class AudioTranscodingService:
             self.get_review_audio_url, source_gcs_path, expiration_minutes
         )
 
+    def get_review_audio_bytes(self, source_gcs_path: str) -> tuple[bytes, str]:
+        """Return (bytes, content_type) of the transcoded review audio.
+
+        Used to proxy the audio through the API instead of 302-redirecting to a
+        signed GCS URL. The waveform visualizer fetch()es + decodeAudioData()s
+        this, which is a cross-origin read; a redirect to storage.googleapis.com
+        makes the browser send `Origin: null` on the redirected request, which
+        the bucket CORS rejects. Proxying keeps it same-origin to the API (which
+        sets the right CORS headers). The transcoded OGG is small (~3 MB), well
+        under Cloud Run's 32 MB response cap.
+        """
+        cache_path = self.transcode_if_needed(source_gcs_path)
+        return self.storage.download_bytes(cache_path), "audio/ogg"
+
+    async def get_review_audio_bytes_async(self, source_gcs_path: str) -> tuple[bytes, str]:
+        """Async wrapper around get_review_audio_bytes via asyncio.to_thread."""
+        return await asyncio.to_thread(self.get_review_audio_bytes, source_gcs_path)
+
     def prepare_review_audio_for_job(self, job) -> list[str]:
         """
         Transcode all review audio files for a job (eager transcoding).

--- a/backend/services/audio_transcoding_service.py
+++ b/backend/services/audio_transcoding_service.py
@@ -147,9 +147,19 @@ class AudioTranscodingService:
         the bucket CORS rejects. Proxying keeps it same-origin to the API (which
         sets the right CORS headers). The transcoded OGG is small (~3 MB), well
         under Cloud Run's 32 MB response cap.
+
+        Falls back to the original (FLAC) source if transcoding fails, mirroring
+        get_review_audio_url, so a transient ffmpeg/cache error doesn't blank the
+        waveform while the source still exists. (A very long FLAC could exceed
+        Cloud Run's 32 MB cap on that rare fallback path — the frontend then just
+        hides the waveform, which is acceptable degradation.)
         """
-        cache_path = self.transcode_if_needed(source_gcs_path)
-        return self.storage.download_bytes(cache_path), "audio/ogg"
+        try:
+            cache_path = self.transcode_if_needed(source_gcs_path)
+            return self.storage.download_bytes(cache_path), "audio/ogg"
+        except Exception as e:
+            logger.warning(f"Transcoding failed for {source_gcs_path}, serving source audio: {e}")
+            return self.storage.download_bytes(source_gcs_path), "audio/flac"
 
     async def get_review_audio_bytes_async(self, source_gcs_path: str) -> tuple[bytes, str]:
         """Async wrapper around get_review_audio_bytes via asyncio.to_thread."""

--- a/backend/services/storage_service.py
+++ b/backend/services/storage_service.py
@@ -64,7 +64,20 @@ class StorageService:
         except Exception as e:
             logger.error(f"Error downloading file {source_path}: {e}")
             raise
-    
+
+    def download_bytes(self, source_path: str) -> bytes:
+        """Download an object from GCS fully into memory. Only use for small
+        objects (e.g. transcoded review audio); large files should stream."""
+        try:
+            blob = self.bucket.blob(source_path)
+            return blob.download_as_bytes()
+        except NotFound:
+            logger.warning(f"Object not found downloading {source_path}")
+            raise
+        except Exception as e:
+            logger.error(f"Error downloading bytes {source_path}: {e}")
+            raise
+
     def copy_blob(self, source_path: str, destination_path: str) -> str:
         """Server-side copy of a blob within the bucket (no download/upload)."""
         try:

--- a/backend/tests/test_audio_transcoding_service.py
+++ b/backend/tests/test_audio_transcoding_service.py
@@ -394,3 +394,52 @@ class TestGetReviewAudioUrlAsync:
         result = await service.get_review_audio_url_async("jobs/abc/input/song.flac")
 
         assert result == "https://signed/url"
+
+
+class TestGetReviewAudioBytes:
+    """get_review_audio_bytes() proxies the audio through the API (CORS-safe)."""
+
+    def test_returns_ogg_bytes_on_success(self):
+        from backend.services.audio_transcoding_service import AudioTranscodingService
+
+        mock_storage = Mock()
+        mock_storage.file_exists.return_value = True  # cache hit
+        mock_storage.download_bytes.return_value = b"OggS-transcoded-bytes"
+        service = AudioTranscodingService(storage_service=mock_storage)
+
+        data, content_type = service.get_review_audio_bytes("jobs/abc/stems/vocals_clean.flac")
+
+        assert data == b"OggS-transcoded-bytes"
+        assert content_type == "audio/ogg"
+        mock_storage.download_bytes.assert_called_once_with("jobs/abc/review-audio/vocals_clean.ogg")
+
+    def test_falls_back_to_source_bytes_on_transcode_error(self):
+        """A transient transcode failure serves the original source, not a 500."""
+        from backend.services.audio_transcoding_service import AudioTranscodingService
+
+        mock_storage = Mock()
+        mock_storage.file_exists.return_value = False  # cache miss → transcode path
+        mock_storage.download_file.side_effect = Exception("ffmpeg input download failed")
+        mock_storage.download_bytes.return_value = b"fLaC-source-bytes"
+        service = AudioTranscodingService(storage_service=mock_storage)
+
+        data, content_type = service.get_review_audio_bytes("jobs/abc/stems/vocals_clean.flac")
+
+        assert data == b"fLaC-source-bytes"
+        assert content_type == "audio/flac"
+        # Fell back to proxying the original source object.
+        mock_storage.download_bytes.assert_called_once_with("jobs/abc/stems/vocals_clean.flac")
+
+    @pytest.mark.asyncio
+    async def test_async_wrapper_delegates(self):
+        from backend.services.audio_transcoding_service import AudioTranscodingService
+
+        mock_storage = Mock()
+        mock_storage.file_exists.return_value = True
+        mock_storage.download_bytes.return_value = b"OggS"
+        service = AudioTranscodingService(storage_service=mock_storage)
+
+        data, content_type = await service.get_review_audio_bytes_async("jobs/abc/stems/vocals_clean.flac")
+
+        assert data == b"OggS"
+        assert content_type == "audio/ogg"

--- a/backend/tests/test_routes_review.py
+++ b/backend/tests/test_routes_review.py
@@ -1135,11 +1135,14 @@ class TestGetPreviewVideoRedirect:
 
 
 class TestGetVocalsAudio:
-    """The vocals waveform endpoint streams the full vocal stem for the timeline.
+    """The vocals waveform endpoint proxies the full vocal stem for the timeline.
 
-    Real jobs never store a plain 'vocals' key — separation writes
-    'vocals_clean' / 'lead_vocals' / 'backing_vocals'. The endpoint must select
-    the fullest vocal mix (vocals_clean) rather than KeyError on 'vocals'.
+    Two behaviours: (1) select the fullest vocal mix (vocals_clean) — real jobs
+    never store a plain 'vocals' key, they store vocals_clean / lead_vocals /
+    backing_vocals. (2) Return the bytes directly (not a 302 to GCS): the
+    waveform fetch()es + decodeAudioData()s the audio, and a cross-origin
+    redirect makes the browser send `Origin: null` which the bucket CORS rejects,
+    so the waveform never loads.
     """
 
     def _call(self, stems):
@@ -1154,8 +1157,8 @@ class TestGetVocalsAudio:
         job_manager.get_job.return_value = job
 
         transcoding = MagicMock()
-        transcoding.get_review_audio_url_async = AsyncMock(
-            return_value="https://signed.example/vocals.ogg?sig=xyz"
+        transcoding.get_review_audio_bytes_async = AsyncMock(
+            return_value=(b"OggS-fake-vocals-bytes", "audio/ogg")
         )
 
         with patch("backend.api.routes.review.JobManager", return_value=job_manager), patch(
@@ -1167,11 +1170,21 @@ class TestGetVocalsAudio:
             )
         return resp, transcoding
 
-    def test_selects_vocals_clean_when_no_plain_vocals_key(self):
-        from starlette.responses import RedirectResponse
+    def test_proxies_bytes_not_redirect(self):
+        from starlette.responses import RedirectResponse, Response
 
+        resp, _ = self._call({"vocals_clean": "jobs/j/stems/vocals_clean.flac"})
+
+        # Must serve the bytes from the API (CORS-friendly), never 302 to GCS.
+        assert not isinstance(resp, RedirectResponse)
+        assert isinstance(resp, Response)
+        assert resp.status_code == 200
+        assert resp.media_type == "audio/ogg"
+        assert resp.body == b"OggS-fake-vocals-bytes"
+
+    def test_selects_vocals_clean_when_no_plain_vocals_key(self):
         # The shape produced by real cloud jobs (no plain "vocals").
-        resp, transcoding = self._call(
+        _, transcoding = self._call(
             {
                 "instrumental_clean": "jobs/j/stems/instrumental_clean.flac",
                 "vocals_clean": "jobs/j/stems/vocals_clean.flac",
@@ -1179,20 +1192,17 @@ class TestGetVocalsAudio:
                 "backing_vocals": "jobs/j/stems/backing_vocals.flac",
             }
         )
-
-        assert isinstance(resp, RedirectResponse)
-        assert resp.status_code == 302
         # Must pick the full vocal mix (vocals_clean), not lead_vocals or KeyError.
-        assert transcoding.get_review_audio_url_async.call_args[0][0] == "jobs/j/stems/vocals_clean.flac"
+        assert transcoding.get_review_audio_bytes_async.call_args[0][0] == "jobs/j/stems/vocals_clean.flac"
 
     def test_prefers_plain_vocals_then_falls_back_to_lead(self):
         # 2-stem split exposes a plain "vocals" — preferred.
         _, transcoding = self._call({"vocals": "jobs/j/stems/vocals.flac"})
-        assert transcoding.get_review_audio_url_async.call_args[0][0] == "jobs/j/stems/vocals.flac"
+        assert transcoding.get_review_audio_bytes_async.call_args[0][0] == "jobs/j/stems/vocals.flac"
 
         # Only lead_vocals available — last-resort fallback.
         _, transcoding = self._call({"lead_vocals": "jobs/j/stems/lead_vocals.flac"})
-        assert transcoding.get_review_audio_url_async.call_args[0][0] == "jobs/j/stems/lead_vocals.flac"
+        assert transcoding.get_review_audio_bytes_async.call_args[0][0] == "jobs/j/stems/lead_vocals.flac"
 
     def test_404_when_no_vocal_stem_present(self):
         from fastapi import HTTPException

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.197.3"
+version = "0.197.4"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Problem
The vocals waveform (#927) still doesn't render in prod even after the bucket GET/HEAD CORS fix (#932). Root cause is **CORS with a cross-origin redirect**:

1. `fetch('https://api.nomadkaraoke.com/.../audio/vocals')` from `gen.nomadkaraoke.com`
2. API returns **302 → signed `storage.googleapis.com` URL**
3. When a CORS `fetch()` follows a **cross-origin redirect**, the browser sends **`Origin: null`** on the redirected request
4. GCS CORS allows `gen.nomadkaraoke.com`, not `null` → no `Access-Control-Allow-Origin` → **blocked**

Verified directly:
```
GCS + Origin: https://gen.nomadkaraoke.com  → access-control-allow-origin present  (a DIRECT fetch)
GCS + Origin: null                          → (no ACAO)                            (the REDIRECTED fetch)
```
`curl` and `<audio>` playback work because neither does a CORS byte-read; only `fetch()`+`decodeAudioData` does.

## Fix
Serve the vocals bytes **directly from the API** for `stem="vocals"` instead of redirecting. The fetch stays same-origin to `api.*` (whose CORS already allows the frontend) — no redirect, no `Origin: null`. The transcoded OGG is ~3 MB, well under Cloud Run's 32 MB response cap. Input audio (`stem="input"`) is `<audio>` playback (no CORS needed), so it keeps the lighter 302.

- `StorageService.download_bytes()` + `AudioTranscodingService.get_review_audio_bytes(_async)()`
- `_stream_audio` branches: vocals → proxied `Response(bytes, audio/ogg)`; input → 302 as before

## Testing
- `TestGetVocalsAudio` updated: asserts bytes-not-redirect + stem selection (4 tests pass)
- Full `test_routes_review.py` (51) + transcoding/storage service tests (51) pass

(#932's bucket GET CORS is now belt-and-braces — harmless, left in place.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vocal review audio is now delivered directly through the API as Ogg audio instead of redirecting to a signed storage URL.
  * Input audio continues using secure signed URL redirects.
  * Vocal stem selection now prioritizes vocals, clean vocals, then lead vocals.

* **Bug Fixes**
  * Improved handling when vocal audio is unavailable, including appropriate not-found responses.

* **Chores**
  * Updated the application version to 0.197.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->