### PR TITLE
Auto-fix phantom parentheticals (P8): delete → auto-ship instead of gate

### DIFF
--- a/backend/services/auto_approval/scorer.py
+++ b/backend/services/auto_approval/scorer.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
+from backend.services.auto_approval.apply import pick_accept_all_winners
 from backend.services.auto_approval.models import (
     AutoApprovabilityVerdict,
     BackingResult,
@@ -154,13 +155,20 @@ def _word_duration(word: Dict[str, Any]) -> float:
 
 def _extract_gating_signals(
     correction_data: Dict[str, Any],
+    deleted_word_ids: Optional[set] = None,
 ) -> Tuple[int, int, int, bool, float, int, int, bool]:
     """Scan corrected_segments for the two never-auto gating classes.
+
+    ``deleted_word_ids`` are words an auto-applied delete suggestion will remove
+    before any human (or the auto-shipped render) sees the lyrics — e.g. the P8
+    phantom-parenthetical fixer. Those words are excluded from the scan so a
+    phantom that WILL be deleted no longer trips the phantom gate.
 
     Returns (vocalization_word_count, vocalization_max_run, long_vocalization_word_count,
     has_vocalization_section, max_word_duration_s, absurd_duration_word_count,
     suspicious_parenthetical_count, has_phantom_signature).
     """
+    deleted = deleted_word_ids or set()
     voc_count = 0
     max_run = 0
     run = 0  # runs continue across segment boundaries (consecutive vocalization lines)
@@ -171,7 +179,8 @@ def _extract_gating_signals(
     suspicious_paren = 0
 
     for seg in correction_data.get("corrected_segments") or []:
-        words = seg.get("words") or []
+        # Only the words that survive the auto-applied deletes.
+        words = [w for w in (seg.get("words") or []) if w.get("id") not in deleted]
         for word in words:
             duration = _word_duration(word)
             max_duration = max(max_duration, duration)
@@ -190,14 +199,17 @@ def _extract_gating_signals(
                 run = 0
 
         # Phantom signature: a short parenthetical line stretched over several seconds
-        # (e.g. three "(I'm sorry)" lines, one 7.4s — corpus job 33453fa0).
-        seg_text = (seg.get("text") or "").strip()
+        # (e.g. three "(I'm sorry)" lines, one 7.4s — corpus job 33453fa0). Recompute
+        # from surviving words so a partially-deleted line is judged on what remains.
+        if not words:
+            continue
+        seg_text = " ".join((w.get("text") or "") for w in words).strip()
         if (
             seg_text.startswith("(")
             and seg_text.endswith(")")
-            and 0 < len(words) <= PHANTOM_PARENTHETICAL_MAX_WORDS
+            and len(words) <= PHANTOM_PARENTHETICAL_MAX_WORDS
         ):
-            seg_start, seg_end = seg.get("start_time"), seg.get("end_time")
+            seg_start, seg_end = words[0].get("start_time"), words[-1].get("end_time")
             if (
                 isinstance(seg_start, (int, float))
                 and isinstance(seg_end, (int, float))
@@ -236,6 +248,25 @@ def _gap_word_ids(correction_data: Dict[str, Any]) -> set:
     ids: set = set()
     for seq in correction_data.get("gap_sequences") or []:
         ids.update(seq.get("transcribed_word_ids") or [])
+    return ids
+
+
+def _deleted_word_ids(ai_suggestions: Optional[List[Dict[str, Any]]]) -> set:
+    """Word ids that an auto-applied WINNING delete suggestion will remove.
+
+    Only winners count: a delete that loses its conflict group to another
+    suggestion won't actually remove the words (the winner rewrites them
+    instead), so treating it as deleted would be optimistic. Mirrors the apply
+    step's accept-all winner selection so the scorer reasons about the exact
+    post-apply state.
+    """
+    if not ai_suggestions:
+        return set()
+    winners = set(pick_accept_all_winners(ai_suggestions))
+    ids: set = set()
+    for s in ai_suggestions:
+        if s.get("op") == "delete" and (s.get("id") in winners):
+            ids.update(s.get("word_ids") or [])
     return ids
 
 
@@ -309,7 +340,7 @@ def extract_lyrics_signals(
         absurd,
         suspicious_paren,
         has_phantom,
-    ) = _extract_gating_signals(correction_data)
+    ) = _extract_gating_signals(correction_data, _deleted_word_ids(ai_suggestions))
 
     return LyricsSignals(
         total_words=total_words,

--- a/backend/services/auto_correct/deterministic.py
+++ b/backend/services/auto_correct/deterministic.py
@@ -20,6 +20,19 @@ human deliberately left alone (Miguel 6d0640fa "though"->"dog" and an
 explicit-lyrics rewrite), while the one edit he did make ("yo Mick," ->
 "Come here,") had the proper-noun signature.
 
+Pattern 8 (fix) — phantom parenthetical: AudioShake hallucinates or mis-segments
+short parenthetical phrases that no confident reference match backs — standalone
+lines "(Instrumental break)" / "(I'm sorry)" / "(Angel baby)", or unanchored
+duplicate copies of a real line wrapped in parens. The 2026-08-30 reconstruction
+re-measure showed these are a recurring human deletion (Clean Bandit 894781ab,
+33453fa0). Previously these only *gated* the job to human review (scorer's
+phantom signature); here we delete the phantom run so the job can auto-ship. The
+decisive signal is that EVERY word of the parenthetical run is a gap word (no
+confident reference match) — this correctly deletes the "(Angel baby)" duplicate
+even though "angel"/"baby" appear elsewhere in the references. Pure vocalization
+parentheticals ("(ooh)") are left to the vocalization gate (timing/grouping is a
+musical judgement, not a clean delete).
+
 Everything here is pure and conservative: no evidence -> no suggestion.
 """
 from __future__ import annotations
@@ -46,6 +59,13 @@ LEADING_CONNECTIVES = frozenset({"and", "but", "so", "oh", "a"})
 # conflicting multi-model AI suggestion wins its conflict group.
 P4_CONFIDENCE = 0.9
 P5_CONFIDENCE = 0.85
+
+# P8 phantom-parenthetical delete: a strong deterministic signal (all-gap
+# parenthetical run), so confident enough to auto-apply.
+P8_CONFIDENCE = 0.9
+# Never delete a long parenthetical block deterministically — a multi-word
+# parenthetical could be a genuine sung aside. The corpus phantoms are 2-4 words.
+P8_MAX_RUN_WORDS = 5
 
 # P5 size guards: never rewrite long spans deterministically.
 P5_MAX_GAP_WORDS = 6
@@ -344,6 +364,90 @@ def reference_majority_suggestions(
     return out
 
 
+def _parenthetical_runs(
+    words: List[Dict[str, Any]],
+) -> List[Tuple[int, int]]:
+    """Maximal (start, end-inclusive) index runs whose words form one parenthetical
+    unit — the first word opens with "(" and the paren balance closes at the end.
+    Handles single-word "(word)" and multi-word "(Instrumental break)"."""
+    runs: List[Tuple[int, int]] = []
+    i = 0
+    n = len(words)
+    while i < n:
+        text = (words[i].get("text") or "").lstrip()
+        if text[:1] == "(":
+            balance = 0
+            j = i
+            closed = False
+            while j < n:
+                tj = words[j].get("text") or ""
+                balance += tj.count("(") - tj.count(")")
+                if balance <= 0:
+                    closed = True
+                    break
+                j += 1
+            if closed and j < n:
+                runs.append((i, j))
+                i = j + 1
+                continue
+        i += 1
+    return runs
+
+
+def phantom_parenthetical_suggestions(
+    segments: List[Dict[str, Any]],
+    correction_data: Dict[str, Any],
+) -> List[Dict[str, Any]]:
+    """Pattern 8 (fix): delete an all-gap parenthetical run that no confident
+    reference match backs (phantom / mis-segmented backing bit).
+
+    Guards: every word of the run is a gap word (the decisive signal); the run is
+    not purely vocalization (those go to the vocalization gate); and it's short
+    (<= P8_MAX_RUN_WORDS). Deleting a whole segment's words is fine — the apply
+    step drops the now-empty segment."""
+    gap_ids: set = set()
+    for gap in correction_data.get("gap_sequences") or []:
+        gap_ids.update(gap.get("transcribed_word_ids") or [])
+    if not gap_ids:
+        return []
+
+    out: List[Dict[str, Any]] = []
+    for seg in segments or []:
+        words = seg.get("words") or []
+        seg_id = seg.get("id") or ""
+        for start, end in _parenthetical_runs(words):
+            run = words[start : end + 1]
+            if not (1 <= len(run) <= P8_MAX_RUN_WORDS):
+                continue
+            run_ids = [w.get("id") for w in run]
+            if not all(run_ids):
+                continue
+            # Decisive signal: the entire parenthetical is unanchored (all gap).
+            if not all(wid in gap_ids for wid in run_ids):
+                continue
+            # Leave pure-vocalization parentheticals to the vocalization gate.
+            if all(_is_vocalization_token(w.get("text") or "") for w in run):
+                continue
+            original = " ".join((w.get("text") or "") for w in run)
+            out.append(
+                _make_suggestion(
+                    op="delete",
+                    word_ids=list(run_ids),
+                    segment_ids=[seg_id],
+                    original_text=original,
+                    new_text="",
+                    reason=(
+                        f'Removed phantom parenthetical "{original.strip()}" — no '
+                        "reference source confidently matches it; the transcription "
+                        "hallucinated or mis-segmented a backing/aside bit"
+                    ),
+                    category="phantom",
+                    confidence=P8_CONFIDENCE,
+                )
+            )
+    return out
+
+
 def deterministic_suggestions(
     segments: List[Dict[str, Any]],
     reference_lyrics: Dict[str, Any],
@@ -361,9 +465,11 @@ def deterministic_suggestions(
         streams = _ref_word_streams(reference_lyrics)
         if not streams:
             return []
-        return leading_connective_suggestions(
-            segments, correction_data, streams
-        ) + reference_majority_suggestions(segments, correction_data, streams)
+        return (
+            leading_connective_suggestions(segments, correction_data, streams)
+            + reference_majority_suggestions(segments, correction_data, streams)
+            + phantom_parenthetical_suggestions(segments, correction_data)
+        )
     except Exception:
         logger.warning("deterministic suggestion generation failed", exc_info=True)
         return []

--- a/backend/tests/services/auto_approval/test_scorer.py
+++ b/backend/tests/services/auto_approval/test_scorer.py
@@ -286,6 +286,52 @@ def test_normal_parenthetical_backing_bit_does_not_gate() -> None:
     assert res.verdict == LyricsVerdict.AUTO
 
 
+def _delete_suggestion(sid: str, word_ids: List[str], conflict_group=None,
+                       consensus: int = 1, confidence: float = 0.9) -> Dict[str, Any]:
+    return {
+        "id": sid, "op": "delete", "word_ids": word_ids, "new_text": "",
+        "conflict_group": conflict_group, "consensus": consensus,
+        "confidence": confidence, "total_models": consensus,
+    }
+
+
+def test_phantom_gate_clears_when_a_delete_suggestion_removes_the_phantom() -> None:
+    # The P8 phantom-parenthetical fixer emits a delete for the phantom line; the
+    # scorer treats those words as removed, so the phantom gate no longer fires.
+    data = _corrections_json(anchor_words=20, gap_words=0, synced=True)
+    data = _with_extra_segment(
+        data,
+        [_timed_word("p0", "(I'm", 0.0, 0.4), _timed_word("p1", "sorry)", 4.4, 4.8)],
+        0.0, 4.8, anchored=False,
+    )
+    gated = score_lyrics(data)
+    assert gated.tier == "phantom-gate"
+
+    cleared = score_lyrics(data, [_delete_suggestion("d0", ["p0", "p1"])])
+    assert not cleared.signals.has_phantom_signature
+    assert cleared.tier != "phantom-gate"
+
+
+def test_phantom_gate_stays_when_the_delete_loses_its_conflict_group() -> None:
+    # A delete that loses its conflict group won't actually remove the words, so
+    # the scorer must NOT treat the phantom as handled.
+    data = _corrections_json(anchor_words=20, gap_words=0, synced=True)
+    data = _with_extra_segment(
+        data,
+        [_timed_word("p0", "(I'm", 0.0, 0.4), _timed_word("p1", "sorry)", 4.4, 4.8)],
+        0.0, 4.8, anchored=False,
+    )
+    losing_delete = _delete_suggestion("d0", ["p0", "p1"], conflict_group="c1",
+                                       consensus=1, confidence=0.9)
+    winning_replace = {
+        "id": "r0", "op": "replace", "word_ids": ["p0", "p1"], "new_text": "I'm sorry",
+        "conflict_group": "c1", "consensus": 3, "confidence": 0.95, "total_models": 3,
+    }
+    res = score_lyrics(data, [losing_delete, winning_replace])
+    assert res.signals.has_phantom_signature
+    assert res.tier == "phantom-gate"
+
+
 def test_verdict_to_dict_is_json_safe() -> None:
     import json
 

--- a/backend/tests/services/auto_correct/test_deterministic.py
+++ b/backend/tests/services/auto_correct/test_deterministic.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 from backend.services.auto_correct.deterministic import (
     deterministic_suggestions,
     leading_connective_suggestions,
+    phantom_parenthetical_suggestions,
     reference_majority_suggestions,
     _ref_word_streams,
 )
@@ -460,6 +461,105 @@ def test_deterministic_respects_min_confidence_setting() -> None:
             correction_data=cd,
         )
     assert result.suggestions == []
+
+
+# ---- Pattern 8: phantom parenthetical ----
+
+
+def _phantom_cd(segments, gap_ids):
+    """correction_data whose gap_sequences mark ``gap_ids`` as gap words."""
+    return {
+        "gap_sequences": [{"id": "g", "transcribed_word_ids": list(gap_ids)}],
+        "anchor_sequences": [],
+    }
+
+
+def test_p8_deletes_all_gap_standalone_parenthetical() -> None:
+    # Clean Bandit 894781ab: "(Instrumental break)" — an all-gap phantom line.
+    segments = [_seg("seg-0", [("w0", "(Instrumental"), ("w1", "break)")])]
+    cd = _phantom_cd(segments, ["w0", "w1"])
+    out = phantom_parenthetical_suggestions(segments, cd)
+    assert len(out) == 1
+    assert out[0]["op"] == "delete"
+    assert out[0]["word_ids"] == ["w0", "w1"]
+    assert out[0]["category"] == "phantom"
+
+
+def test_p8_deletes_single_word_parenthetical() -> None:
+    # Atomic Kitten 5f90b799: trailing "(Dreaming)" echo the human removed.
+    segments = [
+        _seg("seg-0", [("w0", "dreaming?"), ("w1", "(Dreaming)")]),
+    ]
+    cd = _phantom_cd(segments, ["w1"])
+    out = phantom_parenthetical_suggestions(segments, cd)
+    assert len(out) == 1
+    assert out[0]["word_ids"] == ["w1"]
+
+
+def test_p8_deletes_unanchored_duplicate_even_when_tokens_in_refs() -> None:
+    # 33453fa0 "(Angel baby) Angel baby": the parenthetical copy is unanchored
+    # (all gap) so it's deleted; the trailing anchored "Angel baby" is kept —
+    # even though "angel"/"baby" appear elsewhere in the references.
+    segments = [
+        _seg("seg-0", [("w0", "(Angel"), ("w1", "baby)"), ("w2", "Angel"), ("w3", "baby")]),
+    ]
+    cd = _phantom_cd(segments, ["w0", "w1"])  # only the paren copy is a gap
+    out = phantom_parenthetical_suggestions(segments, cd)
+    assert len(out) == 1
+    assert out[0]["word_ids"] == ["w0", "w1"]
+
+
+def test_p8_skips_partially_anchored_parenthetical() -> None:
+    # If any word of the parenthetical is anchored (matched a reference), it is
+    # not a clean phantom — leave it for a human.
+    segments = [_seg("seg-0", [("w0", "(real"), ("w1", "lyric)")])]
+    cd = _phantom_cd(segments, ["w0"])  # w1 anchored
+    assert phantom_parenthetical_suggestions(segments, cd) == []
+
+
+def test_p8_skips_pure_vocalization_parenthetical() -> None:
+    # "(ooh ooh)" is a musical judgement — the vocalization gate handles it.
+    segments = [_seg("seg-0", [("w0", "(ooh"), ("w1", "ooh)")])]
+    cd = _phantom_cd(segments, ["w0", "w1"])
+    assert phantom_parenthetical_suggestions(segments, cd) == []
+
+
+def test_p8_skips_long_parenthetical_block() -> None:
+    words = [("w0", "(this"), ("w1", "is"), ("w2", "a"), ("w3", "very"),
+             ("w4", "long"), ("w5", "aside)")]
+    segments = [_seg("seg-0", words)]
+    cd = _phantom_cd(segments, [w for w, _ in words])
+    assert phantom_parenthetical_suggestions(segments, cd) == []
+
+
+def test_p8_no_gaps_no_suggestions() -> None:
+    segments = [_seg("seg-0", [("w0", "(Instrumental"), ("w1", "break)")])]
+    assert phantom_parenthetical_suggestions(segments, {"gap_sequences": []}) == []
+
+
+def test_p8_three_repeated_phantoms_each_deleted() -> None:
+    # 33453fa0: three separate "(I'm sorry)" phantom segments.
+    segments = [
+        _seg("seg-0", [("a0", "(I'm"), ("a1", "sorry)")]),
+        _seg("seg-1", [("b0", "(I'm"), ("b1", "sorry)")]),
+        _seg("seg-2", [("c0", "(I'm"), ("c1", "sorry)")]),
+    ]
+    cd = _phantom_cd(segments, ["a0", "a1", "b0", "b1", "c0", "c1"])
+    out = phantom_parenthetical_suggestions(segments, cd)
+    assert len(out) == 3
+    assert all(s["op"] == "delete" for s in out)
+
+
+def test_p8_flows_through_deterministic_suggestions() -> None:
+    segments = [_seg("seg-0", [("w0", "(Instrumental"), ("w1", "break)")])]
+    refs = {"genius": _ref_source(["some", "real", "lyrics"], "r")}
+    cd = _phantom_cd(segments, ["w0", "w1"])
+    cd["reference_lyrics"] = refs
+    out = deterministic_suggestions(segments, refs, cd)
+    assert any(
+        s["op"] == "delete" and s["reason"].startswith("Removed phantom parenthetical")
+        for s in out
+    )
 
 
 # ---- module-level helpers ----

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -6,6 +6,38 @@ Key insights for future AI agents working on this codebase.
 
 ---
 
+## Measure Human Edits by RECONSTRUCTION, Not the edit_log (Aug 2026)
+
+The lyrics-review `edit_log_*.json` (typed frontend ops) is **unreliable** as a
+measure of what a human changed during review — do not calibrate the auto-approval
+scorer/gates on edit-log counts:
+
+- **Timing edits are never logged.** `timing_change` exists in the op-type union and
+  the replay UI badges it, but no code path emits it — the TimelineEditor drag/resize
+  and the synchronizer tap-to-sync handlers never call `addEditEntry`.
+- **A null `state_data.last_edit_log_path` is ambiguous.** The log is POSTed only
+  `if (editLog.entries.length > 0)` and best-effort (silent failure), so null means
+  *either* zero edits, edits-not-instrumented, *or* submission-failed.
+- It's an intent-log, not an outcome-diff, so any un-instrumented edit path vanishes.
+
+**Reliable method:** reconstruct the post-AI/pre-human state and diff it against the
+human's final. `apply.build_applied_segments(raw_corrections, suggestions)` gives the
+post-AI segments; `difflib` over word text vs `corrections_updated.json` isolates human
+TEXT edits, and >20 ms start/end deltas on unchanged words isolate TIMING edits.
+Suggestion source: `corrections_updated.metadata.auto_approval.suggestions` (pre_applied
+jobs) or `auto_correct_cache/<hash>.json` (client-applied). Tool + full write-up:
+workspace `docs/automation-corpus/reconstruct_edits.py` +
+`reconstruction-remeasure-2026-08-30.md`.
+
+**P8 phantom-parenthetical fixer (v0.212.0):** the re-measure showed deleting phantom
+parentheticals ("(Instrumental break)", "(I'm sorry)", unanchored "(Angel baby)"
+duplicates) is a recurring, cleanly-deterministic human edit. The decisive signal is
+that **every word of the parenthetical run is a gap word** (no confident reference
+match) — this correctly deletes the duplicate even when its tokens appear elsewhere in
+the references. `deterministic.phantom_parenthetical_suggestions` emits the delete, and
+`scorer._extract_gating_signals` now excludes words a WINNING delete suggestion removes,
+so a phantom that will be auto-deleted no longer trips the phantom gate.
+
 ## Don't Invent Silent Fallbacks — Ask or Fail Loud (Jun 2026)
 
 When the desired behaviour for an edge case is unclear, **do not** invent a quiet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.211.0"
+version = "0.212.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Turns the **P8 phantom-parenthetical** class from a review *gate* into a deterministic *auto-fix*, widening the fully-auto class without loosening the quality bar. Part of the full-auto-review initiative (measurement re-assessment phase).

The 2026-08-30 reconstruction re-measure of the corpus (see below) showed that deleting phantom parentheticals — `(Instrumental break)`, `(I'm sorry)`, and unanchored `(Angel baby)` duplicate copies — is a recurring, cleanly-deterministic human edit. Previously these only *gated* the job to human review; now they're auto-deleted so the affected jobs auto-ship with correct output.

## Changes

- **`deterministic.phantom_parenthetical_suggestions`** — emits a `delete` for a parenthetical run whose **every word is a gap word** (the decisive signal: this correctly deletes an unanchored duplicate even when its tokens appear elsewhere in the references, e.g. `(Angel baby)`). Guards: skips pure-vocalization parentheticals (left to the vocalization gate) and long runs (> 5 words). Wired into `deterministic_suggestions`, so it flows through the same cache / apply / score paths as P4/P5.
- **`scorer._extract_gating_signals`** — now excludes words that a **winning** delete suggestion removes (winner-aware via `pick_accept_all_winners`) before scanning for the phantom/vocalization gates. A phantom that will be auto-deleted no longer trips the phantom gate, while genuine absurd-duration phantoms stay gated.

## Validation

- **Corpus + battery (25 jobs):** 6/6 correct-direction deletes, **zero false positives**. The two known-human cases reproduce exactly (`(I'm sorry)`×3, `(Instrumental break)`); two initially-unverified deletes (`(only to my)`, `(Dreaming)`) confirmed correct — neither appears in the human's final.
- **Private `validate_scorer.py` green:** safety preserved (33453fa0 still not-auto via its genuine gap/anchor signals; raw phantom safety-net gate intact); P8 fires 33453fa0 ×3, 8e465dc7 ×1, 5f90b799 ×1.
- **Tests:** new unit tests for the fixer (8) + scorer delete-awareness incl. winner-vs-loser conflict handling (2). `backend/tests/services` 380 passed; auto_approval + auto_correct 230 passed; review routes + instrumental summary 91 passed.
- **CodeRabbit** local review: no findings.

## Measurement note

Human-edit measurement now uses **reconstruction** (diff post-AI vs final), not the `edit_log` — which was proven unreliable (never logs timing edits; null path is ambiguous). Documented in `docs/LESSONS-LEARNED.md`.

@coderabbitai ignore