### PR TITLE
Pre-apply AI corrections on review load too (C2 completeness) — fixes the ~4s flicker on pre-existing jobs

### DIFF
--- a/backend/api/routes/review.py
+++ b/backend/api/routes/review.py
@@ -580,6 +580,18 @@ async def get_correction_data(
             detail=t("en", "review.reviewNotReady", status=job.status)
         )
 
+    # Server-side pre-apply ON LOAD (C2 completeness): jobs processed before the
+    # screens_worker pre-apply shipped (or whose cache landed after that gate) reach
+    # this endpoint without a pre_applied marker, so the review UI would still run its
+    # on-load client-side apply (the visible ~4s "uncorrected -> corrected" flicker).
+    # Apply here from an EXISTING cache only (generate_on_miss=False so the page never
+    # blocks on a multi-model LLM call). Best-effort + idempotent: a no-op when the
+    # job was already pre-applied, already human-edited, or has no cache. The direct
+    # corrections_updated path below then serves the freshly-written corrected state.
+    if not replay:
+        from backend.services.auto_approval.pre_apply import ensure_and_pre_apply
+        await ensure_and_pre_apply(job_id, generate_on_miss=False)
+
     # Check for updated corrections first (from previous review sessions where user edited lyrics)
     # This mirrors the logic in render_video_worker.py to ensure consistency
     corrections_updated_gcs = job.file_urls.get('lyrics', {}).get('corrections_updated')

--- a/backend/services/auto_approval/pre_apply.py
+++ b/backend/services/auto_approval/pre_apply.py
@@ -102,7 +102,19 @@ async def ensure_and_pre_apply(job_id: str, *, generate_on_miss: bool = True) ->
             "applied_at": datetime.now(timezone.utc).isoformat(),
         }
         updated["metadata"] = metadata
-        storage.upload_json(updated_path, updated)
+        # Create-only write: we only reach here when corrections_updated.json was
+        # absent at the check above, so if_generation_match=0 makes the write atomic —
+        # a concurrent writer (executor auto-complete, or an edit submission) that
+        # created it in the meantime wins and we don't clobber their (newer) state.
+        try:
+            from google.api_core.exceptions import PreconditionFailed
+        except Exception:  # pragma: no cover - google libs always present in prod
+            PreconditionFailed = ()  # type: ignore[assignment]
+        try:
+            storage.upload_json(updated_path, updated, if_generation_match=0)
+        except PreconditionFailed:
+            logger.info(f"[job:{job_id}] pre-apply raced a concurrent write — theirs wins")
+            return {"outcome": "skipped", "reason": "raced_concurrent_write"}
         JobManager().update_file_url(job_id, "lyrics", "corrections_updated", updated_path)
 
         logger.info(

--- a/backend/services/auto_approval/pre_apply.py
+++ b/backend/services/auto_approval/pre_apply.py
@@ -29,10 +29,16 @@ CORRECTIONS_PATH = "jobs/{job_id}/lyrics/corrections.json"
 CORRECTIONS_UPDATED_PATH = "jobs/{job_id}/lyrics/corrections_updated.json"
 
 
-async def ensure_and_pre_apply(job_id: str) -> Dict[str, Any]:
+async def ensure_and_pre_apply(job_id: str, *, generate_on_miss: bool = True) -> Dict[str, Any]:
     """Ensure the suggestion cache exists, apply it, and persist the pre-applied
     corrections with a ``pre_applied`` marker. Returns a small status dict; never
     raises.
+
+    ``generate_on_miss`` (default True, the screens_worker path): when the proactive
+    cache is absent, generate it synchronously (bounded) before applying. The
+    ``/correction-data`` load path passes False — it only applies an EXISTING cache
+    so a review page never blocks on a multi-model LLM call; a cache-miss there
+    falls through to the UI's own client-side apply.
     """
     try:
         from backend.config import get_settings
@@ -62,9 +68,11 @@ async def ensure_and_pre_apply(job_id: str) -> Dict[str, Any]:
 
         corrections = storage.download_json(corrections_path)
 
-        # 1) Ensure the proactive suggestion cache exists (generate on miss).
+        # 1) Ensure the proactive suggestion cache exists (generate on miss, unless
+        #    the caller — e.g. the load-time path — asked to only apply an existing
+        #    cache so the request doesn't block on an LLM call).
         ai_suggestions = _load_ai_suggestions(storage, job_id)
-        if ai_suggestions is None and settings.auto_correct_proactive_enabled:
+        if ai_suggestions is None and generate_on_miss and settings.auto_correct_proactive_enabled:
             logger.info(f"[job:{job_id}] pre-apply: cache miss, generating suggestions synchronously")
             from backend.workers.auto_correct_worker import process_proactive_auto_correct
             await process_proactive_auto_correct(job_id)  # bounded (180s) + best-effort

--- a/backend/services/storage_service.py
+++ b/backend/services/storage_service.py
@@ -288,14 +288,28 @@ class StorageService:
             logger.error(f"Error checking file existence {blob_path}: {e}")
             raise
     
-    def upload_json(self, destination_path: str, data: Dict[str, Any]) -> str:
-        """Upload a JSON object to GCS."""
+    def upload_json(
+        self,
+        destination_path: str,
+        data: Dict[str, Any],
+        if_generation_match: Optional[int] = None,
+    ) -> str:
+        """Upload a JSON object to GCS.
+
+        ``if_generation_match=0`` makes the write a create-only operation: GCS raises
+        ``PreconditionFailed`` (412) if the object already exists, so concurrent
+        writers can't clobber each other. Callers that need this must handle the
+        exception.
+        """
         try:
             blob = self.bucket.blob(destination_path)
             blob.content_type = "application/json"
+            upload_kwargs = {"content_type": "application/json"}
+            if if_generation_match is not None:
+                upload_kwargs["if_generation_match"] = if_generation_match
             blob.upload_from_string(
                 json.dumps(data, indent=2, ensure_ascii=False),
-                content_type="application/json"
+                **upload_kwargs,
             )
             logger.info(f"Uploaded JSON to gs://{settings.gcs_bucket_name}/{destination_path}")
             return destination_path

--- a/backend/tests/services/auto_approval/test_pre_apply.py
+++ b/backend/tests/services/auto_approval/test_pre_apply.py
@@ -69,13 +69,21 @@ class _FakeStorage:
         self._files[path] = data
 
 
-async def _run(storage, *, proactive=True):
+async def _run(storage, *, proactive=True, generate_on_miss=True):
     settings = MagicMock(auto_correct_proactive_enabled=proactive)
     jm = MagicMock()
+    generated = {"called": False}
+
+    async def _fake_generate(job_id):
+        generated["called"] = True
+        return {"status": "generated"}
+
     with patch("backend.config.get_settings", return_value=settings), \
          patch("backend.services.storage_service.StorageService", return_value=storage), \
-         patch("backend.services.job_manager.JobManager", return_value=jm):
-        return await ensure_and_pre_apply("j1"), jm
+         patch("backend.services.job_manager.JobManager", return_value=jm), \
+         patch("backend.workers.auto_correct_worker.process_proactive_auto_correct", _fake_generate):
+        result = await ensure_and_pre_apply("j1", generate_on_miss=generate_on_miss)
+        return result, jm, generated
 
 
 CORR = "jobs/j1/lyrics/corrections.json"
@@ -89,7 +97,7 @@ async def test_pre_apply_writes_marker_and_applies():
         CORR: _corrections(),
         CACHE: {"suggestions": [_replace_suggestion()]},
     })
