### PR TITLE
fix(ci): pin google-cloud-firestore in backend deploy (2.29.0 breaks deploys)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1218,7 +1218,11 @@ jobs:
           echo "GCS deployment complete"
 
       - name: Install Firestore client
-        run: pip install google-cloud-firestore
+        # Pinned to the app's version. google-cloud-firestore 2.29.0 (2026-08-24)
+        # percent-encodes the default database id, so the config read below fails
+        # with "400 Invalid database id %28default%29" — an unpinned install broke
+        # every backend deploy after 2.29.0 shipped. Keep in sync with pyproject.
+        run: pip install 'google-cloud-firestore==2.26.0'
 
       - name: Read Firestore config
         id: config


### PR DESCRIPTION
## Problem — backend deploys are broken

The **Deploy - Backend (Cloud Run)** job's *Read Firestore config* step crashes:

```
google.api_core.exceptions.InvalidArgument: 400 Invalid database id %28default%29
```

`%28default%29` is URL-encoded `(default)`. **`google-cloud-firestore` 2.29.0** (published 2026-08-24T21:55Z) percent-encodes the default database id in the resource path. The deploy step ran an **unpinned** `pip install google-cloud-firestore`, so it started pulling 2.29.0 and failing.

**Impact:** every backend deploy since 2.29.0 shipped has failed (post-merge runs for `c36bcb08` and `7a3c1d66`). #939 (worker-trigger retry) and #940 (job-list summary field) merged but **never reached Cloud Run** — the active revision is still `00913` from #937.

## Fix

Pin the deploy step to `google-cloud-firestore==2.26.0` — the version `pyproject.toml` and prod already run (the running backend reads Firestore fine on 2.26.0). One line + a comment explaining why.

## Testing

- PR CI runs unit tests (deploy jobs are push-to-main only); the pin doesn't affect them.
- On merge, the backend deploy will run with 2.26.0 and should succeed, deploying main (0.199.3 = retry fix + summary field).
- Verified 2.29.0 is the regression via PyPI upload timestamps vs the last good deploy (21:06, used 2.28.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the backend deployment to use a fixed Firestore library version, improving deployment consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->