### PR TITLE
ci(pypi): recurring storage-cap prune reminder (fix failing PyPI publish)

### DIFF
--- a/.github/workflows/pypi-prune-reminder.yml
+++ b/.github/workflows/pypi-prune-reminder.yml
@@ -30,6 +30,11 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       PROJECT: karaoke-gen
       KEEP_DAYS: "60"
+      # Only nag once the project crosses this watermark — pruning holds it at
+      # ~4-7 GB, and there are always old releases to consolidate, so without a
+      # threshold this would open an issue every month for no real reason. 7 GB
+      # leaves ~1 month of ~3 GB/month growth before the 10 GB cap.
+      NAG_THRESHOLD_GB: "7"
       ISSUE_TITLE: "🧹 PyPI storage prune due: karaoke-gen"
     steps:
       - uses: actions/checkout@v4
@@ -49,18 +54,21 @@ jobs:
             --project "$PROJECT" --keep-days "$KEEP_DAYS" \
             --format json --output plan.json
           python - <<'PY' >> "$GITHUB_OUTPUT"
-          import json
+          import json, os
           d = json.load(open("plan.json"))
+          threshold = float(os.environ["NAG_THRESHOLD_GB"])
+          should_nag = d["delete_count"] > 0 and d["current_gb"] >= threshold
           print(f"delete_count={d['delete_count']}")
           print(f"reclaimable_gb={d['reclaimable_gb']:.2f}")
           print(f"current_gb={d['current_gb']:.2f}")
+          print(f"should_nag={'true' if should_nag else 'false'}")
           PY
 
       - name: Job summary
         run: cat plan.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Open or update tracking issue
-        if: steps.plan.outputs.delete_count != '0'
+        if: steps.plan.outputs.should_nag == 'true'
         run: |
           # Search by a stable ASCII substring (emoji in search queries is
           # flaky); the exact-title jq filter below is the real dedupe guard.

