### PR TITLE
fix(review): poll for vocals waveform while audio separation is in progress

### DIFF
--- a/backend/api/routes/review.py
+++ b/backend/api/routes/review.py
@@ -433,6 +433,16 @@ async def _stream_audio(job_id: str, stem: Literal["input"] | Literal["vocals"] 
                 audio_gcs_path = stems[key]
                 break
     if not audio_gcs_path:
+        # Audio separation is decoupled from the lyrics-review critical path, so a
+        # user can open review before the vocal stems have been uploaded (the stem
+        # arrives a minute or two later). Signal "not ready yet, retry" with a 202
+        # so the frontend polls instead of treating it as a terminal 404.
+        # state_data.audio_complete is set both when separation finishes and when
+        # it's skipped entirely (existing-instrumental jobs), so a missing stem
+        # with audio_complete=True really is a permanent 404.
+        if stem == "vocals" and not job.state_data.get("audio_complete", False):
+            logger.info(f"Job {job_id}: Vocal stem not yet available (separation in progress), returning 202")
+            return Response(status_code=202, headers={"Retry-After": "15"})
         raise HTTPException(status_code=404, detail=t("en", "review.audioNotFound"))
 
     try:

--- a/backend/tests/test_routes_review.py
+++ b/backend/tests/test_routes_review.py
@@ -1145,13 +1145,14 @@ class TestGetVocalsAudio:
     so the waveform never loads.
     """
 
-    def _call(self, stems):
+    def _call(self, stems, audio_complete=True):
         import asyncio
         from backend.api.routes.review import _stream_audio
 
         job = MagicMock()
         job.input_media_gcs_path = "jobs/j/input.flac"
         job.file_urls = {"stems": stems}
+        job.state_data = {"audio_complete": audio_complete}
 
         job_manager = MagicMock()
         job_manager.get_job.return_value = job
@@ -1205,8 +1206,29 @@ class TestGetVocalsAudio:
         assert transcoding.get_review_audio_bytes_async.call_args[0][0] == "jobs/j/stems/lead_vocals.flac"
 
     def test_404_when_no_vocal_stem_present(self):
+        """audio_complete=True + no vocal stem = the stem will never exist -> 404."""
         from fastapi import HTTPException
 
         with pytest.raises(HTTPException) as exc_info:
             self._call({"instrumental_clean": "jobs/j/stems/instrumental_clean.flac"})
+        assert exc_info.value.status_code == 404
+
+    def test_202_when_separation_still_in_progress(self):
+        """Users can open lyrics review before audio separation finishes (it's
+        decoupled from the critical path), so a missing vocal stem while
+        audio_complete=False means "not yet" — return 202 so the frontend polls
+        instead of permanently hiding the waveform on a terminal 404."""
+        resp, transcoding = self._call({}, audio_complete=False)
+
+        assert resp.status_code == 202
+        assert resp.headers.get("Retry-After") == "15"
+        transcoding.get_review_audio_bytes_async.assert_not_called()
+
+    def test_404_when_separation_skipped_and_no_vocal_stem(self):
+        """Existing-instrumental jobs set audio_complete=True without ever
+        producing vocal stems — must 404 (terminal), not 202 (retry forever)."""
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            self._call({}, audio_complete=True)
         assert exc_info.value.status_code == 404

--- a/frontend/components/lyrics-review/VocalsAudioDataLoader.tsx
+++ b/frontend/components/lyrics-review/VocalsAudioDataLoader.tsx
@@ -1,4 +1,4 @@
-import { AudioData, fetchAudioData } from '@/lib/audio-data'
+import { AudioData, AudioNotReadyError, fetchAudioData } from '@/lib/audio-data'
 import { createContext, PropsWithChildren, useEffect, useState } from 'react'
 
 export const VocalsAudioDataLoaderContext = createContext<{ audioData: AudioData | null }>({ audioData: null })
@@ -6,6 +6,13 @@ export const VocalsAudioDataLoaderContext = createContext<{ audioData: AudioData
 export interface AudioDataLoaderProps extends PropsWithChildren {
 	audioUrl: string | null
 }
+
+// Audio separation runs in the background while the user reviews lyrics, so the
+// vocal stem often doesn't exist yet on first page load (endpoint returns 202).
+// Poll until it appears; separation takes a few minutes at most, so cap the
+// polling rather than retrying forever if something upstream is wedged.
+const NOT_READY_RETRY_MS = 15_000
+const NOT_READY_MAX_RETRIES = 40 // 40 × 15s = 10 minutes
 
 export const VocalsAudioDataLoader = ({ audioUrl, children }: AudioDataLoaderProps) => {
 	const [audioData, setAudioData] = useState<AudioData | null>(null)
@@ -17,20 +24,29 @@ export const VocalsAudioDataLoader = ({ audioUrl, children }: AudioDataLoaderPro
 		// stem for this job) and (b) a stale in-flight fetch resolving after a newer
 		// audioUrl has already been set.
 		let cancelled = false
+		let retryTimer: ReturnType<typeof setTimeout> | undefined
 
-		fetchAudioData(audioUrl)
-			.then((audioData) => {
-				if (!cancelled) setAudioData(audioData)
-			})
-			.catch((error) => {
-				if (!cancelled) {
+		const load = (attempt: number) => {
+			fetchAudioData(audioUrl)
+				.then((audioData) => {
+					if (!cancelled) setAudioData(audioData)
+				})
+				.catch((error) => {
+					if (cancelled) return
+					if (error instanceof AudioNotReadyError && attempt < NOT_READY_MAX_RETRIES) {
+						retryTimer = setTimeout(() => load(attempt + 1), NOT_READY_RETRY_MS)
+						return
+					}
 					console.error('Failed to load vocals audio data', error)
 					setAudioData(null)
-				}
-			})
+				})
+		}
+
+		load(0)
 
 		return () => {
 			cancelled = true
+			if (retryTimer) clearTimeout(retryTimer)
 			setAudioData(null)
 		}
 	}, [audioUrl])

--- a/frontend/components/lyrics-review/__tests__/VocalsAudioDataLoader.test.tsx
+++ b/frontend/components/lyrics-review/__tests__/VocalsAudioDataLoader.test.tsx
@@ -1,0 +1,116 @@
+import { act, render, screen } from '@testing-library/react'
+import { useContext } from 'react'
+import { AudioData, AudioNotReadyError, fetchAudioData as fetchAudioDataImport } from '@/lib/audio-data'
+import { VocalsAudioDataLoader, VocalsAudioDataLoaderContext } from '../VocalsAudioDataLoader'
+
+jest.mock('@/lib/audio-data', () => {
+  const actual = jest.requireActual('@/lib/audio-data')
+  return { ...actual, fetchAudioData: jest.fn() }
+})
+
+const fetchAudioData = fetchAudioDataImport as jest.Mock
+
+const AUDIO_DATA: AudioData = {
+  duration: 120,
+  peaks: new Float32Array([0.5]),
+  peaksPerSecond: 400,
+}
+
+const Probe = () => {
+  const { audioData } = useContext(VocalsAudioDataLoaderContext)
+  return <div data-testid="probe">{audioData ? 'loaded' : 'empty'}</div>
+}
+
+// Flush the pending promise chain inside the loader's .then/.catch handlers.
+const flushPromises = () => act(async () => {})
+
+describe('VocalsAudioDataLoader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('provides audio data when the fetch succeeds', async () => {
+    fetchAudioData.mockResolvedValue(AUDIO_DATA)
+
+    render(
+      <VocalsAudioDataLoader audioUrl="https://api/audio/vocals">
+        <Probe />
+      </VocalsAudioDataLoader>
+    )
+    await flushPromises()
+
+    expect(screen.getByTestId('probe')).toHaveTextContent('loaded')
+    expect(fetchAudioData).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries while separation is in progress (202), then loads', async () => {
+    // Separation runs in the background during lyrics review — the stem often
+    // doesn't exist on first load. The loader must poll, not give up.
+    fetchAudioData
+      .mockRejectedValueOnce(new AudioNotReadyError())
+      .mockRejectedValueOnce(new AudioNotReadyError())
+      .mockResolvedValue(AUDIO_DATA)
+
+    render(
+      <VocalsAudioDataLoader audioUrl="https://api/audio/vocals">
+        <Probe />
+      </VocalsAudioDataLoader>
+    )
+    await flushPromises()
+    expect(screen.getByTestId('probe')).toHaveTextContent('empty')
+
+    await act(async () => {
+      jest.advanceTimersByTime(15_000)
+    })
+    expect(screen.getByTestId('probe')).toHaveTextContent('empty')
+
+    await act(async () => {
+      jest.advanceTimersByTime(15_000)
+    })
+    expect(fetchAudioData).toHaveBeenCalledTimes(3)
+    expect(screen.getByTestId('probe')).toHaveTextContent('loaded')
+  })
+
+  it('does not retry on a terminal error (e.g. 404: job has no vocal stem)', async () => {
+    fetchAudioData.mockRejectedValue(new Error('Failed to fetch vocals audio: 404'))
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(
+      <VocalsAudioDataLoader audioUrl="https://api/audio/vocals">
+        <Probe />
+      </VocalsAudioDataLoader>
+    )
+    await flushPromises()
+
+    await act(async () => {
+      jest.advanceTimersByTime(60_000)
+    })
+    expect(fetchAudioData).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('probe')).toHaveTextContent('empty')
+    expect(consoleError).toHaveBeenCalled()
+
+    consoleError.mockRestore()
+  })
+
+  it('stops polling on unmount', async () => {
+    fetchAudioData.mockRejectedValue(new AudioNotReadyError())
+
+    const { unmount } = render(
+      <VocalsAudioDataLoader audioUrl="https://api/audio/vocals">
+        <Probe />
+      </VocalsAudioDataLoader>
+    )
+    await flushPromises()
+    unmount()
+
+    await act(async () => {
+      jest.advanceTimersByTime(120_000)
+    })
+    expect(fetchAudioData).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/lib/audio-data.ts
+++ b/frontend/lib/audio-data.ts
@@ -13,11 +13,24 @@ export interface AudioData {
 // whole track tiny in memory. 400/s over a 4-minute song ≈ 96k floats (~384 KB).
 const PEAKS_PER_SECOND = 400
 
+// The vocals endpoint returns 202 while audio separation is still running (the
+// user can open lyrics review before the vocal stem has been uploaded). Callers
+// should catch this and retry after a delay rather than giving up.
+export class AudioNotReadyError extends Error {
+	constructor() {
+		super('Vocals audio not ready yet (separation in progress)')
+		this.name = 'AudioNotReadyError'
+	}
+}
+
 export async function fetchAudioData(url: string): Promise<AudioData> {
 	// fetch() resolves even for 4xx/5xx; the vocals endpoint 404s when a job has
 	// no vocal stem. Fail explicitly so the caller sees "no vocals" rather than an
 	// opaque decodeAudioData error on the JSON/HTML error body.
 	const response = await fetch(url)
+	if (response.status === 202) {
+		throw new AudioNotReadyError()
+	}
 	if (!response.ok) {
 		throw new Error(`Failed to fetch vocals audio: ${response.status}`)
 	}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.198.1"
+version = "0.198.2"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Fixes the blank vocals waveform / console error `Failed to fetch vocals audio: 404` seen on the lyrics review screen (reported on job `d508adb6`).

**Root cause:** audio separation is intentionally decoupled from the lyrics-review critical path — a job reaches `awaiting_review` as soon as lyrics/screens are done, while stems keep uploading in the background. On job `d508adb6` the user opened review at 06:51:21 but `vocals_clean` wasn't uploaded until 06:53:40. The `/api/review/{job_id}/audio/vocals` endpoint correctly found no vocal stem and returned a 404, which the frontend treated as terminal — the edit-timeline waveform then stayed blank for the whole session even though the stem arrived two minutes later.

## Changes

- **Backend** (`review.py`): when no vocal stem exists yet **and** `state_data.audio_complete` is false (separation still running), return `202 Accepted` with `Retry-After: 15` instead of 404. A missing stem with `audio_complete=true` (e.g. existing-instrumental jobs that skip separation entirely) still 404s, so clients don't poll forever for a stem that will never exist.
- **Frontend** (`VocalsAudioDataLoader`, `audio-data.ts`): a 202 now throws a typed `AudioNotReadyError`; the loader retries every 15s (capped at 10 minutes) and renders the waveform once the stem arrives. Terminal errors (404/5xx) still fail once without polling, and polling stops on unmount.

## Testing

- Backend: new tests for 202-while-separating and 404-when-separation-skipped; existing vocals-endpoint tests updated with explicit `state_data` (91 passed across related review/transcoding test files).
- Frontend: new `VocalsAudioDataLoader.test.tsx` covering success, retry-then-load, terminal-error no-retry, and unmount cleanup. Full jest suite: 1146 passed.
- Verified against prod: reproduced the exact 404 from Cloud Run logs (trace-level), confirmed the stem-upload race timeline, and confirmed the endpoint serves the proxied OGG once stems exist.

@coderabbitai ignore