### PR TITLE
fix: clean up published outputs before job delete; admin orphaned-outputs cleanup (v0.206.0)

### DIFF
--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -1888,6 +1888,120 @@ async def delete_job_outputs(
     )
 
 
+class OrphanedOutputsCleanupRequest(BaseModel):
+    """Explicit targets for cleaning up distributed outputs whose owning job doc no
+    longer exists (e.g. a job deleted before its outputs were cleaned up)."""
+    youtube_video_id: Optional[str] = None
+    dropbox_folder_path: Optional[str] = None
+    gdrive_file_ids: List[str] = []
+    mirror_filename_prefix: Optional[str] = None  # e.g. "NOMAD-1583 - Mazzy Star"
+
+
+@router.post("/orphaned-outputs/cleanup")
+async def cleanup_orphaned_outputs(
+    req: OrphanedOutputsCleanupRequest,
+    auth_data: AuthResult = Depends(require_admin),
+) -> dict:
+    """
+    Delete distributed outputs that no longer have an owning job doc (admin only).
+
+    The per-job cleanup endpoints (delete-outputs, cleanup-distribution) all require
+    the job document to resolve file IDs and paths. When a job was deleted while its
+    outputs were still published (the pre-fix DELETE /api/jobs/{id} behavior), those
+    outputs are orphaned and must be targeted explicitly:
+
+    - youtube_video_id: YouTube video to delete (bare video ID)
+    - dropbox_folder_path: full Dropbox folder path to delete
+    - gdrive_file_ids: Google Drive file IDs to delete (from upload logs)
+    - mirror_filename_prefix: "NOMAD-#### - Artist..." prefix for kjbox GCS mirror
+      objects (masters + vocals guides); must include artist text so it can't match
+      another track sharing a recycled brand code
+
+    Returns per-service results; each requested service reports success/failed/error.
+    """
+    admin_email = auth_data.user_email or "unknown"
+    if not any([req.youtube_video_id, req.dropbox_folder_path, req.gdrive_file_ids, req.mirror_filename_prefix]):
+        raise HTTPException(status_code=400, detail="No cleanup targets specified")
+
+    logger.info(
+        f"Admin {admin_email} cleaning up orphaned outputs: "
+        f"youtube={req.youtube_video_id}, dropbox={req.dropbox_folder_path}, "
+        f"gdrive={req.gdrive_file_ids}, mirror_prefix={req.mirror_filename_prefix}"
+    )
+    results: Dict[str, Any] = {}
+
+    if req.youtube_video_id:
+        try:
+            from karaoke_gen.karaoke_finalise.karaoke_finalise import KaraokeFinalise
+            from backend.services.youtube_service import get_youtube_service
+
+            youtube_service = get_youtube_service()
+            if youtube_service.is_configured:
+                finalise = KaraokeFinalise(
+                    dry_run=False,
+                    non_interactive=True,
+                    user_youtube_credentials=youtube_service.get_credentials_dict(),
+                )
+                success = finalise.delete_youtube_video(req.youtube_video_id)
+                results["youtube"] = {
+                    "status": "success" if success else "failed",
+                    "video_id": req.youtube_video_id,
+                }
+            else:
+                results["youtube"] = {"status": "failed", "reason": "YouTube credentials not configured"}
+        except Exception as e:
+            logger.error(f"Error deleting orphaned YouTube video {req.youtube_video_id}: {e}", exc_info=True)
+            results["youtube"] = {"status": "error", "error": str(e)}
+
+    if req.dropbox_folder_path:
+        try:
+            from backend.services.dropbox_service import get_dropbox_service
+
+            dropbox = get_dropbox_service()
+            if dropbox.is_configured:
+                success = dropbox.delete_folder(req.dropbox_folder_path)
+                results["dropbox"] = {
+                    "status": "success" if success else "failed",
+                    "path": req.dropbox_folder_path,
+                }
+            else:
+                results["dropbox"] = {"status": "failed", "reason": "Dropbox credentials not configured"}
+        except Exception as e:
+            logger.error(f"Error deleting orphaned Dropbox folder {req.dropbox_folder_path}: {e}", exc_info=True)
+            results["dropbox"] = {"status": "error", "error": str(e)}
+
+    if req.gdrive_file_ids:
+        try:
+            from backend.services.gdrive_service import get_gdrive_service
+
+            gdrive = get_gdrive_service()
+            if gdrive.is_configured:
+                delete_results = gdrive.delete_files(req.gdrive_file_ids)
+                all_success = all(delete_results.values())
+                results["gdrive"] = {
+                    "status": "success" if all_success else "partial",
+                    "files": delete_results,
+                }
+            else:
+                results["gdrive"] = {"status": "failed", "reason": "Google Drive credentials not configured"}
+        except Exception as e:
+            logger.error(f"Error deleting orphaned GDrive files {req.gdrive_file_ids}: {e}", exc_info=True)
+            results["gdrive"] = {"status": "error", "error": str(e)}
+
+    if req.mirror_filename_prefix:
+        try:
+            from backend.services.nomad_master_mirror import NomadMasterMirror
+
+            counts = NomadMasterMirror().delete_track_objects_by_filename_prefix(req.mirror_filename_prefix)
+            results["mirror"] = {"status": "success", **counts}
+        except Exception as e:
+            logger.error(f"Error deleting orphaned mirror objects for {req.mirror_filename_prefix}: {e}", exc_info=True)
+            results["mirror"] = {"status": "error", "error": str(e)}
+
+    logger.info(f"Orphaned-outputs cleanup by {admin_email} complete: {results}")
+    return {"status": "complete", "results": results}
+
+
 @router.get("/jobs/{job_id}/completion-message", response_model=CompletionMessageResponse)
 async def get_job_completion_message(
     job_id: str,

--- a/backend/api/routes/admin.py
+++ b/backend/api/routes/admin.py
@@ -1923,6 +1923,19 @@ async def cleanup_orphaned_outputs(
     if not any([req.youtube_video_id, req.dropbox_folder_path, req.gdrive_file_ids, req.mirror_filename_prefix]):
         raise HTTPException(status_code=400, detail="No cleanup targets specified")
 
+    if req.mirror_filename_prefix:
+        from backend.services.nomad_master_mirror import is_safe_track_filename_prefix
+
+        if not is_safe_track_filename_prefix(req.mirror_filename_prefix):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Unsafe mirror_filename_prefix {req.mirror_filename_prefix!r}: must be "
+                    f"'NOMAD-#### - Artist...' (brand code plus artist text) so it cannot "
+                    f"match another track sharing a recycled brand code"
+                ),
+            )
+
     logger.info(
         f"Admin {admin_email} cleaning up orphaned outputs: "
         f"youtube={req.youtube_video_id}, dropbox={req.dropbox_folder_path}, "

--- a/backend/api/routes/jobs.py
+++ b/backend/api/routes/jobs.py
@@ -813,27 +813,29 @@ async def delete_job(
         if not _check_job_ownership(job, auth_result):
             raise HTTPException(status_code=403, detail=t(locale, "jobs.noPermissionDelete"))
 
-        # Recycle any unreturned brand code before deleting the job record
+        # If the job still has published outputs (brand code allocated, outputs never
+        # cleaned up), delete the distributed files BEFORE deleting the job record.
+        # The brand code is recycled inside the cleanup only once Dropbox + GDrive are
+        # confirmed clean: recycling while files remain in the public share hands the
+        # same NOMAD-#### to a future job and creates duplicate brand codes (NOMAD-1583
+        # incident, 2026-08-29). If cleanup fails, the code stays allocated — a sequence
+        # gap the GDrive validator surfaces, which is safe and recoverable.
         state_data = job.state_data or {}
         brand_code = state_data.get('brand_code')
-        if brand_code:
-            if not job.outputs_deleted_at:
-                logger.warning(
-                    f"Deleting job {job_id} with brand_code {brand_code} whose outputs "
-                    f"were not cleaned up first. Brand code will be recycled but "
-                    f"distributed files (GDrive/Dropbox/YouTube) may be orphaned."
-                )
-            try:
-                from backend.services.brand_code_service import BrandCodeService, get_brand_code_service
-                prefix, number = BrandCodeService.parse_brand_code(brand_code)
-                get_brand_code_service().recycle_brand_code(prefix, number)
-                logger.info(f"Recycled brand code {brand_code} before deleting job {job_id}")
-            except (ValueError, Exception) as e:
-                logger.warning(f"Failed to recycle brand code {brand_code}: {e}")
+        distribution_cleanup = None
+        if brand_code and not job.outputs_deleted_at:
+            logger.warning(
+                f"Deleting job {job_id} with brand_code {brand_code} whose outputs "
+                f"were not cleaned up first — running distribution cleanup before delete."
+            )
+            distribution_cleanup = _run_distribution_cleanup(job_id, job)
 
         job_manager.delete_job(job_id, delete_files=delete_files)
 
-        return {"status": "success", "message": f"Job {job_id} deleted"}
+        response = {"status": "success", "message": f"Job {job_id} deleted"}
+        if distribution_cleanup is not None:
+            response["distribution_cleanup"] = distribution_cleanup
+        return response
     except HTTPException:
         raise
     except Exception as e:
@@ -2165,41 +2167,23 @@ async def get_worker_logs(
     }
 
 
-@router.post("/{job_id}/cleanup-distribution")
-async def cleanup_distribution(
-    job_id: str,
-    request: Request,
-    delete_job: bool = True,
-    auth_result: AuthResult = Depends(require_admin)
-) -> dict:
+def _run_distribution_cleanup(job_id: str, job) -> dict:
     """
-    Clean up all distributed content for a job (YouTube, Dropbox, Google Drive).
+    Delete a job's distributed outputs (YouTube video, Dropbox folder, Google Drive
+    files, kjbox GCS mirror objects) and recycle its brand code once Dropbox AND
+    GDrive are confirmed clean.
 
-    This admin-only endpoint is designed for E2E test cleanup. It:
-    1. Deletes YouTube video (if uploaded)
-    2. Deletes Dropbox folder (if uploaded)
-    3. Deletes Google Drive files (if uploaded)
-    4. Optionally deletes the job itself
-
-    Args:
-        job_id: Job ID to clean up
-        delete_job: If True, also delete the job after cleaning up distribution
-
-    Returns:
-        Cleanup results for each service
+    Shared by the admin cleanup-distribution endpoint and job deletion. Deleting a
+    job whose outputs are still published MUST run this first: recycling the brand
+    code while the files remain in the public share hands the same NOMAD-#### to a
+    future job and creates duplicate brand codes (NOMAD-1583 incident, 2026-08-29).
     """
-    locale = get_locale_from_request(request)
-    job = job_manager.get_job(job_id)
-    if not job:
-        raise HTTPException(status_code=404, detail=t(locale, "jobs.notFound"))
-
     state_data = job.state_data or {}
     results = {
         "job_id": job_id,
         "youtube": {"status": "skipped", "reason": "no youtube_url in state_data"},
         "dropbox": {"status": "skipped", "reason": "no brand_code or dropbox_path"},
         "gdrive": {"status": "skipped", "reason": "no gdrive_files in state_data"},
-        "job_deleted": False
     }
 
     # Clean up YouTube
@@ -2357,6 +2341,41 @@ async def cleanup_distribution(
             f"(gdrive_cleaned={gdrive_cleaned}). Brand code will remain reserved to prevent "
             f"collisions with leftover GDrive files."
         )
+
+
+    return results
+
+
+@router.post("/{job_id}/cleanup-distribution")
+async def cleanup_distribution(
+    job_id: str,
+    request: Request,
+    delete_job: bool = True,
+    auth_result: AuthResult = Depends(require_admin)
+) -> dict:
+    """
+    Clean up all distributed content for a job (YouTube, Dropbox, Google Drive).
+
+    This admin-only endpoint is designed for E2E test cleanup. It:
+    1. Deletes YouTube video (if uploaded)
+    2. Deletes Dropbox folder (if uploaded)
+    3. Deletes Google Drive files (if uploaded)
+    4. Optionally deletes the job itself
+
+    Args:
+        job_id: Job ID to clean up
+        delete_job: If True, also delete the job after cleaning up distribution
+
+    Returns:
+        Cleanup results for each service
+    """
+    locale = get_locale_from_request(request)
+    job = job_manager.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail=t(locale, "jobs.notFound"))
+
+    results = _run_distribution_cleanup(job_id, job)
+    results["job_deleted"] = False
 
     # Delete the job if requested
     if delete_job:

--- a/backend/api/routes/jobs.py
+++ b/backend/api/routes/jobs.py
@@ -824,11 +824,35 @@ async def delete_job(
         brand_code = state_data.get('brand_code')
         distribution_cleanup = None
         if brand_code and not job.outputs_deleted_at:
+            if not delete_files:
+                # Published outputs cannot be preserved when their job record is
+                # deleted — the record holds the only file IDs/paths needed to ever
+                # clean them up or reconcile the brand code.
+                raise HTTPException(
+                    status_code=400,
+                    detail=t(locale, "jobs.deletePublishedRequiresFiles"),
+                )
             logger.warning(
                 f"Deleting job {job_id} with brand_code {brand_code} whose outputs "
                 f"were not cleaned up first — running distribution cleanup before delete."
             )
             distribution_cleanup = _run_distribution_cleanup(job_id, job)
+            incomplete = [
+                svc for svc in ("youtube", "dropbox", "gdrive")
+                if distribution_cleanup.get(svc, {}).get("status") in ("failed", "partial", "error")
+            ]
+            if incomplete:
+                # Keep the job record: it holds the file IDs/paths needed to retry.
+                # Deleting it anyway would orphan the remaining published files with
+                # no way to resolve them later (NOMAD-1583 incident).
+                logger.error(
+                    f"Aborting delete of job {job_id}: distribution cleanup incomplete "
+                    f"for {incomplete} — {distribution_cleanup}"
+                )
+                raise HTTPException(
+                    status_code=502,
+                    detail=t(locale, "jobs.cleanupFailed", services=", ".join(incomplete)),
+                )
 
         job_manager.delete_job(job_id, delete_files=delete_files)
 

--- a/backend/services/nomad_master_mirror.py
+++ b/backend/services/nomad_master_mirror.py
@@ -14,6 +14,7 @@ Scoped to public Nomad Karaoke masters only (brand prefix ``NOMAD``, excluding t
 here must never break the distribution pipeline — the nightly VM remains the safety net.
 """
 import logging
+import re
 from typing import Optional
 
 from google.cloud import storage
@@ -22,6 +23,12 @@ from google.cloud.exceptions import NotFound
 from backend.config import settings
 
 logger = logging.getLogger(__name__)
+
+# A single-track filename prefix must be a full public brand code PLUS at least part
+# of the artist name ("NOMAD-#### - X..."). Stricter than the by-brand deletes: when a
+# recycled brand code is shared by two tracks (orphaned files), this lets cleanup
+# target exactly one of them without touching the other.
+_TRACK_FILENAME_PREFIX_RE = re.compile(r"^NOMAD-\d{4,} - \S.*")
 
 
 def is_nomad_public_brand(brand_code: Optional[str]) -> bool:
@@ -160,6 +167,45 @@ class NomadMasterMirror:
         except Exception as e:  # noqa: BLE001 - never fatal to the pipeline
             logger.warning("Nomad master mirror prefix-delete failed for %s: %s", prefix, e)
         return deleted
+
+
+    def delete_track_objects_by_filename_prefix(self, filename_prefix: str) -> dict:
+        """Delete mirror objects (720p masters + original-vocals guides) whose filename
+        starts with ``filename_prefix`` — e.g. ``"NOMAD-1583 - Mazzy Star"``.
+
+        Used by orphaned-output cleanup when the owning job doc is gone and a recycled
+        brand code is shared with a live track: the prefix must include artist text
+        (enforced by ``_TRACK_FILENAME_PREFIX_RE``) so only the orphaned track's
+        objects match, never the whole brand code. Best-effort; returns counts.
+        """
+        if not _TRACK_FILENAME_PREFIX_RE.match(filename_prefix or ""):
+            logger.warning(
+                "Refusing mirror track delete for unsafe prefix %r "
+                "(must look like 'NOMAD-#### - Artist...')", filename_prefix,
+            )
+            return {"masters_deleted": 0, "vocals_guides_deleted": 0}
+
+        counts = {"masters_deleted": 0, "vocals_guides_deleted": 0}
+        targets = [
+            ("masters_deleted", settings.nomad_master_gcs_prefix.strip("/")),
+            ("vocals_guides_deleted", settings.nomad_vocals_guide_gcs_prefix.strip("/")),
+        ]
+        for key, gcs_prefix in targets:
+            prefix = f"{gcs_prefix}/{filename_prefix}"
+            try:
+                for blob in self._bucket.list_blobs(prefix=prefix):
+                    try:
+                        blob.delete()
+                        counts[key] += 1
+                        logger.info(
+                            "Removed orphaned mirror object gs://%s/%s",
+                            settings.divebar_files_bucket, blob.name,
+                        )
+                    except Exception as e:  # noqa: BLE001
+                        logger.warning("Failed to delete mirror object %s: %s", blob.name, e)
+            except Exception as e:  # noqa: BLE001 - never fatal to the caller
+                logger.warning("Mirror track prefix-delete failed for %s: %s", prefix, e)
+        return counts
 
 
 def cleanup_nomad_masters(brand_code: Optional[str]) -> int:

--- a/backend/services/nomad_master_mirror.py
+++ b/backend/services/nomad_master_mirror.py
@@ -31,6 +31,11 @@ logger = logging.getLogger(__name__)
 _TRACK_FILENAME_PREFIX_RE = re.compile(r"^NOMAD-\d{4,} - \S.*")
 
 
+def is_safe_track_filename_prefix(filename_prefix: Optional[str]) -> bool:
+    """True if the prefix is specific enough for a single-track mirror delete."""
+    return bool(_TRACK_FILENAME_PREFIX_RE.match(filename_prefix or ""))
+
+
 def is_nomad_public_brand(brand_code: Optional[str]) -> bool:
     """True only for public Nomad releases (``NOMAD-####``), not ``NOMADNP`` privates."""
     if not brand_code:
@@ -176,14 +181,17 @@ class NomadMasterMirror:
         Used by orphaned-output cleanup when the owning job doc is gone and a recycled
         brand code is shared with a live track: the prefix must include artist text
         (enforced by ``_TRACK_FILENAME_PREFIX_RE``) so only the orphaned track's
-        objects match, never the whole brand code. Best-effort; returns counts.
+        objects match, never the whole brand code. Matching is delimiter-bounded — the
+        character after the prefix must be a space or ``.`` — so ``"NOMAD-1583 - Mazzy
+        Star"`` can never match a different track named ``"NOMAD-1583 - Mazzy Starlight
+        - ..."``. Raises ``ValueError`` for an unsafe prefix (callers validate with
+        ``is_safe_track_filename_prefix``); GCS errors stay best-effort.
         """
-        if not _TRACK_FILENAME_PREFIX_RE.match(filename_prefix or ""):
-            logger.warning(
-                "Refusing mirror track delete for unsafe prefix %r "
-                "(must look like 'NOMAD-#### - Artist...')", filename_prefix,
+        if not is_safe_track_filename_prefix(filename_prefix):
+            raise ValueError(
+                f"Unsafe mirror track prefix {filename_prefix!r} "
+                f"(must look like 'NOMAD-#### - Artist...')"
             )
-            return {"masters_deleted": 0, "vocals_guides_deleted": 0}
 
         counts = {"masters_deleted": 0, "vocals_guides_deleted": 0}
         targets = [
@@ -194,6 +202,11 @@ class NomadMasterMirror:
             prefix = f"{gcs_prefix}/{filename_prefix}"
             try:
                 for blob in self._bucket.list_blobs(prefix=prefix):
+                    remainder = blob.name[len(prefix):]
+                    if remainder and remainder[0] not in " .":
+                        # Prefix ends mid-word (a longer artist/title shares it) —
+                        # this object belongs to a different track.
+                        continue
                     try:
                         blob.delete()
                         counts[key] += 1

--- a/backend/tests/test_admin_orphaned_outputs.py
+++ b/backend/tests/test_admin_orphaned_outputs.py
@@ -51,6 +51,20 @@ class TestOrphanedOutputsCleanupValidation:
         assert response.status_code == 400
         assert "No cleanup targets" in response.json()["detail"]
 
+    @pytest.mark.parametrize("prefix", ["NOMAD-1583", "NOMAD-1583 - ", "Mazzy Star"])
+    def test_unsafe_mirror_prefix_returns_400_before_any_cleanup(self, client, prefix):
+        """An unsafe mirror prefix fails the whole request up front — even the other
+        (valid) targets must not run, so a bad call can be corrected and retried
+        atomically."""
+        with patch("backend.services.youtube_service.get_youtube_service") as mock_get_yt:
+            response = client.post(URL, json={
+                "youtube_video_id": "vid",
+                "mirror_filename_prefix": prefix,
+            })
+        assert response.status_code == 400
+        assert "mirror_filename_prefix" in response.json()["detail"]
+        mock_get_yt.assert_not_called()
+
 
 class TestOrphanedOutputsCleanupYouTube:
     def test_deletes_youtube_video_by_id(self, client):

--- a/backend/tests/test_admin_orphaned_outputs.py
+++ b/backend/tests/test_admin_orphaned_outputs.py
@@ -1,0 +1,176 @@
+"""
+Tests for POST /api/admin/orphaned-outputs/cleanup.
+
+This endpoint deletes distributed outputs whose owning job doc no longer exists
+(a job deleted while its outputs were still published). Targets are explicit —
+YouTube video ID, Dropbox folder path, GDrive file IDs, kjbox mirror filename
+prefix — because there is no job doc left to resolve them from.
+
+Origin: NOMAD-1583 duplicate incident (2026-08-29) — a job was deleted with its
+outputs still live, the brand code was recycled and reused, and the orphaned files
+had to be removed without any job record.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.api.routes.admin import router
+from backend.api.dependencies import require_admin
+from backend.services.auth_service import AuthResult, UserType
+
+
+def get_mock_admin():
+    return AuthResult(
+        is_valid=True,
+        user_type=UserType.ADMIN,
+        remaining_uses=999,
+        message="Admin authenticated",
+        user_email="admin@example.com",
+        is_admin=True,
+    )
+
+
+app = FastAPI()
+app.include_router(router, prefix="/api")
+app.dependency_overrides[require_admin] = get_mock_admin
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+URL = "/api/admin/orphaned-outputs/cleanup"
+
+
+class TestOrphanedOutputsCleanupValidation:
+    def test_no_targets_returns_400(self, client):
+        response = client.post(URL, json={})
+        assert response.status_code == 400
+        assert "No cleanup targets" in response.json()["detail"]
+
+
+class TestOrphanedOutputsCleanupYouTube:
+    def test_deletes_youtube_video_by_id(self, client):
+        mock_finalise = MagicMock()
+        mock_finalise.delete_youtube_video.return_value = True
+        mock_yt = MagicMock()
+        mock_yt.is_configured = True
+        mock_yt.get_credentials_dict.return_value = {"token": "x"}
+
+        with patch("karaoke_gen.karaoke_finalise.karaoke_finalise.KaraokeFinalise", return_value=mock_finalise), \
+             patch("backend.services.youtube_service.get_youtube_service", return_value=mock_yt):
+            response = client.post(URL, json={"youtube_video_id": "R3QZm8yXqvw"})
+
+        assert response.status_code == 200
+        assert response.json()["results"]["youtube"] == {"status": "success", "video_id": "R3QZm8yXqvw"}
+        mock_finalise.delete_youtube_video.assert_called_once_with("R3QZm8yXqvw")
+
+    def test_youtube_not_configured_reports_failed(self, client):
+        mock_yt = MagicMock()
+        mock_yt.is_configured = False
+        with patch("backend.services.youtube_service.get_youtube_service", return_value=mock_yt):
+            response = client.post(URL, json={"youtube_video_id": "abc123"})
+        assert response.status_code == 200
+        assert response.json()["results"]["youtube"]["status"] == "failed"
+
+    def test_youtube_error_is_captured_not_raised(self, client):
+        with patch("backend.services.youtube_service.get_youtube_service", side_effect=RuntimeError("boom")):
+            response = client.post(URL, json={"youtube_video_id": "abc123"})
+        assert response.status_code == 200
+        assert response.json()["results"]["youtube"]["status"] == "error"
+
+
+class TestOrphanedOutputsCleanupDropbox:
+    def test_deletes_dropbox_folder(self, client):
+        mock_dropbox = MagicMock()
+        mock_dropbox.is_configured = True
+        mock_dropbox.delete_folder.return_value = True
+        path = "/MediaUnsynced/Karaoke/Tracks-Organized/NOMAD-1583 - Mazzy Star - Fade Into You"
+
+        with patch("backend.services.dropbox_service.get_dropbox_service", return_value=mock_dropbox):
+            response = client.post(URL, json={"dropbox_folder_path": path})
+
+        assert response.status_code == 200
+        assert response.json()["results"]["dropbox"] == {"status": "success", "path": path}
+        mock_dropbox.delete_folder.assert_called_once_with(path)
+
+    def test_dropbox_delete_failure_reported(self, client):
+        mock_dropbox = MagicMock()
+        mock_dropbox.is_configured = True
+        mock_dropbox.delete_folder.return_value = False
+        with patch("backend.services.dropbox_service.get_dropbox_service", return_value=mock_dropbox):
+            response = client.post(URL, json={"dropbox_folder_path": "/x/y"})
+        assert response.json()["results"]["dropbox"]["status"] == "failed"
+
+
+class TestOrphanedOutputsCleanupGDrive:
+    def test_deletes_gdrive_files_by_id(self, client):
+        mock_gdrive = MagicMock()
+        mock_gdrive.is_configured = True
+        mock_gdrive.delete_files.return_value = {"id1": True, "id2": True}
+
+        with patch("backend.services.gdrive_service.get_gdrive_service", return_value=mock_gdrive):
+            response = client.post(URL, json={"gdrive_file_ids": ["id1", "id2"]})
+
+        assert response.status_code == 200
+        assert response.json()["results"]["gdrive"]["status"] == "success"
+        mock_gdrive.delete_files.assert_called_once_with(["id1", "id2"])
+
+    def test_partial_gdrive_failure_reported(self, client):
+        mock_gdrive = MagicMock()
+        mock_gdrive.is_configured = True
+        mock_gdrive.delete_files.return_value = {"id1": True, "id2": False}
+        with patch("backend.services.gdrive_service.get_gdrive_service", return_value=mock_gdrive):
+            response = client.post(URL, json={"gdrive_file_ids": ["id1", "id2"]})
+        assert response.json()["results"]["gdrive"]["status"] == "partial"
+
+
+class TestOrphanedOutputsCleanupMirror:
+    def test_deletes_mirror_objects_by_track_prefix(self, client):
+        mock_mirror = MagicMock()
+        mock_mirror.delete_track_objects_by_filename_prefix.return_value = {
+            "masters_deleted": 1, "vocals_guides_deleted": 1,
+        }
+        with patch("backend.services.nomad_master_mirror.NomadMasterMirror", return_value=mock_mirror):
+            response = client.post(URL, json={"mirror_filename_prefix": "NOMAD-1583 - Mazzy Star"})
+
+        assert response.status_code == 200
+        assert response.json()["results"]["mirror"] == {
+            "status": "success", "masters_deleted": 1, "vocals_guides_deleted": 1,
+        }
+        mock_mirror.delete_track_objects_by_filename_prefix.assert_called_once_with("NOMAD-1583 - Mazzy Star")
+
+
+class TestOrphanedOutputsCleanupCombined:
+    def test_all_targets_cleaned_in_one_call(self, client):
+        mock_finalise = MagicMock()
+        mock_finalise.delete_youtube_video.return_value = True
+        mock_yt = MagicMock(is_configured=True)
+        mock_yt.get_credentials_dict.return_value = {}
+        mock_dropbox = MagicMock(is_configured=True)
+        mock_dropbox.delete_folder.return_value = True
+        mock_gdrive = MagicMock(is_configured=True)
+        mock_gdrive.delete_files.return_value = {"id1": True}
+        mock_mirror = MagicMock()
+        mock_mirror.delete_track_objects_by_filename_prefix.return_value = {
+            "masters_deleted": 1, "vocals_guides_deleted": 0,
+        }
+
+        with patch("karaoke_gen.karaoke_finalise.karaoke_finalise.KaraokeFinalise", return_value=mock_finalise), \
+             patch("backend.services.youtube_service.get_youtube_service", return_value=mock_yt), \
+             patch("backend.services.dropbox_service.get_dropbox_service", return_value=mock_dropbox), \
+             patch("backend.services.gdrive_service.get_gdrive_service", return_value=mock_gdrive), \
+             patch("backend.services.nomad_master_mirror.NomadMasterMirror", return_value=mock_mirror):
+            response = client.post(URL, json={
+                "youtube_video_id": "vid",
+                "dropbox_folder_path": "/a/b",
+                "gdrive_file_ids": ["id1"],
+                "mirror_filename_prefix": "NOMAD-1583 - Mazzy Star",
+            })
+
+        assert response.status_code == 200
+        results = response.json()["results"]
+        assert {results[k]["status"] for k in ("youtube", "dropbox", "gdrive", "mirror")} == {"success"}

--- a/backend/tests/test_jobs_api.py
+++ b/backend/tests/test_jobs_api.py
@@ -215,61 +215,30 @@ class TestDeleteJob:
 
 
 class TestDeleteJobBrandCodeRecycling:
-    """Tests for brand code recycling in DELETE /api/jobs/{job_id}."""
+    """Tests for published-output cleanup + brand code recycling in DELETE /api/jobs/{job_id}.
 
-    def test_brand_code_recycled_before_deletion(self, mock_worker_service, mock_theme_service, auth_headers):
-        """Test that brand code is recycled before the job is deleted."""
-        mock_job_manager = MagicMock()
-        job_with_brand = Job(
-            job_id="test-bc-123",
+    Recycling must ONLY happen via the distribution cleanup (which gates it on
+    Dropbox + GDrive success). Blind-recycling on delete hands the same NOMAD-####
+    to a future job while the old files are still in the public share (duplicate
+    brand code incident, NOMAD-1583, 2026-08-29).
+    """
+
+    @staticmethod
+    def _job_with_brand(job_id, outputs_deleted_at=None):
+        return Job(
+            job_id=job_id,
             status=JobStatus.COMPLETE,
             created_at=datetime.now(UTC),
             updated_at=datetime.now(UTC),
             artist="Test",
             title="Test",
             state_data={"brand_code": "NOMAD-0042"},
-            outputs_deleted_at=datetime.now(UTC),
+            outputs_deleted_at=outputs_deleted_at,
         )
-        mock_job_manager.get_job.return_value = job_with_brand
-        mock_job_manager.delete_job.return_value = True
-        mock_creds = MagicMock()
-        mock_creds.universe_domain = 'googleapis.com'
 
-        with patch('backend.api.routes.jobs.job_manager', mock_job_manager), \
-             patch('backend.api.routes.jobs.worker_service', mock_worker_service), \
-             patch('backend.api.routes.jobs.get_theme_service', return_value=mock_theme_service), \
-             patch('backend.services.job_manager.JobManager', lambda *a, **k: mock_job_manager), \
-             patch('backend.services.firestore_service.firestore'), \
-             patch('backend.services.storage_service.storage'), \
-             patch('google.auth.default', return_value=(mock_creds, 'test-project')), \
-             patch('backend.services.brand_code_service.BrandCodeService.parse_brand_code', return_value=("NOMAD", 42)) as mock_parse, \
-             patch('backend.services.brand_code_service.get_brand_code_service') as mock_get_svc:
-            mock_svc = MagicMock()
-            mock_get_svc.return_value = mock_svc
-
-            from backend.main import app
-            client = TestClient(app)
-            response = client.delete("/api/jobs/test-bc-123", headers=auth_headers)
-
-            assert response.status_code == 200
-            mock_parse.assert_called_once_with("NOMAD-0042")
-            mock_svc.recycle_brand_code.assert_called_once_with("NOMAD", 42)
-            mock_job_manager.delete_job.assert_called_once()
-
-    def test_recycling_failure_does_not_prevent_deletion(self, mock_worker_service, mock_theme_service, auth_headers):
-        """Test that job deletion proceeds even if brand code recycling fails."""
+    def _delete(self, job, auth_headers, mock_worker_service, mock_theme_service, cleanup_patch):
         mock_job_manager = MagicMock()
-        job_with_brand = Job(
-            job_id="test-bc-456",
-            status=JobStatus.COMPLETE,
-            created_at=datetime.now(UTC),
-            updated_at=datetime.now(UTC),
-            artist="Test",
-            title="Test",
-            state_data={"brand_code": "NOMAD-0099"},
-            outputs_deleted_at=datetime.now(UTC),
-        )
-        mock_job_manager.get_job.return_value = job_with_brand
+        mock_job_manager.get_job.return_value = job
         mock_job_manager.delete_job.return_value = True
         mock_creds = MagicMock()
         mock_creds.universe_domain = 'googleapis.com'
@@ -281,14 +250,53 @@ class TestDeleteJobBrandCodeRecycling:
              patch('backend.services.firestore_service.firestore'), \
              patch('backend.services.storage_service.storage'), \
              patch('google.auth.default', return_value=(mock_creds, 'test-project')), \
-             patch('backend.services.brand_code_service.BrandCodeService.parse_brand_code', side_effect=ValueError("Bad format")):
+             patch('backend.api.routes.jobs._run_distribution_cleanup', cleanup_patch) as mock_cleanup:
             from backend.main import app
             client = TestClient(app)
-            response = client.delete("/api/jobs/test-bc-456", headers=auth_headers)
+            response = client.delete(f"/api/jobs/{job.job_id}", headers=auth_headers)
+        return response, mock_job_manager, mock_cleanup
 
-            assert response.status_code == 200
-            # Job should still be deleted despite recycling failure
-            mock_job_manager.delete_job.assert_called_once()
+    def test_published_outputs_cleaned_up_before_deletion(self, mock_worker_service, mock_theme_service, auth_headers):
+        """A job with a brand code and outputs never cleaned up gets full distribution
+        cleanup (which owns the gated recycle) before the record is deleted."""
+        job = self._job_with_brand("test-bc-123", outputs_deleted_at=None)
+        cleanup = MagicMock(return_value={"youtube": {"status": "success"}})
+
+        response, mock_job_manager, mock_cleanup = self._delete(
+            job, auth_headers, mock_worker_service, mock_theme_service, cleanup)
+
+        assert response.status_code == 200
+        mock_cleanup.assert_called_once_with("test-bc-123", job)
+        mock_job_manager.delete_job.assert_called_once()
+        assert response.json()["distribution_cleanup"] == {"youtube": {"status": "success"}}
+
+    def test_outputs_already_deleted_skips_cleanup_and_recycle(self, mock_worker_service, mock_theme_service, auth_headers):
+        """A job whose outputs were already deleted (admin delete-outputs recycled the
+        code then) must NOT be cleaned up or recycled again — re-recycling a code that
+        a new job may have since claimed would create duplicates."""
+        job = self._job_with_brand("test-bc-456", outputs_deleted_at=datetime.now(UTC))
+        cleanup = MagicMock()
+
+        response, mock_job_manager, mock_cleanup = self._delete(
+            job, auth_headers, mock_worker_service, mock_theme_service, cleanup)
+
+        assert response.status_code == 200
+        mock_cleanup.assert_not_called()
+        mock_job_manager.delete_job.assert_called_once()
+        assert "distribution_cleanup" not in response.json()
+
+    def test_unexpected_cleanup_error_aborts_deletion(self, mock_worker_service, mock_theme_service, auth_headers):
+        """If cleanup crashes outright (per-service failures are handled internally),
+        the job record must be preserved — deleting it would orphan the outputs with
+        no way to resolve their IDs later."""
+        job = self._job_with_brand("test-bc-789", outputs_deleted_at=None)
+        cleanup = MagicMock(side_effect=RuntimeError("boom"))
+
+        response, mock_job_manager, _mock_cleanup = self._delete(
+            job, auth_headers, mock_worker_service, mock_theme_service, cleanup)
+
+        assert response.status_code == 500
+        mock_job_manager.delete_job.assert_not_called()
 
     def test_no_brand_code_skips_recycling(self, client, mock_job_manager, auth_headers):
         """Test that deletion without brand code doesn't attempt recycling."""

--- a/backend/tests/test_jobs_api.py
+++ b/backend/tests/test_jobs_api.py
@@ -285,6 +285,49 @@ class TestDeleteJobBrandCodeRecycling:
         mock_job_manager.delete_job.assert_called_once()
         assert "distribution_cleanup" not in response.json()
 
+    def test_delete_files_false_rejected_for_published_job(self, mock_worker_service, mock_theme_service, auth_headers):
+        """Published outputs can't be preserved when their job record is deleted —
+        the record holds the only file IDs/paths needed to ever clean them up."""
+        job = self._job_with_brand("test-bc-df", outputs_deleted_at=None)
+        cleanup = MagicMock()
+        mock_job_manager = MagicMock()
+        mock_job_manager.get_job.return_value = job
+        mock_creds = MagicMock()
+        mock_creds.universe_domain = 'googleapis.com'
+
+        with patch('backend.api.routes.jobs.job_manager', mock_job_manager), \
+             patch('backend.api.routes.jobs.worker_service', mock_worker_service), \
+             patch('backend.api.routes.jobs.get_theme_service', return_value=mock_theme_service), \
+             patch('backend.services.job_manager.JobManager', lambda *a, **k: mock_job_manager), \
+             patch('backend.services.firestore_service.firestore'), \
+             patch('backend.services.storage_service.storage'), \
+             patch('google.auth.default', return_value=(mock_creds, 'test-project')), \
+             patch('backend.api.routes.jobs._run_distribution_cleanup', cleanup):
+            from backend.main import app
+            client = TestClient(app)
+            response = client.delete("/api/jobs/test-bc-df?delete_files=false", headers=auth_headers)
+
+        assert response.status_code == 400
+        cleanup.assert_not_called()
+        mock_job_manager.delete_job.assert_not_called()
+
+    def test_incomplete_cleanup_aborts_deletion(self, mock_worker_service, mock_theme_service, auth_headers):
+        """If any provider cleanup reports failed/partial/error, the job record must
+        be kept so the cleanup can be retried with its IDs intact."""
+        job = self._job_with_brand("test-bc-incomplete", outputs_deleted_at=None)
+        cleanup = MagicMock(return_value={
+            "youtube": {"status": "success"},
+            "dropbox": {"status": "failed", "path": "/x"},
+            "gdrive": {"status": "success"},
+        })
+
+        response, mock_job_manager, _mock_cleanup = self._delete(
+            job, auth_headers, mock_worker_service, mock_theme_service, cleanup)
+
+        assert response.status_code == 502
+        assert "dropbox" in response.json()["detail"]
+        mock_job_manager.delete_job.assert_not_called()
+
     def test_unexpected_cleanup_error_aborts_deletion(self, mock_worker_service, mock_theme_service, auth_headers):
         """If cleanup crashes outright (per-service failures are handled internally),
         the job record must be preserved — deleting it would orphan the outputs with

--- a/backend/tests/test_nomad_master_mirror.py
+++ b/backend/tests/test_nomad_master_mirror.py
@@ -206,3 +206,45 @@ def test_cleanup_nomad_masters_noop_for_non_nomad(brand, monkeypatch):
     # Must not even construct the mirror (no GCS client) for non-Nomad brands.
     monkeypatch.setattr(mod, "NomadMasterMirror", lambda: (_ for _ in ()).throw(AssertionError("should not construct")))
     assert mod.cleanup_nomad_masters(brand) == 0
+
+
+# --- delete_track_objects_by_filename_prefix (single-track orphan cleanup) ---
+
+def test_delete_track_objects_by_filename_prefix_deletes_from_both_prefixes():
+    # One master + one vocals guide for the orphaned track; both must go.
+    mirror, bucket, blobs = _mirror_with_blobs([
+        "files/Nomad Karaoke/MP4-720p/NOMAD-1583 - Mazzy Star - Fade Into You.mp4",
+    ])
+    counts = mirror.delete_track_objects_by_filename_prefix("NOMAD-1583 - Mazzy Star")
+    # list_blobs is called once per GCS prefix (masters, vocals guides)
+    assert bucket.list_blobs.call_count == 2
+    prefixes = [c.kwargs["prefix"] for c in bucket.list_blobs.call_args_list]
+    assert prefixes == [
+        "files/Nomad Karaoke/MP4-720p/NOMAD-1583 - Mazzy Star",
+        "files/Nomad Karaoke/vocals-padded/NOMAD-1583 - Mazzy Star",
+    ]
+    # Mock returns the same blob list for both prefixes: 1 each
+    assert counts == {"masters_deleted": 1, "vocals_guides_deleted": 1}
+    assert blobs[0].delete.call_count == 2
+
+
+@pytest.mark.parametrize("prefix", [
+    "NOMAD-1583",            # bare brand code — would match BOTH tracks sharing it
+    "NOMAD-1583 - ",         # brand code + separator but no artist text
+    "NOMADNP-0001 - X",      # private prefix
+    "Mazzy Star",            # no brand code
+    "",
+    None,
+])
+def test_delete_track_objects_by_filename_prefix_refuses_unsafe_prefixes(prefix):
+    mirror, bucket, _blobs = _mirror_with_blobs([])
+    counts = mirror.delete_track_objects_by_filename_prefix(prefix)
+    assert counts == {"masters_deleted": 0, "vocals_guides_deleted": 0}
+    bucket.list_blobs.assert_not_called()
+
+
+def test_delete_track_objects_by_filename_prefix_non_fatal_on_list_error():
+    mirror, bucket, _blobs = _mirror_with_blobs([])
+    bucket.list_blobs.side_effect = RuntimeError("gcs down")
+    counts = mirror.delete_track_objects_by_filename_prefix("NOMAD-1583 - Mazzy Star")
+    assert counts == {"masters_deleted": 0, "vocals_guides_deleted": 0}

--- a/backend/tests/test_nomad_master_mirror.py
+++ b/backend/tests/test_nomad_master_mirror.py
@@ -210,22 +210,69 @@ def test_cleanup_nomad_masters_noop_for_non_nomad(brand, monkeypatch):
 
 # --- delete_track_objects_by_filename_prefix (single-track orphan cleanup) ---
 
+def _blob(name):
+    b = MagicMock()
+    b.name = name
+    return b
+
+
+def _mirror_with_blobs_per_prefix(blobs_by_prefix):
+    """Mirror whose bucket.list_blobs returns blobs matching the requested prefix,
+    like real GCS (the shared-list shortcut breaks delimiter-bound tests)."""
+    bucket = MagicMock()
+
+    def list_blobs(prefix):
+        return [b for b in blobs_by_prefix if b.name.startswith(prefix)]
+
+    bucket.list_blobs.side_effect = list_blobs
+    client = MagicMock()
+    client.bucket.return_value = bucket
+    return NomadMasterMirror(client=client), bucket
+
+
 def test_delete_track_objects_by_filename_prefix_deletes_from_both_prefixes():
     # One master + one vocals guide for the orphaned track; both must go.
-    mirror, bucket, blobs = _mirror_with_blobs([
-        "files/Nomad Karaoke/MP4-720p/NOMAD-1583 - Mazzy Star - Fade Into You.mp4",
-    ])
+    master = _blob("files/Nomad Karaoke/MP4-720p/NOMAD-1583 - Mazzy Star - Fade Into You.mp4")
+    guide = _blob("files/Nomad Karaoke/vocals-padded/NOMAD-1583 - Mazzy Star - Fade Into You.flac")
+    mirror, bucket = _mirror_with_blobs_per_prefix([master, guide])
+
     counts = mirror.delete_track_objects_by_filename_prefix("NOMAD-1583 - Mazzy Star")
-    # list_blobs is called once per GCS prefix (masters, vocals guides)
-    assert bucket.list_blobs.call_count == 2
-    prefixes = [c.kwargs["prefix"] for c in bucket.list_blobs.call_args_list]
+
+    assert counts == {"masters_deleted": 1, "vocals_guides_deleted": 1}
+    prefixes = [c.kwargs.get("prefix") or c.args[0] for c in bucket.list_blobs.call_args_list]
     assert prefixes == [
         "files/Nomad Karaoke/MP4-720p/NOMAD-1583 - Mazzy Star",
         "files/Nomad Karaoke/vocals-padded/NOMAD-1583 - Mazzy Star",
     ]
-    # Mock returns the same blob list for both prefixes: 1 each
-    assert counts == {"masters_deleted": 1, "vocals_guides_deleted": 1}
-    assert blobs[0].delete.call_count == 2
+    master.delete.assert_called_once()
+    guide.delete.assert_called_once()
+
+
+def test_delete_track_objects_by_filename_prefix_is_delimiter_bounded():
+    # "NOMAD-1583 - Mazzy Star" must NOT match a different track by a longer-named
+    # artist that happens to share the recycled brand code and the string prefix.
+    orphan = _blob("files/Nomad Karaoke/MP4-720p/NOMAD-1583 - Mazzy Star - Fade Into You.mp4")
+    other = _blob("files/Nomad Karaoke/MP4-720p/NOMAD-1583 - Mazzy Starlight - Other Song.mp4")
+    mirror, _bucket = _mirror_with_blobs_per_prefix([orphan, other])
+
+    counts = mirror.delete_track_objects_by_filename_prefix("NOMAD-1583 - Mazzy Star")
+
+    assert counts == {"masters_deleted": 1, "vocals_guides_deleted": 0}
+    orphan.delete.assert_called_once()
+    other.delete.assert_not_called()
+
+
+def test_delete_track_objects_full_stem_matches_extension_boundary():
+    # A full "brand - artist - title" stem must still match its own files (".mp4").
+    master = _blob("files/Nomad Karaoke/MP4-720p/NOMAD-1583 - Mazzy Star - Fade Into You.mp4")
+    mirror, _bucket = _mirror_with_blobs_per_prefix([master])
+
+    counts = mirror.delete_track_objects_by_filename_prefix(
+        "NOMAD-1583 - Mazzy Star - Fade Into You"
+    )
+
+    assert counts == {"masters_deleted": 1, "vocals_guides_deleted": 0}
+    master.delete.assert_called_once()
 
 
 @pytest.mark.parametrize("prefix", [
@@ -238,8 +285,8 @@ def test_delete_track_objects_by_filename_prefix_deletes_from_both_prefixes():
 ])
 def test_delete_track_objects_by_filename_prefix_refuses_unsafe_prefixes(prefix):
     mirror, bucket, _blobs = _mirror_with_blobs([])
-    counts = mirror.delete_track_objects_by_filename_prefix(prefix)
-    assert counts == {"masters_deleted": 0, "vocals_guides_deleted": 0}
+    with pytest.raises(ValueError):
+        mirror.delete_track_objects_by_filename_prefix(prefix)
     bucket.list_blobs.assert_not_called()
 
 

--- a/backend/translations/.en-snapshot.json
+++ b/backend/translations/.en-snapshot.json
@@ -48,7 +48,8 @@
     "invalidInstrumentalSelection": "Invalid instrumental_selection. Must be one of: {valid_selections}",
     "instrumentalSelected": "Instrumental selected. Video generation started.",
     "instrumentalSelectionError": "Error selecting instrumental for job {job_id}: {error}",
-    "downloadUrlsError": "Error getting download URLs: {error}"
+    "downloadUrlsError": "Error getting download URLs: {error}",
+    "deletePublishedRequiresFiles": "This track's published files must be removed when the job is deleted. Retry the delete without delete_files=false."
   },
   "review": {
     "jobNotFound": "Job not found",

--- a/backend/translations/ar.json
+++ b/backend/translations/ar.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "تم تحديد المسار الموسيقي. بدأ إنشاء الفيديو.",
     "instrumentalSelectionError": "خطأ في تحديد المسار الموسيقي للمهمة {job_id}: {error}",
     "downloadUrlsError": "خطأ في الحصول على روابط التنزيل: {error}",
-    "fileNoLongerAvailable": "الملف لم يعد متاحاً"
+    "fileNoLongerAvailable": "الملف لم يعد متاحاً",
+    "deletePublishedRequiresFiles": "يجب إزالة الملفات المنشورة لهذا المسار عند حذف المهمة. يُرجى إعادة محاولة الحذف بدون delete_files=false."
   },
   "review": {
     "jobNotFound": "المهمة غير موجودة",

--- a/backend/translations/ca.json
+++ b/backend/translations/ca.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Pista instrumental seleccionada. S'ha iniciat la generació del vídeo.",
     "instrumentalSelectionError": "Error en seleccionar la pista instrumental per a la tasca {job_id}: {error}",
     "downloadUrlsError": "Error en obtenir els URL de descàrrega: {error}",
-    "fileNoLongerAvailable": "El fitxer ja no està disponible"
+    "fileNoLongerAvailable": "El fitxer ja no està disponible",
+    "deletePublishedRequiresFiles": "Els fitxers publicats d'aquesta pista s'han d'eliminar quan s'elimini la tasca. Torna a intentar l'eliminació sense delete_files=false."
   },
   "review": {
     "jobNotFound": "Tasca no trobada",

--- a/backend/translations/cs.json
+++ b/backend/translations/cs.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Instrumentál vybrán. Začalo generování videa.",
     "instrumentalSelectionError": "Chyba při výběru instrumentálu pro úlohu {job_id}: {error}",
     "downloadUrlsError": "Chyba při získávání adres URL ke stažení: {error}",
-    "fileNoLongerAvailable": "Soubor již není dostupný"
+    "fileNoLongerAvailable": "Soubor již není dostupný",
+    "deletePublishedRequiresFiles": "Při mazání úlohy je nutné odstranit i publikované soubory této skladby. Zkus to smazat znovu bez delete_files=false."
   },
   "review": {
     "jobNotFound": "Úloha nebyla nalezena",

--- a/backend/translations/da.json
+++ b/backend/translations/da.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Instrumental valgt. Videogenerering er startet.",
     "instrumentalSelectionError": "Fejl ved valg af instrumental for job {job_id}: {error}",
     "downloadUrlsError": "Fejl ved hentning af download-URL'er: {error}",
-    "fileNoLongerAvailable": "Filen er ikke længere tilgængelig"
+    "fileNoLongerAvailable": "Filen er ikke længere tilgængelig",
+    "deletePublishedRequiresFiles": "Dette spors udgivne filer skal fjernes, når jobbet slettes. Prøv at slette igen uden delete_files=false."
   },
   "review": {
     "jobNotFound": "Jobbet blev ikke fundet",

--- a/backend/translations/de.json
+++ b/backend/translations/de.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Instrumental ausgewählt. Video-Generierung gestartet.",
     "instrumentalSelectionError": "Fehler bei der Auswahl des Instrumentals für Auftrag {job_id}: {error}",
     "downloadUrlsError": "Fehler beim Abrufen der Download-URLs: {error}",
-    "fileNoLongerAvailable": "Datei nicht mehr verfügbar"
+    "fileNoLongerAvailable": "Datei nicht mehr verfügbar",
+    "deletePublishedRequiresFiles": "Die veröffentlichten Dateien dieses Tracks müssen entfernt werden, wenn der Auftrag gelöscht wird. Versuche den Löschvorgang ohne delete_files=false erneut."
   },
   "review": {
     "jobNotFound": "Auftrag nicht gefunden",

--- a/backend/translations/el.json
+++ b/backend/translations/el.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Το instrumental επιλέχθηκε. Ξεκίνησε η δημιουργία βίντεο.",
     "instrumentalSelectionError": "Σφάλμα κατά την επιλογή instrumental για την εργασία {job_id}: {error}",
     "downloadUrlsError": "Σφάλμα κατά τη λήψη των URL λήψης: {error}",
-    "fileNoLongerAvailable": "Το αρχείο δεν είναι πλέον διαθέσιμο"
+    "fileNoLongerAvailable": "Το αρχείο δεν είναι πλέον διαθέσιμο",
+    "deletePublishedRequiresFiles": "Τα δημοσιευμένα αρχεία αυτού του κομματιού πρέπει να αφαιρεθούν όταν διαγράφεται η εργασία. Δοκίμασε ξανά τη διαγραφή χωρίς το delete_files=false."
   },
   "review": {
     "jobNotFound": "Η εργασία δεν βρέθηκε",

--- a/backend/translations/en.json
+++ b/backend/translations/en.json
@@ -48,7 +48,8 @@
     "invalidInstrumentalSelection": "Invalid instrumental_selection. Must be one of: {valid_selections}",
     "instrumentalSelected": "Instrumental selected. Video generation started.",
     "instrumentalSelectionError": "Error selecting instrumental for job {job_id}: {error}",
-    "downloadUrlsError": "Error getting download URLs: {error}"
+    "downloadUrlsError": "Error getting download URLs: {error}",
+    "deletePublishedRequiresFiles": "This track's published files must be removed when the job is deleted. Retry the delete without delete_files=false."
   },
   "review": {
     "jobNotFound": "Job not found",

--- a/backend/translations/es.json
+++ b/backend/translations/es.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Instrumental seleccionado. Generación de video iniciada.",
     "instrumentalSelectionError": "Error al seleccionar el instrumental para el trabajo {job_id}: {error}",
     "downloadUrlsError": "Error al obtener las URLs de descarga: {error}",
-    "fileNoLongerAvailable": "El archivo ya no está disponible"
+    "fileNoLongerAvailable": "El archivo ya no está disponible",
+    "deletePublishedRequiresFiles": "Los archivos publicados de esta pista deben eliminarse cuando se elimine el trabajo. Vuelve a intentar la eliminación sin delete_files=false."
   },
   "review": {
     "jobNotFound": "Trabajo no encontrado",

--- a/backend/translations/fi.json
+++ b/backend/translations/fi.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Instrumentaali valittu. Videon luonti aloitettu.",
     "instrumentalSelectionError": "Virhe valittaessa instrumentaalia työlle {job_id}: {error}",
     "downloadUrlsError": "Virhe haettaessa latausosoitteita: {error}",
-    "fileNoLongerAvailable": "Tiedosto ei ole enää saatavilla"
+    "fileNoLongerAvailable": "Tiedosto ei ole enää saatavilla",
+    "deletePublishedRequiresFiles": "Tämän kappaleen julkaistut tiedostot täytyy poistaa työn poistamisen yhteydessä. Yritä poistoa uudelleen ilman delete_files=false -määritystä."
   },
   "review": {
     "jobNotFound": "Työtä ei löytynyt",

--- a/backend/translations/fr.json
+++ b/backend/translations/fr.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Instrumental sélectionné. La génération de la vidéo a commencé.",
     "instrumentalSelectionError": "Erreur lors de la sélection de l'instrumental pour la tâche {job_id} : {error}",
     "downloadUrlsError": "Erreur lors de l'obtention des URL de téléchargement : {error}",
-    "fileNoLongerAvailable": "Le fichier n'est plus disponible"
+    "fileNoLongerAvailable": "Le fichier n'est plus disponible",
+    "deletePublishedRequiresFiles": "Les fichiers publiés de cette piste doivent être supprimés en même temps que la tâche. Réessaie la suppression sans delete_files=false."
   },
   "review": {
     "jobNotFound": "Tâche introuvable",

--- a/backend/translations/he.json
+++ b/backend/translations/he.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "הפלייבק נבחר. יצירת הווידאו התחילה.",
     "instrumentalSelectionError": "שגיאה בבחירת פלייבק עבור המשימה {job_id}: {error}",
     "downloadUrlsError": "שגיאה בקבלת כתובות ההורדה: {error}",
-    "fileNoLongerAvailable": "הקובץ אינו זמין יותר"
+    "fileNoLongerAvailable": "הקובץ אינו זמין יותר",
+    "deletePublishedRequiresFiles": "יש להסיר את הקבצים שפורסמו עבור רצועה זו בעת מחיקת המשימה. נסה שוב את המחיקה ללא delete_files=false."
   },
   "review": {
     "jobNotFound": "המשימה לא נמצאה",

--- a/backend/translations/hi.json
+++ b/backend/translations/hi.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "इंस्ट्रुमेंटल चुना गया। वीडियो जनरेशन शुरू हो गया है।",
     "instrumentalSelectionError": "जॉब {job_id} के लिए इंस्ट्रुमेंटल चुनने में त्रुटि: {error}",
     "downloadUrlsError": "डाउनलोड URLs प्राप्त करने में त्रुटि: {error}",
-    "fileNoLongerAvailable": "फ़ाइल अब उपलब्ध नहीं है"
+    "fileNoLongerAvailable": "फ़ाइल अब उपलब्ध नहीं है",
+    "deletePublishedRequiresFiles": "जॉब डिलीट करते समय इस ट्रैक की पब्लिश की गई फ़ाइलों को हटाना ज़रूरी है। delete_files=false के बिना डिलीट करने की दोबारा कोशिश करो।"
   },
   "review": {
     "jobNotFound": "जॉब नहीं मिली",

--- a/backend/translations/hr.json
+++ b/backend/translations/hr.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Instrumental je odabran. Generiranje videa je započelo.",
     "instrumentalSelectionError": "Pogreška pri odabiru instrumentala za zadatak {job_id}: {error}",
     "downloadUrlsError": "Pogreška pri dohvaćanju URL-ova za preuzimanje: {error}",
-    "fileNoLongerAvailable": "Datoteka više nije dostupna"
+    "fileNoLongerAvailable": "Datoteka više nije dostupna",
+    "deletePublishedRequiresFiles": "Objavljene datoteke ove pjesme moraju se ukloniti kada se zadatak izbriše. Pokušaj ponovno obrisati bez delete_files=false."
   },
   "review": {
     "jobNotFound": "Zadatak nije pronađen",

--- a/backend/translations/hu.json
+++ b/backend/translations/hu.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Instrumentális sáv kiválasztva. A videó generálása megkezdődött.",
     "instrumentalSelectionError": "Hiba a(z) {job_id} feladat instrumentális sávjának kiválasztásakor: {error}",
     "downloadUrlsError": "Hiba a letöltési URL-ek lekérésekor: {error}",
-    "fileNoLongerAvailable": "A fájl már nem elérhető"
+    "fileNoLongerAvailable": "A fájl már nem elérhető",
+    "deletePublishedRequiresFiles": "Ennek a számnak a közzétett fájljait el kell távolítani a feladat törlésekor. Próbáld újra a törlést a delete_files=false nélkül."
   },
   "review": {
     "jobNotFound": "A feladat nem található",

--- a/backend/translations/id.json
+++ b/backend/translations/id.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Instrumental dipilih. Pembuatan video dimulai.",
     "instrumentalSelectionError": "Kesalahan saat memilih instrumental untuk tugas {job_id}: {error}",
     "downloadUrlsError": "Kesalahan saat mendapatkan URL unduhan: {error}",
-    "fileNoLongerAvailable": "File sudah tidak tersedia"
+    "fileNoLongerAvailable": "File sudah tidak tersedia",
+    "deletePublishedRequiresFiles": "File yang telah dipublikasikan dari trek ini harus ikut dihapus saat tugas dihapus. Silakan ulangi penghapusan tanpa delete_files=false."
   },
   "review": {
     "jobNotFound": "Tugas tidak ditemukan",

--- a/backend/translations/it.json
+++ b/backend/translations/it.json
@@ -49,7 +49,7 @@
     "instrumentalSelectionError": "Errore durante la selezione della strumentale per il lavoro {job_id}: {error}",
     "downloadUrlsError": "Errore durante il recupero degli URL di download: {error}",
     "fileNoLongerAvailable": "File non più disponibile",
-    "deletePublishedRequiresFiles": "I file pubblicati di questa traccia devono essere rimossi quando il processo viene eliminato. Riprova l'eliminazione senza delete_files=false."
+    "deletePublishedRequiresFiles": "I file pubblicati di questa traccia devono essere rimossi quando il lavoro viene eliminato. Riprova l'eliminazione senza delete_files=false."
   },
   "review": {
     "jobNotFound": "Lavoro non trovato",

--- a/backend/translations/it.json
+++ b/backend/translations/it.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Strumentale selezionata. Generazione del video avviata.",
     "instrumentalSelectionError": "Errore durante la selezione della strumentale per il lavoro {job_id}: {error}",
     "downloadUrlsError": "Errore durante il recupero degli URL di download: {error}",
-    "fileNoLongerAvailable": "File non più disponibile"
+    "fileNoLongerAvailable": "File non più disponibile",
+    "deletePublishedRequiresFiles": "I file pubblicati di questa traccia devono essere rimossi quando il processo viene eliminato. Riprova l'eliminazione senza delete_files=false."
   },
   "review": {
     "jobNotFound": "Lavoro non trovato",

--- a/backend/translations/ja.json
+++ b/backend/translations/ja.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "インストゥルメンタルが選択されました。動画の生成を開始しました。",
     "instrumentalSelectionError": "ジョブ {job_id} のインストゥルメンタル選択中にエラーが発生しました: {error}",
     "downloadUrlsError": "ダウンロードURLの取得中にエラーが発生しました: {error}",
-    "fileNoLongerAvailable": "ファイルはご利用いただけなくなりました"
+    "fileNoLongerAvailable": "ファイルはご利用いただけなくなりました",
+    "deletePublishedRequiresFiles": "ジョブを削除する際は、このトラックの公開済みファイルも削除する必要があります。delete_files=false を指定せずに、削除を再試行してください。"
   },
   "review": {
     "jobNotFound": "ジョブが見つかりません",

--- a/backend/translations/ko.json
+++ b/backend/translations/ko.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "반주가 선택되었습니다. 비디오 생성이 시작되었습니다.",
     "instrumentalSelectionError": "작업 {job_id}의 반주 선택 중 오류 발생: {error}",
     "downloadUrlsError": "다운로드 URL을 가져오는 중 오류 발생: {error}",
-    "fileNoLongerAvailable": "파일을 더 이상 사용할 수 없습니다"
+    "fileNoLongerAvailable": "파일을 더 이상 사용할 수 없습니다",
+    "deletePublishedRequiresFiles": "작업을 삭제할 때 이 트랙에 게시된 파일도 함께 삭제해야 합니다. delete_files=false 없이 삭제를 다시 시도해 주세요."
   },
   "review": {
     "jobNotFound": "작업을 찾을 수 없습니다",

--- a/backend/translations/ms.json
+++ b/backend/translations/ms.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Instrumental dipilih. Penjanaan video bermula.",
     "instrumentalSelectionError": "Ralat memilih instrumental untuk tugasan {job_id}: {error}",
     "downloadUrlsError": "Ralat mendapatkan URL muat turun: {error}",
-    "fileNoLongerAvailable": "Fail tidak lagi tersedia"
+    "fileNoLongerAvailable": "Fail tidak lagi tersedia",
+    "deletePublishedRequiresFiles": "Fail terbitan trek ini mesti dipadamkan apabila tugas dipadamkan. Sila cuba padam semula tanpa delete_files=false."
   },
   "review": {
     "jobNotFound": "Tugasan tidak dijumpai",

--- a/backend/translations/nb.json
+++ b/backend/translations/nb.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Instrumental valgt. Videogenerering startet.",
     "instrumentalSelectionError": "Feil ved valg av instrumental for jobb {job_id}: {error}",
     "downloadUrlsError": "Feil ved henting av nedlastings-URL-er: {error}",
-    "fileNoLongerAvailable": "Filen er ikke lenger tilgjengelig"
+    "fileNoLongerAvailable": "Filen er ikke lenger tilgjengelig",
+    "deletePublishedRequiresFiles": "De publiserte filene for dette sporet må fjernes når jobben slettes. Prøv å slette på nytt uten delete_files=false."
   },
   "review": {
     "jobNotFound": "Jobben ble ikke funnet",

--- a/backend/translations/nl.json
+++ b/backend/translations/nl.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Instrumental geselecteerd. Videogeneratie is gestart.",
     "instrumentalSelectionError": "Fout bij het selecteren van instrumental voor taak {job_id}: {error}",
     "downloadUrlsError": "Fout bij het ophalen van download-URL's: {error}",
-    "fileNoLongerAvailable": "Bestand niet meer beschikbaar"
+    "fileNoLongerAvailable": "Bestand niet meer beschikbaar",
+    "deletePublishedRequiresFiles": "De gepubliceerde bestanden van deze track moeten worden verwijderd als de taak wordt verwijderd. Probeer het verwijderen opnieuw zonder delete_files=false."
   },
   "review": {
     "jobNotFound": "Taak niet gevonden",

--- a/backend/translations/pl.json
+++ b/backend/translations/pl.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Wybrano podkład. Rozpoczęto generowanie wideo.",
     "instrumentalSelectionError": "Błąd podczas wybierania podkładu dla zadania {job_id}: {error}",
     "downloadUrlsError": "Błąd podczas pobierania linków: {error}",
-    "fileNoLongerAvailable": "Plik nie jest już dostępny"
+    "fileNoLongerAvailable": "Plik nie jest już dostępny",
+    "deletePublishedRequiresFiles": "Opublikowane pliki tego utworu muszą zostać usunięte podczas usuwania zadania. Spróbuj usunąć ponownie bez delete_files=false."
   },
   "review": {
     "jobNotFound": "Nie znaleziono zadania",

--- a/backend/translations/pt.json
+++ b/backend/translations/pt.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Instrumental selecionado. Geração de vídeo iniciada.",
     "instrumentalSelectionError": "Erro ao selecionar instrumental para o job {job_id}: {error}",
     "downloadUrlsError": "Erro ao obter URLs de download: {error}",
-    "fileNoLongerAvailable": "O arquivo não está mais disponível"
+    "fileNoLongerAvailable": "O arquivo não está mais disponível",
+    "deletePublishedRequiresFiles": "Os arquivos publicados desta faixa devem ser removidos quando a tarefa for excluída. Tente excluir novamente sem delete_files=false."
   },
   "review": {
     "jobNotFound": "Job não encontrado",

--- a/backend/translations/ro.json
+++ b/backend/translations/ro.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Instrumental selectat. A început generarea videoclipului.",
     "instrumentalSelectionError": "Eroare la selectarea instrumentalului pentru jobul {job_id}: {error}",
     "downloadUrlsError": "Eroare la obținerea adreselor URL de descărcare: {error}",
-    "fileNoLongerAvailable": "Fișierul nu mai este disponibil"
+    "fileNoLongerAvailable": "Fișierul nu mai este disponibil",
+    "deletePublishedRequiresFiles": "Fișierele publicate ale acestei piese trebuie eliminate la ștergerea jobului. Încearcă din nou ștergerea fără delete_files=false."
   },
   "review": {
     "jobNotFound": "Jobul nu a fost găsit",

--- a/backend/translations/ru.json
+++ b/backend/translations/ru.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Инструментал выбран. Началась генерация видео.",
     "instrumentalSelectionError": "Ошибка при выборе инструментала для задачи {job_id}: {error}",
     "downloadUrlsError": "Ошибка при получении URL-адресов для скачивания: {error}",
-    "fileNoLongerAvailable": "Файл больше недоступен"
+    "fileNoLongerAvailable": "Файл больше недоступен",
+    "deletePublishedRequiresFiles": "Опубликованные файлы этого трека нужно удалить вместе с задачей. Повтори удаление без delete_files=false."
   },
   "review": {
     "jobNotFound": "Задача не найдена",

--- a/backend/translations/sk.json
+++ b/backend/translations/sk.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Inštrumentál bol vybraný. Začalo sa generovanie videa.",
     "instrumentalSelectionError": "Chyba pri výbere inštrumentálu pre úlohu {job_id}: {error}",
     "downloadUrlsError": "Chyba pri získavaní adries URL na stiahnutie: {error}",
-    "fileNoLongerAvailable": "Súbor už nie je dostupný"
+    "fileNoLongerAvailable": "Súbor už nie je dostupný",
+    "deletePublishedRequiresFiles": "Publikované súbory tejto skladby musia byť pri odstránení úlohy vymazané. Zopakuj odstránenie bez delete_files=false."
   },
   "review": {
     "jobNotFound": "Úloha sa nenašla",

--- a/backend/translations/sv.json
+++ b/backend/translations/sv.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Instrumental vald. Videogenereringen har startat.",
     "instrumentalSelectionError": "Fel vid val av instrumental för jobb {job_id}: {error}",
     "downloadUrlsError": "Fel vid hämtning av nedladdningslänkar: {error}",
-    "fileNoLongerAvailable": "Filen är inte längre tillgänglig"
+    "fileNoLongerAvailable": "Filen är inte längre tillgänglig",
+    "deletePublishedRequiresFiles": "Det här spårets publicerade filer måste tas bort när jobbet raderas. Försök att radera igen utan delete_files=false."
   },
   "review": {
     "jobNotFound": "Jobbet hittades inte",

--- a/backend/translations/th.json
+++ b/backend/translations/th.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "เลือกดนตรีบรรเลงแล้ว กำลังเริ่มสร้างวิดีโอ",
     "instrumentalSelectionError": "เกิดข้อผิดพลาดในการเลือกดนตรีบรรเลงสำหรับงาน {job_id}: {error}",
     "downloadUrlsError": "เกิดข้อผิดพลาดในการรับ URL สำหรับดาวน์โหลด: {error}",
-    "fileNoLongerAvailable": "ไฟล์ไม่พร้อมใช้งานแล้ว"
+    "fileNoLongerAvailable": "ไฟล์ไม่พร้อมใช้งานแล้ว",
+    "deletePublishedRequiresFiles": "ไฟล์ที่เผยแพร่แล้วของแทร็กนี้ต้องถูกลบออกเมื่อลบงาน โปรดลองลบใหม่อีกครั้งโดยไม่ใช้ delete_files=false"
   },
   "review": {
     "jobNotFound": "ไม่พบงาน",

--- a/backend/translations/tl.json
+++ b/backend/translations/tl.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Napili na ang instrumental. Nagsimula na ang paggawa ng video.",
     "instrumentalSelectionError": "Error sa pagpili ng instrumental para sa job {job_id}: {error}",
     "downloadUrlsError": "Error sa pagkuha ng mga download URL: {error}",
-    "fileNoLongerAvailable": "Hindi na available ang file"
+    "fileNoLongerAvailable": "Hindi na available ang file",
+    "deletePublishedRequiresFiles": "Kailangang tanggalin ang mga na-publish na file ng track na ito kapag na-delete ang job. Subukang i-delete muli nang walang delete_files=false."
   },
   "review": {
     "jobNotFound": "Hindi nahanap ang job",

--- a/backend/translations/tr.json
+++ b/backend/translations/tr.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Enstrümantal seçildi. Video oluşturma başladı.",
     "instrumentalSelectionError": "{job_id} işi için enstrümantal seçme hatası: {error}",
     "downloadUrlsError": "İndirme URL'lerini alma hatası: {error}",
-    "fileNoLongerAvailable": "Dosya artık mevcut değil"
+    "fileNoLongerAvailable": "Dosya artık mevcut değil",
+    "deletePublishedRequiresFiles": "İş silindiğinde bu parçanın yayınlanmış dosyaları da kaldırılmalıdır. Silme işlemini delete_files=false olmadan tekrar dene."
   },
   "review": {
     "jobNotFound": "İş bulunamadı",

--- a/backend/translations/uk.json
+++ b/backend/translations/uk.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Інструментал вибрано. Розпочато генерацію відео.",
     "instrumentalSelectionError": "Помилка вибору інструменталу для завдання {job_id}: {error}",
     "downloadUrlsError": "Помилка отримання URL-адрес для завантаження: {error}",
-    "fileNoLongerAvailable": "Файл більше недоступний"
+    "fileNoLongerAvailable": "Файл більше недоступний",
+    "deletePublishedRequiresFiles": "Опубліковані файли цього треку потрібно видалити під час видалення завдання. Повтори спробу видалення без delete_files=false."
   },
   "review": {
     "jobNotFound": "Завдання не знайдено",

--- a/backend/translations/vi.json
+++ b/backend/translations/vi.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "Đã chọn nhạc nền. Đã bắt đầu tạo video.",
     "instrumentalSelectionError": "Lỗi khi chọn nhạc nền cho công việc {job_id}: {error}",
     "downloadUrlsError": "Lỗi khi lấy URL tải xuống: {error}",
-    "fileNoLongerAvailable": "Tệp không còn khả dụng"
+    "fileNoLongerAvailable": "Tệp không còn khả dụng",
+    "deletePublishedRequiresFiles": "Các tệp đã xuất bản của bài hát này phải được xóa khi xóa tác vụ. Vui lòng thử xóa lại mà không có delete_files=false."
   },
   "review": {
     "jobNotFound": "Không tìm thấy công việc",

--- a/backend/translations/zh.json
+++ b/backend/translations/zh.json
@@ -48,7 +48,8 @@
     "instrumentalSelected": "已选择伴奏。已开始生成视频。",
     "instrumentalSelectionError": "为任务 {job_id} 选择伴奏时出错：{error}",
     "downloadUrlsError": "获取下载 URL 时出错：{error}",
-    "fileNoLongerAvailable": "文件已不可用"
+    "fileNoLongerAvailable": "文件已不可用",
+    "deletePublishedRequiresFiles": "删除任务时，必须移除此曲目已发布的文件。请去掉 delete_files=false 后重试删除。"
   },
   "review": {
     "jobNotFound": "未找到任务",

--- a/docs/GDRIVE-VALIDATOR.md
+++ b/docs/GDRIVE-VALIDATOR.md
@@ -250,9 +250,37 @@ The post-job trigger uses a 5-minute Cloud Tasks delay (via `gdrive-validation-q
 
 This is the most critical alert. Steps:
 1. Check which files have the duplicate: the notification lists them
-2. Determine which is correct (check Firestore job records)
-3. Remove or rename the incorrect file in Google Drive
+2. Determine which is correct (check Firestore job records — usually only ONE of the
+   two tracks still has a job with that `state_data.brand_code`; the other is orphaned)
+3. Remove the orphaned track's outputs (see below)
 4. Re-trigger validation to confirm the fix
+
+**Known cause — job deleted while outputs still published** (NOMAD-1583 incident,
+2026-08-29): before v0.206.0, `DELETE /api/jobs/{id}` recycled the brand code even
+when the job's outputs had never been cleaned up, leaving the files live in the
+public share. The next job to allocate reused the recycled number → duplicate.
+Since v0.206.0, deleting a job with published outputs runs the full distribution
+cleanup first (YouTube + Dropbox + GDrive + kjbox mirror) and only recycles the
+code once Dropbox and GDrive are confirmed clean.
+
+**Cleaning up orphaned outputs when the job doc is gone** — use the admin endpoint
+`POST /api/admin/orphaned-outputs/cleanup` with explicit targets (find file IDs and
+the YouTube video ID in Cloud Run logs from the job's publish window):
+
+```bash
+curl -X POST "https://api.nomadkaraoke.com/api/admin/orphaned-outputs/cleanup" \
+  -H "Authorization: Bearer $KARAOKE_ADMIN_TOKEN" -H "Content-Type: application/json" \
+  -d '{
+    "youtube_video_id": "VIDEO_ID",
+    "dropbox_folder_path": "/MediaUnsynced/Karaoke/Tracks-Organized/NOMAD-XXXX - Artist - Title",
+    "gdrive_file_ids": ["...", "...", "..."],
+    "mirror_filename_prefix": "NOMAD-XXXX - Artist"
+  }'
+```
+
+The `mirror_filename_prefix` must include artist text after the brand code — the
+mirror delete refuses a bare `NOMAD-XXXX` so it can never touch the OTHER track
+legitimately holding the recycled code.
 
 ## Cloud Function vs Local Script
 
@@ -274,4 +302,5 @@ The cloud function does metadata-only checks via the GDrive API (fast, cheap, ca
 - **2026-02-28**: Added SendGrid email (primary), kept Pushbullet (fallback). Added post-job trigger from backend. Added `scripts/check_public_share.py` for manual invocation. Motivated by NOMAD-1271 duplicate brand code incident where daily-only checks left a duplicate undetected for ~24 hours.
 - **2026-03-02**: NOMAD-1276 incident fix. Post-job trigger now uses 5-minute Cloud Tasks delay instead of immediate invocation, preventing false "all clear" when E2E test files are still in GDrive during cleanup. Also fixed cross-folder gap detection (uses global max across all folders) and added 28 unit tests for the Cloud Function.
 - **2026-03-06**: NOMAD-1295 gap. Stale GCE encoding cache (#499) caused job `f4a552bf` to produce bad output on first run (allocated NOMAD-1295, only CDG uploaded). Admin re-triggered the job, which allocated a new brand code (NOMAD-1297) without recycling 1295. Fix: recycled 1295 back to the pool. Updated docs to clarify that new gaps must always be investigated and fixed, never added to KNOWN_GAPS.
+- **2026-08-29**: NOMAD-1583 duplicate. Job `e97475ff` (`Mazzy Star – Fade Into You`) published at 02:15 UTC with NOMAD-1583, then was deleted at 03:02 via `DELETE /api/jobs/{id}?delete_files=true` — which recycled the brand code but left all published outputs live (GDrive ×3, Dropbox folder, YouTube video, kjbox mirror ×2). At 04:16 job `326e1aef` (`Chase & Status – No Problem`) reused the recycled 1583 → duplicate in all three share folders. Fixes (v0.206.0): `DELETE /api/jobs/{id}` now runs full distribution cleanup before deleting when outputs are still published (recycle stays gated on Dropbox+GDrive success, shared `_run_distribution_cleanup` helper); jobs whose outputs were already deleted no longer re-recycle; new `POST /api/admin/orphaned-outputs/cleanup` endpoint removes orphaned outputs by explicit IDs when the job doc is gone (used to clean up the Mazzy Star orphans).
 - **2026-08-18**: NOMAD-1537 gap. A **public→private visibility change** on job `25d076e5` (`Alma Nocturna – Mejor Cállate`) deleted the public GDrive/YouTube/Dropbox outputs and recycled 1537, then the private redistribution crashed (`redistribute_video` drove an illegal `complete → packaging` transition), so the change failed *after* the public files were already gone — a delete-first, no-rollback flow. The daily validator caught the hole; it self-closed when an unrelated public job reused the recycled 1537. **Going-private is a legitimate cause of a transient gap** (the number is recycled and refilled by the next public track) — the alert is expected and desired, not suppressed. Fixes (v0.196.1): `redistribute_video` runs in `redistribute_mode` (no status transition, stays `complete`); `change_to_private` is now **distribute-then-delete** (public outputs removed only after the private archive succeeds; on failure the job stays fully public); failed redistributions recycle any allocated `NOMADNP` code. Validator intentionally left unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.205.0"
+version = "0.206.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Fixes the root cause of tonight's **NOMAD-1583 duplicate brand code** incident and adds the tooling needed to clean up the orphaned files.

**Incident**: job `e97475ff` (Mazzy Star – Fade Into You) published with NOMAD-1583 at 02:15 UTC, was deleted at 03:02 via `DELETE /api/jobs/{id}?delete_files=true` — which recycled the brand code but left every published output live (GDrive ×3, Dropbox folder, YouTube video, kjbox mirror ×2). At 04:16, job `326e1aef` (Chase & Status – No Problem) reused the recycled 1583 → duplicate in all three public share folders, validator alerting on every subsequent job.

## Changes

- **`DELETE /api/jobs/{id}` no longer blind-recycles brand codes.** When a job's outputs are still published, it now runs the full distribution cleanup first (YouTube + Dropbox + GDrive + kjbox GCS mirror) via a shared `_run_distribution_cleanup()` helper (extracted from `cleanup-distribution`); recycle stays gated on Dropbox+GDrive success. Incomplete cleanup aborts the delete (502) so the job record — the only place holding the file IDs — is preserved for retry. `delete_files=false` is rejected (400) for published jobs. Jobs whose outputs were already deleted no longer re-recycle the code.
- **New `POST /api/admin/orphaned-outputs/cleanup`** — removes distributed outputs by explicit IDs (YouTube video ID, Dropbox path, GDrive file IDs, mirror filename prefix) when the owning job doc is gone. Needed to clean up the Mazzy Star orphans.
- **`NomadMasterMirror.delete_track_objects_by_filename_prefix`** — single-track mirror delete requiring a `NOMAD-#### - Artist...` prefix, delimiter-bounded so it can never match the other track legitimately holding a recycled code.
- New i18n key `jobs.deletePublishedRequiresFiles` translated to all 33 locales.
- Runbook + incident history in `docs/GDRIVE-VALIDATOR.md`.

## Testing

- 4111 backend tests pass (18 new: DELETE-route cleanup semantics, admin endpoint, mirror prefix guardrails/delimiter bounding).
- Local CodeRabbit review: 2 cycles, all 4 findings addressed (abort-on-incomplete-cleanup, delete_files honored, delimiter-bounded prefix, unsafe-prefix 400).
- Post-deploy: will run the orphaned-outputs cleanup for the Mazzy Star files and re-run the GDrive validator to confirm a clean report.

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)