-    result, jm = await _run(storage)
+    result, jm, _gen = await _run(storage)
     assert result["outcome"] == "pre_applied"
     assert result["applied"] == 1
     written = storage.uploads[UPD]
@@ -106,7 +114,7 @@ async def test_pre_apply_writes_marker_and_applies():
 async def test_pre_apply_empty_suggestions_still_marks():
     # Known-empty cache: mark pre_applied so the UI doesn't run client-side.
     storage = _FakeStorage({CORR: _corrections(), CACHE: {"suggestions": []}})
-    result, _ = await _run(storage)
+    result, _, _gen = await _run(storage)
     assert result["outcome"] == "pre_applied"
     assert result["applied"] == 0
     assert storage.uploads[UPD]["metadata"]["auto_approval"]["pre_applied"] is True
@@ -116,7 +124,7 @@ async def test_pre_apply_empty_suggestions_still_marks():
 async def test_pre_apply_no_cache_and_proactive_disabled_is_noop():
     # No cache + proactive off -> unknown suggestion set -> do NOT mark (fall back).
     storage = _FakeStorage({CORR: _corrections()})
-    result, _ = await _run(storage, proactive=False)
+    result, _, _gen = await _run(storage, proactive=False)
     assert result["outcome"] == "skipped"
     assert result["reason"] == "no_suggestions_cache"
     assert UPD not in storage.uploads
@@ -129,7 +137,7 @@ async def test_pre_apply_skips_when_already_applied():
         UPD: {"metadata": {"auto_approval": {"auto_approved": True}}},
         CACHE: {"suggestions": [_replace_suggestion()]},
     })
-    result, _ = await _run(storage)
+    result, _, _gen = await _run(storage)
     assert result["outcome"] == "skipped"
     assert result["reason"] == "already_applied"
 
@@ -137,6 +145,41 @@ async def test_pre_apply_skips_when_already_applied():
 @pytest.mark.asyncio
 async def test_pre_apply_no_corrections_is_noop():
     storage = _FakeStorage({})
-    result, _ = await _run(storage)
+    result, _, _gen = await _run(storage)
     assert result["outcome"] == "skipped"
     assert result["reason"] == "no_corrections"
