### PR TITLE
feat: auto-complete user-supplied-instrumental jobs with selection=custom (v0.205.0)

### DIFF
--- a/backend/services/auto_approval/executor.py
+++ b/backend/services/auto_approval/executor.py
@@ -11,11 +11,15 @@ Every call scores the job and records the verdict in
 Enforcement — actually skipping the review screens — happens only when ALL of:
 - the feature flag is on and the job's ``review_mode`` is "auto" (the default);
 - the job is not a made-for-you order (the human QC pass is part of that
-  product) and has no existing/custom instrumental (different selection
-  semantics — revisit later);
-- the scorer's ``overall_auto`` is True (confident lyrics AND non-subjective
-  no-audible-backing decision);
-- audio separation is complete and the clean instrumental stem exists.
+  product);
+- the job is ELIGIBLE: with a user-supplied instrumental (tenant bulk uploads,
+  the existing-instrumental upload option, mute-region edits) there is no
+  instrumental decision to make, so confident lyrics alone qualify and the
+  selection is "custom" — mirroring the human tenant complete-review flow.
+  Otherwise the scorer's ``overall_auto`` must be True (confident lyrics AND a
+  non-subjective backing decision);
+- audio separation is complete and the required instrumental exists (clean or
+  with-backing stem; the video worker validates custom sources itself).
 
 The enforce path replicates exactly what a human clicking "Complete Review"
 does after the UI's on-load auto-apply: apply the cached AI suggestions
@@ -34,7 +38,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from backend.models.job import JobStatus
-from backend.services.auto_approval.models import BackingVerdict
+from backend.services.auto_approval.models import BackingVerdict, LyricsVerdict
 
 logger = logging.getLogger(__name__)
 
@@ -70,10 +74,22 @@ def _enforcement_blockers(job, settings) -> List[str]:
         blockers.append(f"review_mode:{review_mode}")
     if getattr(job, "made_for_you", False):
         blockers.append("made_for_you")
-    stems = (job.file_urls or {}).get("stems", {}) if job.file_urls else {}
-    if getattr(job, "existing_instrumental_gcs_path", None) or stems.get("custom_instrumental"):
-        blockers.append("custom_instrumental")
     return blockers
+
+
+def _has_custom_instrumental(job) -> bool:
+    """True when the user supplied their own instrumental (tenant bulk uploads,
+    the upload flow's existing-instrumental option, or a mute-region edit).
+
+    For these jobs there is NO instrumental decision to make — the human
+    complete-review flow submits ``instrumental_selection="custom"`` — so the
+    auto class is lyrics-only and the backing verdict is moot.
+    """
+    stems = (job.file_urls or {}).get("stems", {}) if job.file_urls else {}
+    return bool(
+        getattr(job, "existing_instrumental_gcs_path", None)
+        or stems.get("custom_instrumental")
+    )
 
 
 async def maybe_auto_complete_review(job_id: str, trigger: str) -> Dict[str, Any]:
