### PR TITLE
feat: deterministic P4/P1/P5 lyrics auto-fixers in the auto-correct pipeline (v0.203.0)

### DIFF
--- a/backend/services/auto_correct/deterministic.py
+++ b/backend/services/auto_correct/deterministic.py
@@ -1,0 +1,369 @@
+"""Deterministic auto-correct suggestion generators (no LLM).
+
+Mechanical residual-edit classes from the 2026-08 20-job replay-review corpus,
+emitted as ordinary suggestions so they flow through the exact same paths as
+the LLM ones: shown in the review UI, auto-applied on load, applied server-side
+by the auto-approval executor, counted by the scorer's gap-coverage signal, and
+cached alongside the LLM output.
+
+Pattern 4 — leading-connective over-insertion: AudioShake is too eager to
+insert a short connective ("And", "Oh", …) at a segment start. When that word
+is a gap word (no confident reference match) and no reference source's reading
+of the gap supports it, emit a delete (+ re-capitalize the next word).
+
+Pattern 5 — reference-majority resolution: when a gap's transcription contains
+an implausible proper noun (capitalized mid-line token absent from every
+reference source) and >=2/3 of the reference sources agree on the same reading
+for that gap, replace the gap with the majority reading. The red-flag token is
+REQUIRED, not just preferred: the corpus shows plain 2/3-majority gaps that the
+human deliberately left alone (Miguel 6d0640fa "though"->"dog" and an
+explicit-lyrics rewrite), while the one edit he did make ("yo Mick," ->
+"Come here,") had the proper-noun signature.
+
+Everything here is pure and conservative: no evidence -> no suggestion.
+"""
+from __future__ import annotations
+
+import difflib
+import logging
+import re
+import uuid
+from typing import Any, Dict, List, Optional, Tuple
+
+from backend.services.auto_approval.scorer import _is_vocalization_token
+
+logger = logging.getLogger(__name__)
+
+# Short connectives/interjections AudioShake over-inserts at segment starts —
+# exactly the set documented in the corpus (Pattern 4: And / But / So / Oh / A).
+# Deliberately NOT the near-misses like "ah"/"yeah": those double as
+# vocalization tokens, where deleting the leading word is a musical judgement.
+# The reference check below does the real gating; this list only scopes
+# which leading words are candidates.
+LEADING_CONNECTIVES = frozenset({"and", "but", "so", "oh", "a"})
+
+# P4/P5 confidences: high enough to auto-apply, below full LLM consensus so a
+# conflicting multi-model AI suggestion wins its conflict group.
+P4_CONFIDENCE = 0.9
+P5_CONFIDENCE = 0.85
+
+# P5 size guards: never rewrite long spans deterministically.
+P5_MAX_GAP_WORDS = 6
+P5_MAX_READING_WORDS = 8
+# A red-flag token this similar to some reference token is a spelling/
+# transliteration variant ("Crick"~"Cricket", "Projectorinsky"~
+# "Projektorinski"), not an implausible name. The right fix there is the
+# LLM's (it handles proper-noun spelling well); the gap alignment is also
+# often skewed in exactly these cases, so the majority "reading" is junk
+# (corpus 507513ba aligned gap "Crick" to reference "and").
+P5_SPELLING_VARIANT_RATIO = 0.75
+
+_TOKEN_NORM_RE = re.compile(r"^[^\w]+|[^\w]+$")
+
+
+def _norm(text: str) -> str:
+    return _TOKEN_NORM_RE.sub("", (text or "").lower())
+
+
+def _norm_join(texts: List[str]) -> str:
+    return " ".join(t for t in (_norm(x) for x in texts) if t)
+
+
+def _ref_word_streams(
+    reference_lyrics: Dict[str, Any],
+) -> Dict[str, Tuple[List[str], Dict[str, int]]]:
+    """Per source: (ordered word texts, word_id -> position)."""
+    streams: Dict[str, Tuple[List[str], Dict[str, int]]] = {}
+    for source, ref in (reference_lyrics or {}).items():
+        texts: List[str] = []
+        index: Dict[str, int] = {}
+        for seg in ref.get("segments") or []:
+            for w in seg.get("words") or []:
+                wid = w.get("id")
+                if wid:
+                    index[wid] = len(texts)
+                texts.append(w.get("text") or "")
+        streams[source] = (texts, index)
+    return streams
+
+
+def _gap_readings(
+    gap: Dict[str, Any],
+    anchors_by_id: Dict[str, Dict[str, Any]],
+    streams: Dict[str, Tuple[List[str], Dict[str, int]]],
+) -> Dict[str, List[str]]:
+    """Each source's reading of the gap (raw word texts).
+
+    Prefer the gap's own per-source alignment. When a source aligned neither
+    gap word (empty list — common), derive the reading from the reference
+    stream around the surrounding anchors: the words strictly between the
+    anchors when both aligned for that source, else the same-count window
+    after the preceding (or before the following) anchor. A source with no
+    usable anchor alignment contributes no reading.
+    """
+    n = len(gap.get("transcribed_word_ids") or [])
+    pre = anchors_by_id.get(gap.get("preceding_anchor_id") or "")
+    fol = anchors_by_id.get(gap.get("following_anchor_id") or "")
+    readings: Dict[str, List[str]] = {}
+    for source, (texts, index) in streams.items():
+        aligned_ids = (gap.get("reference_word_ids") or {}).get(source) or []
+        aligned = [texts[index[i]] for i in aligned_ids if i in index]
+        if aligned:
+            readings[source] = aligned
+            continue
+        pre_ids = ((pre or {}).get("reference_word_ids") or {}).get(source) or []
+        fol_ids = ((fol or {}).get("reference_word_ids") or {}).get(source) or []
+        lo = index[pre_ids[-1]] + 1 if pre_ids and pre_ids[-1] in index else None
+        hi = index[fol_ids[0]] if fol_ids and fol_ids[0] in index else None
+        if lo is not None and hi is not None:
+            if lo <= hi <= lo + n + 4:
+                readings[source] = texts[lo:hi]
+        elif lo is not None:
+            readings[source] = texts[lo : lo + n]
+        elif hi is not None:
+            readings[source] = texts[max(0, hi - n) : hi]
+    return readings
+
+
+def _word_maps(
+    segments: List[Dict[str, Any]],
+) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, str]]:
+    """(word_id -> word dict, word_id -> segment_id) from the CURRENT segments."""
+    words: Dict[str, Dict[str, Any]] = {}
+    seg_of: Dict[str, str] = {}
+    for seg in segments or []:
+        for w in seg.get("words") or []:
+            wid = w.get("id")
+            if wid:
+                words[wid] = w
+                seg_of[wid] = seg.get("id") or ""
+    return words, seg_of
+
+
+def _make_suggestion(
+    *,
+    op: str,
+    word_ids: List[str],
+    segment_ids: List[str],
+    original_text: str,
+    new_text: str,
+    reason: str,
+    category: str,
+    confidence: float,
+) -> Dict[str, Any]:
+    """A suggestion dict shaped exactly like the LLM ones after validation."""
+    return {
+        "id": str(uuid.uuid4()),
+        "op": op,
+        "word_ids": word_ids,
+        "segment_ids": segment_ids,
+        "original_text": original_text,
+        "new_text": new_text,
+        "reason": reason,
+        "category": category,
+        "confidence": confidence,
+        "models": ["deterministic"],
+        "consensus": 1,
+        "total_models": 1,
+        "conflict_group": None,
+    }
+
+
+def _capitalize(text: str) -> str:
+    for i, ch in enumerate(text):
+        if ch.isalpha():
+            return text[:i] + ch.upper() + text[i + 1 :]
+    return text
+
+
+def leading_connective_suggestions(
+    segments: List[Dict[str, Any]],
+    correction_data: Dict[str, Any],
+    streams: Dict[str, Tuple[List[str], Dict[str, int]]],
+) -> List[Dict[str, Any]]:
+    """Pattern 4: delete an unsupported leading connective, re-capitalize next word."""
+    gaps = correction_data.get("gap_sequences") or []
+    anchors_by_id = {
+        a.get("id"): a for a in correction_data.get("anchor_sequences") or [] if a.get("id")
+    }
+    gap_of_word: Dict[str, Dict[str, Any]] = {}
+    for gap in gaps:
+        for wid in gap.get("transcribed_word_ids") or []:
+            gap_of_word[wid] = gap
+
+    out: List[Dict[str, Any]] = []
+    for seg in segments or []:
+        words = seg.get("words") or []
+        if len(words) < 3:
+            continue
+        first = words[0]
+        wid = first.get("id")
+        token = _norm(first.get("text") or "")
+        if not wid or token not in LEADING_CONNECTIVES:
+            continue
+        gap = gap_of_word.get(wid)
+        if gap is None:
+            # A confidently reference-anchored leading word is legitimate.
+            continue
+        if _is_vocalization_token(words[1].get("text") or ""):
+            # "Oh- whoa, ..." — a vocalization run, not an over-inserted
+            # connective before a sentence; grouping there is musical judgement.
+            continue
+        readings = _gap_readings(gap, anchors_by_id, streams)
+        if not readings:
+            continue  # no reference evidence either way -> leave it alone
+        if any(token in {_norm(t) for t in reading} for reading in readings.values()):
+            continue  # some source supports the connective at this position
+        seg_id = seg.get("id") or ""
+        out.append(
+            _make_suggestion(
+                op="delete",
+                word_ids=[wid],
+                segment_ids=[seg_id],
+                original_text=first.get("text") or "",
+                new_text="",
+                reason=(
+                    f'Removed leading "{first.get("text", "").strip()}" — the '
+                    "transcription inserted it at the line start but no reference "
+                    "source has it at this position"
+                ),
+                category="mishearing",
+                confidence=P4_CONFIDENCE,
+            )
+        )
+        nxt = words[1]
+        nxt_text = nxt.get("text") or ""
+        capitalized = _capitalize(nxt_text)
+        if nxt.get("id") and capitalized != nxt_text:
+            out.append(
+                _make_suggestion(
+                    op="replace",
+                    word_ids=[nxt.get("id")],
+                    segment_ids=[seg_id],
+                    original_text=nxt_text,
+                    new_text=capitalized,
+                    reason="Capitalized the new first word of the line",
+                    category="formatting",
+                    confidence=P4_CONFIDENCE,
+                )
+            )
+    return out
+
+
+def _majority_reading(
+    readings: Dict[str, List[str]], total_sources: int
+) -> Optional[List[str]]:
+    """The reading >=2/3 of ALL sources agree on (>=2 absolute), else None."""
+    votes: Dict[str, List[List[str]]] = {}
+    for reading in readings.values():
+        if reading:
+            votes.setdefault(_norm_join(reading), []).append(reading)
+    if not votes:
+        return None
+    key, group = max(votes.items(), key=lambda kv: len(kv[1]))
+    if not key or len(group) < 2 or len(group) * 3 < total_sources * 2:
+        return None
+    return group[0]
+
+
+def reference_majority_suggestions(
+    segments: List[Dict[str, Any]],
+    correction_data: Dict[str, Any],
+    streams: Dict[str, Tuple[List[str], Dict[str, int]]],
+) -> List[Dict[str, Any]]:
+    """Pattern 5: replace an implausible-proper-noun gap with the >=2/3 majority reading."""
+    words_by_id, seg_of = _word_maps(segments)
+    anchors_by_id = {
+        a.get("id"): a for a in correction_data.get("anchor_sequences") or [] if a.get("id")
+    }
+    all_ref_tokens = {
+        _norm(t) for texts, _ in streams.values() for t in texts if _norm(t)
+    }
+    seg_first_word_ids = {
+        (seg.get("words") or [{}])[0].get("id") for seg in segments or []
+    }
+    total_sources = len(streams)
+
+    out: List[Dict[str, Any]] = []
+    for gap in correction_data.get("gap_sequences") or []:
+        gap_ids = gap.get("transcribed_word_ids") or []
+        if not gap_ids or len(gap_ids) > P5_MAX_GAP_WORDS:
+            continue
+        gap_words = [words_by_id.get(i) for i in gap_ids]
+        if any(w is None for w in gap_words):
+            continue  # a gap word no longer exists in the working segments
+        # Red flag (REQUIRED): a capitalized mid-line token no reference knows.
+        # A token merely SIMILAR to a reference token is a spelling variant,
+        # not an implausible name — that's the LLM's fix, not ours.
+        red_flag = None
+        for wid, w in zip(gap_ids, gap_words):
+            text = (w.get("text") or "").strip()
+            norm = _norm(text)
+            if not (
+                text
+                and text[0].isupper()
+                and wid not in seg_first_word_ids
+                and norm
+                and norm not in all_ref_tokens
+            ):
+                continue
+            if any(
+                difflib.SequenceMatcher(None, norm, ref).ratio()
+                >= P5_SPELLING_VARIANT_RATIO
+                for ref in all_ref_tokens
+            ):
+                continue
+            red_flag = text
+            break
+        if red_flag is None:
+            continue
+        readings = _gap_readings(gap, anchors_by_id, streams)
+        majority = _majority_reading(readings, total_sources)
+        if majority is None or len(majority) > P5_MAX_READING_WORDS:
+            continue
+        original = [w.get("text") or "" for w in gap_words]
+        if _norm_join(majority) == _norm_join(original):
+            continue
+        segment_ids = sorted({seg_of.get(i, "") for i in gap_ids})
+        out.append(
+            _make_suggestion(
+                op="replace",
+                word_ids=list(gap_ids),
+                segment_ids=segment_ids,
+                original_text=" ".join(original),
+                new_text=" ".join(majority).strip(),
+                reason=(
+                    f'Transcription "{" ".join(original)}" contains "{red_flag}", '
+                    "which no reference source has; the majority of reference "
+                    f'sources read this as "{" ".join(majority).strip()}"'
+                ),
+                category="mishearing",
+                confidence=P5_CONFIDENCE,
+            )
+        )
+    return out
+
+
+def deterministic_suggestions(
+    segments: List[Dict[str, Any]],
+    reference_lyrics: Dict[str, Any],
+    correction_data: Optional[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """All deterministic suggestions for the current working segments.
+
+    Needs the job's ``corrections.json`` dict for gap/anchor alignment; with
+    none available (or on any internal error) it returns [] — deterministic
+    fixes are an enhancement, never a failure mode.
+    """
+    if not correction_data or not reference_lyrics:
+        return []
+    try:
+        streams = _ref_word_streams(reference_lyrics)
+        if not streams:
+            return []
+        return leading_connective_suggestions(
+            segments, correction_data, streams
+        ) + reference_majority_suggestions(segments, correction_data, streams)
+    except Exception:
+        logger.warning("deterministic suggestion generation failed", exc_info=True)
+        return []

--- a/backend/services/auto_correct/service.py
+++ b/backend/services/auto_correct/service.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import time
 import uuid
 from dataclasses import asdict, dataclass, field
@@ -14,6 +15,7 @@ from google import genai
 from google.genai import types
 
 from backend.config import get_settings
+from backend.services.auto_correct.deterministic import deterministic_suggestions
 from backend.services.auto_correct.pricing import TokenUsage, estimate_cost_usd
 from backend.services.auto_correct.prompts import (
     RESPONSE_SCHEMA,
@@ -127,6 +129,84 @@ class AutoCorrectResult:
     cached: bool = False
 
 
+_NORM_TOKEN_RE = re.compile(r"^[^\w]+|[^\w]+$")
+
+
+def _norm_tokens(text: str) -> set:
+    return {t for t in (_NORM_TOKEN_RE.sub("", w.lower()) for w in (text or "").split()) if t}
+
+
+def _assign_conflict_groups(result: list[Suggestion]) -> None:
+    """(Re)compute conflict groups over a suggestion list, in place.
+
+    Two rules union suggestions into a pick-at-most-one group:
+    - Non-insert suggestions sharing any target word disagree about that span.
+    - An ``insert_after`` whose inserted token(s) also appear in another
+      suggestion's new_text targeting (or anchored on) the same word is the P1
+      self-conflict signature — two overlapping suggestions both adding the
+      same token (corpus f6439692: ``insert_after "fire" -> "you're"`` plus
+      ``replace "fire" -> "fire, you're"`` produced "you're you're"). Grouping
+      them lets accept-all pick one winner instead of double-applying.
+      A plain insert next to an edit with disjoint tokens stays independent.
+    """
+    for s in result:
+        s.conflict_group = None
+
+    parent = list(range(len(result)))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: int, b: int) -> None:
+        parent[find(b)] = find(a)
+
+    by_word: dict[str, list[int]] = {}
+    for i, s in enumerate(result):
+        if s.op == "insert_after":
+            continue
+        for wid in s.word_ids:
+            by_word.setdefault(wid, []).append(i)
+    for overlapping in by_word.values():
+        for other in overlapping[1:]:
+            union(overlapping[0], other)
+
+    for i, s in enumerate(result):
+        if s.op != "insert_after" or not s.word_ids:
+            continue
+        anchor = s.word_ids[0]
+        tokens = _norm_tokens(s.new_text)
+        if not tokens:
+            continue
+        for j, r in enumerate(result):
+            if j == i:
+                continue
+            anchored = (
+                anchor in r.word_ids
+                if r.op != "insert_after"
+                else bool(r.word_ids) and r.word_ids[0] == anchor
+            )
+            if anchored and tokens & _norm_tokens(r.new_text):
+                union(i, j)
+
+    roots: dict[int, list[int]] = {}
+    for i in range(len(result)):
+        roots.setdefault(find(i), []).append(i)
+    for members in roots.values():
+        if len(members) < 2:
+            continue
+        group = str(uuid.uuid4())
+        for i in members:
+            result[i].conflict_group = group
+
+
+def _sort_by_position(result: list[Suggestion], flat: list[tuple[str, str, str]]) -> None:
+    position = {word_id: i for i, (word_id, _, _) in enumerate(flat)}
+    result.sort(key=lambda s: position.get(s.word_ids[0], 0) if s.word_ids else 0)
+
+
 class AutoCorrectService:
     def __init__(self) -> None:
         self.settings = get_settings()
@@ -140,6 +220,7 @@ class AutoCorrectService:
         artist: Optional[str],
         title: Optional[str],
         settings: AutoCorrectSettings,
+        correction_data: Optional[dict] = None,
     ) -> AutoCorrectResult:
         if not segments:
             raise AutoCorrectServiceError("segments is empty")
@@ -227,6 +308,9 @@ class AutoCorrectService:
                 )
 
         merged = self._merge(per_model, flat)