--- a/.github/workflows/pypi-prune-reminder.yml
+++ b/.github/workflows/pypi-prune-reminder.yml
@@ -1,0 +1,80 @@
+name: PyPI prune reminder
+
+# PyPI caps total *project* size at 10 GB. karaoke-gen auto-publishes a ~62 MiB
+# wheel on every merge to main (~3 GB/month), so the project refills the cap
+# every few months and `poetry publish` then fails with "Project size too large".
+#
+# PyPI has NO deletion API (upload tokens are upload-only), so this can't
+# auto-delete. Instead it runs monthly, computes the retention plan
+# (scripts/prune_pypi_releases.py), and opens/updates a single tracking issue
+# containing a paste-into-browser-console snippet you run on your logged-in PyPI
+# releases page to actually prune. No secrets are stored.
+#
+# See docs/PYPI-STORAGE-PRUNE.md.
+
+on:
+  schedule:
+    # 09:00 UTC on the 1st of each month.
+    - cron: "0 9 1 * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  prune-reminder:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PROJECT: karaoke-gen
+      KEEP_DAYS: "60"
+      ISSUE_TITLE: "🧹 PyPI storage prune due: karaoke-gen"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Compute prune plan
+        id: plan
+        run: |
+          python scripts/prune_pypi_releases.py \
+            --project "$PROJECT" --keep-days "$KEEP_DAYS" \
+            --format markdown --output plan.md
+          python scripts/prune_pypi_releases.py \
+            --project "$PROJECT" --keep-days "$KEEP_DAYS" \
+            --format json --output plan.json
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          d = json.load(open("plan.json"))
+          print(f"delete_count={d['delete_count']}")
+          print(f"reclaimable_gb={d['reclaimable_gb']:.2f}")
+          print(f"current_gb={d['current_gb']:.2f}")
+          PY
+
+      - name: Job summary
+        run: cat plan.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open or update tracking issue
+        if: steps.plan.outputs.delete_count != '0'
+        run: |
+          # Search by a stable ASCII substring (emoji in search queries is
+          # flaky); the exact-title jq filter below is the real dedupe guard.
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" \
+            --state open --search "PyPI storage prune due in:title" \
+            --json number,title \
+            --jq "map(select(.title == \"$ISSUE_TITLE\")) | .[0].number // empty")
+          note="🔁 Refreshed $(date -u +%Y-%m-%d): ${{ steps.plan.outputs.delete_count }} releases prunable, ~${{ steps.plan.outputs.reclaimable_gb }} GB reclaimable (project at ${{ steps.plan.outputs.current_gb }} GB)."
+          if [ -n "$existing" ]; then
+            echo "Updating existing issue #$existing"
+            gh issue edit "$existing" --repo "$GITHUB_REPOSITORY" --body-file plan.md
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$note"
+          else
+            echo "Creating new tracking issue"
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "$ISSUE_TITLE" --body-file plan.md
+          fi

--- a/docs/PYPI-STORAGE-PRUNE.md
+++ b/docs/PYPI-STORAGE-PRUNE.md
@@ -1,0 +1,88 @@
+# PyPI storage-cap prune runbook
+
+## The problem
+
+PyPI caps **total project size at 10 GB**. `karaoke-gen` publishes a universal
+`py3-none-any` wheel on every merge to `main` (auto-versioned in CI). Since the
+i18n initiative the wheel bundles a Next.js static export pre-rendered into 33
+locales (the CLI local lyrics-review UI serves it at runtime), so each release is
+**~62 MiB**. At ~50 releases/month that's **~3 GB/month**, so the project refills
+the cap every few months and the publish step fails:
+
+```
+HTTP Error 400: Project size too large. Limit for project 'karaoke-gen'
+total size is 10 GB.
+```
+
+Only the public `pip install` publish step fails — the Cloud Run backend and the
+GCE encoding worker (which pulls the wheel from **GCS**, not PyPI) are unaffected.
+
+## Why we can't just automate deletion
+
+PyPI has **no deletion API**. Upload tokens and Trusted Publishing are
+upload-only, and PyPI mandates 2FA, so deletion is only possible from a
+logged-in browser session — which can't be safely or durably stored in CI. So we
+automate the *decision and the reminder*, and keep the *deletion* a ~1-minute
+human step.
+
+## Retention policy
+
+Keep every release from the **last 60 days**, plus the **newest release of each
+older calendar month**, plus the **latest release overall**. Delete the rest.
+Run recurringly, this holds steady-state around 6–7 GB — permanently under the
+cap. Deletion is irreversible and a deleted version/filename can never be
+re-uploaded; that's acceptable here (nothing builds from source; PyPI is only the
+public `pip install` channel, whose users want recent versions).
+
+## How it runs
+
+- **`.github/workflows/pypi-prune-reminder.yml`** — monthly cron (1st, 09:00
+  UTC) + manual `workflow_dispatch`. Computes the plan and, when there's anything
+  to prune, opens or updates a single tracking issue titled
+  **"🧹 PyPI storage prune due: karaoke-gen"** with the plan + a paste-in
+  deletion snippet. No secrets.
+- **`scripts/prune_pypi_releases.py`** — the planner. Reads the public JSON API,
+  applies the policy, and renders a table / JSON / Markdown / browser-console JS.
+  It never deletes anything itself.
+
+## How to prune (≈1 minute)
+
+1. Open the tracking issue (or run the script locally, below) to get the snippet.
+2. Go to **<https://pypi.org/manage/project/karaoke-gen/releases/>** and log in.
+3. Open browser devtools → **Console**.
+4. Paste the snippet and press Enter. It reads the page's CSRF token and POSTs a
+   whole-version delete for each planned version, ~0.5s apart, logging progress.
+5. Reload to confirm. If a publish was blocked, re-run it: push an empty commit /
+   re-run the failed CI `Deploy - Publish to PyPI` job, or `poetry publish`
+   locally.
+
+> The aggregate `pypi.org/pypi/karaoke-gen/json` is Fastly-cached and lags a few
+> minutes after deletes — trust the logged-in manage page for live state.
+
+## Running the planner locally
+
+```bash
+# Dry-run table (what would be deleted, and the resulting size)
+python scripts/prune_pypi_releases.py
+
+# Just the paste-in deletion snippet
+python scripts/prune_pypi_releases.py --format console-js
+
+# Machine-readable / the Markdown the workflow posts
+python scripts/prune_pypi_releases.py --format json
+python scripts/prune_pypi_releases.py --format markdown
+
+# Tune the window (default 60 days) or target another project
+python scripts/prune_pypi_releases.py --keep-days 90 --project karaoke-gen
+```
+
+Stdlib only — no dependencies to install.
+
+## Related
+
+- One-off escape hatch: request a PyPI storage-limit increase via the
+  `limit-request-project` template on
+  [`pypi/support`](https://github.com/pypi/support) (we filed
+  [pypi/support#12050](https://github.com/pypi/support/issues/12050) for 50 GB).
+  A larger cap just buys time; the recurring prune is the durable fix.
+- History of the first time this bit us: `docs/LESSONS-LEARNED.md`.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -4,6 +4,21 @@ Operational runbooks for known production issues.
 
 ---
 
+## CI "Deploy - Publish to PyPI" fails: "Project size too large"
+
+**Cause:** PyPI caps total project size at 10 GB. Each `karaoke-gen` release is a
+~62 MiB wheel (bundled 33-locale frontend) auto-published on every merge, so the
+project refills the cap every few months. Only the public `pip install` publish
+step fails — Cloud Run and the GCE encoding worker (pulls the wheel from GCS) are
+unaffected.
+
+**Fix:** prune old releases per the retention policy. A monthly workflow
+(`pypi-prune-reminder.yml`) opens/updates a tracking issue with a paste-in
+deletion snippet, or run `python scripts/prune_pypi_releases.py` yourself. Full
+runbook: **[docs/PYPI-STORAGE-PRUNE.md](PYPI-STORAGE-PRUNE.md)**.
+
+---
+
 ## Job stuck at `downloading_audio` status
 
 **Cause:** Before v0.130.0, audio downloads ran as FastAPI BackgroundTasks. Cloud Run would terminate "idle" instances mid-download. Since v0.130.0, downloads use a Cloud Run Job (`audio-download-job`) and a Cloud Scheduler recovery job runs every 5 minutes to fail stuck downloads automatically.

--- a/scripts/prune_pypi_releases.py
+++ b/scripts/prune_pypi_releases.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Compute (and help you execute) a PyPI storage-retention prune for karaoke-gen.
+
+PyPI caps total *project* size at 10 GB. karaoke-gen auto-publishes a ~62 MiB
+universal wheel on every merge to main (~3 GB/month), so the project refills the
+cap every few months and `poetry publish` then fails with HTTP 400 "Project size
+too large". See docs/PYPI-STORAGE-PRUNE.md for the full story.
+
+PyPI offers **no deletion API** (upload tokens and Trusted Publishing are
+upload-only), so this script never deletes anything itself. It:
+
+  1. reads the project's release list from the public JSON API,
+  2. computes which releases to KEEP vs DELETE under the retention policy —
+     "keep every release younger than --keep-days, plus the most recent release
+     of each older calendar month, plus the latest release overall" — and
+  3. emits the plan as a table / JSON / Markdown report, and a ready-to-paste
+     **browser-console snippet** that performs the deletions from your logged-in
+     PyPI session (the only mechanism PyPI supports).
+
+A scheduled GitHub Action (.github/workflows/pypi-prune-reminder.yml) runs this
+monthly and posts the plan to a tracking issue; you paste the snippet into the
+console on your logged-in PyPI releases page to actually prune.
+
+Deletion is irreversible and a deleted version/filename can never be re-uploaded.
+For karaoke-gen this is safe: nothing builds from source and the GCE encoding
+worker pulls the wheel from GCS, not PyPI — PyPI is purely the public `pip
+install` channel, whose users want recent versions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import sys
+import urllib.request
+from dataclasses import dataclass, field
+
+PYPI_TOTAL_SIZE_CAP_GB = 10.0  # PyPI's default project-wide storage limit.
+
+
+@dataclass
+class ReleasePlan:
+    """Result of applying the retention policy to a project's releases."""
+
+    keep: list[str] = field(default_factory=list)
+    delete: list[str] = field(default_factory=list)
+    sizes: dict[str, int] = field(default_factory=dict)  # version -> bytes
+    current_bytes: int = 0
+    delete_bytes: int = 0
+    keep_days: int = 0
+
+    @property
+    def kept_bytes(self) -> int:
+        return self.current_bytes - self.delete_bytes
+
+
+def _version_date(files: list[dict]) -> datetime.date | None:
+    """Latest upload date across a version's files (None if none dated)."""
+    dates = [f["upload_time_iso_8601"][:10] for f in files if f.get("upload_time_iso_8601")]
+    if not dates:
+        return None
+    return datetime.date.fromisoformat(max(dates))
+
+
+def compute_plan(
+    releases: dict[str, list[dict]],
+    *,
+    keep_days: int,
+    now: datetime.date,
+) -> ReleasePlan:
+    """Decide which versions to keep vs delete.
+
+    ``releases`` is the ``releases`` object from PyPI's JSON API: a mapping of
+    version string -> list of uploaded-file dicts (each with ``size`` and
+    ``upload_time_iso_8601``).
+
+    Policy: keep every version whose latest upload is within ``keep_days`` of
+    ``now``; for anything older, keep only the newest version of each calendar
+    month; always keep the newest version overall. Empty releases (all files
+    yanked/removed) contribute nothing and are ignored.
+    """
+    plan = ReleasePlan(keep_days=keep_days)
+
+    # Collect (version, date, size) for every non-empty release.
+    dated: list[tuple[str, datetime.date, int]] = []
+    for version, files in releases.items():
+        if not files:
+            continue
+        date = _version_date(files)
+        if date is None:
+            continue
+        size = sum(int(f.get("size") or 0) for f in files)
+        dated.append((version, date, size))
+        plan.sizes[version] = size
+        plan.current_bytes += size
+
+    if not dated:
+        return plan
+
+    # Always keep the newest release overall, regardless of policy.
+    newest_version = max(dated, key=lambda d: d[1])[0]
+
+    # For releases older than the window, keep the newest per calendar month.
+    month_latest: dict[str, tuple[datetime.date, str]] = {}
+    for version, date, _ in dated:
+        age_days = (now - date).days
+        if age_days <= keep_days:
+            continue  # inside the full-fidelity window; handled below
+        ym = date.strftime("%Y-%m")
+        if ym not in month_latest or date > month_latest[ym][0]:
+            month_latest[ym] = (date, version)
+    monthly_keepers = {v for _, v in month_latest.values()}
+
+    for version, date, size in dated:
+        age_days = (now - date).days
+        keep = age_days <= keep_days or version == newest_version or version in monthly_keepers
+        if keep:
+            plan.keep.append(version)
+        else:
+            plan.delete.append(version)
+            plan.delete_bytes += size
+
+    # Present most-recent-first so a human scanning the delete list sees the
+    # boundary of what's being removed.
+    date_by_version = {v: d for v, d, _ in dated}
+    plan.keep.sort(key=lambda v: date_by_version[v], reverse=True)
+    plan.delete.sort(key=lambda v: date_by_version[v], reverse=True)
+    return plan
+
+
+def fetch_releases(project: str) -> dict[str, list[dict]]:
+    """Fetch the ``releases`` map from PyPI's public JSON API (stdlib only)."""
+    url = f"https://pypi.org/pypi/{project}/json"
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310 (trusted host)
+        data = json.load(resp)
+    return data.get("releases", {})
+
+
+def _gib(n_bytes: int) -> float:
+    return n_bytes / (1024**3)
+
+
+def _gb(n_bytes: int) -> float:
+    return n_bytes / 1e9
+
+
+def render_console_js(project: str, versions: list[str]) -> str:
+    """A snippet to paste into the browser console on the logged-in PyPI page:
+    https://pypi.org/manage/project/<project>/releases/
+
+    It reads the session CSRF token from the page and POSTs a whole-version
+    delete for each listed version, ~500ms apart, logging progress.
+    """
+    versions_json = json.dumps(versions)
+    return f"""// Paste on https://pypi.org/manage/project/{project}/releases/ while logged in.
+(async () => {{
+  const project = {json.dumps(project)};
+  const versions = {versions_json};
+  const el = document.querySelector('input[name="csrf_token"]');
+  if (!el) {{ console.error("No csrf_token on page — are you on the releases management page, logged in?"); return; }}
+  const csrf = el.value;
+  let ok = 0, fail = 0;
+  for (const v of versions) {{
+    try {{
+      const res = await fetch(`/manage/project/${{project}}/release/${{encodeURIComponent(v)}}/`, {{
+        method: "POST",
+        credentials: "include",
+        headers: {{ "Content-Type": "application/x-www-form-urlencoded" }},
+        body: `csrf_token=${{encodeURIComponent(csrf)}}&confirm_delete_version=${{encodeURIComponent(v)}}`,
+      }});
+      if (res.ok || res.redirected) {{ ok++; console.log(`✓ deleted ${{v}} (${{ok}}/${{versions.length}})`); }}
+      else {{ fail++; console.warn(`✗ ${{v}} → HTTP ${{res.status}}`); }}
+    }} catch (e) {{ fail++; console.warn(`✗ ${{v}}`, e); }}
+    await new Promise(r => setTimeout(r, 500));
+  }}
+  console.log(`Done. deleted=${{ok}} failed=${{fail}}. Reload to confirm.`);
+}})();
+"""
+
+
+def render_table(plan: ReleasePlan) -> str:
+    lines = [
+        f"Project size: {_gb(plan.current_bytes):.2f} GB " f"({_gib(plan.current_bytes):.2f} GiB) of {PYPI_TOTAL_SIZE_CAP_GB:.0f} GB cap",
+        f"Policy: keep last {plan.keep_days} days + newest release per older month + latest overall",
+        f"Keep:   {len(plan.keep)} releases",
+        f"Delete: {len(plan.delete)} releases  " f"(reclaims {_gb(plan.delete_bytes):.2f} GB → {_gb(plan.kept_bytes):.2f} GB after)",
+    ]
+    if plan.delete:
+        lines.append("")
+        lines.append("Would delete:")
+        lines.extend(f"  - {v}" for v in plan.delete)
+    return "\n".join(lines) + "\n"
+
+
+def render_json(project: str, plan: ReleasePlan) -> str:
+    return json.dumps(
+        {
+            "project": project,
+            "keep_days": plan.keep_days,
+            "current_gb": _gb(plan.current_bytes),
+            "kept_gb": _gb(plan.kept_bytes),
+            "reclaimable_gb": _gb(plan.delete_bytes),
+            "cap_gb": PYPI_TOTAL_SIZE_CAP_GB,
+            "keep_count": len(plan.keep),
+            "delete_count": len(plan.delete),
+            "delete_versions": plan.delete,
+        },
+        indent=2,
+    )
+
+
+def render_markdown(project: str, plan: ReleasePlan, now: datetime.date) -> str:
+    cur = _gb(plan.current_bytes)
+    after = _gb(plan.kept_bytes)
+    reclaim = _gb(plan.delete_bytes)
+    urgent = cur > 8.5
+    header = "## 🧹 PyPI storage prune due" + (" — ⚠️ NEAR CAP" if urgent else "")
+    manage_url = f"https://pypi.org/manage/project/{project}/releases/"
+    md = [
+        header,
+        "",
+        f"`{project}` is at **{cur:.2f} GB** of PyPI's **{PYPI_TOTAL_SIZE_CAP_GB:.0f} GB** "
+        f"project cap ({now.isoformat()}). Prune to keep publishing.",
+        "",
+        "| | Count | Size |",
+        "|---|---:|---:|",
+        f"| **Keep** | {len(plan.keep)} | {after:.2f} GB |",
+        f"| **Delete** | {len(plan.delete)} | −{reclaim:.2f} GB |",
+        f"| **After prune** | {len(plan.keep)} | **{after:.2f} GB** |",
+        "",
+        f"**Policy:** keep every release from the last **{plan.keep_days} days**, "
+        "plus the newest release of each older calendar month, plus the latest overall.",
+        "",
+        "### How to prune (≈1 minute, no secrets)",
+        "",
+        f"1. Open **<{manage_url}>** (log in if needed).",
+        "2. Open your browser devtools **Console**.",
+        "3. Paste the snippet below and press Enter. It deletes exactly the "
+        "planned versions using your session, ~0.5s apart, logging progress.",
+        "4. Reload the page to confirm; re-run `poetry publish` / the CI publish " "step if it was blocked.",
+        "",
+        "```js",
+        render_console_js(project, plan.delete).rstrip(),
+        "```",
+        "",
+        "<details><summary>Full delete list " f"({len(plan.delete)} releases)</summary>",
+        "",
+        *(f"- `{v}`" for v in plan.delete),
+        "",
+        "</details>",
+        "",
+        "---",
+        "_Deletion is irreversible and versions can't be re-uploaded. Safe here: "
+        "nothing builds karaoke-gen from source and the encoding worker pulls the "
+        "wheel from GCS — PyPI is only the public `pip install` channel. "
+        "Regenerate this plan any time with `python scripts/prune_pypi_releases.py`._",
+    ]
+    return "\n".join(md) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project", default="karaoke-gen")
+    parser.add_argument(
+        "--keep-days",
+        type=int,
+        default=60,
+        help="Keep every release younger than this many days (default: 60).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json", "markdown", "console-js"],
+        default="table",
+    )
+    parser.add_argument(
+        "--output",
+        help="Write to this file instead of stdout.",
+    )
+    parser.add_argument(
+        "--now",
+        help="Override 'today' as YYYY-MM-DD (for testing/reproducibility).",
+    )
+    args = parser.parse_args(argv)
+
+    now = datetime.date.fromisoformat(args.now) if args.now else datetime.datetime.now(datetime.timezone.utc).date()
+
+    releases = fetch_releases(args.project)
+    plan = compute_plan(releases, keep_days=args.keep_days, now=now)
+
+    if args.format == "table":
+        out = render_table(plan)
+    elif args.format == "json":
+        out = render_json(args.project, plan) + "\n"
+    elif args.format == "markdown":
+        out = render_markdown(args.project, plan, now)
+    else:  # console-js
+        out = render_console_js(args.project, plan.delete)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            fh.write(out)
+    else:
+        sys.stdout.write(out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prune_pypi_releases.py
+++ b/scripts/prune_pypi_releases.py
@@ -55,12 +55,20 @@ class ReleasePlan:
         return self.current_bytes - self.delete_bytes
 
 
-def _version_date(files: list[dict]) -> datetime.date | None:
-    """Latest upload date across a version's files (None if none dated)."""
-    dates = [f["upload_time_iso_8601"][:10] for f in files if f.get("upload_time_iso_8601")]
-    if not dates:
+def _version_timestamp(files: list[dict]) -> str | None:
+    """Latest upload timestamp (full ISO 8601) across a version's files.
+
+    Returns the raw ``upload_time_iso_8601`` string (e.g.
+    ``2026-08-29T23:56:57.396484Z``), or None if no file is dated. PyPI always
+    reports these in UTC with a fixed format, so lexicographic ordering equals
+    chronological ordering — we keep the full timestamp (not just the day) so
+    same-day releases are ranked by actual upload time, independent of the JSON
+    API's mapping order.
+    """
+    stamps = [f["upload_time_iso_8601"] for f in files if f.get("upload_time_iso_8601")]
+    if not stamps:
         return None
-    return datetime.date.fromisoformat(max(dates))
+    return max(stamps)
 
 
 def compute_plan(
@@ -82,39 +90,43 @@ def compute_plan(
     """
     plan = ReleasePlan(keep_days=keep_days)
 
-    # Collect (version, date, size) for every non-empty release.
-    dated: list[tuple[str, datetime.date, int]] = []
+    # Collect (version, full_timestamp, size) for every non-empty release. The
+    # full ISO timestamp (not just the day) drives every chronological
+    # comparison so same-day releases rank by real upload time.
+    dated: list[tuple[str, str, int]] = []
     for version, files in releases.items():
         if not files:
             continue
-        date = _version_date(files)
-        if date is None:
+        ts = _version_timestamp(files)
+        if ts is None:
             continue
         size = sum(int(f.get("size") or 0) for f in files)
-        dated.append((version, date, size))
+        dated.append((version, ts, size))
         plan.sizes[version] = size
         plan.current_bytes += size
 
     if not dated:
         return plan
 
-    # Always keep the newest release overall, regardless of policy.
+    def _age_days(ts: str) -> int:
+        return (now - datetime.date.fromisoformat(ts[:10])).days
+
+    # Always keep the newest release overall, regardless of policy (full-
+    # timestamp max, so a same-day burst keeps the genuinely-latest one).
     newest_version = max(dated, key=lambda d: d[1])[0]
 
     # For releases older than the window, keep the newest per calendar month.
-    month_latest: dict[str, tuple[datetime.date, str]] = {}
-    for version, date, _ in dated:
-        age_days = (now - date).days
-        if age_days <= keep_days:
+    month_latest: dict[str, tuple[str, str]] = {}  # "YYYY-MM" -> (timestamp, version)
+    for version, ts, _ in dated:
+        if _age_days(ts) <= keep_days:
             continue  # inside the full-fidelity window; handled below
-        ym = date.strftime("%Y-%m")
-        if ym not in month_latest or date > month_latest[ym][0]:
-            month_latest[ym] = (date, version)
+        ym = ts[:7]
+        if ym not in month_latest or ts > month_latest[ym][0]:
+            month_latest[ym] = (ts, version)
     monthly_keepers = {v for _, v in month_latest.values()}
 
-    for version, date, size in dated:
-        age_days = (now - date).days
-        keep = age_days <= keep_days or version == newest_version or version in monthly_keepers
+    for version, ts, size in dated:
+        keep = _age_days(ts) <= keep_days or version == newest_version or version in monthly_keepers
         if keep:
             plan.keep.append(version)
         else:
@@ -123,9 +135,9 @@ def compute_plan(
 
     # Present most-recent-first so a human scanning the delete list sees the
     # boundary of what's being removed.
-    date_by_version = {v: d for v, d, _ in dated}
-    plan.keep.sort(key=lambda v: date_by_version[v], reverse=True)
-    plan.delete.sort(key=lambda v: date_by_version[v], reverse=True)
+    ts_by_version = {v: ts for v, ts, _ in dated}
+    plan.keep.sort(key=lambda v: ts_by_version[v], reverse=True)
+    plan.delete.sort(key=lambda v: ts_by_version[v], reverse=True)
     return plan
 
 

--- a/tests/unit/test_prune_pypi_releases.py
+++ b/tests/unit/test_prune_pypi_releases.py
@@ -1,0 +1,147 @@
+"""Unit tests for the PyPI retention-policy planner (scripts/prune_pypi_releases.py).
+
+The script isn't part of the installed package, so we load it by path.
+"""
+
+import datetime
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "prune_pypi_releases.py"
+_spec = importlib.util.spec_from_file_location("prune_pypi_releases", _SCRIPT)
+prune = importlib.util.module_from_spec(_spec)
+# Register before exec so @dataclass can resolve the module via sys.modules.
+sys.modules[_spec.name] = prune
+_spec.loader.exec_module(prune)
+
+
+def _release(date: str, size: int = 62_000_000) -> list[dict]:
+    """A one-file release uploaded on ``date`` (YYYY-MM-DD)."""
+    return [{"size": size, "upload_time_iso_8601": f"{date}T12:00:00.000000Z"}]
+
+
+NOW = datetime.date(2026, 8, 29)
+
+
+def test_recent_releases_are_all_kept():
+    releases = {
+        "1.0.0": _release("2026-08-01"),  # 28 days old
+        "1.0.1": _release("2026-08-20"),  # 9 days old
+        "1.0.2": _release("2026-08-29"),  # today
+    }
+    plan = prune.compute_plan(releases, keep_days=60, now=NOW)
+    assert set(plan.keep) == {"1.0.0", "1.0.1", "1.0.2"}
+    assert plan.delete == []
+
+
+def test_old_month_keeps_only_its_latest():
+    releases = {
+        # All well outside the 60-day window (Jan 2026).
+        "0.1.0": _release("2026-01-05"),
+        "0.1.1": _release("2026-01-15"),
+        "0.1.2": _release("2026-01-28"),  # newest in January -> kept
+        # A newer release to be the overall-latest so January isn't protected.
+        "0.9.0": _release("2026-08-29"),
+    }
+    plan = prune.compute_plan(releases, keep_days=60, now=NOW)
+    assert "0.1.2" in plan.keep  # newest of the old month
+    assert set(plan.delete) == {"0.1.0", "0.1.1"}
+
+
+def test_one_keeper_per_distinct_old_month():
+    releases = {
+        "0.1.0": _release("2026-01-10"),
+        "0.1.1": _release("2026-01-20"),  # Jan keeper
+        "0.2.0": _release("2026-02-10"),
+        "0.2.1": _release("2026-02-25"),  # Feb keeper
+        "9.9.9": _release("2026-08-29"),  # latest overall
+    }
+    plan = prune.compute_plan(releases, keep_days=60, now=NOW)
+    assert "0.1.1" in plan.keep and "0.2.1" in plan.keep
+    assert set(plan.delete) == {"0.1.0", "0.2.0"}
+
+
+def test_latest_overall_always_kept_even_if_ancient_and_alone_in_month():
+    # A single very old release is both "latest overall" and "newest in month".
+    releases = {"0.0.1": _release("2024-01-01")}
+    plan = prune.compute_plan(releases, keep_days=60, now=NOW)
+    assert plan.keep == ["0.0.1"]
+    assert plan.delete == []
+
+
+def test_sizes_and_reclaim_math():
+    releases = {
+        "0.1.0": _release("2026-01-10", size=100),  # deleted
+        "0.1.1": _release("2026-01-20", size=200),  # Jan keeper
+        "9.9.9": _release("2026-08-29", size=50),  # latest
+    }
+    plan = prune.compute_plan(releases, keep_days=60, now=NOW)
+    assert plan.current_bytes == 350
+    assert plan.delete == ["0.1.0"]
+    assert plan.delete_bytes == 100
+    assert plan.kept_bytes == 250
+
+
+def test_empty_and_undated_releases_ignored():
+    releases = {
+        "0.1.0": [],  # fully yanked -> no files
+        "0.1.1": [{"size": 5}],  # no upload_time -> undated, skipped
+        "9.9.9": _release("2026-08-29", size=10),
+    }
+    plan = prune.compute_plan(releases, keep_days=60, now=NOW)
+    assert plan.keep == ["9.9.9"]
+    assert plan.delete == []
+    assert plan.current_bytes == 10  # empty/undated contribute nothing
+
+
+def test_delete_list_sorted_most_recent_first():
+    releases = {
+        "0.1.0": _release("2026-01-10"),
+        "0.2.0": _release("2026-02-10"),
+        "0.3.0": _release("2026-03-10"),
+        # keepers: one per month is the only one per month here, so add extras
+        "0.1.9": _release("2026-01-11"),
+        "0.2.9": _release("2026-02-11"),
+        "0.3.9": _release("2026-03-11"),
+        "9.9.9": _release("2026-08-29"),
+    }
+    plan = prune.compute_plan(releases, keep_days=60, now=NOW)
+    # Deleted are the earlier-in-month ones; list must be newest-first.
+    assert plan.delete == ["0.3.0", "0.2.0", "0.1.0"]
+
+
+def test_console_js_is_wellformed_and_contains_versions():
+    js = prune.render_console_js("karaoke-gen", ["1.2.3", "4.5.6"])
+    assert "confirm_delete_version" in js
+    assert "csrf_token" in js
+    assert json.dumps(["1.2.3", "4.5.6"]) in js
+    assert "/manage/project/${project}/release/" in js
+
+
+def test_render_json_shape():
+    releases = {
+        "0.1.0": _release("2026-01-05", size=100),  # deleted (superseded in Jan)
+        "0.1.5": _release("2026-01-20", size=200),  # January keeper
+        "9.9.9": _release("2026-08-29", size=50),  # latest overall
+    }
+    plan = prune.compute_plan(releases, keep_days=60, now=NOW)
+    payload = json.loads(prune.render_json("karaoke-gen", plan))
+    assert payload["delete_count"] == 1
+    assert payload["delete_versions"] == ["0.1.0"]
+    assert payload["cap_gb"] == prune.PYPI_TOTAL_SIZE_CAP_GB
+    assert payload["keep_count"] == 2
+
+
+@pytest.mark.parametrize("keep_days,expected_deleted", [(60, {"0.5.0"}), (400, set())])
+def test_keep_days_window_is_configurable(keep_days, expected_deleted):
+    releases = {
+        "0.5.0": _release("2026-06-01"),  # 89 days old
+        "0.5.1": _release("2026-06-15"),  # 75 days old, June keeper
+        "9.9.9": _release("2026-08-29"),
+    }
+    plan = prune.compute_plan(releases, keep_days=keep_days, now=NOW)
+    assert set(plan.delete) == expected_deleted

--- a/tests/unit/test_prune_pypi_releases.py
+++ b/tests/unit/test_prune_pypi_releases.py
@@ -19,9 +19,9 @@ sys.modules[_spec.name] = prune
 _spec.loader.exec_module(prune)
 
 
-def _release(date: str, size: int = 62_000_000) -> list[dict]:
-    """A one-file release uploaded on ``date`` (YYYY-MM-DD)."""
-    return [{"size": size, "upload_time_iso_8601": f"{date}T12:00:00.000000Z"}]
+def _release(date: str, size: int = 62_000_000, time: str = "12:00:00.000000") -> list[dict]:
+    """A one-file release uploaded on ``date`` (YYYY-MM-DD) at ``time`` (UTC)."""
+    return [{"size": size, "upload_time_iso_8601": f"{date}T{time}Z"}]
 
 
 NOW = datetime.date(2026, 8, 29)
@@ -112,6 +112,34 @@ def test_delete_list_sorted_most_recent_first():
     plan = prune.compute_plan(releases, keep_days=60, now=NOW)
     # Deleted are the earlier-in-month ones; list must be newest-first.
     assert plan.delete == ["0.3.0", "0.2.0", "0.1.0"]
+
+
+def test_same_day_uploads_ranked_by_time_not_api_order():
+    # Two releases on the same (old) day: the later-in-day one must win as the
+    # month's keeper, regardless of the dict/API insertion order.
+    releases = {
+        # Insertion order deliberately puts the EARLIER upload last.
+        "0.1.1": _release("2026-01-20", time="18:30:00.000000"),  # later -> keeper
+        "0.1.0": _release("2026-01-20", time="03:00:00.000000"),  # earlier -> delete
+        "9.9.9": _release("2026-08-29"),  # latest overall
+    }
+    plan = prune.compute_plan(releases, keep_days=60, now=NOW)
+    assert "0.1.1" in plan.keep
+    assert plan.delete == ["0.1.0"]
+
+
+def test_same_day_uploads_pick_latest_overall():
+    # When the newest *day* is also outside the window (abandoned project) and
+    # has multiple uploads, the genuinely-latest one is the kept "latest overall".
+    releases = {
+        "2.0.0": _release("2025-01-01", time="09:00:00.000000"),
+        "2.0.2": _release("2025-01-01", time="23:00:00.000000"),  # truly latest
+        "2.0.1": _release("2025-01-01", time="15:00:00.000000"),
+    }
+    plan = prune.compute_plan(releases, keep_days=60, now=NOW)
+    # All share one month, so the month keeper == latest overall == 2.0.2.
+    assert "2.0.2" in plan.keep
+    assert set(plan.delete) == {"2.0.0", "2.0.1"}
 
 
 def test_console_js_is_wellformed_and_contains_versions():


### PR DESCRIPTION
## Problem

The `Deploy - Publish to PyPI` step on `main` has been failing:

```
HTTP Error 400: Project size too large. Limit for project 'karaoke-gen'
total size is 10 GB.
```

This is a recurrence of the known 10 GB PyPI project cap. The project is at
**10.71 GB / 479 releases**; each release is a ~62 MiB universal wheel (bundled
33-locale frontend) auto-published on every merge (~3 GB/month), so it refills
the cap every few months. **Only the public `pip install` publish step fails** —
Cloud Run and the GCE encoding worker (pulls the wheel from GCS) are unaffected.

The prior fix (v0.187.5) was wheel-only publishing + a one-time manual deletion,
which only bought ~2 months. This makes the cleanup **recurring and durable**.

## Why not just automate deletion in CI?

PyPI has **no deletion API** (upload tokens / Trusted Publishing are upload-only,
and 2FA is mandatory). Deletion is only possible from a logged-in browser
session, which can't be safely/durably stored in CI. So we automate the
*decision + reminder* and keep the *deletion* a ~1-minute human step.

## What this adds

- **`scripts/prune_pypi_releases.py`** (stdlib-only) — reads the public JSON API
  and computes a retention plan: **keep last 60 days + newest release per older
  calendar month + latest overall**. Renders a table / JSON / Markdown report and
  a **paste-into-browser-console** deletion snippet. Never deletes anything
  itself. Today's plan: keep 82, delete 397, **10.71 GB → 4.17 GB**.
- **`.github/workflows/pypi-prune-reminder.yml`** — monthly cron (+ manual
  dispatch) that runs the planner and, once the project crosses a 7 GB watermark,
  opens/updates a single tracking issue with the plan + snippet. No secrets.
- **`docs/PYPI-STORAGE-PRUNE.md`** runbook + a `TROUBLESHOOTING.md` entry.
- **`tests/unit/test_prune_pypi_releases.py`** — 13 tests covering the policy
  (recency window, per-month keeper, latest-overall, same-day timestamp ranking,
  empty/undated releases, sizes, rendering).

## Testing

- `pytest tests/unit/test_prune_pypi_releases.py` → 13 passed.
- Ran the planner against live PyPI data; generated JS validated with `node --check`.
- `black` clean; workflow YAML validated; `should_nag` gate verified.

## Notes

- **No version bump** — tooling/CI/docs only, nothing in the wheel changes.
  Merging therefore **skips** the publish step (tag `v0.209.1` already exists),
  so this PR does not itself add another fat wheel while we're over the cap.
- **To unblock publishing now:** after merge, run the prune (locally via the
  script or trigger the workflow with `workflow_dispatch`), paste the snippet on
  the logged-in PyPI releases page, then re-run the publish. The monthly cron
  keeps it under the cap going forward.
- Related: filed [pypi/support#12050](https://github.com/pypi/support/issues/12050)
  requesting a 50 GB limit as a one-off buffer; the recurring prune is the
  durable fix.

@coderabbitai ignore