@@ -122,9 +138,18 @@ async def maybe_auto_complete_review(job_id: str, trigger: str) -> Dict[str, Any
 
         verdict = score_job(corrections, backing_analysis, ai_suggestions)
         blockers = _enforcement_blockers(job, settings)
-        keep_backing = verdict.backing.verdict == BackingVerdict.WITH_BACKING
+        custom_instrumental = _has_custom_instrumental(job)
+        keep_backing = (
+            not custom_instrumental
+            and verdict.backing.verdict == BackingVerdict.WITH_BACKING
+        )
         if not audio_complete:
             blockers.append("audio_incomplete")
+        elif custom_instrumental:
+            # User-supplied instrumental -> selection is "custom" by
+            # definition; no separated-stem requirements. The video worker
+            # validates the custom source itself.
+            pass
         elif keep_backing:
             # Confident-keep (3-stem decider) selects the with-backing
             # instrumental — gated shadow-first behind its own flag.
@@ -135,10 +160,22 @@ async def maybe_auto_complete_review(job_id: str, trigger: str) -> Dict[str, Any
         elif not stems.get("instrumental_clean"):
             blockers.append("no_clean_stem")
 
+        # Eligibility: with a user-supplied instrumental the backing decision
+        # is moot, so confident lyrics alone qualify; otherwise the narrow
+        # intersection (confident lyrics AND non-subjective backing) applies.
+        if custom_instrumental:
+            eligible = verdict.lyrics.verdict == LyricsVerdict.AUTO
+            enforcement_basis = "lyrics_only_custom_instrumental"
+        else:
+            eligible = verdict.overall_auto
+            enforcement_basis = "overall_auto"
+
         payload = verdict.to_dict()
         payload.update({
             "mode": "shadow",  # flipped to "enforce" only when we actually enforce
             "enforcement_eligible": not blockers,
+            "enforcement_basis": enforcement_basis,
+            "custom_instrumental": custom_instrumental,
             "trigger": trigger,
             "enforcement_blockers": blockers,
             "audio_complete_at_scoring": audio_complete,
@@ -148,14 +185,14 @@ async def maybe_auto_complete_review(job_id: str, trigger: str) -> Dict[str, Any
         })
 
         summary = (
-            f"auto-approval [{trigger}]: overall_auto={verdict.overall_auto} "
+            f"auto-approval [{trigger}]: eligible={eligible} ({enforcement_basis}) "
             f"lyrics={verdict.lyrics.verdict.value}/{verdict.lyrics.tier} "
             f"backing={verdict.backing.verdict.value} blockers={blockers or 'none'} "
             f"(scorer v{verdict.scorer_version})"
         )
         logger.info(f"[job:{job_id}] {summary}")
 
-        if not verdict.overall_auto or blockers:
+        if not eligible or blockers:
             payload["outcome"] = "review"
             job_manager.update_processing_metadata(job_id, "auto_approval", payload)
             return {"outcome": "review", "overall_auto": verdict.overall_auto,
@@ -190,10 +227,15 @@ async def maybe_auto_complete_review(job_id: str, trigger: str) -> Dict[str, Any
             )
             return {"outcome": "aborted", "reason": applied_info["aborted"]}
 
-        # Non-subjective backing verdict -> matching instrumental selection:
-        # CLEAN ("no audible backing") -> clean stem; WITH_BACKING (confident
-        # 3-stem decider keep, flag-gated above) -> with-backing stem.
-        selection = "with_backing" if keep_backing else "clean"
+        # Instrumental selection: user-supplied instrumental -> "custom"
+        # (mirrors the human tenant complete-review flow); otherwise the
+        # non-subjective backing verdict picks the separated stem — CLEAN
+        # ("no audible backing") -> clean, WITH_BACKING (confident 3-stem
+        # decider keep, flag-gated above) -> with-backing.
+        if custom_instrumental:
+            selection = "custom"
+        else:
+            selection = "with_backing" if keep_backing else "clean"
         job_manager.update_state_data(job_id, "instrumental_selection", selection)
 
         # Clear worker progress keys so downstream workers run fresh (mirrors
@@ -208,9 +250,13 @@ async def maybe_auto_complete_review(job_id: str, trigger: str) -> Dict[str, Any
             message=(
                 "Auto-approved: lyrics verified against synced references and "
                 + (
-                    "clear backing vocals retained"
-                    if keep_backing
-                    else "no audible backing vocals"
+                    "using your provided instrumental"
+                    if custom_instrumental
+                    else (
+                        "clear backing vocals retained"
+                        if keep_backing
+                        else "no audible backing vocals"
+                    )
                 )
                 + " — skipping review, rendering video"
             ),

--- a/backend/services/auto_approval/executor.py
+++ b/backend/services/auto_approval/executor.py
@@ -173,7 +173,7 @@ async def maybe_auto_complete_review(job_id: str, trigger: str) -> Dict[str, Any
         payload = verdict.to_dict()
         payload.update({
             "mode": "shadow",  # flipped to "enforce" only when we actually enforce
-            "enforcement_eligible": not blockers,
+            "enforcement_eligible": eligible and not blockers,
             "enforcement_basis": enforcement_basis,
             "custom_instrumental": custom_instrumental,
             "trigger": trigger,

--- a/backend/tests/services/auto_approval/test_executor.py
+++ b/backend/tests/services/auto_approval/test_executor.py
@@ -192,12 +192,41 @@ async def test_incomplete_audio_blocks_enforcement() -> None:
 
 
 @pytest.mark.asyncio
-async def test_existing_instrumental_blocks_enforcement() -> None:
+async def test_existing_instrumental_completes_with_custom_selection() -> None:
+    # Tenant/bulk jobs with a user-supplied instrumental have NO instrumental
+    # decision — confident lyrics alone auto-complete with selection="custom",
+    # even with NO backing analysis at all (the backing verdict is moot).
     result, jm, _, _ = await _run(
-        _job(backing=_clean_backing(), existing_instrumental="jobs/j1/custom.flac")
+        _job(backing=None, existing_instrumental="jobs/j1/custom.flac")
+    )
+    assert result["outcome"] == "auto_completed"
+    jm.update_state_data.assert_any_call("j1", "instrumental_selection", "custom")
+    payload = jm.update_processing_metadata.call_args.args[2]
+    assert payload["enforcement_basis"] == "lyrics_only_custom_instrumental"
+    assert payload["custom_instrumental"] is True
+
+
+@pytest.mark.asyncio
+async def test_custom_instrumental_stem_also_selects_custom() -> None:
+    job = _job(backing=None)
+    job.file_urls["stems"]["custom_instrumental"] = "jobs/j1/stems/custom.flac"
+    # No separated instrumental required for custom jobs.
+    del job.file_urls["stems"]["instrumental_clean"]
+    result, jm, _, _ = await _run(job)
+    assert result["outcome"] == "auto_completed"
+    jm.update_state_data.assert_any_call("j1", "instrumental_selection", "custom")
+
+
+@pytest.mark.asyncio
+async def test_existing_instrumental_still_requires_confident_lyrics() -> None:
+    corrections = _confident_corrections()
+    corrections["reference_lyrics"] = {}  # no references -> lyrics review
+    result, jm, _, _ = await _run(
+        _job(backing=None, existing_instrumental="jobs/j1/custom.flac"),
+        corrections=corrections,
     )
     assert result["outcome"] == "review"
-    assert "custom_instrumental" in result["blockers"]
+    jm.transition_to_state.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/docs/archive/2026-08-25-full-auto-review-design.md
+++ b/docs/archive/2026-08-25-full-auto-review-design.md
@@ -417,3 +417,15 @@ Build-order item #4 shipped (decider + signals; enforcement shadow-first):
 - Flip-on procedure: review shadow verdicts vs human picks for a while, then set
   `AUTO_APPROVAL_BACKING_KEEP_ENABLED=true` on the backend service. The Cher-class jobs
   (lyrics solved, gated only by audible backing — 46201da4) then become fully auto.
+
+## Session 7 update (2026-08-28 evening) — Phase 2D: user-supplied-instrumental jobs auto-complete (v0.205.0)
+
+Tenant/bulk jobs (and any job with `existing_instrumental_gcs_path` or a `custom_instrumental`
+stem) previously carried the `custom_instrumental` enforcement blocker. But these jobs have NO
+instrumental decision — the human flow completes them with `instrumental_selection="custom"`
+(validated in review.py complete; video worker prefers the user-provided source). Executor now:
+confident lyrics alone ⇒ auto-complete with selection="custom"
+(`enforcement_basis="lyrics_only_custom_instrumental"` recorded in the payload; backing verdict
+moot). Non-custom jobs unchanged (`overall_auto`). Per-job opt-out stays `review_mode=
+"always_review"`; per-tenant default config is future work (workstream C/D follow-up).
+This makes tenant bulk uploads the highest-auto-rate population (B2B throughput).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.204.0"
+version = "0.205.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Phase 2D of fully-automated review (follows #949/#950) — the highest-business-value slice: tenant bulk-upload jobs (and any job with a user-supplied instrumental) can now complete fully automatically.

Jobs with `existing_instrumental_gcs_path` or a `custom_instrumental` stem have **no instrumental decision to make** — the human complete-review flow submits `instrumental_selection="custom"` (review.py validates it exactly under these conditions; the video worker prefers the user-provided source). The executor previously excluded these jobs outright via the `custom_instrumental` blocker. Now:

- **Confident lyrics alone auto-complete them** with `instrumental_selection="custom"`, mirroring the human tenant complete-review exactly. The backing verdict is moot (no separated-stem requirements; the video worker validates custom sources itself).
- Non-custom jobs are unchanged: the `overall_auto` intersection (confident lyrics AND non-subjective backing) still applies.
- `processing_metadata.auto_approval` now records `enforcement_basis` (`lyrics_only_custom_instrumental` vs `overall_auto`) and `custom_instrumental` for shadow analysis, and `enforcement_eligible` now reflects verdict eligibility AND blockers (CodeRabbit catch).
- Per-job opt-out remains `review_mode="always_review"` (admin-editable). A per-tenant default is future work.

This makes tenant bulk uploads the highest-auto-rate population: their jobs skip both review screens whenever the scorer is confident in the lyrics, going straight to render with the instrumental the tenant supplied.

## Testing

- Executor tests updated: the old `custom_instrumental`-blocks test replaced by three new tests — auto-complete with selection="custom" even with NO backing analysis (moot), custom-stem variant without separated stems, and weak-lyrics still gating to review.
- Full backend suite: 4056 passed, 0 failed. Backend-only change.
- Live validation planned tonight: a Vocal Star tenant bulk upload (~10 tracks) after deploy, watching `enforcement_basis`/outcomes in prod.

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)