+
+
+@pytest.mark.asyncio
+async def test_load_path_applies_existing_cache_without_generating():
+    # generate_on_miss=False (the /correction-data load path): an existing cache is
+    # applied, but generation is never triggered (page must not block on an LLM call).
+    storage = _FakeStorage({
+        CORR: _corrections(),
+        CACHE: {"suggestions": [_replace_suggestion()]},
+    })
+    result, jm, gen = await _run(storage, generate_on_miss=False)
+    assert result["outcome"] == "pre_applied"
+    assert gen["called"] is False
+    assert storage.uploads[UPD]["metadata"]["auto_approval"]["pre_applied"] is True
+
+
+@pytest.mark.asyncio
+async def test_load_path_cache_miss_does_not_generate_or_mark():
+    # No cache + proactive ON but generate_on_miss=False -> no generation, no marker;
+    # the UI falls back to its client-side apply (no page hang).
+    storage = _FakeStorage({CORR: _corrections()})
+    result, _, gen = await _run(storage, proactive=True, generate_on_miss=False)
+    assert gen["called"] is False
+    assert result["outcome"] == "skipped"
+    assert result["reason"] == "no_suggestions_cache"
+    assert UPD not in storage.uploads
+
+
+@pytest.mark.asyncio
+async def test_screens_path_generates_on_cache_miss():
+    # Default generate_on_miss=True (screens_worker path): generation IS triggered
+    # on a cache miss.
+    storage = _FakeStorage({CORR: _corrections()})
+    result, _, gen = await _run(storage, proactive=True, generate_on_miss=True)
+    assert gen["called"] is True

--- a/backend/tests/services/auto_approval/test_pre_apply.py
+++ b/backend/tests/services/auto_approval/test_pre_apply.py
@@ -64,7 +64,12 @@ class _FakeStorage:
     def list_files(self, prefix: str) -> List[str]:
         return [p for p in self._files if p.startswith(prefix)]
 
-    def upload_json(self, path: str, data: Any):
+    def upload_json(self, path: str, data: Any, if_generation_match=None):
+        # Model create-only semantics: if_generation_match=0 fails when the object
+        # already exists (mirrors GCS raising PreconditionFailed).
+        if if_generation_match == 0 and path in self._files:
+            from google.api_core.exceptions import PreconditionFailed
+            raise PreconditionFailed("object exists")
         self.uploads[path] = data
         self._files[path] = data
 
@@ -183,3 +188,21 @@ async def test_screens_path_generates_on_cache_miss():
     storage = _FakeStorage({CORR: _corrections()})
     result, _, gen = await _run(storage, proactive=True, generate_on_miss=True)
     assert gen["called"] is True
+
+
+@pytest.mark.asyncio
+async def test_pre_apply_raced_concurrent_write_does_not_clobber():
+    # A concurrent writer created corrections_updated.json AFTER our existence check
+    # (invisible to the check, present for the create-only upload) -> theirs wins.
+    storage = _FakeStorage({
+        CORR: _corrections(),
+        CACHE: {"suggestions": [_replace_suggestion()]},
+        UPD: {"metadata": {}, "corrected_segments": [{"id": "s0", "words": [{"id": "x"}]}]},
+    })
+    orig_exists = storage.file_exists
+    storage.file_exists = lambda p: False if p == UPD else orig_exists(p)
+    result, _, _gen = await _run(storage)
+    assert result["outcome"] == "skipped"
+    assert result["reason"] == "raced_concurrent_write"
+    # The concurrent writer's content is untouched.
+    assert storage._files[UPD]["metadata"] == {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.209.1"
+version = "0.209.2"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
Follow-up to workstream C (#957). Andrew opened an in-review job (`c00a06d2`) and still saw the review page show uncorrected AudioShake lyrics for ~4s before the AI corrections applied — the exact race C2 was meant to kill.

## Why it still happened
The C2 server-side pre-apply runs in `screens_worker`, right before the `AWAITING_REVIEW` transition. Jobs processed **before** that code shipped (or whose suggestion cache landed after that gate) already passed it, so their `corrections_updated.json` has no `pre_applied` marker and the frontend falls back to its on-load client-side apply — the visible flicker.

## Fix
Also pre-apply at the **load event itself** — the `/correction-data` fetch, which is literally "when the lyrics review page launches":
- The endpoint now calls `ensure_and_pre_apply(job_id, generate_on_miss=False)`.
- New `generate_on_miss` flag: the load path applies an **existing** cache only, so the page never blocks on a multi-model LLM call. The `screens_worker` path keeps `generate_on_miss=True` (generates ahead of the notification for new jobs).
- Best-effort + idempotent: a no-op when the job was already pre-applied, already human-edited, or has no cache (then the UI's client-side apply still runs). Since prod runs proactive auto-correct, the cache almost always exists → old jobs now load corrected instantly.

## Concurrency (CodeRabbit)
The write is now **create-only** (`upload_json(..., if_generation_match=0)`); if the executor auto-complete or an edit submission created `corrections_updated.json` between our existence check and the upload, GCS raises `PreconditionFailed` and we skip — their newer state wins.

## Tests
- `test_pre_apply.py`: load-path applies existing cache without generating; load-path cache-miss doesn't generate or mark; screens-path still generates on miss; raced concurrent write doesn't clobber. Full backend suite: 4151 pass.
- Frontend unchanged (the `pre_applied` marker handling from #957 already covers this).

Local CodeRabbit review completed and addressed (create-only write).

@coderabbitai ignore