+        merged = self._add_deterministic(
+            merged, job_id, segments, reference_lyrics, correction_data, settings, flat
+        )
         elapsed = time.time() - t0
         model_label = ", ".join(per_model.keys())
         logger.info(
@@ -307,8 +391,10 @@ class AutoCorrectService:
         artist: Optional[str],
         title: Optional[str],
     ) -> str:
+        # v2: deterministic suggestions (P4/P1/P5 fixers) joined the pipeline —
+        # older cached results predate them, so they must not be served.
         payload = {
-            "v": 1,
+            "v": 2,
             "models": models,
             "settings": settings.to_dict(),
             "words": [[word_id, text] for word_id, text, _seg in flat],
@@ -402,41 +488,71 @@ class AutoCorrectService:
                     existing.confidence = max(existing.confidence, s.confidence)
 
         result = list(merged.values())
-
-        # Conflict groups: suggestions sharing any target word but not merged
-        # above disagree about the same span — reviewer picks at most one.
-        # (insert_after anchors are excluded: inserting after a word does not
-        # conflict with editing that word.)
-        by_word: dict[str, list[int]] = {}
-        for i, s in enumerate(result):
-            if s.op == "insert_after":
-                continue
-            for wid in s.word_ids:
-                by_word.setdefault(wid, []).append(i)
-        parent = list(range(len(result)))
-
-        def find(x: int) -> int:
-            while parent[x] != x:
-                parent[x] = parent[parent[x]]
-                x = parent[x]
-            return x
-
-        for overlapping in by_word.values():
-            for other in overlapping[1:]:
-                parent[find(other)] = find(overlapping[0])
-        roots: dict[int, list[int]] = {}
-        for i in range(len(result)):
-            roots.setdefault(find(i), []).append(i)
-        for members in roots.values():
-            if len(members) < 2:
-                continue
-            group = str(uuid.uuid4())
-            for i in members:
-                result[i].conflict_group = group
-
-        position = {word_id: i for i, (word_id, _, _) in enumerate(flat)}
-        result.sort(key=lambda s: position.get(s.word_ids[0], 0) if s.word_ids else 0)
+        _assign_conflict_groups(result)
+        _sort_by_position(result, flat)
         return result
+
+    def _add_deterministic(
+        self,
+        merged: list[Suggestion],
+        job_id: str,
+        segments: list[dict],
+        reference_lyrics: dict[str, dict],
+        correction_data: Optional[dict],
+        settings: AutoCorrectSettings,
+        flat: list[tuple[str, str, str]],
+    ) -> list[Suggestion]:
+        """Fold the deterministic (P4/P5) suggestions into the LLM set.
+
+        A deterministic suggestion identical to an LLM one just tags the
+        existing suggestion; new ones are appended. Conflict groups are then
+        recomputed over the combined set so a deterministic fix that disagrees
+        with an LLM suggestion becomes a pick-one conflict, not a double-apply.
+        """
+        if correction_data is None:
+            # The proactive worker passes corrections.json in; the review-UI
+            # route doesn't have it, so fetch it (best-effort) — it holds the
+            # gap/anchor alignment the generators key off.
+            try:
+                path = f"jobs/{job_id}/lyrics/corrections.json"
+                storage = self._get_storage()
+                if storage.bucket.blob(path).exists():
+                    correction_data = storage.download_json(path)
+            except Exception:
+                logger.warning(
+                    "auto-correct: corrections.json unavailable for %s; "
+                    "skipping deterministic suggestions", job_id, exc_info=True,
+                )
+        raw = deterministic_suggestions(segments, reference_lyrics, correction_data)
+        deterministic = [
+            Suggestion(**s)
+            for s in raw
+            if float(s.get("confidence", 0.0)) >= settings.min_confidence
+        ]
+        if not deterministic:
+            return merged
+
+        by_key = {
+            (s.op, tuple(s.word_ids), " ".join(s.new_text.lower().split())): s
+            for s in merged
+        }
+        added = 0
+        for s in deterministic:
+            key = (s.op, tuple(s.word_ids), " ".join(s.new_text.lower().split()))
+            existing = by_key.get(key)
+            if existing is not None:
+                existing.models.append("deterministic")
+                existing.confidence = max(existing.confidence, s.confidence)
+                continue
+            merged.append(s)
+            added += 1
+        logger.info(
+            "auto-correct deterministic job=%s generated=%d added=%d",
+            job_id, len(deterministic), added,
+        )
+        _assign_conflict_groups(merged)
+        _sort_by_position(merged, flat)
+        return merged
 
     # ---- internals ----
 

--- a/backend/services/auto_correct/service.py
+++ b/backend/services/auto_correct/service.py
@@ -541,7 +541,13 @@ class AutoCorrectService:
             key = (s.op, tuple(s.word_ids), " ".join(s.new_text.lower().split()))
             existing = by_key.get(key)
             if existing is not None:
+                # The deterministic generator counts as an agreeing source:
+                # keeps the consensus == len(models) invariant, and lets an
+                # LLM+deterministic agreement outrank a conflicting
+                # single-model suggestion in winner selection.
                 existing.models.append("deterministic")
+                existing.consensus += 1
+                existing.total_models += 1
                 existing.confidence = max(existing.confidence, s.confidence)
                 continue
             merged.append(s)

--- a/backend/tests/services/auto_correct/test_deterministic.py
+++ b/backend/tests/services/auto_correct/test_deterministic.py
@@ -392,6 +392,10 @@ def test_suggest_dedupes_identical_llm_and_deterministic() -> None:
     assert len(deletes) == 1
     assert "deterministic" in deletes[0].models
     assert deletes[0].confidence == 0.9  # bumped to the deterministic confidence
+    # The deterministic generator counts as an agreeing source.
+    assert deletes[0].consensus == 2
+    assert deletes[0].total_models == 2
+    assert deletes[0].consensus == len(deletes[0].models)
 
 
 def test_suggest_groups_conflicting_llm_and_deterministic() -> None:

--- a/backend/tests/services/auto_correct/test_deterministic.py
+++ b/backend/tests/services/auto_correct/test_deterministic.py
@@ -1,0 +1,477 @@
+"""Tests for the deterministic (no-LLM) suggestion generators + P1 conflict grouping.
+
+Scenarios mirror the 2026-08 replay-review corpus jobs that motivated each
+pattern: P4 leading-connective over-insertion (8f2305ee "And they" -> "They"),
+P5 reference-majority resolution (6d0640fa "yo Mick," -> "Come here,"), and the
+P1 AI self-conflict (f6439692 insert+replace both adding "you're").
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from backend.services.auto_correct.deterministic import (
+    deterministic_suggestions,
+    leading_connective_suggestions,
+    reference_majority_suggestions,
+    _ref_word_streams,
+)
+from backend.services.auto_correct.service import (
+    AutoCorrectService,
+    Suggestion,
+    _assign_conflict_groups,
+)
+from backend.services.auto_correct.settings import AutoCorrectSettings
+
+
+def _ref_source(word_texts, prefix):
+    """A reference source with ids <prefix>0, <prefix>1, ..."""
+    return {
+        "segments": [
+            {
+                "text": " ".join(word_texts),
+                "words": [
+                    {"id": f"{prefix}{i}", "text": t} for i, t in enumerate(word_texts)
+                ],
+            }
+        ]
+    }
+
+
+def _seg(seg_id, words):
+    return {
+        "id": seg_id,
+        "text": " ".join(t for _, t in words),
+        "words": [{"id": wid, "text": t} for wid, t in words],
+    }
+
+
+# ---- Pattern 4: leading connective ----
+
+
+def _p4_fixture(ref_line="They count everything", gap_ref_ids=None):
+    """Segment "And they count ..." where "And" is a gap word.
+
+    The single reference reads "They count everything" — no "And" — with the
+    gap aligned to reference word r0 ("They") unless overridden.
+    """
+    segments = [
+        _seg("seg-0", [("w0", "And"), ("w1", "they"), ("w2", "count"), ("w3", "everything")])
+    ]
+    refs = {"genius": _ref_source(ref_line.split(), "r")}
+    correction_data = {
+        "gap_sequences": [
+            {
+                "id": "gap-0",
+                "transcribed_word_ids": ["w0"],
+                "reference_word_ids": {"genius": gap_ref_ids if gap_ref_ids is not None else ["r0"]},
+            }
+        ],
+        "anchor_sequences": [],
+    }
+    return segments, refs, correction_data
+
+
+def test_p4_deletes_unsupported_leading_connective_and_recapitalizes() -> None:
+    segments, refs, cd = _p4_fixture()
+    out = deterministic_suggestions(segments, refs, cd)
+    assert [s["op"] for s in out] == ["delete", "replace"]
+    delete, recap = out
+    assert delete["word_ids"] == ["w0"]
+    assert delete["new_text"] == ""
+    assert recap["word_ids"] == ["w1"]
+    assert recap["new_text"] == "They"
+    assert all(s["models"] == ["deterministic"] for s in out)
+
+
+def test_p4_skips_when_a_reference_supports_the_connective() -> None:
+    segments, refs, cd = _p4_fixture(ref_line="And they count everything")
+    out = deterministic_suggestions(segments, refs, cd)
+    assert out == []
+
+
+def test_p4_skips_when_no_reference_evidence() -> None:
+    # Gap aligned to nothing and no usable anchors -> no reading -> no delete.
+    segments, refs, cd = _p4_fixture(gap_ref_ids=[])
+    out = deterministic_suggestions(segments, refs, cd)
+    assert out == []
+
+
+def test_p4_skips_anchored_leading_connective() -> None:
+    segments, refs, cd = _p4_fixture()
+    cd["gap_sequences"] = []  # "And" is not a gap word
+    assert deterministic_suggestions(segments, refs, cd) == []
+
+
+def test_p4_skips_vocalization_run() -> None:
+    # "Oh- whoa whoa whoa" — grouping vocalizations is a musical judgement.
+    segments = [
+        _seg("seg-0", [("w0", "Oh-"), ("w1", "whoa,"), ("w2", "whoa,"), ("w3", "whoa")])
+    ]
+    refs = {"genius": _ref_source(["Whoa,", "whoa,", "whoa"], "r")}
+    cd = {
+        "gap_sequences": [
+            {
+                "id": "gap-0",
+                "transcribed_word_ids": ["w0"],
+                "reference_word_ids": {"genius": ["r0"]},
+            }
+        ],
+        "anchor_sequences": [],
+    }
+    assert deterministic_suggestions(segments, refs, cd) == []
+
+
+def test_p4_skips_two_word_segment() -> None:
+    segments = [_seg("seg-0", [("w0", "And"), ("w1", "run")])]
+    refs = {"genius": _ref_source(["Run"], "r")}
+    cd = {
+        "gap_sequences": [
+            {"id": "g", "transcribed_word_ids": ["w0"], "reference_word_ids": {"genius": ["r0"]}}
+        ],
+        "anchor_sequences": [],
+    }
+    assert deterministic_suggestions(segments, refs, cd) == []
+
+
+def test_p4_already_capitalized_next_word_gets_no_recap_suggestion() -> None:
+    segments = [
+        _seg("seg-0", [("w0", "And"), ("w1", "Mary"), ("w2", "sings"), ("w3", "loud")])
+    ]
+    refs = {"genius": _ref_source(["Mary", "sings", "loud"], "r")}
+    cd = {
+        "gap_sequences": [
+            {"id": "g", "transcribed_word_ids": ["w0"], "reference_word_ids": {"genius": ["r0"]}}
+        ],
+        "anchor_sequences": [],
+    }
+    out = deterministic_suggestions(segments, refs, cd)
+    assert [s["op"] for s in out] == ["delete"]
+
+
+# ---- Pattern 5: reference majority ----
+
+
+def _p5_fixture():
+    """The 6d0640fa shape: transcription "yo Mick," where genius aligned
+    "My man," on the gap, and lrclib/spotify (unaligned on the gap) read
+    "Come here," after the preceding anchor."""
+    segments = [
+        _seg(
+            "seg-0",
+            [
+                ("w0", "Hit"),
+                ("w1", "the"),
+                ("w2", "button,"),
+                ("w3", "yo"),
+                ("w4", "Mick,"),
+                ("w5", "come"),
+                ("w6", "on"),
+            ],
+        )
+    ]
+    refs = {
+        "lrclib": _ref_source(["Hit", "the", "button,", "Come", "here,", "come", "on"], "l"),
+        "spotify": _ref_source(["Hit", "the", "button,", "Come", "here,", "come", "on"], "s"),
+        "genius": _ref_source(["Hit", "the", "button,", "My", "man,", "come", "on"], "g"),
+    }
+    correction_data = {
+        "gap_sequences": [
+            {
+                "id": "gap-0",
+                "transcribed_word_ids": ["w3", "w4"],
+                "preceding_anchor_id": "anchor-0",
+                "following_anchor_id": None,
+                "reference_word_ids": {"lrclib": [], "spotify": [], "genius": ["g3", "g4"]},
+            }
+        ],
+        "anchor_sequences": [
+            {
+                "id": "anchor-0",
+                "transcribed_word_ids": ["w0", "w1", "w2"],
+                "reference_word_ids": {
+                    "lrclib": ["l0", "l1", "l2"],
+                    "spotify": ["s0", "s1", "s2"],
+                    "genius": ["g0", "g1", "g2"],
+                },
+            }
+        ],
+    }
+    return segments, refs, correction_data
+
+
+def test_p5_replaces_implausible_proper_noun_with_majority_reading() -> None:
+    segments, refs, cd = _p5_fixture()
+    out = deterministic_suggestions(segments, refs, cd)
+    assert len(out) == 1
+    s = out[0]
+    assert s["op"] == "replace"
+    assert s["word_ids"] == ["w3", "w4"]
+    assert s["new_text"] == "Come here,"
+    assert "Mick," in s["reason"]
+
+
+def test_p5_requires_the_red_flag_token() -> None:
+    # Same majority disagreement but the transcription is plausible lowercase
+    # ("though" vs 2/3 "dog") -> the human deliberately leaves these; so do we.
+    segments, refs, cd = _p5_fixture()
+    segments[0]["words"][3]["text"] = "yo"
+    segments[0]["words"][4]["text"] = "mick,"
+    assert deterministic_suggestions(segments, refs, cd) == []
+
+
+def test_p5_skips_spelling_variant_of_reference_token() -> None:
+    # "Crick" ~ "Cricket": a truncation/spelling variant, the LLM's fix.
+    segments, refs, cd = _p5_fixture()
+    segments[0]["words"][4]["text"] = "Herre,"  # close to reference "here,"
+    assert deterministic_suggestions(segments, refs, cd) == []
+
+
+def test_p5_requires_two_thirds_majority() -> None:
+    segments, refs, cd = _p5_fixture()
+    # Make spotify read something else -> no 2/3 agreement.
+    for w, t in zip(refs["spotify"]["segments"][0]["words"][3:5], ["Over", "there,"]):
+        w["text"] = t
+    assert deterministic_suggestions(segments, refs, cd) == []
+
+
+def test_p5_ignores_segment_initial_capitalization() -> None:
+    # A capitalized SEGMENT-FIRST word is sentence case, not a proper noun.
+    segments = [_seg("seg-0", [("w0", "Mick,"), ("w1", "come"), ("w2", "on")])]
+    refs = {
+        "lrclib": _ref_source(["Quick,", "come", "on"], "l"),
+        "spotify": _ref_source(["Quick,", "come", "on"], "s"),
+        "genius": _ref_source(["Slick,", "come", "on"], "g"),
+    }
+    cd = {
+        "gap_sequences": [
+            {
+                "id": "gap-0",
+                "transcribed_word_ids": ["w0"],
+                "reference_word_ids": {"lrclib": ["l0"], "spotify": ["s0"], "genius": ["g0"]},
+            }
+        ],
+        "anchor_sequences": [],
+    }
+    assert deterministic_suggestions(segments, refs, cd) == []
+
+
+def test_p5_skips_stale_gap_word_ids() -> None:
+    segments, refs, cd = _p5_fixture()
+    cd["gap_sequences"][0]["transcribed_word_ids"] = ["w3", "gone"]
+    assert deterministic_suggestions(segments, refs, cd) == []
+
+
+def test_generators_never_raise_on_garbage() -> None:
+    assert deterministic_suggestions([], {}, None) == []
+    assert deterministic_suggestions([{"weird": True}], {"x": {}}, {"gap_sequences": [{}]}) == []
+
+
+# ---- Pattern 1: insert/replace self-conflict grouping ----
+
+
+def _s(id_, op, word_ids, new_text, confidence=0.9, consensus=1):
+    return Suggestion(
+        id=id_,
+        op=op,
+        word_ids=word_ids,
+        segment_ids=["seg-0"],
+        original_text="fire" if op != "insert_after" else "",
+        new_text=new_text,
+        reason="r",
+        category="mishearing",
+        confidence=confidence,
+        models=["m"],
+        consensus=consensus,
+        total_models=1,
+        conflict_group=None,
+    )
+
+
+def test_p1_insert_and_replace_adding_same_token_share_a_group() -> None:
+    # f6439692: insert_after "fire" -> "you're" AND replace "fire" ->
+    # "fire, you're" both applied -> "you're you're". Must become a conflict.
+    insert = _s("i", "insert_after", ["w-fire"], "you're", confidence=0.75)
+    replace = _s("r", "replace", ["w-fire"], "fire, you're", confidence=0.95)
+    suggestions = [insert, replace]
+    _assign_conflict_groups(suggestions)
+    assert insert.conflict_group is not None
+    assert insert.conflict_group == replace.conflict_group
+
+
+def test_p1_disjoint_tokens_stay_independent() -> None:
+    # Replacing a word AND inserting different text after it is legitimate.
+    insert = _s("i", "insert_after", ["w-fire"], "gasoline")
+    replace = _s("r", "replace", ["w-fire"], "fire,")
+    suggestions = [insert, replace]
+    _assign_conflict_groups(suggestions)
+    assert insert.conflict_group is None
+    assert replace.conflict_group is None
+
+
+def test_p1_two_inserts_same_anchor_same_token_share_a_group() -> None:
+    a = _s("a", "insert_after", ["w-fire"], "you're")
+    b = _s("b", "insert_after", ["w-fire"], "you're baby")
+    suggestions = [a, b]
+    _assign_conflict_groups(suggestions)
+    assert a.conflict_group is not None
+    assert a.conflict_group == b.conflict_group
+
+
+def test_p1_insert_vs_delete_not_grouped() -> None:
+    insert = _s("i", "insert_after", ["w-fire"], "you're")
+    delete = _s("d", "delete", ["w-fire"], "")
+    suggestions = [insert, delete]
+    _assign_conflict_groups(suggestions)
+    assert insert.conflict_group is None
+
+
+def test_assign_conflict_groups_is_idempotent_and_resets() -> None:
+    a = _s("a", "replace", ["w1"], "x")
+    b = _s("b", "replace", ["w2"], "y")
+    a.conflict_group = b.conflict_group = "stale-group"
+    suggestions = [a, b]
+    _assign_conflict_groups(suggestions)
+    assert a.conflict_group is None
+    assert b.conflict_group is None
+
+
+def test_word_overlap_grouping_still_works() -> None:
+    a = _s("a", "replace", ["w1", "w2"], "x")
+    b = _s("b", "delete", ["w2"], "")
+    suggestions = [a, b]
+    _assign_conflict_groups(suggestions)
+    assert a.conflict_group is not None
+    assert a.conflict_group == b.conflict_group
+
+
+# ---- pipeline integration: suggest() folds deterministic suggestions in ----
+
+
+def _run_single_model(llm_suggestions, segments, refs, correction_data):
+    service = AutoCorrectService()
+
+    def fake_call(model, system_prompt, user_prompt, *, job_id):
+        return {"suggestions": llm_suggestions}, None
+
+    with patch.object(service, "_cache_get", return_value=None), \
+            patch.object(service, "_cache_put"), \
+            patch.object(service, "_call_model", side_effect=fake_call):
+        return service.suggest(
+            job_id="job-1",
+            segments=segments,
+            reference_lyrics=refs,
+            artist="A",
+            title="T",
+            settings=AutoCorrectSettings(),
+            correction_data=correction_data,
+        )
+
+
+def test_suggest_appends_deterministic_suggestions() -> None:
+    segments, refs, cd = _p4_fixture()
+    result = _run_single_model([], segments, refs, cd)
+    assert [s.op for s in result.suggestions] == ["delete", "replace"]
+    assert all(s.models == ["deterministic"] for s in result.suggestions)
+
+
+def test_suggest_dedupes_identical_llm_and_deterministic() -> None:
+    segments, refs, cd = _p4_fixture()
+    llm = [
+        {
+            "op": "delete",
+            "start_idx": 0,
+            "end_idx": 0,
+            "new_text": "",
+            "reason": "spurious leading word",
+            "category": "mishearing",
+            "confidence": 0.8,
+        }
+    ]
+    result = _run_single_model(llm, segments, refs, cd)
+    deletes = [s for s in result.suggestions if s.op == "delete"]
+    assert len(deletes) == 1
+    assert "deterministic" in deletes[0].models
+    assert deletes[0].confidence == 0.9  # bumped to the deterministic confidence
+
+
+def test_suggest_groups_conflicting_llm_and_deterministic() -> None:
+    segments, refs, cd = _p4_fixture()
+    llm = [
+        {
+            "op": "replace",
+            "start_idx": 0,
+            "end_idx": 0,
+            "new_text": "And,",
+            "reason": "punctuation",
+            "category": "formatting",
+            "confidence": 0.7,
+        }
+    ]
+    result = _run_single_model(llm, segments, refs, cd)
+    on_w0 = [s for s in result.suggestions if s.word_ids == ["w0"]]
+    assert len(on_w0) == 2
+    assert on_w0[0].conflict_group is not None
+    assert on_w0[0].conflict_group == on_w0[1].conflict_group
+
+
+def test_suggest_without_correction_data_still_works() -> None:
+    segments, refs, _ = _p4_fixture()
+    service = AutoCorrectService()
+
+    def fake_call(model, system_prompt, user_prompt, *, job_id):
+        return {"suggestions": []}, None
+
+    with patch.object(service, "_cache_get", return_value=None), \
+            patch.object(service, "_cache_put"), \
+            patch.object(service, "_get_storage", side_effect=RuntimeError("no gcs")), \
+            patch.object(service, "_call_model", side_effect=fake_call):
+        result = service.suggest(
+            job_id="job-1",
+            segments=segments,
+            reference_lyrics=refs,
+            artist="A",
+            title="T",
+            settings=AutoCorrectSettings(),
+        )
+    assert result.suggestions == []
+
+
+def test_deterministic_respects_min_confidence_setting() -> None:
+    segments, refs, cd = _p4_fixture()
+    service = AutoCorrectService()
+
+    def fake_call(model, system_prompt, user_prompt, *, job_id):
+        return {"suggestions": []}, None
+
+    with patch.object(service, "_cache_get", return_value=None), \
+            patch.object(service, "_cache_put"), \
+            patch.object(service, "_call_model", side_effect=fake_call):
+        result = service.suggest(
+            job_id="job-1",
+            segments=segments,
+            reference_lyrics=refs,
+            artist="A",
+            title="T",
+            settings=AutoCorrectSettings(min_confidence=0.95),
+            correction_data=cd,
+        )
+    assert result.suggestions == []
+
+
+# ---- module-level helpers ----
+
+
+def test_ref_word_streams_indexes_ids() -> None:
+    streams = _ref_word_streams({"genius": _ref_source(["a", "b"], "g")})
+    texts, index = streams["genius"]
+    assert texts == ["a", "b"]
+    assert index == {"g0": 0, "g1": 1}
+
+
+def test_direct_generator_calls_share_stream_shape() -> None:
+    segments, refs, cd = _p4_fixture()
+    streams = _ref_word_streams(refs)
+    assert leading_connective_suggestions(segments, cd, streams)
+    segments5, refs5, cd5 = _p5_fixture()
+    streams5 = _ref_word_streams(refs5)
+    assert reference_majority_suggestions(segments5, cd5, streams5)

--- a/backend/workers/auto_correct_worker.py
+++ b/backend/workers/auto_correct_worker.py
@@ -70,6 +70,9 @@ async def process_proactive_auto_correct(job_id: str) -> dict:
                 # Must match what the review UI sends (default settings,
                 # multi-model) or the cache key won't line up.
                 settings=AutoCorrectSettings(compare_models=True),
+                # Already loaded — saves the service re-fetching it for the
+                # deterministic (P4/P5) generators.
+                correction_data=data,
             ),
             timeout=180,
         )

--- a/docs/archive/2026-08-25-full-auto-review-design.md
+++ b/docs/archive/2026-08-25-full-auto-review-design.md
@@ -344,3 +344,46 @@ narrow fully-confident class:
 Expected initial auto rate ~5% of jobs (1/20 in the calibration corpus): lyrics must be
 synced-perfect or ai-resolved AND backing must be non-subjectively clean. Widening comes from
 build-order #2-#4 (P4 fixer, vocalization detector already gating, backing decider).
+
+## Session 5 update (2026-08-28) — Phase 2A: deterministic P4/P1/P5 fixers (v0.203.0)
+
+Build-order item #2 shipped: the three mechanical residual-edit classes from the corpus are now
+**deterministic suggestion generators inside the auto-correct pipeline** (not executor hacks), so
+one mechanism feeds the review UI's on-load auto-apply, the executor's server-side apply, the
+scorer's gap-coverage signal, and the proactive cache.
+
+- **`backend/services/auto_correct/deterministic.py`** (new) — pure generators keyed off
+  `corrections.json` gap/anchor alignment:
+  - **P4 leading-connective delete**: segment starts with And/But/So/Oh/A, the word is a gap
+    word, and no reference source's reading of that gap contains it → emit `delete` (+ a
+    `replace` re-capitalizing the next word when lowercase). Guard: skipped when the next word is
+    a vocalization token (an "Oh- whoa," run is musical judgement, corpus 5c80991d).
+  - **P5 reference-majority replace**: a gap whose transcription contains an implausible proper
+    noun (capitalized mid-line token absent from every reference) and where ≥2/3 of reference
+    sources agree on the same reading → replace with the majority reading. The red flag is
+    REQUIRED — plain 2/3 majority over-fires on gaps the human deliberately left (6d0640fa
+    "though"→"dog", explicit-lyrics rewrite). Spelling-variant guard: a red-flag token
+    string-similar (≥0.75) to a reference token is a transliteration/truncation ("Crick"~
+    "Cricket", "Projectorinsky"~"Projektorinski") whose gap alignment is often junk → skip
+    (that's the LLM's fix).
+  - Per-source gap readings come from the gap's own `reference_word_ids`, else are derived by
+    walking the reference stream past the surrounding anchors (the 6d0640fa "Come here," case —
+    the aligner had empty alignments for 2 of 3 sources).
+- **P1 self-conflict grouping at source** — `service._assign_conflict_groups` (extracted, reused
+  post-integration) now also unions an `insert_after` with any suggestion targeting/anchored on
+  the same word whose new_text shares a token: the f6439692 "insert you're + replace fire→fire,
+  you're → 'you're you're'" signature becomes a pick-one conflict group (winner by consensus→
+  confidence picks the 0.95 replace — correct). Executor's `find_suspicious_duplicates` abort
+  stays as belt-and-braces.
+- Pipeline: `suggest(..., correction_data=None)` — proactive worker passes corrections.json in;
+  the review route lets the service fetch it (best-effort). Deterministic suggestions identical
+  to an LLM one just tag it (`models += ["deterministic"]`); new ones append; conflict groups are
+  recomputed over the combined set. Suggestion-cache key bumped to v2 (old cached results predate
+  the fixers).
+- **Corpus validation** (private validate_scorer.py, extended with FIXER assertions): safety
+  still 100% (all MUST_NOT_AUTO stay review; gates unchanged). P4 fires on all six corpus
+  examples; P5 reproduces Andrew's one ref-majority edit ("yo Mick,"→"Come here,") and fires
+  nowhere it must not. **6d0640fa (Miguel) now scores lyrics=auto + clean backing → would fully
+  auto-ship WITH the human's exact edit applied**; ae0cd7e8 (Samson corpus job) now has its P4
+  edits actually applied when auto-shipping. `ai-resolved` caps deliberately NOT loosened
+  (69ca7c1e still 14 uncovered words — needs more coverage, not looser caps).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.202.1"
+version = "0.203.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Phase 2A of fully-automated review (follows #947/#948): the three mechanical residual-edit classes from the 20-job replay-review corpus become **deterministic suggestion generators inside the auto-correct pipeline** — one mechanism feeding the review UI's on-load auto-apply, the auto-approval executor's server-side apply, the scorer's gap-coverage signal, and the proactive suggestion cache.

- **P4 — leading-connective over-insertion** (most common residual class): a segment starting with And/But/So/Oh/A that is a gap word and unsupported by every reference source's reading of that gap → `delete` + re-capitalize the next word. Guard: skipped when the next word is a vocalization token (an "Oh- whoa," run is a musical judgement).
- **P5 — reference-majority resolution**: a gap whose transcription contains an implausible proper noun (capitalized mid-line token absent from every reference) where ≥2/3 of reference sources agree on the same reading → replace with the majority reading. The red flag is REQUIRED (plain 2/3-majority over-fires on gaps the human deliberately left), and a spelling-variant guard (similarity ≥0.75 to a reference token) skips transliteration/truncation cases whose gap alignment is typically junk.
- **P1 — AI self-conflict fixed at source**: conflict grouping now also unions an `insert_after` with any suggestion targeting/anchored on the same word whose new_text shares a token, so accept-all picks one winner instead of double-applying ("you're you're"). The executor's duplicate-word abort stays as belt-and-braces.

Per-source gap readings come from the gap's own reference alignment, else are derived by walking the reference stream past the surrounding anchors (recovers the readings the aligner left empty). Suggestion-cache key bumped to v2 so pre-fixer cached results aren't served.

## Validation

- **Corpus (private validate_scorer.py, extended with FIXER assertions): all safety + gate checks still 100%.** P4 fires on all six corpus examples (8f2305ee, ae0cd7e8, 1d45b286, 5f90b799, 33453fa0, f247364e); P5 reproduces the human's exact edit on 6d0640fa ("yo Mick," → "Come here,") and fires nowhere the human deliberately made no edit (507513ba, d508adb6, and the other 6d0640fa gaps).
- The Miguel corpus job (6d0640fa) now scores lyrics=auto with clean backing → would fully auto-ship **with the human's exact edit applied**; the Samson corpus job's P4 edits now get applied rather than skipped.
- `ai-resolved` caps deliberately NOT loosened.

## Testing

- 27 new unit tests (`backend/tests/services/auto_correct/test_deterministic.py`) covering both generators, all guards, P1 grouping, and pipeline integration (append/dedupe/conflict/min-confidence/no-corrections fallback).
- Full backend suite: 4033 passed, 0 failed.
- Backend-only change; no frontend files or user-facing strings.

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)