### PR TITLE
feat: 3-stem backing-vocals decider — confident WITH_BACKING verdict, shadow-first enforcement (v0.204.0)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -132,6 +132,16 @@ class Settings(BaseSettings):
         "AUTO_APPROVAL_ENFORCE_ENABLED", "true"
     ).lower() in ("true", "1", "yes")
 
+    # Backing decider ENFORCEMENT (Phase 2B): allow a confident WITH_BACKING
+    # verdict from the 3-stem decider to auto-select the with-backing
+    # instrumental. SHADOW-FIRST: default off — the verdict is scored and
+    # recorded on every job regardless, so prod shadow data accumulates
+    # alongside human picks; flip on after reviewing it. While off, confident
+    # WITH_BACKING jobs simply go to normal human review (status quo).
+    auto_approval_backing_keep_enabled: bool = os.getenv(
+        "AUTO_APPROVAL_BACKING_KEEP_ENABLED", "false"
+    ).lower() in ("true", "1", "yes")
+
     # Match judge — artist/title formatting + match-acceptance for the job
     # submission flow. Deterministic + catalog layers always run; the light AI
     # layer (Vertex Gemini Flash) fires only when those aren't confident.

--- a/backend/services/audio_analysis_service.py
+++ b/backend/services/audio_analysis_service.py
@@ -101,35 +101,43 @@ class AudioAnalysisService:
         gcs_audio_path: str,
         job_id: str,
         gcs_waveform_destination: str,
-    ) -> tuple[AnalysisResult, str]:
+        gcs_lead_vocals_path: Optional[str] = None,
+        gcs_vocals_path: Optional[str] = None,
+    ) -> tuple[AnalysisResult, str, Optional[dict]]:
         """
-        Analyze backing vocals and generate a waveform image.
-        
+        Analyze backing vocals, generate a waveform image, and (when the lead
+        and full-vocals stems are provided) compute the 3-stem comparison
+        signals for the backing-vocals decider.
+
         This method:
         1. Downloads the audio file from GCS
         2. Runs analysis using AudioAnalyzer
         3. Generates waveform image using WaveformGenerator
         4. Uploads the waveform image to GCS
-        5. Returns analysis result and waveform GCS path
-        
+        5. Optionally downloads lead_vocals + vocals stems and runs
+           compare_stems (best-effort — a failure yields a comparison dict
+           with ``error`` set, never an exception)
+
         Args:
-            gcs_audio_path: Path to the audio file in GCS
+            gcs_audio_path: Path to the backing-vocals audio file in GCS
             job_id: Job ID for logging
             gcs_waveform_destination: Where to upload the waveform image in GCS
-        
+            gcs_lead_vocals_path: Optional GCS path of the lead_vocals stem
+            gcs_vocals_path: Optional GCS path of the full vocals stem
+
         Returns:
-            Tuple of (AnalysisResult, waveform_gcs_path)
+            Tuple of (AnalysisResult, waveform_gcs_path, stem_comparison dict or None)
         """
         logger.info(f"[{job_id}] Analyzing and generating waveform: {gcs_audio_path}")
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
             # Download audio file
             local_audio_path = os.path.join(temp_dir, "backing_vocals.flac")
             self.storage_service.download_file(gcs_audio_path, local_audio_path)
-            
+
             # Run analysis
             result = self.analyzer.analyze(local_audio_path)
-            
+
             # Generate waveform
             local_waveform_path = os.path.join(temp_dir, "waveform.png")
             self.waveform_generator.generate(
@@ -139,19 +147,64 @@ class AudioAnalysisService:
                 show_time_axis=True,
                 silence_threshold_db=self.analyzer.silence_threshold_db,
             )
-            
+
             # Upload waveform to GCS
             self.storage_service.upload_file(
                 local_waveform_path,
                 gcs_waveform_destination
             )
-            
+
+            comparison: Optional[dict] = None
+            if gcs_lead_vocals_path and gcs_vocals_path:
+                comparison = self._compare_stems(
+                    job_id, temp_dir, local_audio_path,
+                    gcs_lead_vocals_path, gcs_vocals_path,
+                )
+
             logger.info(
                 f"[{job_id}] Analysis and waveform generation complete. "
                 f"Waveform uploaded to: {gcs_waveform_destination}"
             )
