### PR TITLE
Tenant flow: harden E2E invariants + retry transient Cloud Run Jobs trigger errors

### DIFF
--- a/backend/services/worker_service.py
+++ b/backend/services/worker_service.py
@@ -15,11 +15,13 @@ Observability:
 - Propagates trace context through Cloud Tasks for distributed tracing
 - All worker invocations create spans linked to original request trace
 """
+import asyncio
 import logging
 import os
 import json
 from typing import Optional
 import httpx
+from google.api_core import exceptions as gcp_exceptions
 from google.protobuf import duration_pb2
 
 from backend.config import get_settings
@@ -27,6 +29,21 @@ from backend.services.tracing import inject_trace_context
 
 
 logger = logging.getLogger(__name__)
+
+
+# Transient control-plane errors from the Cloud Run Jobs Admin API (`JobsClient.run_job`)
+# that are safe to retry. run_job only *enqueues* an execution, so a one-off 5xx/429 from
+# the API control plane should be retried rather than hard-failing a real job's trigger.
+# (2026-08-24: a single 503 from lyrics-transcription-job's trigger failed a real job's
+# transcription with no retry — this is the guard.)
+_TRANSIENT_RUN_JOB_ERRORS = (
+    gcp_exceptions.ServiceUnavailable,    # 503
+    gcp_exceptions.InternalServerError,   # 500
+    gcp_exceptions.GatewayTimeout,        # 504
+    gcp_exceptions.TooManyRequests,       # 429
+)
+_RUN_JOB_MAX_ATTEMPTS = 3
+_RUN_JOB_BASE_DELAY_SECONDS = 1.0
 
 
 # Mapping of worker types to their Cloud Tasks queue names
@@ -411,7 +428,9 @@ class WorkerService:
                     ]
                 ),
             )
-            operation = client.run_job(request=request)
+            operation = await self._run_job_with_retry(
+                client, request, log_prefix=f"[batch:{batch_id}]"
+            )
             logger.info(f"[batch:{batch_id}] Started Cloud Run Job bulk-search-job: {operation.metadata}")
             return True
         except Exception as e:
@@ -538,6 +557,33 @@ class WorkerService:
             worker_module="video_worker",
         )
 
+    async def _run_job_with_retry(self, client, request, log_prefix: str):
+        """Invoke ``JobsClient.run_job`` with a small bounded retry on transient errors.
+
+        ``run_job`` only enqueues an execution, so a one-off 5xx/429 from the Cloud Run
+        Jobs Admin control plane is safe to retry rather than hard-failing the trigger.
+        Non-transient errors (NotFound / PermissionDenied / InvalidArgument) are NOT
+        caught here — they propagate immediately to the caller's error handling.
+        Sleeps with ``asyncio.sleep`` so the event loop isn't blocked between attempts.
+        """
+        last_exc: Optional[Exception] = None
+        for attempt in range(1, _RUN_JOB_MAX_ATTEMPTS + 1):
+            try:
+                return client.run_job(request=request)
+            except _TRANSIENT_RUN_JOB_ERRORS as e:
+                last_exc = e
+                if attempt >= _RUN_JOB_MAX_ATTEMPTS:
+                    break
+                delay = _RUN_JOB_BASE_DELAY_SECONDS * (2 ** (attempt - 1))
+                logger.warning(
+                    f"{log_prefix} transient error triggering Cloud Run Job "
+                    f"({type(e).__name__}, attempt {attempt}/{_RUN_JOB_MAX_ATTEMPTS}); "
+                    f"retrying in {delay:.0f}s"
+                )
+                await asyncio.sleep(delay)
+        # Exhausted transient retries — re-raise so the caller logs + returns False.
+        raise last_exc
+
     async def _trigger_worker_cloud_run_job(
         self,
         job_id: str,
@@ -590,8 +636,10 @@ class WorkerService:
                 )
             )
 
-            # Run the job (async operation)
-            operation = client.run_job(request=request)
+            # Run the job (async operation), retrying transient control-plane errors.
+            operation = await self._run_job_with_retry(
+                client, request, log_prefix=f"[job:{job_id}]"
+            )
             logger.info(
                 f"[job:{job_id}] Started Cloud Run Job {cloud_run_job_name}: "
                 f"{operation.metadata}"

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -244,7 +244,112 @@ class TestWorkerService:
                 call_args = mock_run_v2.RunJobRequest.call_args
                 assert call_args is not None
                 assert "lyrics-transcription-job" in str(call_args)
-    
+
+    def _mock_run_v2(self, run_job_side_effect):
+        """Build a mocked run_v2 module whose JobsClient.run_job uses side_effect."""
+        mock_jobs_client = MagicMock()
+        mock_jobs_client.run_job.side_effect = run_job_side_effect
+        mock_run_v2 = MagicMock()
+        mock_run_v2.JobsClient.return_value = mock_jobs_client
+        mock_run_v2.RunJobRequest = MagicMock()
+        mock_run_v2.RunJobRequest.Overrides = MagicMock()
+        mock_run_v2.RunJobRequest.Overrides.ContainerOverride = MagicMock()
+        return mock_run_v2, mock_jobs_client
+
+    @pytest.mark.asyncio
+    async def test_trigger_worker_retries_transient_503_then_succeeds(self):
+        """A one-off transient 503 from the Jobs Admin API is retried, not fatal."""
+        from google.api_core import exceptions as gcp_exceptions
+        from backend.services.worker_service import (
+            WorkerService, reset_worker_service, _RUN_JOB_MAX_ATTEMPTS,
+        )
+        reset_worker_service()
+
+        with patch('backend.services.worker_service.get_settings') as mock_settings, \
+             patch('backend.services.worker_service.asyncio.sleep', new=AsyncMock()) as mock_sleep:
+            mock_settings.return_value.admin_tokens = "test-token"
+            mock_settings.return_value.google_cloud_project = "test-project"
+            mock_settings.return_value.enable_cloud_tasks = False
+            mock_settings.return_value.gcp_region = "us-central1"
+            mock_settings.return_value.use_cloud_run_jobs_for_video = False
+
+            mock_operation = MagicMock()
+            mock_operation.metadata = "test-metadata"
+            # Fail once with a transient 503, then succeed on retry.
+            mock_run_v2, mock_jobs_client = self._mock_run_v2(
+                [gcp_exceptions.ServiceUnavailable("503 unavailable"), mock_operation]
+            )
+
+            import google.cloud
+            with patch.dict('sys.modules', {'google.cloud.run_v2': mock_run_v2}), \
+                 patch.object(google.cloud, 'run_v2', mock_run_v2, create=True):
+                service = WorkerService()
+                result = await service.trigger_lyrics_worker("test123")
+
+            assert result is True
+            assert mock_jobs_client.run_job.call_count == 2  # first fails, retry succeeds
+            assert mock_sleep.await_count == 1  # backed off once between attempts
+            assert _RUN_JOB_MAX_ATTEMPTS >= 2
+
+    @pytest.mark.asyncio
+    async def test_trigger_worker_gives_up_after_max_attempts(self):
+        """Persistent transient errors exhaust retries and return False (not a raise)."""
+        from google.api_core import exceptions as gcp_exceptions
+        from backend.services.worker_service import (
+            WorkerService, reset_worker_service, _RUN_JOB_MAX_ATTEMPTS,
+        )
+        reset_worker_service()
+
+        with patch('backend.services.worker_service.get_settings') as mock_settings, \
+             patch('backend.services.worker_service.asyncio.sleep', new=AsyncMock()):
+            mock_settings.return_value.admin_tokens = "test-token"
+            mock_settings.return_value.google_cloud_project = "test-project"
+            mock_settings.return_value.enable_cloud_tasks = False
+            mock_settings.return_value.gcp_region = "us-central1"
+            mock_settings.return_value.use_cloud_run_jobs_for_video = False
+
+            mock_run_v2, mock_jobs_client = self._mock_run_v2(
+                gcp_exceptions.ServiceUnavailable("503 unavailable")
+            )
+
+            import google.cloud
+            with patch.dict('sys.modules', {'google.cloud.run_v2': mock_run_v2}), \
+                 patch.object(google.cloud, 'run_v2', mock_run_v2, create=True):
+                service = WorkerService()
+                result = await service.trigger_lyrics_worker("test123")
+
+            assert result is False
+            assert mock_jobs_client.run_job.call_count == _RUN_JOB_MAX_ATTEMPTS
+
+    @pytest.mark.asyncio
+    async def test_trigger_worker_does_not_retry_permanent_error(self):
+        """Non-transient errors (e.g. PermissionDenied) fail fast without retry."""
+        from google.api_core import exceptions as gcp_exceptions
+        from backend.services.worker_service import WorkerService, reset_worker_service
+        reset_worker_service()
+
+        with patch('backend.services.worker_service.get_settings') as mock_settings, \
+             patch('backend.services.worker_service.asyncio.sleep', new=AsyncMock()) as mock_sleep:
+            mock_settings.return_value.admin_tokens = "test-token"
+            mock_settings.return_value.google_cloud_project = "test-project"
+            mock_settings.return_value.enable_cloud_tasks = False
+            mock_settings.return_value.gcp_region = "us-central1"
+            mock_settings.return_value.use_cloud_run_jobs_for_video = False
+
+            mock_run_v2, mock_jobs_client = self._mock_run_v2(
+                gcp_exceptions.PermissionDenied("permission denied")
+            )
+
+            import google.cloud
+            with patch.dict('sys.modules', {'google.cloud.run_v2': mock_run_v2}), \
+                 patch.object(google.cloud, 'run_v2', mock_run_v2, create=True):
+                service = WorkerService()
+                result = await service.trigger_lyrics_worker("test123")
+
+            assert result is False
+            assert mock_jobs_client.run_job.call_count == 1  # no retry on permanent error
+            assert mock_sleep.await_count == 0
+
     @pytest.mark.asyncio
     async def test_trigger_screens_worker(self):
         """Test triggering screens worker via internal HTTP."""

--- a/frontend/e2e/production/tenant-happy-path.spec.ts
+++ b/frontend/e2e/production/tenant-happy-path.spec.ts
@@ -217,24 +217,22 @@ test.describe(`Tenant Portal Happy Path — ${TENANT_ID}`, () => {
       return r.json();
     };
 
-    // For a pre-supplied (tenant) instrumental there is nothing to pick, so
-    // "Proceed to Instrumental Review" completes the review directly and the
-    // instrumental route redirects to /app. For a selectable instrumental an
-    // InstrumentalSelector (#submit-btn) renders instead. Handle both.
+    // Core tenant invariant: the operator ALWAYS uploads their own instrumental, so
+    // there is no audio separation and therefore NO instrumental-selection step —
+    // "Proceed to Instrumental Review" must complete the review directly (redirect to
+    // /app). If the InstrumentalSelector (#submit-btn) ever renders, the tenant flow
+    // has regressed (separation ran / the operator is being asked to pick a stem),
+    // which is exactly the real-world scenario this test exists to protect.
     const submitBtn = page.locator('#submit-btn');
-    let hasInstrumentalStep = false;
-    try {
-      // waitFor actually blocks up to the timeout (isVisible would not); if the
-      // selector never appears the review already completed on "Proceed".
-      await submitBtn.waitFor({ state: 'visible', timeout: 15_000 });
-      hasInstrumentalStep = true;
-    } catch { /* pre-supplied tenant instrumental: review completed directly */ }
-    if (hasInstrumentalStep) {
-      const opt = page.locator('.selection-option').first();
-      if (await opt.isVisible().catch(() => false)) await opt.click();
-      await submitBtn.click();
-      console.log(`[${TENANT_ID}] Instrumental confirmed`);
-    }
+    const instrumentalStepAppeared = await submitBtn
+      .waitFor({ state: 'visible', timeout: 15_000 })
+      .then(() => true)
+      .catch(() => false);
+    expect(
+      instrumentalStepAppeared,
+      'tenant with a pre-supplied instrumental must NOT be shown an instrumental-selection step (no audio separation)',
+    ).toBe(false);
+    console.log(`[${TENANT_ID}] No instrumental-selection step (as expected for pre-supplied instrumental)`);
 
     // Confirm the review actually advanced (left awaiting_review) before waiting
     // on the render — otherwise a silent no-op would masquerade as a render hang.
@@ -275,6 +273,14 @@ test.describe(`Tenant Portal Happy Path — ${TENANT_ID}`, () => {
     for (const f of ['lossy_4k_mp4', 'lossy_720p_mp4', 'with_vocals_mp4']) expect(finals).toContain(f);
     for (const p of ['cdg_zip', 'txt_zip']) expect(packages).toContain(p);
     expect(job.is_private, 'tenant job is private').toBeTruthy();
-    console.log(`[${TENANT_ID}] PASSED — complete, Dropbox present, no YouTube, downloads available`);
+
+    // Real-world tenant-scenario invariants (beyond "it completed"): these guard the
+    // exact flow tenant operators rely on — they upload their own audio + instrumental,
+    // so audio search / separation / instrumental review must all be bypassed.
+    // 1. The operator's uploaded instrumental is what's used, not a separated stem.
+    expect(sd.instrumental_selection, 'uploaded instrumental used (custom), not a separated stem').toBe('custom');
+    // 2. Lyrics were transcribed + corrected — the job did real work, not a short-circuit.
+    expect(sd.lyrics_complete, 'lyrics transcription completed').toBeTruthy();
+    console.log(`[${TENANT_ID}] PASSED — complete, private, Dropbox present, no YouTube, uploaded instrumental used, downloads available`);
   });
 });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.199.1"
+version = "0.199.2"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Why

FROG: validate the white-label tenant portals (Vocal Star) work seamlessly end-to-end, and make the flow robust. Two related changes, both about the exact flow tenant operators rely on.

## 1. Harden the tenant E2E to actually test the real scenario

The tenant happy-path E2E verified a job *completed and distributed privately*, but **tolerated a regression in the tenant-specific flow**: it "handled both" an instrumental-selection step appearing or not, so a regression that forced audio separation / an instrumental-review step on a tenant (who always uploads their own instrumental) would still have passed — the same "looks done but is broken" class as the June latent bugs.

Tightened `tenant-happy-path.spec.ts` to lock the real-world invariants:
- Assert the InstrumentalSelector **never** renders (no separation → no stem to pick).
- Assert `state_data.instrumental_selection === 'custom'` (the uploaded instrumental is used, not a separated stem).
- Assert `state_data.lyrics_complete` (transcription actually ran; not a short-circuit).

Verified against a real completed vocalstar prod job (`ef72f5f8`): all new assertions hold.

## 2. Retry transient Cloud Run Jobs Admin API errors when triggering workers

During validation, a real singa job hit `Failed to trigger Cloud Run Job lyrics-transcription-job: 503 The service is currently unavailable`. Root cause: `JobsClient.run_job()` had **no retry** — a one-off transient 5xx/429 from the Jobs Admin control plane hard-failed the trigger (the except just logged + returned False). `run_job` only *enqueues* an execution, so this is safe to retry. The daily E2E masked it with a workflow-level retry; a real customer job would have just failed at transcription.

Added `_run_job_with_retry` (bounded async retry, 3 attempts, `asyncio.sleep` backoff) shared by **both** `run_job` call sites (`_trigger_worker_cloud_run_job` — audio-download / separation / lyrics / video — and `trigger_bulk_search_worker`). Retries transient errors only (503/500/504/429); permanent errors (NotFound/PermissionDenied/InvalidArgument) fail fast; re-raises after exhausting so the existing handler logs + returns False.

## Testing

- New unit tests: transient-then-success retries once; persistent transient exhausts to False after N attempts; permanent error fails fast without retry. `backend/tests/test_services.py -k trigger` → 13/13 pass.
- E2E assertions verified against a real completed prod job.
- CodeRabbit local review: 0 findings.
- Version bumped 0.199.1 → 0.199.2.

@coderabbitai ignore