### PR TITLE
fix: backing-keep enforcement default true in code (audio-worker trigger env gap)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -134,12 +134,16 @@ class Settings(BaseSettings):
 
     # Backing decider ENFORCEMENT (Phase 2B): allow a confident WITH_BACKING
     # verdict from the 3-stem decider to auto-select the with-backing
-    # instrumental. SHADOW-FIRST: default off — the verdict is scored and
-    # recorded on every job regardless, so prod shadow data accumulates
-    # alongside human picks; flip on after reviewing it. While off, confident
-    # WITH_BACKING jobs simply go to normal human review (status quo).
+    # instrumental. Shadow-validated 2026-08-28/29 (20-job corpus + live
+    # batteries + human review pass: 10/11 pick agreement, the one
+    # auto-eligible job shipped identically to the human) -> default ON.
+    # Default lives HERE, not per-environment env vars, because the executor
+    # runs in BOTH the backend service and the audio-separation Cloud Run Job
+    # (independent env; a service-only env flip left the audio_worker trigger
+    # reading false). Kill switch: set false in ci.yml backend deploy env
+    # AND infrastructure audio-separation-job envs (or revert this default).
     auto_approval_backing_keep_enabled: bool = os.getenv(
-        "AUTO_APPROVAL_BACKING_KEEP_ENABLED", "false"
+        "AUTO_APPROVAL_BACKING_KEEP_ENABLED", "true"
     ).lower() in ("true", "1", "yes")
 
     # Match judge — artist/title formatting + match-acceptance for the job

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.207.0"
+version = "0.207.1"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Follow-up to #953. The env-var flip only reached the backend Cloud Run *service*, but `maybe_auto_complete_review` also runs inside the **audio-separation Cloud Run Job** (the audio-lags-lyrics second-chance trigger), whose env is Pulumi-managed and independent — so scorings from that trigger still read the `false` default and blocked with `backing_keep_disabled`. Observed live: The xx — Islands scored lyrics `auto/ai-resolved` + backing `with_backing` but was blocked by the phantom flag; it would have completed fully auto.

Fix: with shadow validation complete (20-job corpus, live batteries, human review pass at 10/11 agreement), the default moves into code (`"true"`), matching the `AUTO_APPROVAL_ENFORCE_ENABLED` pattern — one deploy covers every environment the executor runs in. Env var remains the kill switch (must be set `false` in both the ci.yml backend deploy and the Pulumi job envs, or revert this).

Same gotcha class as the audio-download-job POSTMARK env gap (Cloud Run Jobs have independent env).

## Testing
- auto_approval + config suites pass (92).
- Live proof after deploy: next candidate batch should auto-complete confident jobs from either trigger.

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)