### PR TITLE
fix(frontend): confirm backend unreachable via health probe before showing connectivity banner

### DIFF
--- a/docs/archive/2026-08-22-health-check-alert-noise-and-graceful-degradation.md
+++ b/docs/archive/2026-08-22-health-check-alert-noise-and-graceful-degradation.md
@@ -54,6 +54,18 @@ instead of every screen throwing a generic error.
   outstanding** (`beginRequest`/`endRequest`): `reconnecting` at
   `STALL_RECONNECTING_MS` (10s), `unavailable` at `STALL_UNAVAILABLE_MS` (20s),
   back to `online` the instant the stalled read settles.
+
+  **Addendum (2026-08-23, v0.198.3): stall + health-probe confirmation.** A stall
+  alone turned out not to be proof of an outage either — first-time
+  instrumental-analysis / lyrics-review loads transcode audio server-side and can
+  legitimately run 20–60s, false-firing the banner. Now, once a stall crosses the
+  threshold, the store confirms with a cheap `GET /api/health` probe (registered by
+  `lib/api.ts` via `configureHealthProbe`; 4s timeout, `Promise.race`d so a hung
+  origin can't wedge it). While the probe answers OK — or has no verdict yet — the
+  banner stays hidden; only a failed/timed-out probe (as during a real recycle,
+  when the origin hangs) lets it surface (~4s later than before). The probe
+  re-fires every `PROBE_FRESH_MS` (10s) while the stall persists, so recovery
+  clears the banner even if the original read is still hung.
 - **`lib/api.ts` — `apiFetch`** wraps every backend call (drop-in for `fetch`;
   internals use `globalThis.fetch`). Design decisions:
   - **The banner keys on a genuine STALL, not slowness.** A read that completes —

--- a/frontend/__tests__/api-fetch.test.ts
+++ b/frontend/__tests__/api-fetch.test.ts
@@ -6,9 +6,10 @@
  * and backend calls are addressed with relative "/api/..." URLs.
  */
 
-import { apiFetch, BackendUnavailableError } from '@/lib/api'
+import { apiFetch, BackendUnavailableError, __backendHealthProbe } from '@/lib/api'
 import {
   getBackendStatus,
+  configureHealthProbe,
   STALL_RECONNECTING_MS,
   STALL_UNAVAILABLE_MS,
 } from '@/lib/backend-status'
@@ -42,6 +43,8 @@ describe('apiFetch', () => {
   beforeEach(() => {
     fetchMock.mockReset()
     ;(globalThis as unknown as { fetch: unknown }).fetch = fetchMock
+    // Re-register the real probe so its cached verdict resets between tests.
+    configureHealthProbe(__backendHealthProbe)
   })
 
   afterEach(() => {
@@ -108,21 +111,57 @@ describe('apiFetch', () => {
     expect(getBackendStatus()).toBe('online')
   })
 
-  it('surfaces the banner only once a GET has STALLED past the thresholds, then clears', async () => {
+  it('surfaces the banner for a stalled GET once the health probe confirms the outage, then clears', async () => {
     jest.useFakeTimers()
-    const d = deferredFetch()
-    fetchMock.mockImplementation(d.fn)
+    // Everything hangs — the backend is genuinely unreachable (recycle-style: the
+    // origin holds requests open, so the probe only fails via its own timeout).
+    let settleGet!: (r: Response) => void
+    fetchMock.mockImplementation((url: unknown) => {
+      if (String(url).includes('/api/health')) return new Promise<Response>(() => {})
+      return new Promise<Response>((res) => {
+        settleGet = res
+      })
+    })
 
     const p = apiFetch('/api/jobs/abc')
     p.catch(() => {}) // avoid unhandled rejection if it ever fails
 
     expect(getBackendStatus()).toBe('online')
+    // Stall threshold crossed → probe fires, but until it has a verdict the banner
+    // stays hidden (a slow endpoint must not alarm the user without evidence).
     await jest.advanceTimersByTimeAsync(STALL_RECONNECTING_MS)
+    expect(getBackendStatus()).toBe('online')
+    // Probe times out (~4s) → outage confirmed → the hint appears.
+    await jest.advanceTimersByTimeAsync(5_000)
     expect(getBackendStatus()).toBe('reconnecting')
-    await jest.advanceTimersByTimeAsync(STALL_UNAVAILABLE_MS - STALL_RECONNECTING_MS)
+    await jest.advanceTimersByTimeAsync(STALL_UNAVAILABLE_MS - STALL_RECONNECTING_MS - 5_000)
     expect(getBackendStatus()).toBe('unavailable')
 
-    d.settle(mockResponse(200, { ok: true }))
+    settleGet(mockResponse(200, { ok: true }))
+    await p
+    expect(getBackendStatus()).toBe('online')
+  })
+
+  it('never surfaces the banner for a slow GET while the backend is reachable (health probe OK)', async () => {
+    jest.useFakeTimers()
+    // The read is legitimately slow (e.g. first-time instrumental-analysis
+    // transcoding) but /api/health answers instantly — no banner, ever.
+    let settleGet!: (r: Response) => void
+    fetchMock.mockImplementation((url: unknown) => {
+      if (String(url).includes('/api/health')) return Promise.resolve(mockResponse(200))
+      return new Promise<Response>((res) => {
+        settleGet = res
+      })
+    })
+
+    const p = apiFetch('/api/jobs/abc')
+    p.catch(() => {})
+
+    // Well past both stall thresholds (but under the 45s hard timeout).
+    await jest.advanceTimersByTimeAsync(STALL_UNAVAILABLE_MS + 15_000)
+    expect(getBackendStatus()).toBe('online')
+
+    settleGet(mockResponse(200, { ok: true }))
     await p
     expect(getBackendStatus()).toBe('online')
   })

--- a/frontend/__tests__/backend-status.test.ts
+++ b/frontend/__tests__/backend-status.test.ts
@@ -10,8 +10,10 @@ import {
   getBackendStatus,
   beginRequest,
   endRequest,
+  configureHealthProbe,
   STALL_RECONNECTING_MS,
   STALL_UNAVAILABLE_MS,
+  PROBE_FRESH_MS,
 } from '@/lib/backend-status'
 
 describe('backend-status store (stall-based)', () => {
@@ -86,5 +88,74 @@ describe('backend-status store (stall-based)', () => {
     endRequest(a)
     open = []
     expect(getBackendStatus()).toBe('online')
+  })
+})
+
+describe('backend-status store (health-probe confirmation)', () => {
+  let open: number[] = []
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    open = []
+  })
+
+  afterEach(() => {
+    open.forEach((id) => endRequest(id))
+    // Restore pure stall-based behavior so other suites are unaffected.
+    configureHealthProbe(null)
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  })
+
+  it('suppresses the banner while the probe reports the backend reachable', async () => {
+    const probe = jest.fn(() => Promise.resolve(true))
+    configureHealthProbe(probe)
+
+    open.push(beginRequest())
+    await jest.advanceTimersByTimeAsync(STALL_UNAVAILABLE_MS + 5000)
+    expect(getBackendStatus()).toBe('online')
+    expect(probe).toHaveBeenCalled()
+  })
+
+  it('shows the banner once the probe confirms the backend is unreachable', async () => {
+    configureHealthProbe(() => Promise.resolve(false))
+
+    open.push(beginRequest())
+    await jest.advanceTimersByTimeAsync(STALL_RECONNECTING_MS)
+    expect(getBackendStatus()).toBe('reconnecting')
+
+    await jest.advanceTimersByTimeAsync(STALL_UNAVAILABLE_MS - STALL_RECONNECTING_MS)
+    expect(getBackendStatus()).toBe('unavailable')
+  })
+
+  it('re-probes as the verdict goes stale, and clears the banner if the backend recovers', async () => {
+    let reachable = false
+    const probe = jest.fn(() => Promise.resolve(reachable))
+    configureHealthProbe(probe)
+
+    open.push(beginRequest())
+    await jest.advanceTimersByTimeAsync(STALL_UNAVAILABLE_MS)
+    expect(getBackendStatus()).toBe('unavailable')
+
+    // Backend comes back (even though the old read is still hung) — the next
+    // re-probe succeeds and the banner clears.
+    reachable = true
+    await jest.advanceTimersByTimeAsync(PROBE_FRESH_MS + 2000)
+    expect(getBackendStatus()).toBe('online')
+    expect(probe.mock.calls.length).toBeGreaterThan(1)
+  })
+
+  it('holds the banner back while the probe has no verdict yet', async () => {
+    // A probe that takes 3s to fail (e.g. its own timeout racing a hung origin).
+    configureHealthProbe(
+      () => new Promise((res) => setTimeout(() => res(false), 3000)),
+    )
+
+    open.push(beginRequest())
+    await jest.advanceTimersByTimeAsync(STALL_RECONNECTING_MS)
+    expect(getBackendStatus()).toBe('online') // stalled, but not yet confirmed
+
+    await jest.advanceTimersByTimeAsync(3000) // verdict lands
+    expect(getBackendStatus()).toBe('reconnecting')
   })
 })

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -5,7 +5,7 @@
 import type { VideoThemeSummary, VideoThemeDetail, ThemesListResponse, ThemeDetailResponse, ColorOverrides } from './video-themes';
 import type { MagicLinkResponse, VerifyMagicLinkResponse, UserProfileResponse, ReferralInterstitial, ReferralDashboard, ReferralLink } from './types';
 import type { CorrectionData, CorrectionAnnotation, EditLog, SearchLyricsResponse } from './lyrics-review/types';
-import { beginRequest, endRequest } from './backend-status';
+import { beginRequest, endRequest, configureHealthProbe } from './backend-status';
 
 // In development, use relative URLs to go through Next.js proxy (avoids CORS)
 // In production (static export), use the full backend URL
@@ -488,6 +488,31 @@ const RETRY_BACKOFF_MS = [600, 1500];
 const TRANSIENT_STATUS = new Set([502, 503, 504, 520, 521, 522, 523, 524]);
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** How long the reachability probe gets before we treat the backend as unreachable.
+ *  During a recycle the origin HANGS (rather than erroring), so the probe must race
+ *  its own timer — fetch abort support can't be relied on to settle the promise. */
+const HEALTH_PROBE_TIMEOUT_MS = 4_000;
+
+// Confirm-before-banner probe: a stalled GET only surfaces the connectivity banner
+// once this probe says the backend is genuinely unreachable (see backend-status.ts).
+// /api/health is unauthenticated and returns instantly, so a legitimately slow read
+// (first-time instrumental-analysis / lyrics-review transcoding) never false-fires.
+/** Exported so tests can re-register the real probe to reset its cached verdict. */
+export function __backendHealthProbe(): Promise<boolean> {
+  const controller = new AbortController();
+  return Promise.race([
+    globalThis
+      .fetch(`${API_BASE_URL}/api/health`, { cache: 'no-store', signal: controller.signal })
+      .then((res) => res.ok)
+      .catch(() => false),
+    sleep(HEALTH_PROBE_TIMEOUT_MS).then(() => {
+      controller.abort();
+      return false;
+    }),
+  ]);
+}
+configureHealthProbe(__backendHealthProbe);
 
 /** True only for calls to our own backend API — GCS signed-URL uploads and any other
  *  third-party host pass straight through apiFetch untouched (no timeout/retry/status).

--- a/frontend/lib/backend-status.ts
+++ b/frontend/lib/backend-status.ts
@@ -20,6 +20,14 @@
  * Only GETs are tracked: reads are what a page waits on during a recycle, and long
  * POSTs (search, generate, auto-correct) are legitimately slow and must never trip
  * the banner. See lib/api.ts (apiFetch) for the begin/endRequest wiring.
+ *
+ * A stall alone is still not proof of an outage: some reads legitimately run past
+ * the thresholds (e.g. first-time instrumental-analysis / lyrics-review loads that
+ * transcode audio server-side). So once a stall crosses the threshold, we confirm
+ * with a cheap /api/health probe (registered via configureHealthProbe): if the probe
+ * answers, the backend is reachable and the endpoint is just slow — no banner. Only
+ * a probe that fails (or times out, as it does during a recycle when the origin
+ * hangs) lets the banner surface.
  */
 
 import { useSyncExternalStore } from 'react'
@@ -37,6 +45,8 @@ export type BackendStatus =
 export const STALL_RECONNECTING_MS = 10_000
 /** ...and this long before we escalate to the full assertive message. */
 export const STALL_UNAVAILABLE_MS = 20_000
+/** A health-probe verdict is trusted this long before we re-probe during a stall. */
+export const PROBE_FRESH_MS = 10_000
 
 let nextId = 1
 /** id -> startedAt (ms) for every tracked backend GET currently in flight. */
@@ -46,6 +56,17 @@ let devOverride: BackendStatus | null = null
 
 let status: BackendStatus = 'online'
 let ticker: ReturnType<typeof setInterval> | null = null
+
+/** Cheap reachability check (e.g. GET /api/health). Must resolve within a few
+ *  seconds — implementations race against their own timeout and NEVER reject. */
+type HealthProbe = () => Promise<boolean>
+let healthProbe: HealthProbe | null = null
+let probeInFlight = false
+/** Last probe verdict (null = no verdict yet) and when it settled. */
+let lastProbeOk: boolean | null = null
+let lastProbeAt = 0
+/** Bumped on configureHealthProbe so a probe from a previous config can't land. */
+let probeEpoch = 0
 
 const listeners = new Set<() => void>()
 
@@ -71,8 +92,35 @@ function computeFromStalls(): BackendStatus {
   return 'online'
 }
 
+/** Fire a health probe if one isn't running and the last verdict has gone stale. */
+function maybeStartProbe() {
+  if (!healthProbe || probeInFlight) return
+  if (lastProbeOk !== null && Date.now() - lastProbeAt < PROBE_FRESH_MS) return
+  probeInFlight = true
+  const epoch = probeEpoch
+  healthProbe()
+    .then(
+      (ok) => (epoch === probeEpoch ? (lastProbeOk = ok) : undefined),
+      () => (epoch === probeEpoch ? (lastProbeOk = false) : undefined),
+    )
+    .finally(() => {
+      if (epoch !== probeEpoch) return
+      probeInFlight = false
+      lastProbeAt = Date.now()
+      recompute()
+    })
+}
+
 function recompute() {
-  setStatus(devOverride ?? computeFromStalls())
+  let next = devOverride ?? computeFromStalls()
+  // A stall only becomes a banner once the health probe CONFIRMS the backend is
+  // unreachable. While the probe answers OK (or hasn't answered yet), the stalled
+  // read is treated as a legitimately slow endpoint and the banner stays hidden.
+  if (devOverride === null && next !== 'online' && healthProbe) {
+    maybeStartProbe()
+    if (lastProbeOk !== false) next = 'online'
+  }
+  setStatus(next)
   // Stop the clock once nothing is outstanding (and no dev override needs it).
   if (inFlight.size === 0 && devOverride === null && ticker) {
     clearInterval(ticker)
@@ -101,6 +149,20 @@ export function beginRequest(): number {
 /** Mark a tracked read as settled. */
 export function endRequest(id: number): void {
   if (inFlight.delete(id)) recompute()
+}
+
+/**
+ * Register the reachability probe used to confirm a stall before the banner shows.
+ * The probe must never reject and must settle within a few seconds (race against
+ * your own timeout). Registered once by lib/api.ts. Passing null (tests) restores
+ * pure stall-based behavior and clears any cached verdict.
+ */
+export function configureHealthProbe(probe: HealthProbe | null): void {
+  probeEpoch++
+  healthProbe = probe
+  probeInFlight = false
+  lastProbeOk = null
+  lastProbeAt = 0
 }
 
 export function getBackendStatus(): BackendStatus {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10894,6 +10894,17 @@
         }
       }
     },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -11402,6 +11413,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10894,17 +10894,6 @@
         }
       }
     },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -11413,7 +11402,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.198.2"
+version = "0.198.3"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Slow-but-legitimate page loads (e.g. **first-time instrumental-analysis / lyrics-review loads**, which transcode audio stems server-side via ffmpeg and can run 20–60s) were tripping the stall-based connectivity banner, showing *"We're having trouble reaching our servers"* during a perfectly normal load.

**Fix:** a stalled GET now only surfaces the banner once a cheap `GET /api/health` probe confirms the backend is actually unreachable.

- When the oldest in-flight GET crosses the 10s stall threshold, `lib/backend-status.ts` fires the probe registered by `lib/api.ts` (`configureHealthProbe`).
- Probe answers OK (or no verdict yet) → backend is reachable, the read is just a slow endpoint → **no banner**.
- Probe fails or times out (4s, `Promise.race`d so a hung origin can't wedge it — during a Cloud Run recycle the origin *hangs* rather than erroring) → outage confirmed → banner appears (~4s later than before).
- Probe re-fires every 10s while a stall persists, so recovery clears the banner even if the original read is still hung.
- Dev-override hook and pure stall-based behavior (when no probe is configured) are unchanged.

Also bumps version to 0.198.3 and adds an addendum to the 2026-08-22 design doc.

## Testing

- Reworked `__tests__/api-fetch.test.ts` stall test for the new confirm-before-banner flow + new test: slow GET with healthy `/api/health` never shows the banner.
- New `__tests__/backend-status.test.ts` suite: probe-OK suppression, probe-fail escalation, stale-verdict re-probe + recovery clearing, no-verdict hold-back.
- Full `make test` green: 91 suites / 1151 frontend tests + backend suites.

@coderabbitai ignore
(Local CodeRabbit review completed on this branch — no findings.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)