-            
-            return result, gcs_waveform_destination
+
+            return result, gcs_waveform_destination, comparison
+
+    def _compare_stems(
+        self,
+        job_id: str,
+        temp_dir: str,
+        local_backing_path: str,
+        gcs_lead_vocals_path: str,
+        gcs_vocals_path: str,
+    ) -> Optional[dict]:
+        """Download lead + vocals stems and run the 3-stem comparison.
+
+        Best-effort: returns None when the extra stems can't even be
+        downloaded; compare_stems itself reports internal failures via the
+        ``error`` field rather than raising.
+        """
+        from karaoke_gen.instrumental_review.stem_comparison import compare_stems
+
+        try:
+            local_lead = os.path.join(temp_dir, "lead_vocals.flac")
+            local_vocals = os.path.join(temp_dir, "vocals.flac")
+            self.storage_service.download_file(gcs_lead_vocals_path, local_lead)
+            self.storage_service.download_file(gcs_vocals_path, local_vocals)
+        except Exception as e:
+            logger.warning(f"[{job_id}] stem comparison skipped (download failed): {e}")
+            return None
+        comparison = compare_stems(
+            local_backing_path,
+            local_lead,
+            local_vocals,
+            silence_threshold_db=self.analyzer.silence_threshold_db,
+        )
+        logger.info(
+            f"[{job_id}] Stem comparison: coverage_ratio={comparison.coverage_ratio}, "
+            f"corr_backing_vocals={comparison.corr_backing_vocals}, "
+            f"lead_overlap={comparison.lead_overlap_fraction}, "
+            f"flat_fraction={comparison.flat_fraction}, error={comparison.error}"
+        )
+        return comparison.to_dict()
     
     def get_waveform_data(
         self,

--- a/backend/services/auto_approval/executor.py
+++ b/backend/services/auto_approval/executor.py
@@ -34,6 +34,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from backend.models.job import JobStatus
+from backend.services.auto_approval.models import BackingVerdict
 
 logger = logging.getLogger(__name__)
 
@@ -121,8 +122,16 @@ async def maybe_auto_complete_review(job_id: str, trigger: str) -> Dict[str, Any
 
         verdict = score_job(corrections, backing_analysis, ai_suggestions)
         blockers = _enforcement_blockers(job, settings)
+        keep_backing = verdict.backing.verdict == BackingVerdict.WITH_BACKING
         if not audio_complete:
             blockers.append("audio_incomplete")
+        elif keep_backing:
+            # Confident-keep (3-stem decider) selects the with-backing
+            # instrumental — gated shadow-first behind its own flag.
+            if not settings.auto_approval_backing_keep_enabled:
+                blockers.append("backing_keep_disabled")
+            if not stems.get("instrumental_with_backing"):
+                blockers.append("no_with_backing_stem")
         elif not stems.get("instrumental_clean"):
             blockers.append("no_clean_stem")
 
@@ -181,8 +190,11 @@ async def maybe_auto_complete_review(job_id: str, trigger: str) -> Dict[str, Any
             )
             return {"outcome": "aborted", "reason": applied_info["aborted"]}
 
-        # Backing verdict CLEAN (non-subjective "no audible backing") -> clean stem.
-        job_manager.update_state_data(job_id, "instrumental_selection", "clean")
+        # Non-subjective backing verdict -> matching instrumental selection:
+        # CLEAN ("no audible backing") -> clean stem; WITH_BACKING (confident
+        # 3-stem decider keep, flag-gated above) -> with-backing stem.
+        selection = "with_backing" if keep_backing else "clean"
+        job_manager.update_state_data(job_id, "instrumental_selection", selection)
 
         # Clear worker progress keys so downstream workers run fresh (mirrors
         # complete_review — idempotency keys would otherwise skip re-runs).
@@ -194,8 +206,13 @@ async def maybe_auto_complete_review(job_id: str, trigger: str) -> Dict[str, Any
             new_status=JobStatus.REVIEW_COMPLETE,
             progress=70,
             message=(
-                "Auto-approved: lyrics verified against synced references and no "
-                "audible backing vocals — skipping review, rendering video"
+                "Auto-approved: lyrics verified against synced references and "
+                + (
+                    "clear backing vocals retained"
+                    if keep_backing
+                    else "no audible backing vocals"
+                )
+                + " — skipping review, rendering video"
             ),
         )
 

--- a/backend/services/auto_approval/models.py
+++ b/backend/services/auto_approval/models.py
@@ -80,6 +80,19 @@ class BackingSignals:
     loud_segment_count: int = 0
     peak_amplitude_db: Optional[float] = None
     recommended_selection: Optional[str] = None
+    # 3-stem comparison (backing vs lead vs full vocals) — present on jobs
+    # analyzed since the Phase-2B backing decider; absent before that.
+    comparison_present: bool = False
+    coverage_ratio: float = 0.0
+    corr_backing_vocals: float = 0.0
+    corr_backing_lead: float = 0.0
+    lead_overlap_fraction: float = 0.0
+    lead_audible_fraction: float = 0.0
+    backing_audible_fraction: float = 0.0
+    backing_median_db: Optional[float] = None
+    lead_median_db: Optional[float] = None
+    backing_db_std: float = 0.0
+    flat_fraction: float = 0.0
 
 
 @dataclass

--- a/backend/services/auto_approval/scorer.py
+++ b/backend/services/auto_approval/scorer.py
@@ -40,7 +40,7 @@ from backend.services.auto_approval.models import (
     LyricsVerdict,
 )
 
-SCORER_VERSION = "0.2.0"
+SCORER_VERSION = "0.3.0"
 
 # --- Lyrics thresholds (deliberately conservative; the safe intersection first) ---
 # The AUTO tier requires a synced reference the transcription matches with ZERO
@@ -92,6 +92,36 @@ PHANTOM_PARENTHETICAL_MAX_WORDS = 4
 # A tiny non-zero floor absorbs separation noise but stays extremely conservative.
 NON_SUBJECTIVE_MAX_AUDIBLE_PCT = 0.5  # percent
 LOUD_SEGMENT_DB = -20.0
+
+# --- 3-stem backing decider thresholds (Phase 2B) ---
+# Calibrated on the 20-job replay-review corpus signals (private
+# validate_backing_decider.py — rerun after ANY change here). Corpus rules:
+# pink present -> KEEP (the human under-keeps; every with_backing pick was
+# correct), EXCEPT the "pink but don't keep" modes below.
+#
+# Backing-stem-IS-the-lead (1d45b286 — catastrophic if kept): the backing stem
+# tracks the whole vocal line while the real lead stem is comparatively
+# sparse. Corpus values: covR 0.94 / corr 0.95 / backing 60% audible vs lead
+# 18%. The coverage comparison (backing > lead) is the decisive discriminator:
+# the nearest genuine keep (33453fa0) hits covR 0.77 / corr 0.86 but its
+# backing coverage (28%) sits well BELOW its lead coverage (34%).
+BACKING_IS_LEAD_MIN_COVERAGE_RATIO = 0.80
+BACKING_IS_LEAD_MIN_CORR = 0.80
+# Noise-floor pink (95d8e844, grungegaze): a fuzzy mix pushes the backing
+# stem's noise floor just above the -40 dB threshold, producing widespread
+# near-threshold "pink" that does not correlate with the vocal line (corpus:
+# median -38.6 dB over 30% of the track, corr -0.23). Genuine quiet harmonies
+# (d508adb6: -38.1 dB but only 1% audible; 44622ffa: -35.9 dB, 11%) are sparse.
+# Marginal either way per the corpus -> REVIEW, never a confident verdict.
+NOISE_FLOOR_MAX_MEDIAN_DB = -35.0
+NOISE_FLOOR_MIN_AUDIBLE_FRACTION = 0.15
+NOISE_FLOOR_MAX_CORR = 0.05
+# Lead bleed (ae0cd7e8): tiny audible content riding entirely on lead
+# activity. The corpus bleed case is already caught by the near-silent rule;
+# this catches slightly-larger blobs. Deliberately NARROW (overlap >= 0.95):
+# d508adb6's genuine harmonies overlap the lead 0.89 and must stay keepable.
+BLEED_MAX_AUDIBLE_PCT = 3.0
+BLEED_MIN_LEAD_OVERLAP = 0.95
 
 _TOKEN_STRIP_RE = re.compile(r"^[^\w]+|[^\w]+$")
 
@@ -424,7 +454,7 @@ def extract_backing_signals(backing_analysis: Optional[Dict[str, Any]]) -> Backi
         if isinstance(pk, (int, float)):
             peak = pk if peak is None else max(peak, pk)
 
-    return BackingSignals(
+    signals = BackingSignals(
         analysis_present=True,
         has_audible_content=bool(backing_analysis.get("has_audible_content", True)),
         audible_percentage=float(backing_analysis.get("audible_percentage", 0.0) or 0.0),
@@ -433,6 +463,31 @@ def extract_backing_signals(backing_analysis: Optional[Dict[str, Any]]) -> Backi
         peak_amplitude_db=peak,
         recommended_selection=backing_analysis.get("recommended_selection"),
     )
+
+    # 3-stem comparison (Phase 2B). A comparison that errored is treated as
+    # absent — never as evidence in either direction.
+    comparison = backing_analysis.get("stem_comparison") or {}
+    if comparison and not comparison.get("error"):
+        def _num(key: str, default: float = 0.0) -> float:
+            value = comparison.get(key)
+            return float(value) if isinstance(value, (int, float)) else default
+
+        signals.comparison_present = True
+        signals.coverage_ratio = _num("coverage_ratio")
+        signals.corr_backing_vocals = _num("corr_backing_vocals")
+        signals.corr_backing_lead = _num("corr_backing_lead")
+        signals.lead_overlap_fraction = _num("lead_overlap_fraction")
+        signals.lead_audible_fraction = _num("lead_audible_fraction")
+        signals.backing_audible_fraction = _num("backing_audible_fraction")
+        signals.backing_db_std = _num("backing_db_std")
+        signals.flat_fraction = _num("flat_fraction")
+        backing_median = comparison.get("backing_median_db")
+        lead_median = comparison.get("lead_median_db")
+        if isinstance(backing_median, (int, float)):
+            signals.backing_median_db = float(backing_median)
+        if isinstance(lead_median, (int, float)):
+            signals.lead_median_db = float(lead_median)
+    return signals
 
 
 def score_backing(backing_analysis: Optional[Dict[str, Any]]) -> BackingResult:
@@ -456,13 +511,72 @@ def score_backing(backing_analysis: Optional[Dict[str, Any]]) -> BackingResult:
         )
         return BackingResult(BackingVerdict.CLEAN, True, s, reasons)
 
-    # Audible backing exists -> the clean-vs-with call is a taste/quality judgement.
+    # Audible backing exists. Without the 3-stem comparison the clean-vs-with
+    # call stays a human judgement (pre-Phase-2B jobs, or comparison failed).
+    if not s.comparison_present:
+        reasons.append(
+            f"audible backing present ({s.audible_percentage:.1f}%, {s.segment_count} segments, "
+            f"{s.loud_segment_count} loud) but no 3-stem comparison available — "
+            "retain-or-not needs a human listen"
+        )
+        return BackingResult(BackingVerdict.REVIEW, False, s, reasons)
+
+    # -- "pink but don't keep" mode 1: the backing stem IS the lead --
+    # (separation misclassified a quiet/reverby lead; keeping it would put the
+    # lead vocal back into the karaoke track — the worst possible output.)
+    if (
+        s.coverage_ratio >= BACKING_IS_LEAD_MIN_COVERAGE_RATIO
+        and s.corr_backing_vocals >= BACKING_IS_LEAD_MIN_CORR
+        and s.backing_audible_fraction > s.lead_audible_fraction
+    ):
+        reasons.append(
+            f"backing stem appears to BE the lead vocal: covers "
+            f"{s.coverage_ratio:.0%} of the vocal line with envelope correlation "
+            f"{s.corr_backing_vocals:.2f}, and is more present than the lead stem "
+            f"({s.backing_audible_fraction:.0%} vs {s.lead_audible_fraction:.0%} "
+            "audible) — keeping it would re-insert the lead; needs a human listen"
+        )
+        return BackingResult(BackingVerdict.REVIEW, False, s, reasons)
+
+    # -- mode 2: noise-floor pink (lo-fi/fuzzy mix) --
+    if (
+        s.backing_median_db is not None
+        and s.backing_median_db <= NOISE_FLOOR_MAX_MEDIAN_DB
+        and s.backing_audible_fraction >= NOISE_FLOOR_MIN_AUDIBLE_FRACTION
+        and s.corr_backing_vocals <= NOISE_FLOOR_MAX_CORR
+    ):
+        reasons.append(
+            f"widespread near-threshold backing (median "
+            f"{s.backing_median_db:.1f} dB over {s.backing_audible_fraction:.0%} "
+            f"of the track) uncorrelated with the vocal line "
+            f"({s.corr_backing_vocals:.2f}) — noise-floor signature; marginal "
+            "either way, needs a human listen"
+        )
+        return BackingResult(BackingVerdict.REVIEW, False, s, reasons)
+
+    # -- mode 3: lead bleed (small blobs riding entirely on lead activity) --
+    if (
+        s.audible_percentage <= BLEED_MAX_AUDIBLE_PCT
+        and s.lead_overlap_fraction >= BLEED_MIN_LEAD_OVERLAP
+    ):
+        reasons.append(
+            f"sparse backing ({s.audible_percentage:.1f}%) almost entirely "
+            f"overlapping lead activity ({s.lead_overlap_fraction:.0%}) — "
+            "likely lead bleed, not harmony; needs a human listen"
+        )
+        return BackingResult(BackingVerdict.REVIEW, False, s, reasons)
+
+    # Real pink harmony remains -> KEEP. Corpus: the human under-keeps (every
+    # with_backing pick was right, 2 of 8 clean picks were wrong); with the
+    # three don't-keep modes carved out above, retaining is the non-subjective
+    # default ("retain backing vocals where possible").
     reasons.append(
-        f"audible backing present ({s.audible_percentage:.1f}%, {s.segment_count} segments, "
-        f"{s.loud_segment_count} loud) — retain-or-not is subjective; energy heuristic says "
-        f"'{s.recommended_selection}'"
+        f"clear backing-vocal content present ({s.audible_percentage:.1f}%, "
+        f"{s.segment_count} segments, {s.loud_segment_count} loud; flat fraction "
+        f"{s.flat_fraction:.0%}, vocal-line coverage {s.coverage_ratio:.0%}) with "
+        "no lead-bleed / misclassified-lead / noise signature — retain"
     )
-    return BackingResult(BackingVerdict.REVIEW, False, s, reasons)
+    return BackingResult(BackingVerdict.WITH_BACKING, True, s, reasons)
 
 
 def score_job(

--- a/backend/tests/services/auto_approval/test_backing_decider.py
+++ b/backend/tests/services/auto_approval/test_backing_decider.py
@@ -1,0 +1,248 @@
+"""Tests for the Phase-2B 3-stem backing decider (scorer branch + executor gating).
+
+Comparison fixtures mirror the real corpus signal profiles (private
+validate_backing_decider.py table, 2026-08-28): the catastrophic
+backing-stem-is-the-lead job (1d45b286), the noise-floor grungegaze job
+(95d8e844), the quiet-genuine-harmonies job (d508adb6), and the high-corr
+genuine keep that must NOT trip the lead gate (33453fa0).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.services.auto_approval.models import BackingVerdict
+from backend.services.auto_approval.scorer import extract_backing_signals, score_backing
+
+
+def _analysis(
+    audible_percentage: float = 25.0,
+    loud: int = 2,
+    comparison: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    segments = [
+        {
+            "start_seconds": 10.0 * i,
+            "end_seconds": 10.0 * i + 5.0,
+            "duration_seconds": 5.0,
+            "avg_amplitude_db": -15.0 if i < loud else -35.0,
+            "peak_amplitude_db": -10.0,
+        }
+        for i in range(4)
+    ]
+    data: Dict[str, Any] = {
+        "has_audible_content": True,
+        "audible_percentage": audible_percentage,
+        "audible_segments": segments,
+        "recommended_selection": "with_backing",
+    }
+    if comparison is not None:
+        data["stem_comparison"] = comparison
+    return data
+
+
+def _comparison(**overrides: Any) -> Dict[str, Any]:
+    base = {
+        "window_ms": 100,
+        "silence_threshold_db": -40.0,
+        "duration_seconds": 200.0,
+        "backing_audible_fraction": 0.30,
+        "lead_audible_fraction": 0.65,
+        "vocals_audible_fraction": 0.70,
+        "coverage_ratio": 0.43,
+        "corr_backing_vocals": 0.40,
+        "corr_backing_lead": 0.20,
+        "backing_median_db": -26.0,
+        "lead_median_db": -18.0,
+        "vocals_median_db": -17.0,
+        "lead_overlap_fraction": 0.80,
+        "backing_db_std": 4.5,
+        "flat_fraction": 0.05,
+        "error": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_genuine_backing_is_confident_keep() -> None:
+    result = score_backing(_analysis(comparison=_comparison()))
+    assert result.verdict == BackingVerdict.WITH_BACKING
+    assert result.non_subjective is True
+
+
+def test_no_comparison_stays_review() -> None:
+    result = score_backing(_analysis())
+    assert result.verdict == BackingVerdict.REVIEW
+    assert result.non_subjective is False
+
+
+def test_errored_comparison_reads_as_absent() -> None:
+    result = score_backing(
+        _analysis(comparison=_comparison(error="boom"))
+    )
+    assert result.verdict == BackingVerdict.REVIEW
+    assert result.signals.comparison_present is False
+
+
+def test_backing_stem_is_lead_never_keeps() -> None:
+    # 1d45b286 profile: covR 0.94, corr 0.95, backing 60% vs lead 18%.
+    result = score_backing(
+        _analysis(
+            audible_percentage=60.0,
+            comparison=_comparison(
+                coverage_ratio=0.94,
+                corr_backing_vocals=0.95,
+                backing_audible_fraction=0.60,
+                lead_audible_fraction=0.18,
+            ),
+        )
+    )
+    assert result.verdict == BackingVerdict.REVIEW
+    assert "BE the lead" in " ".join(result.reasons)
+
+
+def test_high_corr_keep_with_stronger_lead_does_not_trip_lead_gate() -> None:
+    # 33453fa0 profile: covR 0.77 / corr 0.86 but backing (28%) < lead (34%).
+    result = score_backing(
+        _analysis(
+            audible_percentage=28.0,
+            comparison=_comparison(
+                coverage_ratio=0.77,
+                corr_backing_vocals=0.86,
+                backing_audible_fraction=0.28,
+                lead_audible_fraction=0.34,
+                backing_median_db=-33.0,
+            ),
+        )
+    )
+    assert result.verdict == BackingVerdict.WITH_BACKING
+
+
+def test_noise_floor_signature_is_review() -> None:
+    # 95d8e844 profile: median -38.6 dB over 30% of the track, corr -0.23.
+    result = score_backing(
+        _analysis(
+            audible_percentage=30.0,
+            comparison=_comparison(
+                backing_median_db=-38.6,
+                backing_audible_fraction=0.30,
+                corr_backing_vocals=-0.23,
+                coverage_ratio=0.42,
+            ),
+        )
+    )
+    assert result.verdict == BackingVerdict.REVIEW
+    assert "noise-floor" in " ".join(result.reasons)
+
+
+def test_quiet_sparse_harmonies_still_keep() -> None:
+    # d508adb6 profile: 1% audible at -38 dB, overlap 0.89 — genuine harmonies.
+    result = score_backing(
+        _analysis(
+            audible_percentage=1.0,
+            loud=1,
+            comparison=_comparison(
+                backing_median_db=-38.1,
+                backing_audible_fraction=0.01,
+                corr_backing_vocals=0.19,
+                coverage_ratio=0.01,
+                lead_overlap_fraction=0.89,
+            ),
+        )
+    )
+    assert result.verdict == BackingVerdict.WITH_BACKING
+
+
+def test_sparse_full_lead_overlap_is_bleed_review() -> None:
+    result = score_backing(
+        _analysis(
+            audible_percentage=2.0,
+            comparison=_comparison(
+                backing_audible_fraction=0.02,
+                coverage_ratio=0.03,
+                lead_overlap_fraction=0.99,
+            ),
+        )
+    )
+    assert result.verdict == BackingVerdict.REVIEW
+    assert "bleed" in " ".join(result.reasons)
+
+
+def test_near_silent_rule_still_wins_over_comparison() -> None:
+    analysis = _analysis(audible_percentage=0.1, comparison=_comparison())
+    analysis["audible_segments"] = []
+    result = score_backing(analysis)
+    assert result.verdict == BackingVerdict.CLEAN
+
+
+def test_comparison_signals_extracted() -> None:
+    s = extract_backing_signals(_analysis(comparison=_comparison()))
+    assert s.comparison_present is True
+    assert s.coverage_ratio == 0.43
+    assert s.corr_backing_vocals == 0.40
+    assert s.lead_overlap_fraction == 0.80
+    assert s.backing_median_db == -26.0
+    assert s.flat_fraction == 0.05
+
+
+# ---- executor gating for WITH_BACKING enforcement ----
+
+from backend.models.job import JobStatus  # noqa: E402
+from backend.tests.services.auto_approval.test_executor import (  # noqa: E402
+    _confident_corrections,
+    _job,
+    _run,
+)
+
+
+def _keep_backing_analysis() -> Dict[str, Any]:
+    return _analysis(comparison=_comparison())
+
+
+def _keep_job(with_backing_stem: bool = True) -> SimpleNamespace:
+    job = _job(backing=_keep_backing_analysis())
+    if with_backing_stem:
+        job.file_urls["stems"]["instrumental_with_backing"] = (
+            "jobs/j1/stems/instrumental_with_backing.flac"
+        )
+    return job
+
+
+def _settings(keep_enabled: bool) -> SimpleNamespace:
+    return SimpleNamespace(
+        auto_approval_enforce_enabled=True,
+        auto_approval_backing_keep_enabled=keep_enabled,
+    )
+
+
+@pytest.mark.asyncio
+async def test_confident_keep_blocked_while_flag_off() -> None:
+    result, job_manager, *_ = await _run(_keep_job(), settings=_settings(False))
+    assert result["outcome"] == "review"
+    assert "backing_keep_disabled" in result["blockers"]
+    payload = job_manager.update_processing_metadata.call_args[0][2]
+    assert payload["backing"]["verdict"] == "with_backing"
+
+
+@pytest.mark.asyncio
+async def test_confident_keep_enforced_when_flag_on() -> None:
+    result, job_manager, _storage, worker = await _run(
+        _keep_job(), settings=_settings(True)
+    )
+    assert result["outcome"] == "auto_completed"
+    job_manager.update_state_data.assert_any_call(
+        "j1", "instrumental_selection", "with_backing"
+    )
+    worker.trigger_render_video_worker.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_confident_keep_needs_with_backing_stem() -> None:
+    result, *_ = await _run(
+        _keep_job(with_backing_stem=False), settings=_settings(True)
+    )
+    assert result["outcome"] == "review"
+    assert "no_with_backing_stem" in result["blockers"]

--- a/backend/tests/services/auto_approval/test_stem_comparison.py
+++ b/backend/tests/services/auto_approval/test_stem_comparison.py
@@ -1,0 +1,105 @@
+"""Tests for the pure 3-stem comparison signal extraction.
+
+Synthesizes tiny WAVs with pydub so the signal math is exercised on real
+audio decoding, not mocks.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+from pydub import AudioSegment
+from pydub.generators import Sine, WhiteNoise
+
+from karaoke_gen.instrumental_review.stem_comparison import (
+    StemComparison,
+    compare_stems,
+)
+
+
+def _silence(ms: int = 4000) -> AudioSegment:
+    return AudioSegment.silent(duration=ms, frame_rate=16000)
+
+
+def _tone_bursts(ms: int = 4000, *, burst_ms: int = 500, gain_db: float = -10.0) -> AudioSegment:
+    """Alternating 500ms tone / 500ms silence."""
+    out = AudioSegment.silent(duration=0, frame_rate=16000)
+    tone = Sine(440, sample_rate=16000).to_audio_segment(duration=burst_ms).apply_gain(gain_db)
+    quiet = AudioSegment.silent(duration=burst_ms, frame_rate=16000)
+    while len(out) < ms:
+        out += tone + quiet
+    return out[:ms]
+
+
+def _write(tmp_path, name: str, audio: AudioSegment) -> str:
+    path = os.path.join(tmp_path, name)
+    audio.export(path, format="wav")
+    return path
+
+
+def test_silent_backing_has_zero_fractions(tmp_path) -> None:
+    backing = _write(tmp_path, "b.wav", _silence())
+    lead = _write(tmp_path, "l.wav", _tone_bursts())
+    vocals = _write(tmp_path, "v.wav", _tone_bursts())
+    c = compare_stems(backing, lead, vocals)
+    assert c.error is None
+    assert c.backing_audible_fraction == 0.0
+    assert c.coverage_ratio == 0.0
+    assert c.lead_overlap_fraction == 0.0
+    assert c.lead_audible_fraction > 0.3
+
+
+def test_backing_identical_to_vocals_is_high_corr_full_coverage(tmp_path) -> None:
+    # The backing-stem-is-the-lead shape: backing tracks the whole vocal line
+    # while the lead stem is empty.
+    bursts = _tone_bursts()
+    backing = _write(tmp_path, "b.wav", bursts)
+    lead = _write(tmp_path, "l.wav", _silence())
+    vocals = _write(tmp_path, "v.wav", bursts)
+    c = compare_stems(backing, lead, vocals)
+    assert c.error is None
+    assert c.coverage_ratio == 1.0
+    assert c.corr_backing_vocals > 0.95
+    assert c.backing_audible_fraction > c.lead_audible_fraction
+    assert c.lead_overlap_fraction == 0.0
+
+
+def test_offset_backing_has_low_overlap_and_corr(tmp_path) -> None:
+    # Backing sings only in the lead's gaps (genuine call-and-response shape).
+    bursts = _tone_bursts()
+    offset = _silence(500) + bursts
+    backing = _write(tmp_path, "b.wav", offset[: len(bursts)])
+    lead = _write(tmp_path, "l.wav", bursts)
+    vocals = _write(tmp_path, "v.wav", bursts)
+    c = compare_stems(backing, lead, vocals)
+    assert c.error is None
+    assert c.corr_backing_vocals < 0.0  # anti-phase with the vocal line
+    assert c.lead_overlap_fraction < 0.2
+
+
+def test_continuous_noise_floor_is_flat(tmp_path) -> None:
+    noise = WhiteNoise(sample_rate=16000).to_audio_segment(duration=8000).apply_gain(-25.0)
+    backing = _write(tmp_path, "b.wav", noise)
+    lead = _write(tmp_path, "l.wav", _tone_bursts(8000))
+    vocals = _write(tmp_path, "v.wav", _tone_bursts(8000))
+    c = compare_stems(backing, lead, vocals)
+    assert c.error is None
+    assert c.backing_audible_fraction == 1.0
+    assert c.flat_fraction > 0.9  # sustained low-variance content
+    assert c.backing_db_std < 2.5
+
+
+def test_missing_file_reports_error_not_raise(tmp_path) -> None:
+    lead = _write(tmp_path, "l.wav", _silence(500))
+    c = compare_stems(os.path.join(tmp_path, "nope.wav"), lead, lead)
+    assert isinstance(c, StemComparison)
+    assert c.error is not None
+
+
+def test_to_dict_round_trips_json_safe(tmp_path) -> None:
+    import json
+
+    p = _write(tmp_path, "a.wav", _tone_bursts(1000))
+    c = compare_stems(p, p, p)
+    payload = c.to_dict()
+    assert json.loads(json.dumps(payload)) == payload

--- a/backend/tests/test_audio_analysis_service.py
+++ b/backend/tests/test_audio_analysis_service.py
@@ -177,11 +177,12 @@ class TestAnalyzeAndGenerateWaveform:
         service = AudioAnalysisService()
         
         # Call method
-        result, waveform_path = service.analyze_and_generate_waveform(
+        result, waveform_path, comparison = service.analyze_and_generate_waveform(
             gcs_audio_path="uploads/job123/backing.flac",
             job_id="job123",
             gcs_waveform_destination="uploads/job123/waveform.png",
         )
+        assert comparison is None  # no lead/vocals stems passed
         
         # Verify analysis was performed
         mock_analyzer.analyze.assert_called_once()

--- a/backend/tests/test_audio_services.py
+++ b/backend/tests/test_audio_services.py
@@ -145,17 +145,78 @@ class TestAudioAnalysisService:
         mock_storage_service.upload_file.return_value = "jobs/test/analysis/waveform.png"
         
         service = AudioAnalysisService(storage_service=mock_storage_service)
-        result, waveform_path = service.analyze_and_generate_waveform(
+        result, waveform_path, comparison = service.analyze_and_generate_waveform(
             gcs_audio_path="jobs/test/stems/backing_vocals.flac",
             job_id="test-job",
             gcs_waveform_destination="jobs/test/analysis/waveform.png",
         )
-        
+
         # Verify upload was called
         mock_storage_service.upload_file.assert_called_once()
-        
+
         # Verify waveform path is returned
         assert waveform_path == "jobs/test/analysis/waveform.png"
+        # No lead/vocals stems passed -> no 3-stem comparison
+        assert comparison is None
+
+    def test_analyze_with_extra_stems_returns_comparison(
+        self, mock_storage_service, temp_audio_file
+    ):
+        """Passing lead + vocals stem paths yields a stem_comparison dict."""
+        from backend.services.audio_analysis_service import AudioAnalysisService
+
+        def mock_download(gcs_path, local_path):
+            import shutil
+            shutil.copy(temp_audio_file, local_path)
+            return local_path
+
+        mock_storage_service.download_file.side_effect = mock_download
+        mock_storage_service.upload_file.return_value = "jobs/test/analysis/waveform.png"
+
+        service = AudioAnalysisService(storage_service=mock_storage_service)
+        _result, _waveform, comparison = service.analyze_and_generate_waveform(
+            gcs_audio_path="jobs/test/stems/backing_vocals.flac",
+            job_id="test-job",
+            gcs_waveform_destination="jobs/test/analysis/waveform.png",
+            gcs_lead_vocals_path="jobs/test/stems/lead_vocals.flac",
+            gcs_vocals_path="jobs/test/stems/vocals_clean.flac",
+        )
+
+        assert comparison is not None
+        assert comparison["error"] is None
+        # All three "stems" are the same file here -> full coverage + corr 1.
+        assert comparison["coverage_ratio"] == 1.0
+
+    def test_comparison_download_failure_is_non_fatal(
+        self, mock_storage_service, temp_audio_file
+    ):
+        """A failure fetching the extra stems yields comparison=None, no raise."""
+        from backend.services.audio_analysis_service import AudioAnalysisService
+
+        calls = {"n": 0}
+
+        def mock_download(gcs_path, local_path):
+            import shutil
+            calls["n"] += 1
+            if calls["n"] > 1:  # backing succeeds, extra stems fail
+                raise RuntimeError("gcs down")
+            shutil.copy(temp_audio_file, local_path)
+            return local_path
+
+        mock_storage_service.download_file.side_effect = mock_download
+        mock_storage_service.upload_file.return_value = "jobs/test/analysis/waveform.png"
+
+        service = AudioAnalysisService(storage_service=mock_storage_service)
+        _result, waveform_path, comparison = service.analyze_and_generate_waveform(
+            gcs_audio_path="jobs/test/stems/backing_vocals.flac",
+            job_id="test-job",
+            gcs_waveform_destination="jobs/test/analysis/waveform.png",
+            gcs_lead_vocals_path="jobs/test/stems/lead_vocals.flac",
+            gcs_vocals_path="jobs/test/stems/vocals_clean.flac",
+        )
+
+        assert waveform_path == "jobs/test/analysis/waveform.png"
+        assert comparison is None
     
     def test_get_waveform_data_returns_amplitudes(
         self, mock_storage_service, temp_audio_file

--- a/backend/workers/screens_worker.py
+++ b/backend/workers/screens_worker.py
@@ -575,7 +575,8 @@ async def _analyze_backing_vocals(
             return
 
         # Get backing vocals path
-        backing_vocals_path = job.file_urls.get('stems', {}).get('backing_vocals')
+        stems = job.file_urls.get('stems', {})
+        backing_vocals_path = stems.get('backing_vocals')
         if not backing_vocals_path:
             job_log.warning("No backing vocals file found - skipping analysis")
             return
@@ -588,11 +589,16 @@ async def _analyze_backing_vocals(
         # Define output path for waveform
         waveform_gcs_path = f"jobs/{job_id}/analysis/backing_vocals_waveform.png"
 
-        # Run analysis and generate waveform
-        result, waveform_path = analysis_service.analyze_and_generate_waveform(
+        # Run analysis and generate waveform. Passing the lead + full-vocals
+        # stems as well enables the 3-stem comparison the backing-vocals
+        # decider uses to tell genuine harmonies from lead bleed / a
+        # misclassified lead / flat noise (best-effort — None when missing).
+        result, waveform_path, stem_comparison = analysis_service.analyze_and_generate_waveform(
             gcs_audio_path=backing_vocals_path,
             job_id=job_id,
             gcs_waveform_destination=waveform_gcs_path,
+            gcs_lead_vocals_path=stems.get('lead_vocals'),
+            gcs_vocals_path=stems.get('vocals_clean'),
         )
 
         # Store analysis results in job state_data
@@ -614,6 +620,8 @@ async def _analyze_backing_vocals(
             'audible_percentage': result.audible_percentage,
             'silence_threshold_db': result.silence_threshold_db,
         }
+        if stem_comparison is not None:
+            analysis_data['stem_comparison'] = stem_comparison
 
         job_manager.update_state_data(job_id, 'backing_vocals_analysis', analysis_data)
 

--- a/docs/archive/2026-08-25-full-auto-review-design.md
+++ b/docs/archive/2026-08-25-full-auto-review-design.md
@@ -387,3 +387,33 @@ scorer's gap-coverage signal, and the proactive cache.
   auto-ship WITH the human's exact edit applied**; ae0cd7e8 (Samson corpus job) now has its P4
   edits actually applied when auto-shipping. `ai-resolved` caps deliberately NOT loosened
   (69ca7c1e still 14 uncovered words — needs more coverage, not looser caps).
+
+## Session 6 update (2026-08-28) — Phase 2B: 3-stem backing decider (v0.204.0)
+
+Build-order item #4 shipped (decider + signals; enforcement shadow-first):
+
+- **`karaoke_gen/instrumental_review/stem_comparison.py`** (new, pure pydub) — compares the
+  backing / lead / full-vocals stems: audible coverage per stem + coverage ratio, envelope
+  Pearson correlations (backing↔vocals, backing↔lead), median audible levels, lead-overlap
+  fraction, within-run flatness. Wired into `_analyze_backing_vocals` (screens_worker →
+  AudioAnalysisService) → stored as `backing_vocals_analysis.stem_comparison` on every new job.
+- **Scorer v0.3.0** — `score_backing` decides the pink-present branch (previously always
+  review): confident **WITH_BACKING** (non-subjective keep) unless one of the corpus-validated
+  "pink but don't keep" modes fires: backing-stem-IS-the-lead (covR ≥0.80 + corr ≥0.80 +
+  backing more present than lead — the decisive discriminator; the dB-margin idea nearly
+  misfired on a genuine keep), noise-floor signature (median ≤ −35 dB over ≥15% of track,
+  corr ≤0.05 — REVIEW, marginal per corpus), narrow bleed rule (≤3% audible, lead overlap
+  ≥0.95 — d508adb6's genuine 0.89-overlap harmonies must stay keepable).
+- **Corpus validation (validate_backing_decider.py, private; ~2.4 GB stems cached locally):
+  13/14 true keeps → confident WITH_BACKING — including BOTH jobs the human under-kept
+  (44622ffa, 35ed9697): the decider beats the human's quick review. 95d8e844 (marginal
+  grungegaze) → review. All clean-correct jobs → clean. 1d45b286 (catastrophic
+  backing-is-lead) → review. Zero unsafe outcomes.**
+- **Executor**: WITH_BACKING verdict enforces `instrumental_selection="with_backing"` ONLY
+  behind `AUTO_APPROVAL_BACKING_KEEP_ENABLED` (default **false** — shadow-first per plan);
+  while off, such jobs record blocker `backing_keep_disabled` + full verdict/signals in
+  `processing_metadata.auto_approval` for prod shadow calibration alongside human picks.
+  Requires the `instrumental_with_backing` stem (blocker `no_with_backing_stem`).
+- Flip-on procedure: review shadow verdicts vs human picks for a while, then set
+  `AUTO_APPROVAL_BACKING_KEEP_ENABLED=true` on the backend service. The Cher-class jobs
+  (lyrics solved, gated only by audible backing — 46201da4) then become fully auto.

--- a/karaoke_gen/instrumental_review/stem_comparison.py
+++ b/karaoke_gen/instrumental_review/stem_comparison.py
@@ -1,0 +1,254 @@
+"""3-stem comparison signals for the backing-vocals decider.
+
+Compares the backing_vocals stem against the lead_vocals stem and the full
+vocals stem (stage-1 "vocals_clean") to distinguish genuine backing harmonies
+from the "pink but don't keep" failure modes identified in the 2026-08
+replay-review corpus (docs/automation-corpus/backing-vocals-decision-logic.md,
+private):
+
+- **Backing stem IS the lead** (catastrophic if kept): a quiet/reverby lead is
+  misclassified as "backing", so the backing stem tracks the entire vocal line.
+  Tells: backing audible-coverage ≈ full-vocals coverage, high envelope
+  correlation with the vocals stem, and a lead stem that is quiet/sparse
+  relative to the backing stem.
+- **Lead-vocal bleed**: a few backing blobs coincide with lead activity.
+  Tell: backing-audible windows mostly overlap lead-audible windows.
+- **Flat-noise pink** (lo-fi/fuzzy mixes): the noise floor sits above the
+  silence threshold, producing sustained low-dynamics "pink" that is noise,
+  not voice. Tell: low within-run amplitude variance.
+
+Pure Python + pydub (same dependency set as ``analyzer.py``); works on local
+file paths so it runs identically in the cloud workers and the local CLI.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import List, Optional
+
+from pydub import AudioSegment
+
+logger = logging.getLogger(__name__)
+
+SILENT_DB = -100.0
+
+
+@dataclass
+class StemComparison:
+    """Signals from comparing backing / lead / full-vocals stems.
+
+    All fractions are 0..1. ``None`` medians mean the stem had no audible
+    windows. JSON-serializable via ``to_dict`` for ``state_data`` storage.
+    """
+
+    window_ms: int = 100
+    silence_threshold_db: float = -40.0
+    duration_seconds: float = 0.0
+    # Audible coverage (fraction of windows above the silence threshold).
+    backing_audible_fraction: float = 0.0
+    lead_audible_fraction: float = 0.0
+    vocals_audible_fraction: float = 0.0
+    # backing coverage relative to the full vocal line (capped at 1.0).
+    coverage_ratio: float = 0.0
+    # Pearson correlation of linear RMS envelopes.
+    corr_backing_vocals: float = 0.0
+    corr_backing_lead: float = 0.0
+    # Median window level (dBFS) over each stem's own audible windows.
+    backing_median_db: Optional[float] = None
+    lead_median_db: Optional[float] = None
+    vocals_median_db: Optional[float] = None
+    # Fraction of backing-audible windows where the lead stem is also audible.
+    lead_overlap_fraction: float = 0.0
+    # Amplitude dynamics of the backing stem's audible content.
+    backing_db_std: float = 0.0
+    # Fraction of backing-audible time inside "flat" runs (sustained, low
+    # within-run variance — the noise signature).
+    flat_fraction: float = 0.0
+    error: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _rms_db_envelope(path: str, window_ms: int) -> List[float]:
+    """RMS level (dBFS) per window for a mono-mixed audio file."""
+    audio = AudioSegment.from_file(path)
+    if audio.channels > 1:
+        audio = audio.set_channels(1)
+    envelope: List[float] = []
+    duration_ms = len(audio)
+    for start_ms in range(0, duration_ms, window_ms):
+        window = audio[start_ms : start_ms + window_ms]
+        if window.rms > 0:
+            envelope.append(
+                20 * math.log10(window.rms / window.max_possible_amplitude)
+            )
+        else:
+            envelope.append(SILENT_DB)
+    return envelope
+
+
+def _db_to_linear(db: float) -> float:
+    return 10.0 ** (db / 20.0) if db > SILENT_DB else 0.0
+
+
+def _pearson(a: List[float], b: List[float]) -> float:
+    n = min(len(a), len(b))
+    if n < 2:
+        return 0.0
+    a, b = a[:n], b[:n]
+    mean_a = sum(a) / n
+    mean_b = sum(b) / n
+    cov = sum((x - mean_a) * (y - mean_b) for x, y in zip(a, b))
+    var_a = sum((x - mean_a) ** 2 for x in a)
+    var_b = sum((y - mean_b) ** 2 for y in b)
+    if var_a <= 0.0 or var_b <= 0.0:
+        return 0.0
+    return cov / math.sqrt(var_a * var_b)
+
+
+def _median(values: List[float]) -> Optional[float]:
+    if not values:
+        return None
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2.0
+
+
+def _std(values: List[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    mean = sum(values) / len(values)
+    return math.sqrt(sum((v - mean) ** 2 for v in values) / len(values))
+
+
+def _flat_fraction(
+    envelope_db: List[float],
+    threshold_db: float,
+    *,
+    window_ms: int,
+    min_run_seconds: float = 3.0,
+    flat_std_db: float = 2.5,
+) -> float:
+    """Fraction of audible windows sitting in long, low-variance ("flat") runs.
+
+    Noise pushed above the silence threshold by a fuzzy mix is sustained and
+    even; real voice has onsets/peaks. A run is a maximal stretch of
+    consecutive audible windows; long runs whose within-run dB std is small
+    count as flat.
+    """
+    min_run_windows = max(2, int(min_run_seconds * 1000 / window_ms))
+    audible_total = 0
+    flat_total = 0
+    run: List[float] = []
+
+    def close_run() -> None:
+        nonlocal flat_total
+        if len(run) >= min_run_windows and _std(run) < flat_std_db:
+            flat_total += len(run)
+
+    for db in envelope_db:
+        if db > threshold_db:
+            audible_total += 1
+            run.append(db)
+        else:
+            close_run()
+            run = []
+    close_run()
+    return flat_total / audible_total if audible_total else 0.0
+
+
+def compare_stems(
+    backing_path: str,
+    lead_path: str,
+    vocals_path: str,
+    *,
+    silence_threshold_db: float = -40.0,
+    window_ms: int = 100,
+) -> StemComparison:
+    """Compute the 3-stem comparison signals from local audio files.
+
+    Never raises: any failure returns a StemComparison with ``error`` set so
+    the caller stores an explicit "comparison unavailable" marker (the scorer
+    treats that as no-comparison, never as evidence).
+    """
+    try:
+        for p in (backing_path, lead_path, vocals_path):
+            if not Path(p).exists():
+                raise FileNotFoundError(p)
+
+        backing = _rms_db_envelope(backing_path, window_ms)
+        lead = _rms_db_envelope(lead_path, window_ms)
+        vocals = _rms_db_envelope(vocals_path, window_ms)
+        n = min(len(backing), len(lead), len(vocals))
+        backing, lead, vocals = backing[:n], lead[:n], vocals[:n]
+        if n == 0:
+            raise ValueError("empty audio")
+
+        thr = silence_threshold_db
+        backing_audible = [db for db in backing if db > thr]
+        lead_audible = [db for db in lead if db > thr]
+        vocals_audible = [db for db in vocals if db > thr]
+
+        backing_fraction = len(backing_audible) / n
+        vocals_fraction = len(vocals_audible) / n
+        overlap_windows = sum(
+            1 for b, l in zip(backing, lead) if b > thr and l > thr
+        )
+
+        return StemComparison(
+            window_ms=window_ms,
+            silence_threshold_db=thr,
+            duration_seconds=round(n * window_ms / 1000.0, 2),
+            backing_audible_fraction=round(backing_fraction, 4),
+            lead_audible_fraction=round(len(lead_audible) / n, 4),
+            vocals_audible_fraction=round(vocals_fraction, 4),
+            coverage_ratio=round(
+                min(1.0, backing_fraction / vocals_fraction)
+                if vocals_fraction > 0
+                else 0.0,
+                4,
+            ),
+            corr_backing_vocals=round(
+                _pearson(
+                    [_db_to_linear(db) for db in backing],
+                    [_db_to_linear(db) for db in vocals],
+                ),
+                4,
+            ),
+            corr_backing_lead=round(
+                _pearson(
+                    [_db_to_linear(db) for db in backing],
+                    [_db_to_linear(db) for db in lead],
+                ),
+                4,
+            ),
+            backing_median_db=_round_opt(_median(backing_audible)),
+            lead_median_db=_round_opt(_median(lead_audible)),
+            vocals_median_db=_round_opt(_median(vocals_audible)),
+            lead_overlap_fraction=round(
+                overlap_windows / len(backing_audible), 4
+            )
+            if backing_audible
+            else 0.0,
+            backing_db_std=round(_std(backing_audible), 3),
+            flat_fraction=round(
+                _flat_fraction(backing, thr, window_ms=window_ms), 4
+            ),
+        )
+    except Exception as e:  # noqa: BLE001 — comparison is best-effort by design
+        logger.warning("stem comparison failed: %s", e, exc_info=True)
+        return StemComparison(
+            window_ms=window_ms,
+            silence_threshold_db=silence_threshold_db,
+            error=str(e),
+        )
+
+
+def _round_opt(value: Optional[float]) -> Optional[float]:
+    return None if value is None else round(value, 2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.203.0"
+version = "0.204.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Phase 2B of fully-automated review (follows #949): the backing-vocals decision gets a real decider. Today any track with audible ("pink") backing content goes to human review; per the 20-job replay-review corpus, pink → KEEP is right essentially always — the human systematically *under*-keeps — except three detectable "pink but don't keep" failure modes. This PR builds the 3-stem analysis that detects them and lets the scorer emit a confident **WITH_BACKING** verdict.

- **New `karaoke_gen/instrumental_review/stem_comparison.py`** (pure pydub): compares the backing / lead / full-vocals stems — per-stem audible coverage + coverage ratio, envelope Pearson correlations, median audible levels, lead-overlap fraction, within-run flatness. Runs in the existing backing-vocals analysis step (screens_worker → AudioAnalysisService) and is stored as `backing_vocals_analysis.stem_comparison` on every new job. Best-effort: any failure stores an error marker, never blocks the job.
- **Scorer v0.3.0**: the pink-present branch now decides — confident WITH_BACKING (non-subjective, bias-to-keep per corpus) unless:
  - **backing stem IS the lead** (catastrophic if kept): coverage ratio ≥0.80 + backing↔vocals correlation ≥0.80 + backing more audible than the lead stem (the decisive discriminator — a plain dB-margin rule nearly misfired on a genuine keep) → review;
  - **noise-floor pink** (lo-fi mixes): median ≤ −35 dB across ≥15% of the track, uncorrelated with the vocal line → review (marginal either way per corpus);
  - **lead bleed** (narrow): ≤3% audible with ≥0.95 lead overlap → review.
- **Executor**: a WITH_BACKING verdict auto-selects the with-backing instrumental **only** behind `AUTO_APPROVAL_BACKING_KEEP_ENABLED` (default **false** — shadow-first). While off, such jobs record blocker `backing_keep_disabled` plus the full verdict/signals in `processing_metadata.auto_approval`, accumulating prod shadow data alongside human picks. Also requires the `instrumental_with_backing` stem.

## Validation (real corpus stems, ~2.4 GB, private harness)

Downloaded all 20 corpus jobs' three stems from GCS and ran the decider against the replay-review ground truth:

- **13/14 true keeps → confident WITH_BACKING**, including BOTH jobs the human wrongly cleaned on quick review (44622ffa harmonized ahhs, 35ed9697 self-harmony hooks) — the decider beats the human here.
- 95d8e844 (marginal grungegaze, mostly noise pink) → review. All clean-correct jobs → clean. **1d45b286 (backing stem is the lead — worst-case if kept) → review.** Zero unsafe outcomes.
- Lyrics-side corpus validation (validate_scorer.py) unchanged and green.

## Testing

- 21 new unit tests: synthetic-audio stem-comparison signal tests, scorer decision branches modeled on the real corpus signal profiles, executor flag/stem gating.
- Full backend suite: 4056 passed, 0 failed. Backend-only change (no frontend, no user-facing strings).

## Rollout

Shadow-first: nothing changes for users at deploy. After reviewing prod shadow verdicts vs human picks, set `AUTO_APPROVAL_BACKING_KEEP_ENABLED=true` to let confident-keep jobs (e.g. the Cher-class: lyrics solved, gated only by audible backing) complete fully auto.

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)