### PR TITLE
feat(admin): create users from admin UI + auto-create account on job user_email reassignment

### DIFF
--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -967,6 +967,23 @@ async def update_job(
     if not job:
         raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
 
+    # Reassigning a job to an email with no account would orphan it (the user
+    # couldn't log in to see it, and impersonation would 404) — so normalize the
+    # email and auto-create the account if needed.
+    user_created_email = None
+    if isinstance(updates.get("user_email"), str):
+        normalized_email = updates["user_email"].strip().lower()
+        updates["user_email"] = normalized_email
+        if normalized_email:
+            user_service = get_user_service()
+            if not user_service.get_user(normalized_email):
+                user_service.get_or_create_user(normalized_email)
+                user_created_email = normalized_email
+                logger.info(
+                    f"Admin {admin_email} reassigned job {job_id} to {normalized_email} — "
+                    f"no account existed, created one"
+                )
+
     # Check if we're toggling is_private from False to True on a completed job
     # If so, auto-delete existing outputs (YouTube, Dropbox, GDrive)
     toggling_to_private = (
@@ -1016,6 +1033,8 @@ async def update_job(
     )
 
     message = f"Successfully updated {len(updates)} field(s)"
+    if user_created_email:
+        message += f". Created new user account for {user_created_email}."
     if auto_deleted:
         message += ". Existing outputs were auto-deleted (job set to private)."
 

--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -973,16 +973,20 @@ async def update_job(
     user_created_email = None
     if isinstance(updates.get("user_email"), str):
         normalized_email = updates["user_email"].strip().lower()
+        if not normalized_email or "@" not in normalized_email:
+            raise HTTPException(
+                status_code=400,
+                detail="user_email must be a valid email address"
+            )
         updates["user_email"] = normalized_email
-        if normalized_email:
-            user_service = get_user_service()
-            if not user_service.get_user(normalized_email):
-                user_service.get_or_create_user(normalized_email)
-                user_created_email = normalized_email
-                logger.info(
-                    f"Admin {admin_email} reassigned job {job_id} to {normalized_email} — "
-                    f"no account existed, created one"
-                )
+        user_service = get_user_service()
+        if not user_service.get_user(normalized_email):
+            user_service.get_or_create_user(normalized_email)
+            user_created_email = normalized_email
+            logger.info(
+                f"Admin {admin_email} reassigned job {job_id} to {normalized_email} — "
+                f"no account existed, created one"
+            )
 
     # Check if we're toggling is_private from False to True on a completed job
     # If so, auto-delete existing outputs (YouTube, Dropbox, GDrive)

--- a/backend/api/routes/users.py
+++ b/backend/api/routes/users.py
@@ -48,6 +48,8 @@ from backend.models.user import (
     ResendFromTokenResponse,
     AddCreditsRequest,
     AddCreditsResponse,
+    AdminCreateUserRequest,
+    AdminCreateUserResponse,
     UserListResponse,
     UserFeedback,
     UserFeedbackRequest,
@@ -1998,6 +2000,68 @@ async def get_user_detail(
         referral_discount_expires_at=user.referral_discount_expires_at.isoformat() if user.referral_discount_expires_at and hasattr(user.referral_discount_expires_at, 'isoformat') else str(user.referral_discount_expires_at) if user.referral_discount_expires_at else None,
         referral_code=user.referral_code,
         recent_sessions=active_sessions,
+    )
+
+
+@router.post("/admin/users", response_model=AdminCreateUserResponse, status_code=201)
+async def admin_create_user(
+    request: AdminCreateUserRequest,
+    auth_data: AuthResult = Depends(require_admin),
+    user_service: UserService = Depends(get_user_service),
+):
+    """
+    Create a user account directly (admin only).
+
+    Use this to set up an account for someone who has never logged in, so you can
+    grant them credits, submit jobs on their behalf, or impersonate them. The user
+    can later log in normally via magic link with the same email.
+
+    Users created this way with initial credits do NOT receive the automatic
+    welcome credit on first login (welcome_credits_granted is set to prevent
+    double-granting).
+    """
+    admin_id = auth_data.user_email or "admin:unknown"
+    email = request.email.strip().lower()
+
+    if request.initial_credits < 0 or request.initial_credits > 1000:
+        raise HTTPException(status_code=400, detail="initial_credits must be between 0 and 1000")
+
+    if user_service.get_user(email):
+        raise HTTPException(status_code=409, detail=f"User {email} already exists")
+
+    user = user_service.get_or_create_user(email)
+
+    extra_updates = {}
+    if request.display_name and request.display_name.strip():
+        extra_updates["display_name"] = request.display_name.strip()
+
+    if request.initial_credits > 0:
+        success, new_balance, message = user_service.add_credits(
+            email=email,
+            amount=request.initial_credits,
+            reason=request.credit_reason,
+            admin_email=admin_id,
+        )
+        if not success:
+            raise HTTPException(status_code=500, detail=f"User created but adding credits failed: {message}")
+        user.credits = new_balance
+        # Admin-granted starter credits replace the automatic welcome credit
+        extra_updates["welcome_credits_granted"] = True
+
+    if extra_updates:
+        user_service.update_user(email, **extra_updates)
+
+    logger.info(
+        f"Admin {admin_id} created user {email} "
+        f"(initial_credits={request.initial_credits}, display_name={request.display_name or '—'})"
+    )
+
+    return AdminCreateUserResponse(
+        status="success",
+        email=email,
+        credits=user.credits,
+        message=f"Created user {email}"
+        + (f" with {request.initial_credits} credit(s)" if request.initial_credits > 0 else ""),
     )
 
 

--- a/backend/api/routes/users.py
+++ b/backend/api/routes/users.py
@@ -2052,8 +2052,8 @@ async def admin_create_user(
         user_service.update_user(email, **extra_updates)
 
     logger.info(
-        f"Admin {admin_id} created user {email} "
-        f"(initial_credits={request.initial_credits}, display_name={request.display_name or '—'})"
+        f"Admin {admin_id} created user {_mask_email(email)} "
+        f"(initial_credits={request.initial_credits})"
     )
 
     return AdminCreateUserResponse(

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -10,7 +10,7 @@ Supports:
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Optional, List, Dict
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field
 
 
 class UserRole(str, Enum):
@@ -254,6 +254,22 @@ class AddCreditsResponse(BaseModel):
     email: str
     credits_added: int
     new_balance: int
+    message: str
+
+
+class AdminCreateUserRequest(BaseModel):
+    """Admin request to create a user account directly."""
+    email: EmailStr
+    display_name: Optional[str] = None
+    initial_credits: int = 0
+    credit_reason: str = "admin_grant"
+
+
+class AdminCreateUserResponse(BaseModel):
+    """Response after admin creates a user."""
+    status: str
+    email: str
+    credits: int
     message: str
 
 

--- a/backend/tests/test_admin_create_user.py
+++ b/backend/tests/test_admin_create_user.py
@@ -1,0 +1,187 @@
+"""
+Unit tests for the admin create-user endpoint.
+
+Tests POST /api/users/admin/users, which lets admins create a user account
+directly (e.g. to grant credits, submit jobs on behalf of, or impersonate
+someone who has never logged in).
+"""
+import pytest
+from unittest.mock import Mock
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+
+from backend.api.routes.users import router
+from backend.api.dependencies import require_admin
+from backend.services.user_service import get_user_service
+from backend.services.auth_service import AuthResult, UserType
+from backend.models.user import User
+
+
+app = FastAPI()
+app.include_router(router, prefix="/api")
+
+
+def get_mock_admin():
+    """Override for require_admin dependency."""
+    return AuthResult(
+        is_valid=True,
+        user_type=UserType.ADMIN,
+        remaining_uses=-1,
+        message="Admin session valid",
+        user_email="admin@nomadkaraoke.com",
+        is_admin=True,
+    )
+
+
+@pytest.fixture
+def mock_user_service():
+    service = Mock()
+    service.get_user.return_value = None  # default: user doesn't exist
+    new_user = Mock(spec=User)
+    new_user.email = "new@example.com"
+    new_user.credits = 0
+    service.get_or_create_user.return_value = new_user
+    service.add_credits.return_value = (True, 3, "Added 3 credits")
+    return service
+
+
+@pytest.fixture
+def client(mock_user_service):
+    app.dependency_overrides[require_admin] = get_mock_admin
+    app.dependency_overrides[get_user_service] = lambda: mock_user_service
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+class TestAdminCreateUser:
+    """Tests for POST /api/users/admin/users."""
+
+    def test_create_user_minimal(self, client, mock_user_service):
+        """Creating with just an email creates the account with zero credits."""
+        response = client.post(
+            "/api/users/admin/users",
+            json={"email": "new@example.com"},
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["email"] == "new@example.com"
+        assert data["credits"] == 0
+        mock_user_service.get_or_create_user.assert_called_once_with("new@example.com")
+        mock_user_service.add_credits.assert_not_called()
+        mock_user_service.update_user.assert_not_called()
+
+    def test_create_user_with_credits_and_display_name(self, client, mock_user_service):
+        """Initial credits are granted and the welcome-credit flag is set."""
+        response = client.post(
+            "/api/users/admin/users",
+            json={
+                "email": "new@example.com",
+                "display_name": "Uwe Schreiber",
+                "initial_credits": 3,
+                "credit_reason": "made-for-you order",
+            },
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["credits"] == 3
+        assert "3 credit(s)" in data["message"]
+
+        mock_user_service.add_credits.assert_called_once_with(
+            email="new@example.com",
+            amount=3,
+            reason="made-for-you order",
+            admin_email="admin@nomadkaraoke.com",
+        )
+        # display_name saved + welcome credit suppressed (admin credits replace it)
+        update_kwargs = mock_user_service.update_user.call_args.kwargs
+        assert update_kwargs["display_name"] == "Uwe Schreiber"
+        assert update_kwargs["welcome_credits_granted"] is True
+
+    def test_create_without_credits_leaves_welcome_credit_eligible(self, client, mock_user_service):
+        """No initial credits → welcome_credits_granted is left untouched."""
+        response = client.post(
+            "/api/users/admin/users",
+            json={"email": "new@example.com", "display_name": "Somebody"},
+        )
+
+        assert response.status_code == 201
+        update_kwargs = mock_user_service.update_user.call_args.kwargs
+        assert "welcome_credits_granted" not in update_kwargs
+
+    def test_email_normalized_to_lowercase(self, client, mock_user_service):
+        """Mixed-case emails are lowercased before lookup and creation."""
+        response = client.post(
+            "/api/users/admin/users",
+            json={"email": "Schreiber.Uwe@GoogleMail.com"},
+        )
+
+        assert response.status_code == 201
+        assert response.json()["email"] == "schreiber.uwe@googlemail.com"
+        mock_user_service.get_user.assert_called_once_with("schreiber.uwe@googlemail.com")
+        mock_user_service.get_or_create_user.assert_called_once_with("schreiber.uwe@googlemail.com")
+
+    def test_duplicate_user_returns_409(self, client, mock_user_service):
+        """Creating a user that already exists returns 409."""
+        mock_user_service.get_user.return_value = Mock(spec=User)
+
+        response = client.post(
+            "/api/users/admin/users",
+            json={"email": "existing@example.com"},
+        )
+
+        assert response.status_code == 409
+        assert "already exists" in response.json()["detail"]
+        mock_user_service.get_or_create_user.assert_not_called()
+
+    def test_invalid_email_rejected(self, client, mock_user_service):
+        """A malformed email fails validation with 422."""
+        response = client.post(
+            "/api/users/admin/users",
+            json={"email": "not-an-email"},
+        )
+
+        assert response.status_code == 422
+        mock_user_service.get_or_create_user.assert_not_called()
+
+    def test_credits_out_of_range_rejected(self, client, mock_user_service):
+        """initial_credits outside 0-1000 is rejected."""
+        for bad_amount in (-1, 1001):
+            response = client.post(
+                "/api/users/admin/users",
+                json={"email": "new@example.com", "initial_credits": bad_amount},
+            )
+            assert response.status_code == 400
+        mock_user_service.get_or_create_user.assert_not_called()
+
+    def test_add_credits_failure_returns_500(self, client, mock_user_service):
+        """If granting credits fails after creation, the endpoint reports it."""
+        mock_user_service.add_credits.return_value = (False, 0, "Firestore unavailable")
+
+        response = client.post(
+            "/api/users/admin/users",
+            json={"email": "new@example.com", "initial_credits": 2},
+        )
+
+        assert response.status_code == 500
+        assert "adding credits failed" in response.json()["detail"]
+
+    def test_requires_admin(self, mock_user_service):
+        """Non-admin requests are rejected."""
+        def deny_admin():
+            from fastapi import HTTPException
+            raise HTTPException(status_code=403, detail="Admin access required")
+
+        app.dependency_overrides[require_admin] = deny_admin
+        app.dependency_overrides[get_user_service] = lambda: mock_user_service
+        try:
+            client = TestClient(app)
+            response = client.post(
+                "/api/users/admin/users",
+                json={"email": "new@example.com"},
+            )
+            assert response.status_code == 403
+        finally:
+            app.dependency_overrides.clear()

--- a/backend/tests/test_admin_create_user.py
+++ b/backend/tests/test_admin_create_user.py
@@ -78,7 +78,7 @@ class TestAdminCreateUser:
             "/api/users/admin/users",
             json={
                 "email": "new@example.com",
-                "display_name": "Uwe Schreiber",
+                "display_name": "Jane Singer",
                 "initial_credits": 3,
                 "credit_reason": "made-for-you order",
             },
@@ -97,7 +97,7 @@ class TestAdminCreateUser:
         )
         # display_name saved + welcome credit suppressed (admin credits replace it)
         update_kwargs = mock_user_service.update_user.call_args.kwargs
-        assert update_kwargs["display_name"] == "Uwe Schreiber"
+        assert update_kwargs["display_name"] == "Jane Singer"
         assert update_kwargs["welcome_credits_granted"] is True
 
     def test_create_without_credits_leaves_welcome_credit_eligible(self, client, mock_user_service):
@@ -115,13 +115,13 @@ class TestAdminCreateUser:
         """Mixed-case emails are lowercased before lookup and creation."""
         response = client.post(
             "/api/users/admin/users",
-            json={"email": "Schreiber.Uwe@GoogleMail.com"},
+            json={"email": "Mixed.Case@Example.COM"},
         )
 
         assert response.status_code == 201
-        assert response.json()["email"] == "schreiber.uwe@googlemail.com"
-        mock_user_service.get_user.assert_called_once_with("schreiber.uwe@googlemail.com")
-        mock_user_service.get_or_create_user.assert_called_once_with("schreiber.uwe@googlemail.com")
+        assert response.json()["email"] == "mixed.case@example.com"
+        mock_user_service.get_user.assert_called_once_with("mixed.case@example.com")
+        mock_user_service.get_or_create_user.assert_called_once_with("mixed.case@example.com")
 
     def test_duplicate_user_returns_409(self, client, mock_user_service):
         """Creating a user that already exists returns 409."""

--- a/backend/tests/test_admin_job_update.py
+++ b/backend/tests/test_admin_job_update.py
@@ -420,3 +420,21 @@ class TestUpdateJobUserEmailAutoCreate:
 
             assert response.status_code == 200
             mock_get_us.assert_not_called()
+
+    def test_blank_user_email_rejected(self, client, mock_job):
+        """Whitespace-only or non-email values for user_email return 400."""
+        for bad_value in ("   ", "not-an-email"):
+            with patch('backend.api.routes.admin.JobManager') as mock_jm_class, \
+                 patch('backend.api.routes.admin.get_user_service') as mock_get_us:
+                mock_jm = Mock()
+                mock_jm.get_job.return_value = mock_job
+                mock_jm_class.return_value = mock_jm
+
+                response = client.patch(
+                    "/api/admin/jobs/test-job-123",
+                    json={"user_email": bad_value},
+                )
+
+                assert response.status_code == 400
+                assert "valid email" in response.json()["detail"]
+                mock_jm.update_job.assert_not_called()

--- a/backend/tests/test_admin_job_update.py
+++ b/backend/tests/test_admin_job_update.py
@@ -396,13 +396,14 @@ class TestUpdateJobUserEmailAutoCreate:
 
             response = client.patch(
                 "/api/admin/jobs/test-job-123",
-                json={"user_email": "  Schreiber.Uwe@GoogleMail.com "},
+                json={"user_email": "  Mixed.Case@Example.COM "},
             )
 
             assert response.status_code == 200
             call_args = mock_jm.update_job.call_args
-            assert call_args[0][1]["user_email"] == "schreiber.uwe@googlemail.com"
-            mock_us.get_or_create_user.assert_called_once_with("schreiber.uwe@googlemail.com")
+            assert call_args[0][1]["user_email"] == "mixed.case@example.com"
+            mock_us.get_user.assert_called_once_with("mixed.case@example.com")
+            mock_us.get_or_create_user.assert_called_once_with("mixed.case@example.com")
 
     def test_other_field_updates_skip_user_lookup(self, client, mock_job):
         """Updating non-email fields never touches the user service."""

--- a/backend/tests/test_admin_job_update.py
+++ b/backend/tests/test_admin_job_update.py
@@ -127,11 +127,13 @@ class TestUpdateJob:
 
     def test_update_user_email(self, client, mock_job):
         """Test updating user_email field."""
-        with patch('backend.api.routes.admin.JobManager') as mock_jm_class:
+        with patch('backend.api.routes.admin.JobManager') as mock_jm_class, \
+             patch('backend.api.routes.admin.get_user_service') as mock_get_us:
             mock_jm = Mock()
             mock_jm.get_job.return_value = mock_job
             mock_jm.update_job.return_value = True
             mock_jm_class.return_value = mock_jm
+            mock_get_us.return_value.get_user.return_value = Mock()  # user exists
 
             response = client.patch(
                 "/api/admin/jobs/test-job-123",
@@ -324,3 +326,97 @@ class TestUpdateJobAuthorization:
                 app.dependency_overrides[require_admin] = original_override
             else:
                 app.dependency_overrides[require_admin] = get_mock_admin
+
+
+class TestUpdateJobUserEmailAutoCreate:
+    """Tests for auto-creating a user account when user_email is reassigned."""
+
+    def _patch(self, mock_job, existing_user):
+        """Return patched JobManager + user_service context managers."""
+        jm_patch = patch('backend.api.routes.admin.JobManager')
+        us_patch = patch('backend.api.routes.admin.get_user_service')
+        return jm_patch, us_patch
+
+    def test_creates_user_when_email_unknown(self, client, mock_job):
+        """Reassigning to an email with no account auto-creates the account."""
+        with patch('backend.api.routes.admin.JobManager') as mock_jm_class, \
+             patch('backend.api.routes.admin.get_user_service') as mock_get_us:
+            mock_jm = Mock()
+            mock_jm.get_job.return_value = mock_job
+            mock_jm.update_job.return_value = True
+            mock_jm_class.return_value = mock_jm
+
+            mock_us = Mock()
+            mock_us.get_user.return_value = None  # no account exists
+            mock_get_us.return_value = mock_us
+
+            response = client.patch(
+                "/api/admin/jobs/test-job-123",
+                json={"user_email": "brandnew@example.com"},
+            )
+
+            assert response.status_code == 200
+            mock_us.get_or_create_user.assert_called_once_with("brandnew@example.com")
+            assert "Created new user account for brandnew@example.com" in response.json()["message"]
+
+    def test_does_not_create_when_user_exists(self, client, mock_job):
+        """Reassigning to an existing user's email does not create anything."""
+        with patch('backend.api.routes.admin.JobManager') as mock_jm_class, \
+             patch('backend.api.routes.admin.get_user_service') as mock_get_us:
+            mock_jm = Mock()
+            mock_jm.get_job.return_value = mock_job
+            mock_jm.update_job.return_value = True
+            mock_jm_class.return_value = mock_jm
+
+            mock_us = Mock()
+            mock_us.get_user.return_value = Mock()  # account exists
+            mock_get_us.return_value = mock_us
+
+            response = client.patch(
+                "/api/admin/jobs/test-job-123",
+                json={"user_email": "existing@example.com"},
+            )
+
+            assert response.status_code == 200
+            mock_us.get_or_create_user.assert_not_called()
+            assert "Created new user account" not in response.json()["message"]
+
+    def test_email_is_normalized_to_lowercase(self, client, mock_job):
+        """Mixed-case emails are lowercased before saving to the job."""
+        with patch('backend.api.routes.admin.JobManager') as mock_jm_class, \
+             patch('backend.api.routes.admin.get_user_service') as mock_get_us:
+            mock_jm = Mock()
+            mock_jm.get_job.return_value = mock_job
+            mock_jm.update_job.return_value = True
+            mock_jm_class.return_value = mock_jm
+
+            mock_us = Mock()
+            mock_us.get_user.return_value = None
+            mock_get_us.return_value = mock_us
+
+            response = client.patch(
+                "/api/admin/jobs/test-job-123",
+                json={"user_email": "  Schreiber.Uwe@GoogleMail.com "},
+            )
+
+            assert response.status_code == 200
+            call_args = mock_jm.update_job.call_args
+            assert call_args[0][1]["user_email"] == "schreiber.uwe@googlemail.com"
+            mock_us.get_or_create_user.assert_called_once_with("schreiber.uwe@googlemail.com")
+
+    def test_other_field_updates_skip_user_lookup(self, client, mock_job):
+        """Updating non-email fields never touches the user service."""
+        with patch('backend.api.routes.admin.JobManager') as mock_jm_class, \
+             patch('backend.api.routes.admin.get_user_service') as mock_get_us:
+            mock_jm = Mock()
+            mock_jm.get_job.return_value = mock_job
+            mock_jm.update_job.return_value = True
+            mock_jm_class.return_value = mock_jm
+
+            response = client.patch(
+                "/api/admin/jobs/test-job-123",
+                json={"artist": "Someone Else"},
+            )
+
+            assert response.status_code == 200
+            mock_get_us.assert_not_called()

--- a/docs/API.md
+++ b/docs/API.md
@@ -1533,6 +1533,41 @@ Authorization: Bearer ADMIN_TOKEN
 `text_body`, addressing, `status`, `delivered_at`, `open_count`, `click_count`,
 `bounce`, and the raw `events`.
 
+### Create User (Admin)
+
+Create a user account directly — e.g. to grant credits, submit jobs on behalf of,
+or impersonate someone who has never logged in. The user can later log in normally
+via magic link with the same email.
+
+```http
+POST /api/users/admin/users
+Authorization: Bearer ADMIN_TOKEN
+Content-Type: application/json
+
+{
+  "email": "user@example.com",
+  "display_name": "Optional Name",
+  "initial_credits": 3,
+  "credit_reason": "made-for-you order"
+}
+```
+
+Response (201):
+```json
+{
+  "status": "success",
+  "email": "user@example.com",
+  "credits": 3,
+  "message": "Created user user@example.com with 3 credit(s)"
+}
+```
+
+Notes:
+- `display_name`, `initial_credits` (0-1000), and `credit_reason` are optional
+- If `initial_credits` > 0, `welcome_credits_granted` is set so the user does NOT
+  also receive the automatic welcome credit on first login
+- Returns 409 if the user already exists
+
 ### Add Credits (Admin)
 
 ```http
@@ -1807,6 +1842,11 @@ Content-Type: application/json
 Updates editable job fields. Allowed fields: `artist`, `title`, `user_email`, `theme_id`, `brand_prefix`, `discord_webhook_url`, `youtube_description`, `youtube_description_template`, `customer_email`, `customer_notes`, `enable_cdg`, `enable_txt`, `enable_youtube_upload`, `non_interactive`, `prep_only`, `is_private`.
 
 **Note:** Setting `is_private=true` on a completed job with existing outputs triggers automatic output deletion.
+
+**Note:** `user_email` is trimmed and lowercased before saving. If no account exists
+for that email, one is auto-created (so the recipient can log in and see the job,
+and the admin can impersonate them immediately). The response message notes when
+an account was created.
 
 Response:
 ```json

--- a/docs/archive/2026-08-24-admin-create-users.md
+++ b/docs/archive/2026-08-24-admin-create-users.md
@@ -1,0 +1,69 @@
+# Admin Create Users + Auto-Create on Job Reassignment (2026-08-24)
+
+## Task (Andrew's prompt, verbatim)
+
+> I'd like to be able to create users from the gen admin users page, so I can submit jobs
+> on their behalf (while logged in as admin, after impersonating the new user account) and
+> assign free credits to users who have never logged in before. I've actually just edited
+> an admin-created job to change the user email address to this:
+> "schreiber.uwe@googlemail.com" but that user didn't exist yet, so i'm not sure what
+> happens in this case. Ideally in this scenario that user account would get created on the
+> fly and the job would be assigned to the new user account
+
+## What happened with the reassigned job (investigation)
+
+Job `0eebb248` (Jonny Hill & Linda Feller – Darling) had `user_email` set to
+`schreiber.uwe@googlemail.com`, but `PATCH /api/admin/jobs/{id}` only wrote the string to
+the job doc — no `gen_users` account was created. Consequences: notification emails still
+send (notifier uses the raw email, falls back to `en` locale), and the job would appear in
+the user's list if they ever logged in (jobs are associated purely by the `user_email`
+string; magic-link login lazily creates the account). But until then: no account, no
+credits, impersonation 404s.
+
+## Changes (v0.199.0)
+
+1. **`POST /api/users/admin/users`** (`backend/api/routes/users.py`) — admin creates a
+   user account directly: `email` (required), `display_name`, `initial_credits` (0-1000),
+   `credit_reason`. 409 if exists. If initial credits are granted,
+   `welcome_credits_granted` is set so the user doesn't also get the automatic welcome
+   credit on first login. Models in `backend/models/user.py`
+   (`AdminCreateUserRequest/Response`).
+
+2. **Auto-create on job reassignment** (`backend/api/routes/admin.py` `update_job`) —
+   when an admin PATCHes `user_email`, the email is trimmed + lowercased before saving,
+   and if no `gen_users` account exists one is created via `get_or_create_user`. The
+   response message notes the creation, and the admin jobs page toast surfaces it.
+
+3. **Admin users page** (`frontend/app/admin/users/page.tsx`) — "Create User" button +
+   dialog (email, optional display name, optional initial credits). On success the list
+   is filtered to the new user, so the existing Impersonate / Add Credits buttons work
+   immediately (impersonation only requires the account doc to exist).
+
+4. `adminApi.createUser` in `frontend/lib/api.ts`; docs in `docs/API.md`.
+
+## Tests
+
+- New `backend/tests/test_admin_create_user.py` (9 tests: minimal create, credits +
+  display name + welcome-flag suppression, lowercase normalization, 409 duplicate,
+  422 invalid email, 400 out-of-range credits, 500 add-credits failure, 403 non-admin).
+- `backend/tests/test_admin_job_update.py`: new `TestUpdateJobUserEmailAutoCreate` class
+  (creates when unknown, skips when existing, lowercases, non-email edits never touch
+  user service).
+- Full backend suite: 3917 passed. Frontend: 1151 Jest tests passed; eslint + tsc clean
+  on touched files.
+
+## Post-deploy TODO
+
+- Backfill the account for `schreiber.uwe@googlemail.com` (job `0eebb248`): either
+  re-save the `user_email` field on the job in the admin UI (now auto-creates), or call
+  the new create endpoint — then grant credits/impersonate as desired.
+
+## Design decisions
+
+- Admin-granted initial credits suppress the automatic welcome credit (set
+  `welcome_credits_granted=True`) to avoid double-granting.
+- `email_verified` stays false on admin-created accounts — verification still happens on
+  first magic-link login.
+- Job reassignment now lowercases the email; job→user association is a string match on
+  `user_email`, and all account doc IDs are lowercased emails, so mixed-case entry would
+  otherwise silently orphan the job.

--- a/docs/archive/2026-08-24-admin-create-users.md
+++ b/docs/archive/2026-08-24-admin-create-users.md
@@ -6,14 +6,14 @@
 > on their behalf (while logged in as admin, after impersonating the new user account) and
 > assign free credits to users who have never logged in before. I've actually just edited
 > an admin-created job to change the user email address to this:
-> "schreiber.uwe@googlemail.com" but that user didn't exist yet, so i'm not sure what
-> happens in this case. Ideally in this scenario that user account would get created on the
-> fly and the job would be assigned to the new user account
+> "[customer email redacted — public repo]" but that user didn't exist yet, so i'm not sure
+> what happens in this case. Ideally in this scenario that user account would get created
+> on the fly and the job would be assigned to the new user account
 
 ## What happened with the reassigned job (investigation)
 
-Job `0eebb248` (Jonny Hill & Linda Feller – Darling) had `user_email` set to
-`schreiber.uwe@googlemail.com`, but `PATCH /api/admin/jobs/{id}` only wrote the string to
+The reassigned job had `user_email` set to the customer's email, but
+`PATCH /api/admin/jobs/{id}` only wrote the string to
 the job doc — no `gen_users` account was created. Consequences: notification emails still
 send (notifier uses the raw email, falls back to `en` locale), and the job would appear in
 the user's list if they ever logged in (jobs are associated purely by the `user_email`
@@ -54,9 +54,10 @@ credits, impersonation 404s.
 
 ## Post-deploy TODO
 
-- Backfill the account for `schreiber.uwe@googlemail.com` (job `0eebb248`): either
-  re-save the `user_email` field on the job in the admin UI (now auto-creates), or call
-  the new create endpoint — then grant credits/impersonate as desired.
+- Backfill the account for the customer whose job was reassigned before this shipped
+  (details in agent memory, kept out of this public repo): either re-save the
+  `user_email` field on the job in the admin UI (now auto-creates), or call the new
+  create endpoint — then grant credits/impersonate as desired.
 
 ## Design decisions
 

--- a/frontend/app/admin/jobs/page.tsx
+++ b/frontend/app/admin/jobs/page.tsx
@@ -338,14 +338,17 @@ function AdminJobsPageContent() {
     try {
       setSaving(true)
       const updates: JobUpdateRequest = { [field]: editValue }
-      await adminApi.updateJob(selectedJobId, updates)
+      const result = await adminApi.updateJob(selectedJobId, updates)
 
       // Update local state
       setSelectedJob({ ...selectedJob, [field]: editValue })
 
+      // Surface anything beyond the generic success message (e.g. "Created new
+      // user account for x@y.com" when reassigning user_email)
+      const extra = result?.message?.replace(/^Successfully updated \d+ field\(s\)\.?\s*/, "")
       toast({
         title: "Updated",
-        description: `${field} has been updated`,
+        description: extra ? `${field} has been updated. ${extra}` : `${field} has been updated`,
       })
 
       setEditingField(null)

--- a/frontend/app/admin/jobs/page.tsx
+++ b/frontend/app/admin/jobs/page.tsx
@@ -337,11 +337,14 @@ function AdminJobsPageContent() {
 
     try {
       setSaving(true)
-      const updates: JobUpdateRequest = { [field]: editValue }
+      // The backend trims + lowercases user_email; mirror that locally so the
+      // displayed value matches what was saved
+      const savedValue = field === "user_email" ? editValue.trim().toLowerCase() : editValue
+      const updates: JobUpdateRequest = { [field]: savedValue }
       const result = await adminApi.updateJob(selectedJobId, updates)
 
       // Update local state
-      setSelectedJob({ ...selectedJob, [field]: editValue })
+      setSelectedJob({ ...selectedJob, [field]: savedValue })
 
       // Surface anything beyond the generic success message (e.g. "Created new
       // user account for x@y.com" when reassigning user_email)

--- a/frontend/app/admin/users/page.tsx
+++ b/frontend/app/admin/users/page.tsx
@@ -573,7 +573,7 @@ export default function AdminUsersPage() {
               <Label htmlFor="new-user-display-name">Display Name (optional)</Label>
               <Input
                 id="new-user-display-name"
-                placeholder="e.g., Uwe Schreiber"
+                placeholder="e.g., Jane Singer"
                 value={newUserDisplayName}
                 onChange={(e) => setNewUserDisplayName(e.target.value)}
               />

--- a/frontend/app/admin/users/page.tsx
+++ b/frontend/app/admin/users/page.tsx
@@ -38,6 +38,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Plus,
+  UserPlus,
   Loader2,
   CreditCard,
   LogIn,
@@ -100,6 +101,13 @@ export default function AdminUsersPage() {
 
   // Impersonation state - tracks which user is being impersonated (for loading indicator)
   const [impersonatingEmail, setImpersonatingEmail] = useState<string | null>(null)
+
+  // Create user dialog state
+  const [createDialogOpen, setCreateDialogOpen] = useState(false)
+  const [newUserEmail, setNewUserEmail] = useState("")
+  const [newUserDisplayName, setNewUserDisplayName] = useState("")
+  const [newUserCredits, setNewUserCredits] = useState("")
+  const [creatingUser, setCreatingUser] = useState(false)
 
   const loadUsers = useCallback(async () => {
     try {
@@ -178,6 +186,60 @@ export default function AdminUsersPage() {
     }
   }
 
+  const handleCreateUser = async () => {
+    const email = newUserEmail.trim().toLowerCase()
+    if (!email || !email.includes("@")) {
+      toast({
+        title: "Invalid Email",
+        description: "Please enter a valid email address",
+        variant: "destructive",
+      })
+      return
+    }
+
+    let credits = 0
+    if (newUserCredits.trim()) {
+      credits = parseInt(newUserCredits.trim(), 10)
+      if (!Number.isInteger(credits) || credits < 0 || credits > 1000) {
+        toast({
+          title: "Invalid Credits",
+          description: "Initial credits must be between 0 and 1,000",
+          variant: "destructive",
+        })
+        return
+      }
+    }
+
+    try {
+      setCreatingUser(true)
+      const result = await adminApi.createUser({
+        email,
+        display_name: newUserDisplayName.trim() || undefined,
+        initial_credits: credits,
+      })
+      toast({
+        title: "User Created",
+        description: result.message,
+      })
+      setCreateDialogOpen(false)
+      setNewUserEmail("")
+      setNewUserDisplayName("")
+      setNewUserCredits("")
+      // Surface the new user in the list
+      setSearchInput(email)
+      setSearch(email)
+      setOffset(0)
+    } catch (err: any) {
+      toast({
+        title: "Error",
+        description: err.message || "Failed to create user",
+        variant: "destructive",
+      })
+    } finally {
+      setCreatingUser(false)
+    }
+  }
+
   const handleImpersonate = async (user: AdminUser) => {
     // Don't allow impersonating yourself
     if (user.email === currentUser?.email) {
@@ -229,10 +291,16 @@ export default function AdminUsersPage() {
             Manage user accounts and credits
           </p>
         </div>
-        <Button variant="outline" size="sm" onClick={loadUsers} disabled={loading}>
-          <RefreshCw className={`w-4 h-4 mr-2 ${loading ? "animate-spin" : ""}`} />
-          Refresh
-        </Button>
+        <div className="flex gap-2">
+          <Button size="sm" onClick={() => setCreateDialogOpen(true)}>
+            <UserPlus className="w-4 h-4 mr-2" />
+            Create User
+          </Button>
+          <Button variant="outline" size="sm" onClick={loadUsers} disabled={loading}>
+            <RefreshCw className={`w-4 h-4 mr-2 ${loading ? "animate-spin" : ""}`} />
+            Refresh
+          </Button>
+        </div>
       </div>
 
       {/* Filters */}
@@ -474,6 +542,65 @@ export default function AdminUsersPage() {
             >
               {addingCredits && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
               Add Credits
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Create User Dialog */}
+      <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create User</DialogTitle>
+            <DialogDescription>
+              Create an account for someone who hasn&apos;t logged in yet, so you can
+              grant credits, submit jobs on their behalf, or impersonate them. They
+              can log in later via magic link with the same email.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="new-user-email">Email</Label>
+              <Input
+                id="new-user-email"
+                type="email"
+                placeholder="user@example.com"
+                value={newUserEmail}
+                onChange={(e) => setNewUserEmail(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="new-user-display-name">Display Name (optional)</Label>
+              <Input
+                id="new-user-display-name"
+                placeholder="e.g., Uwe Schreiber"
+                value={newUserDisplayName}
+                onChange={(e) => setNewUserDisplayName(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="new-user-credits">Initial Credits (optional)</Label>
+              <Input
+                id="new-user-credits"
+                type="number"
+                min="0"
+                max="1000"
+                placeholder="0"
+                value={newUserCredits}
+                onChange={(e) => setNewUserCredits(e.target.value)}
+              />
+              <p className="text-sm text-muted-foreground">
+                If set, these replace the automatic welcome credit on first login.
+              </p>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleCreateUser} disabled={!newUserEmail.trim() || creatingUser}>
+              {creatingUser && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+              Create User
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -2521,6 +2521,32 @@ export const adminApi = {
   },
 
   /**
+   * Create a user account directly (e.g. to grant credits or impersonate
+   * someone who has never logged in)
+   */
+  async createUser(data: {
+    email: string;
+    display_name?: string;
+    initial_credits?: number;
+    credit_reason?: string;
+  }): Promise<{
+    status: string;
+    email: string;
+    credits: number;
+    message: string;
+  }> {
+    const response = await apiFetch(`${API_BASE_URL}/api/users/admin/users`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...getAuthHeaders()
+      },
+      body: JSON.stringify(data),
+    });
+    return handleResponse(response);
+  },
+
+  /**
    * Add credits to a user
    */
   async addCredits(email: string, amount: number, reason: string): Promise<{

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.198.3"
+version = "0.199.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Lets admins provision user accounts before the user has ever logged in — so we can grant free credits, submit jobs on their behalf, and impersonate them — and fixes the gap where reassigning a job's `user_email` to an unknown email left the job orphaned (no account, no credits, impersonation 404s).

### Changes

- **`POST /api/users/admin/users`** — create a user account directly: `email` (required), `display_name`, `initial_credits` (0-1000), `credit_reason`. Returns 409 on duplicate. Initial credits set `welcome_credits_granted` so the user doesn't also get the automatic welcome credit on first login.
- **`PATCH /api/admin/jobs/{id}`** — `user_email` is now trimmed + lowercased (account doc IDs are lowercased emails; mixed case would silently orphan the job), blank/invalid values are rejected with 400, and a `gen_users` account is auto-created when none exists. Response message notes the creation.
- **Admin users page** — "Create User" button + dialog; on success the list filters to the new user so Impersonate / Add Credits work immediately.
- **Admin jobs page** — field-save toast surfaces the account-created message; local state mirrors the backend's email normalization.

### Testing

- New `backend/tests/test_admin_create_user.py` (9 tests) + `TestUpdateJobUserEmailAutoCreate` (5 tests) in `test_admin_job_update.py`
- Full backend suite: 3917 passed. Frontend: 1151 Jest tests passed; eslint/tsc clean on touched files
- CodeRabbit local review: 2 cycles, all findings addressed (PII redaction, blank-email 400, masked audit log, normalized local state)

Version bump: 0.198.3 → 0.199.0

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)