### PR TITLE
fix(lyrics-review): Tap To Sync timing corruption + padded edit-segment timeline

### DIFF
--- a/docs/REPLAY.md
+++ b/docs/REPLAY.md
@@ -47,6 +47,19 @@ Then in the browser:
 Audio, vocals waveform, and backing-vocals previews all play (proxied through the
 local backend). The submit/mutation controls are hidden; nothing can be changed.
 
+### Editable replay (`&edit=1`) — dev only
+
+Append `&edit=1` to the replay URL to make the review UI **editable** against the
+real job's data + audio (e.g. to exercise Tap To Sync / segment editing locally):
+
+```
+http://localhost:3000/en/app/jobs?baseApiUrl=http://127.0.0.1:8000&replay=1&edit=1#/<JOB_ID>/review
+```
+
+The header reads "Replay (editable · dev)". This flag is guarded by
+`NODE_ENV !== 'production'` — it is ignored in production builds, where replay stays
+strictly read-only. Edits are local-only (the replay backend makes no writes).
+
 ## Using it for the recording sessions
 
 Work through the job list in the private corpus

--- a/frontend/app/[locale]/app/jobs/[[...slug]]/client.tsx
+++ b/frontend/app/[locale]/app/jobs/[[...slug]]/client.tsx
@@ -312,6 +312,15 @@ function LyricsReviewWrapper({ job, isLocalMode = false, isReplay = false }: { j
   const [showPostAi, setShowPostAi] = useState(false)
   useEffect(() => { setShowPostAi(false) }, [job.job_id])
 
+  // DEV-ONLY: `&edit=1` makes a replay session editable so the review UI (incl. Tap To Sync)
+  // can be exercised against REAL job data + audio locally. Ignored in production builds — replay
+  // stays strictly read-only there.
+  const replayEditable =
+    isReplay &&
+    process.env.NODE_ENV !== 'production' &&
+    typeof window !== 'undefined' &&
+    new URLSearchParams(window.location.search).get('edit') === '1'
+
   // Create the API client for this job
   const apiClient = createLyricsReviewApiClient(job.job_id)
 
@@ -400,7 +409,7 @@ function LyricsReviewWrapper({ job, isLocalMode = false, isReplay = false }: { j
               style={{ height: 40 }}
             />
             <h1 className="text-lg font-bold">
-              {isReplay ? "Lyrics Review — Replay (read-only)" : "Lyrics Transcription Review"}
+              {isReplay ? (replayEditable ? "Lyrics Review — Replay (editable · dev)" : "Lyrics Review — Replay (read-only)") : "Lyrics Transcription Review"}
             </h1>
             {(job.artist || job.title) && (
               <span className="text-xs md:text-sm text-muted-foreground truncate">
@@ -449,7 +458,7 @@ function LyricsReviewWrapper({ job, isLocalMode = false, isReplay = false }: { j
           onFileLoad={handleFileLoad}
           onShowMetadata={handleShowMetadata}
           apiClient={apiClient}
-          isReadOnly={isReplay}
+          isReadOnly={isReplay && !replayEditable}
           audioHash={correctionData.metadata?.audio_hash || job.audio_hash || job.job_id}
           isLocalMode={isLocalMode}
           jobId={job.job_id}

--- a/frontend/components/lyrics-review/EditTimelineSection.tsx
+++ b/frontend/components/lyrics-review/EditTimelineSection.tsx
@@ -60,6 +60,8 @@ const TapButton = memo(function TapButton({
 
 interface EditTimelineSectionProps {
   words: Word[]
+  /** Neighbouring segments' words, drawn greyed/read-only in the timeline padding for context. */
+  contextWords?: Word[]
   startTime: number
   endTime: number
   currentTime?: number
@@ -75,6 +77,7 @@ interface EditTimelineSectionProps {
 
 export default function EditTimelineSection({
   words,
+  contextWords,
   startTime,
   endTime,
   currentTime,
@@ -108,6 +111,7 @@ export default function EditTimelineSection({
       <div>
         <TimelineEditor
           words={words}
+          contextWords={contextWords}
           startTime={startTime}
           endTime={endTime}
           onWordUpdate={onWordUpdate}

--- a/frontend/components/lyrics-review/LyricsAnalyzer.tsx
+++ b/frontend/components/lyrics-review/LyricsAnalyzer.tsx
@@ -62,7 +62,7 @@ import AutoCorrectModal from './AutoCorrectModal'
 import AutoCorrectPanel from './AutoCorrectPanel'
 import { useAutoCorrect } from '@/hooks/useAutoCorrect'
 import { getWordsFromIds } from '@/lib/lyrics-review/utils/wordUtils'
-import { applyOffsetToCorrectionData, applyOffsetToSegment } from '@/lib/lyrics-review/utils/timingUtils'
+import { applyOffsetToCorrectionData, applyOffsetToSegment, applyOffsetToWord } from '@/lib/lyrics-review/utils/timingUtils'
 import { VocalsAudioDataLoader } from './VocalsAudioDataLoader'
 
 // Add type for window augmentation
@@ -1334,6 +1334,27 @@ export default function LyricsAnalyzer({
     return timingOffsetMs !== 0 ? applyOffsetToCorrectionData(data, timingOffsetMs) : data
   }, [data, timingOffsetMs])
 
+  // Words from OTHER segments that sit near the segment being edited, so the Edit Segment
+  // timeline can show them as greyed read-only context in its ±padding. Kept to a small window
+  // around the segment (the timeline filters again to its exact view); offset-applied to match.
+  const editContextWords = useMemo(() => {
+    if (!editModalSegment) return []
+    const seg = editModalSegment.segment
+    const segStart = seg.start_time ?? 0
+    const segEnd = seg.end_time ?? segStart
+    const lo = segStart - 2
+    const hi = segEnd + 2
+    const nearby: Word[] = []
+    data.corrected_segments.forEach((s, i) => {
+      if (i === editModalSegment.index) return
+      s.words.forEach((w) => {
+        if (w.start_time === null || w.end_time === null) return
+        if (w.end_time >= lo && w.start_time <= hi) nearby.push(w)
+      })
+    })
+    return timingOffsetMs !== 0 ? nearby.map((w) => applyOffsetToWord(w, timingOffsetMs)) : nearby
+  }, [editModalSegment, data.corrected_segments, timingOffsetMs])
+
   // Timing offset handlers
   const handleOpenTimingOffsetModal = useCallback(() => {
     setIsTimingOffsetModalOpen(true)
@@ -1574,6 +1595,7 @@ export default function LyricsAnalyzer({
           onMergeSegment={handleMergeSegment}
           onPlaySegment={handlePlaySegment}
           currentTime={currentAudioTime}
+          contextWords={editContextWords}
           originalTranscribedSegment={
             editModalSegment?.segment &&
             editModalSegment?.index !== null &&

--- a/frontend/components/lyrics-review/TimelineEditor.tsx
+++ b/frontend/components/lyrics-review/TimelineEditor.tsx
@@ -6,8 +6,14 @@ import { cn } from '@/lib/utils'
 import { WaveformVisualizer } from './WaveformVisualizer'
 import { VocalsAudioDataLoaderContext } from './VocalsAudioDataLoader'
 
+// Seconds of context shown (and playable) on each side of the segment in the Edit Segment
+// timeline. Exported so the modal's play/stop range matches the visible padded view.
+export const TIMELINE_PAD_SECONDS = 1
+
 interface TimelineEditorProps {
   words: Word[]
+  /** Neighbouring segments' words, drawn greyed/read-only where they fall in the padded view. */
+  contextWords?: Word[]
   startTime: number
   endTime: number
   onWordUpdate: (index: number, updates: Partial<Word>) => void
@@ -19,6 +25,7 @@ interface TimelineEditorProps {
 
 export default function TimelineEditor({
   words,
+  contextWords,
   startTime,
   endTime,
   onWordUpdate,
@@ -37,6 +44,14 @@ export default function TimelineEditor({
   } | null>(null)
 
   const MIN_DURATION = 0.1 // Minimum word duration in seconds
+
+  // Show a little context on each side of the segment (greyed out) so the first word can be
+  // dragged/synced earlier and the last word later, and so the surrounding waveform + any word
+  // blocks that spill just outside the segment stay visible. The whole timeline maps this padded
+  // "view domain" to 0–100%; the segment itself is the un-shaded band in the middle.
+  const viewStart = Math.max(0, startTime - TIMELINE_PAD_SECONDS)
+  const viewEnd = endTime + TIMELINE_PAD_SECONDS
+  const viewDuration = viewEnd - viewStart
 
   const checkCollision = (
     proposedStart: number,
@@ -79,18 +94,17 @@ export default function TimelineEditor({
   }
 
   const timeToPosition = (time: number): number => {
-    const duration = endTime - startTime
-    const position = ((time - startTime) / duration) * 100
+    const position = ((time - viewStart) / viewDuration) * 100
     return Math.max(0, Math.min(100, position))
   }
 
   const generateTimelineMarks = () => {
     const marks = []
-    const startSecond = Math.floor(startTime)
-    const endSecond = Math.ceil(endTime)
+    const startSecond = Math.floor(viewStart)
+    const endSecond = Math.ceil(viewEnd)
 
     for (let time = startSecond; time <= endSecond; time++) {
-      if (time >= startTime && time <= endTime) {
+      if (time >= viewStart && time <= viewEnd) {
         const position = timeToPosition(time)
         marks.push(
           <div key={time}>
@@ -123,7 +137,7 @@ export default function TimelineEditor({
     if (word.start_time === null || word.end_time === null) return
 
     const initialX = e.clientX - rect.left
-    const initialTime = (initialX / rect.width) * (endTime - startTime)
+    const initialTime = (initialX / rect.width) * viewDuration
 
     setDragState({
       wordIndex,
@@ -152,7 +166,7 @@ export default function TimelineEditor({
 
     if (dragState.type === 'resize-right') {
       const initialWordDuration = dragState.word.end_time - dragState.word.start_time
-      const initialWordWidth = (initialWordDuration / (endTime - startTime)) * width
+      const initialWordWidth = (initialWordDuration / viewDuration) * width
       const pixelDelta = x - dragState.initialX
       const percentageMoved = pixelDelta / initialWordWidth
       const timeDelta = initialWordDuration * percentageMoved
@@ -170,7 +184,7 @@ export default function TimelineEditor({
       })
     } else if (dragState.type === 'resize-left') {
       const initialWordDuration = dragState.word.end_time - dragState.word.start_time
-      const initialWordWidth = (initialWordDuration / (endTime - startTime)) * width
+      const initialWordWidth = (initialWordDuration / viewDuration) * width
       const pixelDelta = x - dragState.initialX
       const percentageMoved = pixelDelta / initialWordWidth
       const timeDelta = initialWordDuration * percentageMoved
@@ -187,7 +201,7 @@ export default function TimelineEditor({
         end_time: currentWord.end_time,
       })
     } else if (dragState.type === 'move') {
-      const pixelsPerSecond = width / (endTime - startTime)
+      const pixelsPerSecond = width / viewDuration
       const pixelDelta = x - dragState.initialX
       const timeDelta = pixelDelta / pixelsPerSecond
 
@@ -195,7 +209,9 @@ export default function TimelineEditor({
       const proposedStart = dragState.word.start_time + timeDelta
       const proposedEnd = proposedStart + wordDuration
 
-      if (proposedStart < startTime || proposedEnd > endTime) return
+      // Allow dragging a little outside the segment (into the padded view) so the first/last
+      // word can extend the segment; updateSegment recomputes the segment bounds from the words.
+      if (proposedStart < viewStart || proposedEnd > viewEnd) return
       if (checkCollision(proposedStart, proposedEnd, dragState.wordIndex, false)) return
 
       onWordUpdate(dragState.wordIndex, {
@@ -234,7 +250,7 @@ export default function TimelineEditor({
     if (rect.width <= 0) return
 
     const x = e.clientX - rect.left
-    const clickedPosition = (x / rect.width) * (endTime - startTime) + startTime
+    const clickedPosition = (x / rect.width) * viewDuration + viewStart
     if (!Number.isFinite(clickedPosition)) return
 
     onPlaySegment(clickedPosition)
@@ -248,6 +264,18 @@ export default function TimelineEditor({
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseUp}
     >
+      {/* Out-of-segment padding: greyed bands on each side of the real segment. These sit above
+          the waveform but below the word bars and are click-through so playback scrubbing still
+          works. Boundary lines mark exactly where the current segment starts/ends. */}
+      <div
+        className="absolute inset-y-0 left-0 bg-muted-foreground/10 pointer-events-none z-[5] border-r border-dashed border-muted-foreground/40"
+        style={{ width: `${timeToPosition(startTime)}%` }}
+      />
+      <div
+        className="absolute inset-y-0 right-0 bg-muted-foreground/10 pointer-events-none z-[5] border-l border-dashed border-muted-foreground/40"
+        style={{ width: `${100 - timeToPosition(endTime)}%` }}
+      />
+
       {/* Timeline ruler */}
       <div
         className="h-10 border-b border-border cursor-pointer"
@@ -256,8 +284,8 @@ export default function TimelineEditor({
         {generateTimelineMarks()}
       </div>
 
-      {/* Playback cursor */}
-      {showPlaybackIndicator && currentTime >= startTime && currentTime <= endTime && (
+      {/* Playback cursor — visible across the padded view (incl. lead-in/out) */}
+      {showPlaybackIndicator && currentTime >= viewStart && currentTime <= viewEnd && (
         <div
           className="absolute top-0 w-0.5 h-full bg-destructive pointer-events-none transition-[left] duration-100 z-10"
           style={{ left: `${timeToPosition(currentTime)}%` }}
@@ -266,6 +294,34 @@ export default function TimelineEditor({
 
       {/* Word blocks */}
       <div className="relative h-[30px]">
+        {/* Neighbouring segments' words that fall in the padded view — greyed, read-only context. */}
+        {(contextWords ?? []).map((word, index) => {
+          if (word.start_time === null || word.end_time === null) return null
+          if (word.end_time < viewStart || word.start_time > viewEnd) return null
+
+          const leftPosition = timeToPosition(word.start_time)
+          const rightPosition = timeToPosition(word.end_time)
+          const width = rightPosition - leftPosition
+
+          return (
+            <div
+              key={`ctx-${word.id ?? index}`}
+              className={cn(
+                'absolute bg-muted-foreground/25 text-muted-foreground rounded px-2 py-1',
+                'select-none flex items-center text-sm font-sans pointer-events-none',
+                'border border-dashed border-muted-foreground/40 overflow-hidden whitespace-nowrap'
+              )}
+              style={{
+                left: `${leftPosition}%`,
+                width: `${width}%`,
+                maxWidth: `calc(${100 - leftPosition}%)`,
+              }}
+              title={`${word.text} (neighbouring segment)`}
+            >
+              {word.text}
+            </div>
+          )
+        })}
         {words.map((word, index) => {
           if (word.start_time === null || word.end_time === null) return null
 
@@ -317,8 +373,10 @@ export default function TimelineEditor({
       <VocalsAudioDataLoaderContext.Consumer>
         {({ audioData: vocalsAudioData }) => (
           vocalsAudioData && <WaveformVisualizer
-            startTime={startTime}
-            endTime={endTime}
+            startTime={viewStart}
+            endTime={viewEnd}
+            fadeBeforeTime={startTime}
+            fadeAfterTime={endTime}
             audioData={vocalsAudioData}
             className="w-[100%] h-[35px]"
           />

--- a/frontend/components/lyrics-review/WaveformVisualizer.tsx
+++ b/frontend/components/lyrics-review/WaveformVisualizer.tsx
@@ -8,6 +8,12 @@ export interface WaveformVisualizerProps extends Omit<HTMLProps<HTMLCanvasElemen
 	endTime: number
 	audioData: AudioData | null
 	barColor?: string
+	/** Bars whose time is before this are drawn faded (used to dim the out-of-segment lead-in). */
+	fadeBeforeTime?: number
+	/** Bars whose time is after this are drawn faded (used to dim the out-of-segment lead-out). */
+	fadeAfterTime?: number
+	/** Opacity applied to faded (out-of-segment) bars. */
+	fadedOpacity?: number
 }
 
 export const WaveformVisualizer = ({
@@ -16,6 +22,9 @@ export const WaveformVisualizer = ({
 	audioData,
 	className,
 	barColor = colors.yellow['500'],
+	fadeBeforeTime,
+	fadeAfterTime,
+	fadedOpacity = 0.28,
 	... canvasProps
 }: WaveformVisualizerProps) => {
 	const containerRef = useRef<HTMLDivElement | null>(null)
@@ -64,7 +73,16 @@ export const WaveformVisualizer = ({
 		const audioData = readAudioData(startTime, endTime)
 		if (!audioData) return
 
+		const windowDuration = endTime - startTime
+
 		for (let x = 0; x < ctx.canvas.width; x++) {
+			// Dim bars that fall outside the segment (the padded lead-in/out context regions).
+			const barTime = startTime + ((x + 0.5) / ctx.canvas.width) * windowDuration
+			const isFaded =
+				(fadeBeforeTime !== undefined && barTime < fadeBeforeTime) ||
+				(fadeAfterTime !== undefined && barTime > fadeAfterTime)
+			ctx.globalAlpha = isFaded ? fadedOpacity : 1
+
 			// Clamp the first pixel: (x - 0.5) is negative at x=0, and a negative
 			// slice start would sample peaks from the end of the window instead.
 			const dataPointIndex = Math.max(0, Math.floor((x - 0.5) / ctx.canvas.width * audioData.length))
@@ -84,7 +102,9 @@ export const WaveformVisualizer = ({
 
 			ctx.fillRect(x, (ctx.canvas.height - barHeight) / 2, 1, barHeight)
 		}
-	}, [readAudioData, barColor])
+
+		ctx.globalAlpha = 1
+	}, [readAudioData, barColor, fadeBeforeTime, fadeAfterTime, fadedOpacity])
 
 	// Re-render when the data (readAudioData is memoized on audioData), the window,
 	// the canvas size, or the colour changes. audioData arrives asynchronously, so

--- a/frontend/components/lyrics-review/modals/EditModal.tsx
+++ b/frontend/components/lyrics-review/modals/EditModal.tsx
@@ -11,6 +11,7 @@ import { LyricsSegment, Word } from '@/lib/lyrics-review/types'
 import { nanoid } from 'nanoid'
 import EditWordList from '../EditWordList'
 import EditTimelineSection from '../EditTimelineSection'
+import { TIMELINE_PAD_SECONDS } from '../TimelineEditor'
 import useManualSync from '@/hooks/useManualSync'
 import { setModalHandler } from '@/lib/lyrics-review/utils/keyboardHandlers'
 import { useAudioReady } from '@/lib/lyrics-review/hooks/useAudioReady'
@@ -26,6 +27,8 @@ interface EditModalProps {
   onSave: (updatedSegment: LyricsSegment) => void
   onPlaySegment?: (startTime: number) => void
   currentTime?: number
+  /** Words from neighbouring segments near this one, shown as greyed read-only context in the timeline padding. */
+  contextWords?: Word[]
   onDelete?: (segmentIndex: number) => void
   onAddSegment?: (segmentIndex: number) => void
   onSplitSegment?: (segmentIndex: number, afterWordIndex: number) => void
@@ -45,6 +48,7 @@ export default function EditModal({
   onSave,
   onPlaySegment,
   currentTime = 0,
+  contextWords,
   onDelete,
   onAddSegment,
   onSplitSegment,
@@ -144,11 +148,12 @@ export default function EditModal({
     }
   }, [open, handleSpacebar])
 
-  // Auto-stop playback at segment end (not during manual sync or for global segments)
+  // Auto-stop playback a lead-out past the segment end (matches the padded timeline view, so the
+  // last word's run-out is audible). Not during manual sync or for global segments.
   useEffect(() => {
     if (!editedSegment || isManualSyncing || isGlobal) return
 
-    const endTime = editedSegment.end_time ?? 0
+    const endTime = (editedSegment.end_time ?? 0) + TIMELINE_PAD_SECONDS
     if (isPlaying && currentTime > endTime) {
       window.toggleAudioPlayback?.()
     }
@@ -328,7 +333,9 @@ export default function EditModal({
     if (isPlaying) {
       window.toggleAudioPlayback?.()
     } else {
-      onPlaySegment(segment.start_time ?? 0)
+      // Start a lead-in before the segment (matches the padded timeline view) so the first
+      // word's onset is audible in context.
+      onPlaySegment(Math.max(0, (segment.start_time ?? 0) - TIMELINE_PAD_SECONDS))
     }
   }, [segment, onPlaySegment, isPlaying])
 
@@ -385,7 +392,7 @@ export default function EditModal({
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
-      <DialogContent className="max-w-[960px] max-h-[90vh] overflow-hidden flex flex-col gap-2" onKeyDown={handleKeyDown}>
+      <DialogContent className="w-[95vw] max-w-[1400px] max-h-[90vh] overflow-hidden flex flex-col gap-2" onKeyDown={handleKeyDown}>
         <DialogHeader>
           {/* Left: title (with the segment's time range folded into the heading)
               + play. Right: Tap To Sync, moved up here to reclaim vertical space
@@ -471,6 +478,7 @@ export default function EditModal({
               <div className="flex-grow">
                 <EditTimelineSection
                   words={editedSegment.words}
+                  contextWords={contextWords}
                   startTime={startTime}
                   endTime={endTime}
                   currentTime={currentTime}

--- a/frontend/hooks/__tests__/useManualSync.tapSync.test.tsx
+++ b/frontend/hooks/__tests__/useManualSync.tapSync.test.tsx
@@ -1,0 +1,147 @@
+import { act, renderHook } from '@testing-library/react'
+import useManualSync from '../useManualSync'
+import { LyricsSegment, Word } from '@/lib/lyrics-review/types'
+
+/**
+ * Regression tests for the Tap To Sync flow.
+ *
+ * Bug: when re-syncing a segment whose words already had timings, advancing to the
+ * next word compared the just-tapped word's end against the *next* word's STALE start
+ * (it hadn't been re-tapped yet) and pulled the end back to it, producing
+ * end_time < start_time (negative duration). The segment sanitizer then reported
+ * "Fixed N word timing(s) that fell outside this segment." on reopen.
+ */
+
+function w(id: string, text: string, start: number | null, end: number | null): Word {
+  return { id, text, start_time: start, end_time: end }
+}
+
+function makeSegment(words: Word[]): LyricsSegment {
+  const starts = words.map((x) => x.start_time).filter((t): t is number => t !== null)
+  const ends = words.map((x) => x.end_time).filter((t): t is number => t !== null)
+  return {
+    id: 'seg-16',
+    text: words.map((x) => x.text).join(' '),
+    words,
+    start_time: starts.length ? Math.min(...starts) : null,
+    end_time: ends.length ? Math.max(...ends) : null,
+  }
+}
+
+// Mirror EditModal.updateSegment: recompute segment bounds from word min/max.
+function recompute(segment: LyricsSegment, newWords: Word[]): LyricsSegment {
+  const starts = newWords.map((x) => x.start_time).filter((t): t is number => t !== null)
+  const ends = newWords.map((x) => x.end_time).filter((t): t is number => t !== null)
+  return {
+    ...segment,
+    words: newWords,
+    text: newWords.map((x) => x.text).join(' '),
+    start_time: starts.length ? Math.min(...starts) : null,
+    end_time: ends.length ? Math.max(...ends) : null,
+  }
+}
+
+// Re-fetch the handler between keydown and keyup: React commits `isSpacebarPressed` and
+// re-creates the callback after keydown, and production re-registers the fresh closure via
+// setModalHandler on every render. `result` is the renderHook result so `.current` is live.
+function tap(result: { current: { handleSpacebar: (e: KeyboardEvent) => void } }) {
+  const mk = (type: 'keydown' | 'keyup') =>
+    ({ type, code: 'Space', preventDefault: () => {}, stopPropagation: () => {} } as unknown as KeyboardEvent)
+  act(() => result.current.handleSpacebar(mk('keydown')))
+  act(() => result.current.handleSpacebar(mk('keyup')))
+}
+
+describe('useManualSync — tap-to-sync end times', () => {
+  beforeEach(() => {
+    window.isAudioPlaying = false
+    window.toggleAudioPlayback = jest.fn()
+  })
+
+  it('never produces a word whose end_time is before its start_time when re-syncing', () => {
+    // Segment already fully synced with OLD timings — re-syncing moves words later.
+    const initial = makeSegment([
+      w('a', 'You', 88.9, 89.0),
+      w('b', 'know', 89.0, 89.3),
+      w('c', 'why,', 89.3, 89.8),
+      w('d', 'the', 90.9, 91.0),
+    ])
+
+    let segment = initial
+    let currentTime = 88.9
+
+    const { result, rerender } = renderHook(
+      ({ seg, time }) =>
+        useManualSync({
+          editedSegment: seg,
+          currentTime: time,
+          onPlaySegment: () => {},
+          // Mirror production: recompute bounds and feed the new segment back in.
+          updateSegment: (newWords: Word[]) => {
+            segment = recompute(segment, newWords)
+          },
+        }),
+      { initialProps: { seg: segment, time: currentTime } }
+    )
+
+    act(() => result.current.startManualSync())
+
+    // Re-tap each word at a LATER playhead position than its old start.
+    const tapTimes = [91.2, 91.6, 92.0, 92.4]
+    tapTimes.forEach((t) => {
+      currentTime = t
+      rerender({ seg: segment, time: currentTime })
+      tap(result)
+      rerender({ seg: segment, time: currentTime })
+    })
+
+    // Invariant: every word with both timings must have end_time >= start_time.
+    segment.words.forEach((word) => {
+      if (word.start_time !== null && word.end_time !== null) {
+        expect(word.end_time).toBeGreaterThanOrEqual(word.start_time)
+      }
+    })
+  })
+
+  it('extends the segment end when the last word is tapped near the old end', () => {
+    // Segment ends at 3.00; re-tap so the LAST word lands at 2.90 — its default 0.5s tap
+    // duration pushes its end to ~3.40, past the old end. The segment must grow to include it,
+    // not hard-cut the word at 3.00.
+    const initial = makeSegment([
+      w('a', 'one', 0.5, 0.9),
+      w('b', 'two', 1.0, 1.4),
+      w('c', 'three', 2.9, 3.0),
+    ])
+
+    let segment = initial
+    let currentTime = 0.5
+
+    const { result, rerender } = renderHook(
+      ({ seg, time }) =>
+        useManualSync({
+          editedSegment: seg,
+          currentTime: time,
+          onPlaySegment: () => {},
+          updateSegment: (newWords: Word[]) => {
+            segment = recompute(segment, newWords)
+          },
+        }),
+      { initialProps: { seg: segment, time: currentTime } }
+    )
+
+    act(() => result.current.startManualSync())
+
+    const tapTimes = [0.5, 1.0, 2.9]
+    tapTimes.forEach((t) => {
+      currentTime = t
+      rerender({ seg: segment, time: currentTime })
+      tap(result)
+      rerender({ seg: segment, time: currentTime })
+    })
+
+    const lastWord = segment.words[segment.words.length - 1]
+    // Last word's end extended past the old segment end (3.00)…
+    expect(lastWord.end_time).toBeGreaterThan(3.0)
+    // …and the segment end grew to include it (no hard cut at 3.00).
+    expect(segment.end_time).toBeGreaterThanOrEqual(lastWord.end_time as number)
+  })
+})

--- a/frontend/hooks/__tests__/useManualSync.test.ts
+++ b/frontend/hooks/__tests__/useManualSync.test.ts
@@ -13,4 +13,30 @@ describe('clampSyncTime', () => {
   it('falls back gracefully when segment bounds are null', () => {
     expect(clampSyncTime(5, null, null)).toBe(5)
   })
+
+  describe('with a lead-in window (playback starts before the segment)', () => {
+    it('keeps a legitimate tap in the lead-in instead of shoving it to segStart', () => {
+      // Regression: re-syncing "Well," — tapped at 0.468, segStart had ratcheted to 0.688.
+      // Old behaviour clamped up to 0.688 and squished the word; now it's kept.
+      expect(clampSyncTime(0.468, 0.688, 4.48, 3)).toBe(0.468)
+    })
+    it('keeps a tap a second before a mid-song segment start', () => {
+      expect(clampSyncTime(14.0, 15.18, 18.04, 3)).toBe(14.0)
+    })
+    it('still clamps a genuine playhead-at-0 glitch up to (segStart - leadIn)', () => {
+      expect(clampSyncTime(0, 15.18, 18.04, 3)).toBeCloseTo(12.18, 5)
+    })
+    it('floors the lower bound at 0 for segments near the song start', () => {
+      expect(clampSyncTime(0, 0.688, 4.48, 3)).toBe(0)
+    })
+    it('clamps a far-future glitch to the segment end when no lead-out is given', () => {
+      expect(clampSyncTime(99, 15.18, 18.04, 3)).toBe(18.04)
+    })
+    it('keeps a tap just past the segment end within the lead-out (extends the segment)', () => {
+      expect(clampSyncTime(18.5, 15.18, 18.04, 3, 3)).toBe(18.5)
+    })
+    it('still clamps a far-future glitch to (segEnd + leadOut)', () => {
+      expect(clampSyncTime(99, 15.18, 18.04, 3, 3)).toBeCloseTo(21.04, 5)
+    })
+  })
 })

--- a/frontend/hooks/useManualSync.ts
+++ b/frontend/hooks/useManualSync.ts
@@ -11,19 +11,39 @@ interface UseManualSyncProps {
   onTimingClamped?: (wordText: string, snappedTo: number) => void
 }
 
+// Manual sync plays this many seconds before the segment starts, so the user can hear the
+// run-up and tap the very first word on time. Taps anywhere in that lead-in are legitimate.
+const LEAD_IN_SECONDS = 3
+// Symmetric window AFTER the segment end: the user may tap/hold the last word past the old end
+// (extending the segment). Taps within this lead-out are legitimate and grow the segment.
+const LEAD_OUT_SECONDS = 3
+
 /**
- * Clamp a manual-sync tap time into the segment's audio window. A tap should always land
- * within the segment being synced; a value outside (e.g. the playhead sitting at 0) is a
- * sync glitch — the source of the start=0/end=-0.005 corruption. Null bounds => no clamp.
+ * Clamp a manual-sync tap time into the segment's *playback* window `[segStart - leadIn, segEnd + leadOut]`.
+ *
+ * A tap should land within the window Tap To Sync actually plays/allows. Playback starts `leadIn`
+ * seconds BEFORE the segment (see LEAD_IN_SECONDS) because the user hears the run-up and often taps
+ * the first word just before the old segment start (especially when re-syncing to move it earlier).
+ * Symmetrically, `leadOut` lets the last word be tapped/held just past the old end to extend the
+ * segment. Only values outside that widened window (e.g. the playhead stuck at 0 for a mid-song
+ * segment) are sync glitches worth clamping. Clamping to the tight `[segStart, segEnd]` instead
+ * would (a) shove every legitimate lead-in tap up to segStart, (b) ratchet the segment start forward
+ * so it could never be re-synced earlier, and (c) hard-cut the last word at the old end. The lower
+ * bound is floored at 0. `leadIn`/`leadOut` default to 0 for back-compat; pass the constants from
+ * the sync handlers. Null start/end => that bound is skipped.
  */
 export function clampSyncTime(
   time: number,
   segStart: number | null,
-  segEnd: number | null
+  segEnd: number | null,
+  leadIn: number = 0,
+  leadOut: number = 0
 ): number {
   let t = time
-  if (typeof segStart === 'number' && Number.isFinite(segStart)) t = Math.max(t, segStart)
-  if (typeof segEnd === 'number' && Number.isFinite(segEnd)) t = Math.min(t, segEnd)
+  if (typeof segStart === 'number' && Number.isFinite(segStart)) {
+    t = Math.max(t, Math.max(0, segStart - leadIn))
+  }
+  if (typeof segEnd === 'number' && Number.isFinite(segEnd)) t = Math.min(t, segEnd + leadOut)
   return t
 }
 
@@ -55,6 +75,13 @@ export default function useManualSync({
   useEffect(() => {
     currentTimeRef.current = currentTime
   }, [currentTime])
+
+  // Mirror isSpacebarPressed into a ref so the auto-stop interval can read the live value
+  // (its closure would otherwise capture a stale state snapshot) without restarting the interval.
+  const isSpacebarPressedRef = useRef(isSpacebarPressed)
+  useEffect(() => {
+    isSpacebarPressedRef.current = isSpacebarPressed
+  }, [isSpacebarPressed])
 
   // Keep wordsRef up to date
   useEffect(() => {
@@ -143,7 +170,9 @@ export default function useManualSync({
           const currentStartTime = clampSyncTime(
             rawStartTime,
             editedSegment?.start_time ?? null,
-            editedSegment?.end_time ?? null
+            editedSegment?.end_time ?? null,
+            LEAD_IN_SECONDS,
+            LEAD_OUT_SECONDS
           )
           if (currentStartTime !== rawStartTime) {
             onTimingClamped?.(newWords[syncWordIndex]?.text ?? '', currentStartTime)
@@ -256,23 +285,33 @@ export default function useManualSync({
     [isManualSyncing, editedSegment, syncWordIndex, isSpacebarPressed, isPaused]
   )
 
-  // Add a handler for when the next word starts to adjust previous word's end time if needed
+  // Safety net for when we advance to the next word: if the word we just synced ends
+  // after the *next* word's start, pull its end back so they don't overlap.
+  //
+  // Two guards are essential here. When this effect fires, `currentWord` (the next word)
+  // has NOT been re-synced yet — it still holds its OLD start_time from a previous sync.
+  // So we must only act when that start is genuinely *later* than the previous word's
+  // start (`currentWord.start_time > prevWord.start_time`); otherwise a re-sync that moves
+  // words to later times would pull the just-tapped word's end back to a stale, earlier
+  // timestamp — producing end_time < start_time (a negative-duration word the segment
+  // sanitizer then has to "fix" on reopen). We also clamp the new end to never fall below
+  // the previous word's own start_time.
   useEffect(() => {
     if (isManualSyncing && editedSegment && syncWordIndex > 0) {
       const newWords = [...wordsRef.current]
       const prevWord = newWords[syncWordIndex - 1]
       const currentWord = newWords[syncWordIndex]
 
-      // If the previous word's end time overlaps with the current word's start time,
-      // adjust the previous word's end time
       if (
         prevWord &&
         currentWord &&
         prevWord.end_time !== null &&
+        prevWord.start_time !== null &&
         currentWord.start_time !== null &&
+        currentWord.start_time > prevWord.start_time &&
         prevWord.end_time > currentWord.start_time
       ) {
-        prevWord.end_time = currentWord.start_time - OVERLAP_BUFFER
+        prevWord.end_time = Math.max(currentWord.start_time - OVERLAP_BUFFER, prevWord.start_time)
 
         // Update our ref
         wordsRef.current = newWords
@@ -422,7 +461,7 @@ export default function useManualSync({
     spacebarPressTimeRef.current = null
     needsSegmentUpdateRef.current = false
     // Start playing 3 seconds before segment start
-    onPlaySegment((editedSegment.start_time ?? 0) - 3)
+    onPlaySegment((editedSegment.start_time ?? 0) - LEAD_IN_SECONDS)
   }, [isManualSyncing, editedSegment, onPlaySegment, cleanupManualSync])
 
   // Auto-stop sync if we go past the end time (but not for global replacement segments)
@@ -438,7 +477,12 @@ export default function useManualSync({
     const checkAutoStop = () => {
       const endTime = editedSegment.end_time ?? 0
 
-      if (window.isAudioPlaying && currentTimeRef.current > endTime) {
+      // Never cut the user off mid-tap/hold: they may be holding the LAST word past the old
+      // segment end to extend it (updateSegment grows end_time once the word lands). Only stop
+      // once playback is a full lead-out past the end AND the spacebar isn't currently down.
+      if (isSpacebarPressedRef.current) return
+
+      if (window.isAudioPlaying && currentTimeRef.current > endTime + LEAD_OUT_SECONDS) {
         window.toggleAudioPlayback?.()
         cleanupManualSync()
       }

--- a/frontend/hooks/useManualSync.ts
+++ b/frontend/hooks/useManualSync.ts
@@ -355,7 +355,9 @@ export default function useManualSync({
       const currentStartTime = clampSyncTime(
         rawStartTime,
         editedSegment?.start_time ?? null,
-        editedSegment?.end_time ?? null
+        editedSegment?.end_time ?? null,
+        LEAD_IN_SECONDS,
+        LEAD_OUT_SECONDS
       )
       if (currentStartTime !== rawStartTime) {
         onTimingClamped?.(newWords[syncWordIndex]?.text ?? '', currentStartTime)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.207.1"
+version = "0.208.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"

--- a/scripts/review_test_fixtures.py
+++ b/scripts/review_test_fixtures.py
@@ -30,7 +30,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 import uvicorn
 
@@ -436,13 +436,92 @@ class FixtureReviewServer:
 
         @self.app.get("/api/audio/{audio_hash}")
         async def get_audio(audio_hash: str):
-            """No audio available for fixture review."""
-            raise HTTPException(status_code=404, detail="Audio not available in fixture review mode")
+            """Serve synthetic audio so the review UI's player/waveform can load."""
+            return Response(content=self._get_synthetic_wav(), media_type="audio/wav")
 
         @self.app.get("/api/review/{job_id}/audio/{audio_hash}")
         async def get_audio_review(job_id: str, audio_hash: str):
-            """No audio available for fixture review."""
-            raise HTTPException(status_code=404, detail="Audio not available in fixture review mode")
+            """Serve synthetic audio (vocals/instrumental/etc.) for fixture review.
+
+            Real stems aren't available offline, but the manual "Tap To Sync" flow needs a
+            playable, seekable audio element and a decodable buffer for the waveform. A quiet
+            synthetic tone satisfies both without any external asset.
+            """
+            return Response(content=self._get_synthetic_wav(), media_type="audio/wav")
+
+    def _get_synthetic_wav(self, sample_rate: int = 16000) -> bytes:
+        """Generate (and cache per fixture) a mono WAV *click track* for the review audio player.
+
+        Real vocal stems aren't available offline, so a flat tone gives nothing to sync to. Instead
+        we place a short audible click at every word's onset (start_time) for the CURRENT fixture,
+        so the manual "Tap To Sync" flow can actually be exercised — tap on each click. Also yields a
+        decodable buffer for the waveform and a seekable element for playback. Cached per fixture.
+        """
+        cache = getattr(self, "_synthetic_wav_cache", None)
+        if cache is None:
+            cache = {}
+            self._synthetic_wav_cache = cache
+        idx = self.current_index
+        if idx in cache:
+            return cache[idx]
+
+        import io
+        import math
+        import struct
+        import wave
+
+        # Collect word onsets (and the latest end) from the current fixture's segments.
+        onsets: List[float] = []
+        max_end = 0.0
+        try:
+            fixture_data = self.fixtures[idx][1]
+            for seg in fixture_data.get("original_segments", []):
+                for w in seg.get("words", []):
+                    st = w.get("start_time")
+                    en = w.get("end_time")
+                    if isinstance(st, (int, float)):
+                        onsets.append(float(st))
+                    if isinstance(en, (int, float)):
+                        max_end = max(max_end, float(en))
+        except (IndexError, KeyError, TypeError):
+            pass
+
+        duration_s = max(int(max_end) + 5, 30)
+        n_frames = duration_s * sample_rate
+        samples = [0] * n_frames
+
+        # Percussive 1 kHz click, ~60ms with exponential decay, at each onset.
+        click_len = int(0.06 * sample_rate)
+        click_amp = 9000  # ~27% of int16 full-scale — clearly audible
+        two_pi_click = 2 * math.pi * 1000.0
+        for onset in onsets:
+            start = int(onset * sample_rate)
+            for j in range(click_len):
+                pos = start + j
+                if 0 <= pos < n_frames:
+                    tau = j / sample_rate
+                    env = math.exp(-tau * 45.0)
+                    samples[pos] += int(click_amp * env * math.sin(two_pi_click * tau))
+
+        buf = io.BytesIO()
+        with wave.open(buf, "wb") as wav:
+            wav.setnchannels(1)
+            wav.setsampwidth(2)  # 16-bit PCM
+            wav.setframerate(sample_rate)
+            frames = bytearray()
+            for s in samples:
+                # Clamp to int16 range in case overlapping clicks sum past the limit.
+                s = 32767 if s > 32767 else -32768 if s < -32768 else s
+                frames += struct.pack("<h", s)
+            wav.writeframes(bytes(frames))
+
+        data = buf.getvalue()
+        cache[idx] = data
+        logging.info(
+            f"🔊 Generated {duration_s}s click-track WAV ({len(data) // 1024} KB, "
+            f"{len(onsets)} word onsets) for fixture #{idx}"
+        )
+        return data
 
     def _do_navigate(self, direction: str) -> dict:
         """Perform navigation to next/previous fixture."""


### PR DESCRIPTION
## Summary

Fixes **Tap To Sync timing corruption** in the Edit Segment modal and reworks the segment timeline for easier re-timing of the first/last words.

### Tap To Sync fixes (`useManualSync`)
- **Negative durations on re-sync** — the overlap-correction effect pulled a just-tapped word's end back to the *next* word's **stale** start (it hadn't been re-tapped yet), producing `end_time < start_time`. The sanitizer then reported *"Fixed N word timing(s) that fell outside this segment"* on reopen. Now guarded + clamped so it never inverts.
- **First word squished / segment start ratcheting** — `clampSyncTime` forced every tap into the tight `[segStart, segEnd]`, so a legit tap in the 3s playback lead-in got shoved up to `segStart` and the start could never be re-synced earlier. Now allows taps in `[segStart − leadIn, segEnd + leadOut]` (floored at 0).
- **Last word cut off** — symmetric lead-out + auto-stop no longer fires while the spacebar is held, so the last word can extend the segment (hold past the end / default-duration overshoot) instead of being truncated.
- Both keyboard **and touch** sync paths use the widened window.

### Edit Segment timeline UX
- ±1s **greyed context padding** on each side (dashed boundary), **faded waveform** outside the segment, and **neighbouring segments' words** as read-only context blocks. Word bars, drag, ruler, cursor and click-to-scrub all map over the padded view; words can be dragged/synced into the padding to extend the segment.
- Modal widened `960px → 95vw / max 1400px`.
- Header **play button** starts 1s before and auto-stops 1s after the segment.

### Dev tooling (dev-gated, no prod impact)
- `&edit=1` makes a replay session editable locally (guarded by `NODE_ENV !== 'production'`) so the real review UI can be exercised against real job data + audio. Documented in `docs/REPLAY.md`.
- `review_test_fixtures.py` now serves a synthetic **click-track** so Tap To Sync is exercisable offline.

## Testing
- New/expanded unit tests in `hooks/__tests__/useManualSync*.ts(x)`: negative-duration regression (fails on old code, passes on fix), lead-in/lead-out clamp cases, and segment-end extension. All 13 pass; 178 lyrics-review + hook tests green.
- Typecheck clean on touched files.
- Verified end-to-end in the browser against a real completed job (replay + real vocals): tap-sync produces valid monotonic timings, no sanitizer banner, first/last words extend correctly, timeline padding + fade + neighbour words render as intended.

## Notes
- CodeRabbit reviewed locally; its one finding (touch path missing the lead window) is fixed.

@coderabbitai ignore
