### PR TITLE
gen: shrink preview video + name the instrumental variant in the preview pill

### DIFF
--- a/frontend/components/lyrics-review/PreviewVideoSection.tsx
+++ b/frontend/components/lyrics-review/PreviewVideoSection.tsx
@@ -106,6 +106,16 @@ function PreviewVideoSection(
   const selectedOption = options.find((o) => o.id === selectedId) ?? defaultOption
   const instrumentalUrl = selectedOption?.audio_url ?? null
 
+  // The "Instrumental" preview pill names the variant it will play so it's clear
+  // whether you're auditioning the clean or the with-backing stem (it tracks the
+  // reviewer's final-output choice in the modal below).
+  const instrumentalPillLabel =
+    selectedOption?.id === 'with_backing'
+      ? t('audioInstrumentalPillBacking')
+      : selectedOption?.id === 'clean'
+        ? t('audioInstrumentalPillClean')
+        : t('audioInstrumental')
+
   const setVideoEl = useCallback(
     (el: HTMLVideoElement | null) => {
       internalVideoRef.current = el
@@ -338,7 +348,9 @@ function PreviewVideoSection(
             controls
             autoPlay
             src={previewState.videoUrl}
-            className="block w-full h-auto"
+            // Cap the height so the audio toggle + final-output choice below stay
+            // visible without scrolling; keep the aspect ratio (works for portrait too).
+            className="mx-auto block h-auto max-h-[45vh] w-auto max-w-full"
           >
             {t('unsupportedBrowser')}
           </video>
@@ -376,7 +388,7 @@ function PreviewVideoSection(
                   : 'bg-muted text-muted-foreground hover:bg-muted/70'
               }`}
             >
-              {t('audioInstrumental')}
+              {instrumentalPillLabel}
             </button>
           </div>
         </div>

--- a/frontend/components/lyrics-review/__tests__/PreviewVideoSection.test.tsx
+++ b/frontend/components/lyrics-review/__tests__/PreviewVideoSection.test.tsx
@@ -191,7 +191,8 @@ describe('PreviewVideoSection', () => {
     await flush()
 
     expect(screen.getByRole('button', { name: /original \(with vocals\)/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /^instrumental$/i })).toBeInTheDocument()
+    // Pill names the auto-selected variant (with_backing).
+    expect(screen.getByRole('button', { name: /instrumental \(plus backing vocals\)/i })).toBeInTheDocument()
     // Hidden stem player points at the auto-selected (with_backing) stem.
     const audio = document.querySelector('audio')
     expect(audio).not.toBeNull()
@@ -224,7 +225,8 @@ describe('PreviewVideoSection', () => {
     expect(video.muted).toBe(false)
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
-    await user.click(screen.getByRole('button', { name: /^instrumental$/i }))
+    // autoSelection=clean → pill reads "Instrumental (clean)".
+    await user.click(screen.getByRole('button', { name: /instrumental \(clean\)/i }))
     await flush()
 
     expect(video.muted).toBe(true)
@@ -243,7 +245,7 @@ describe('PreviewVideoSection', () => {
     )
     await flush()
 
-    expect(screen.getByRole('button', { name: /^instrumental$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /instrumental \(plus backing vocals\)/i })).toBeInTheDocument()
     // No decision pills here anymore — those moved to the modal's radio group.
     expect(screen.queryByRole('button', { name: /instrumental \+ backing vocals/i })).not.toBeInTheDocument()
     // Hidden stem player starts on the auto-selected (with_backing) stem.
@@ -268,6 +270,8 @@ describe('PreviewVideoSection', () => {
     const video = document.querySelector('video') as HTMLVideoElement
     expect((document.querySelector('audio') as HTMLAudioElement).src).toBe('http://test/backing.ogg')
     expect(video.muted).toBe(false)
+    // Pill starts on the backing variant.
+    expect(screen.getByRole('button', { name: /instrumental \(plus backing vocals\)/i })).toBeInTheDocument()
 
     act(() => {
       ref.current!.auditionInstrumental('clean', 5)
@@ -278,5 +282,7 @@ describe('PreviewVideoSection', () => {
     expect((document.querySelector('audio') as HTMLAudioElement).src).toBe('http://test/clean.ogg')
     expect(video.muted).toBe(true)
     expect(video.currentTime).toBe(5)
+    // Pill label tracks the new selection.
+    expect(screen.getByRole('button', { name: /instrumental \(clean\)/i })).toBeInTheDocument()
   })
 })

--- a/frontend/messages/ar.json
+++ b/frontend/messages/ar.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "تم الاحتفاظ بالأصوات الخلفية في الموسيقى — انقر للاستماع إلى هذا الجزء.",
       "audioInstrumental": "موسيقى (بدون غناء)",
       "audioInstrumentalBacking": "موسيقى + أصوات مساندة",
-      "audioInstrumentalClean": "موسيقى نقية"
+      "audioInstrumentalClean": "موسيقى نقية",
+      "audioInstrumentalPillBacking": "موسيقى (مع غناء مساند)",
+      "audioInstrumentalPillClean": "موسيقى (صافية)"
     },
     "gapNavigator": {
       "previousGap": "الفجوة السابقة (P)",

--- a/frontend/messages/ca.json
+++ b/frontend/messages/ca.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Veus de fons mantingudes a l'instrumental — fes clic per escoltar aquesta part.",
       "audioInstrumental": "Instrumental",
       "audioInstrumentalBacking": "Instrumental + cors",
-      "audioInstrumentalClean": "Instrumental net"
+      "audioInstrumentalClean": "Instrumental net",
+      "audioInstrumentalPillBacking": "Instrumental (amb cors)",
+      "audioInstrumentalPillClean": "Instrumental (net)"
     },
     "gapNavigator": {
       "previousGap": "Buit anterior (P)",

--- a/frontend/messages/cs.json
+++ b/frontend/messages/cs.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Doprovodné vokály zůstaly v instrumentální verzi – kliknutím si tuto část poslechneš.",
       "audioInstrumental": "Instrumentální",
       "audioInstrumentalBacking": "Instrumentální verze + doprovodné vokály",
-      "audioInstrumentalClean": "Čistá instrumentální verze"
+      "audioInstrumentalClean": "Čistá instrumentální verze",
+      "audioInstrumentalPillBacking": "Instrumentální (plus doprovodné vokály)",
+      "audioInstrumentalPillClean": "Instrumentální (čistá)"
     },
     "gapNavigator": {
       "previousGap": "Předchozí mezera (P)",

--- a/frontend/messages/da.json
+++ b/frontend/messages/da.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Baggrundsvokalen er bevaret i instrumentalsporet — klik for at høre denne del.",
       "audioInstrumental": "Instrumental",
       "audioInstrumentalBacking": "Instrumental + baggrundsvokal",
-      "audioInstrumentalClean": "Ren instrumental"
+      "audioInstrumentalClean": "Ren instrumental",
+      "audioInstrumentalPillBacking": "Instrumental (plus baggrundsvokal)",
+      "audioInstrumentalPillClean": "Instrumental (ren)"
     },
     "gapNavigator": {
       "previousGap": "Forrige hul (P)",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Hintergrundgesang im Instrumental beibehalten — klicke, um diesen Teil zu hören.",
       "audioInstrumental": "Instrumental",
       "audioInstrumentalBacking": "Instrumental + Hintergrundgesang",
-      "audioInstrumentalClean": "Reines Instrumental"
+      "audioInstrumentalClean": "Reines Instrumental",
+      "audioInstrumentalPillBacking": "Instrumental (plus Hintergrundgesang)",
+      "audioInstrumentalPillClean": "Instrumental (rein)"
     },
     "gapNavigator": {
       "previousGap": "Vorherige Lücke (P)",

--- a/frontend/messages/el.json
+++ b/frontend/messages/el.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Τα δεύτερα φωνητικά διατηρήθηκαν στο ορχηστρικό — κάνε κλικ για να ακούσεις αυτό το μέρος.",
       "audioInstrumental": "Ορχηστρικό",
       "audioInstrumentalBacking": "Ορχηστρικό + δεύτερες φωνές",
-      "audioInstrumentalClean": "Καθαρό ορχηστρικό"
+      "audioInstrumentalClean": "Καθαρό ορχηστρικό",
+      "audioInstrumentalPillBacking": "Ορχηστρικό (με δεύτερες φωνές)",
+      "audioInstrumentalPillClean": "Ορχηστρικό (καθαρό)"
     },
     "gapNavigator": {
       "previousGap": "Προηγούμενο κενό (P)",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1026,6 +1026,8 @@
       "audioLabel": "Preview audio:",
       "audioOriginal": "Original (with vocals)",
       "audioInstrumental": "Instrumental",
+      "audioInstrumentalPillBacking": "Instrumental (plus backing vocals)",
+      "audioInstrumentalPillClean": "Instrumental (clean)",
       "audioInstrumentalBacking": "Instrumental + backing vocals",
       "audioInstrumentalClean": "Clean instrumental",
       "backingVocalsWaveformHint": "Backing vocals kept in the instrumental — click to hear this part."

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Coros mantenidos en el instrumental — haz clic para escuchar esta parte.",
       "audioInstrumental": "Instrumental",
       "audioInstrumentalBacking": "Instrumental + coros",
-      "audioInstrumentalClean": "Instrumental limpio"
+      "audioInstrumentalClean": "Instrumental limpio",
+      "audioInstrumentalPillBacking": "Instrumental (con coros)",
+      "audioInstrumentalPillClean": "Instrumental (limpio)"
     },
     "gapNavigator": {
       "previousGap": "Hueco anterior (P)",

--- a/frontend/messages/fi.json
+++ b/frontend/messages/fi.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Taustalaulut on säilytetty instrumentaalissa — klikkaa kuullaksesi tämän kohdan.",
       "audioInstrumental": "Instrumentaali",
       "audioInstrumentalBacking": "Instrumentaali + taustalaulut",
-      "audioInstrumentalClean": "Puhdas instrumentaali"
+      "audioInstrumentalClean": "Puhdas instrumentaali",
+      "audioInstrumentalPillBacking": "Instrumentaali (mukana taustalaulut)",
+      "audioInstrumentalPillClean": "Instrumentaali (puhdas)"
     },
     "gapNavigator": {
       "previousGap": "Edellinen aukko (P)",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Chœurs conservés dans l'instrumental — clique pour écouter cette partie.",
       "audioInstrumental": "Instrumental",
       "audioInstrumentalBacking": "Instrumental + chœurs",
-      "audioInstrumentalClean": "Instrumental pur"
+      "audioInstrumentalClean": "Instrumental pur",
+      "audioInstrumentalPillBacking": "Instrumental (avec chœurs)",
+      "audioInstrumentalPillClean": "Instrumental (pur)"
     },
     "gapNavigator": {
       "previousGap": "Écart précédent (P)",

--- a/frontend/messages/he.json
+++ b/frontend/messages/he.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "קולות רקע נשמרו בגרסה האינסטרומנטלית — לחצו כדי לשמוע חלק זה.",
       "audioInstrumental": "אינסטרומנטלי",
       "audioInstrumentalBacking": "אינסטרומנטלי + קולות רקע",
-      "audioInstrumentalClean": "אינסטרומנטלי נקי"
+      "audioInstrumentalClean": "אינסטרומנטלי נקי",
+      "audioInstrumentalPillBacking": "אינסטרומנטלי (כולל קולות רקע)",
+      "audioInstrumentalPillClean": "אינסטרומנטלי (נקי)"
     },
     "gapNavigator": {
       "previousGap": "פער קודם (P)",

--- a/frontend/messages/hi.json
+++ b/frontend/messages/hi.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "इंस्ट्रुमेंटल में बैकिंग वोकल्स रखे गए हैं — इस हिस्से को सुनने के लिए क्लिक करो।",
       "audioInstrumental": "इंस्ट्रुमेंटल",
       "audioInstrumentalBacking": "इंस्ट्रुमेंटल + बैकिंग वोकल्स",
-      "audioInstrumentalClean": "क्लीन इंस्ट्रुमेंटल"
+      "audioInstrumentalClean": "क्लीन इंस्ट्रुमेंटल",
+      "audioInstrumentalPillBacking": "इंस्ट्रुमेंटल (बैकिंग वोकल्स के साथ)",
+      "audioInstrumentalPillClean": "इंस्ट्रुमेंटल (क्लीन)"
     },
     "gapNavigator": {
       "previousGap": "पिछला गैप (P)",

--- a/frontend/messages/hr.json
+++ b/frontend/messages/hr.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Prateći vokali zadržani u instrumentalu — klikni da čuješ ovaj dio.",
       "audioInstrumental": "Instrumental",
       "audioInstrumentalBacking": "Instrumental + prateći vokali",
-      "audioInstrumentalClean": "Čisti instrumental"
+      "audioInstrumentalClean": "Čisti instrumental",
+      "audioInstrumentalPillBacking": "Instrumental (s pratećim vokalima)",
+      "audioInstrumentalPillClean": "Instrumental (čisti)"
     },
     "gapNavigator": {
       "previousGap": "Prethodna praznina (P)",

--- a/frontend/messages/hu.json
+++ b/frontend/messages/hu.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "A háttérvokálok megmaradtak az instrumentális sávban — kattints ide, hogy meghallgasd ezt a részt.",
       "audioInstrumental": "Instrumentális",
       "audioInstrumentalBacking": "Zenei alap + háttérvokál",
-      "audioInstrumentalClean": "Tiszta zenei alap"
+      "audioInstrumentalClean": "Tiszta zenei alap",
+      "audioInstrumentalPillBacking": "Instrumentális (plusz háttérvokál)",
+      "audioInstrumentalPillClean": "Instrumentális (tiszta)"
     },
     "gapNavigator": {
       "previousGap": "Előző hézag (P)",

--- a/frontend/messages/id.json
+++ b/frontend/messages/id.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Vokal latar dipertahankan dalam instrumental — klik untuk mendengarkan bagian ini.",
       "audioInstrumental": "Instrumental",
       "audioInstrumentalBacking": "Instrumental + vokal latar",
-      "audioInstrumentalClean": "Instrumental bersih"
+      "audioInstrumentalClean": "Instrumental bersih",
+      "audioInstrumentalPillBacking": "Instrumental (dengan vokal latar)",
+      "audioInstrumentalPillClean": "Instrumental (bersih)"
     },
     "gapNavigator": {
       "previousGap": "Celah sebelumnya (P)",

--- a/frontend/messages/it.json
+++ b/frontend/messages/it.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Cori mantenuti nella base strumentale — clicca per ascoltare questa parte.",
       "audioInstrumental": "Strumentale",
       "audioInstrumentalBacking": "Strumentale + cori",
-      "audioInstrumentalClean": "Strumentale pulita"
+      "audioInstrumentalClean": "Strumentale pulita",
+      "audioInstrumentalPillBacking": "Strumentale (con cori)",
+      "audioInstrumentalPillClean": "Strumentale (pulita)"
     },
     "gapNavigator": {
       "previousGap": "Lacuna precedente (P)",

--- a/frontend/messages/ja.json
+++ b/frontend/messages/ja.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "インスト音源に残っているバックコーラス — クリックするとこの部分を試聴できます。",
       "audioInstrumental": "インストゥルメンタル",
       "audioInstrumentalBacking": "インストゥルメンタル + バックボーカル",
-      "audioInstrumentalClean": "インストゥルメンタルのみ"
+      "audioInstrumentalClean": "インストゥルメンタルのみ",
+      "audioInstrumentalPillBacking": "インストゥルメンタル（バックボーカル入り）",
+      "audioInstrumentalPillClean": "インストゥルメンタル（バックボーカルなし）"
     },
     "gapNavigator": {
       "previousGap": "前のギャップ (P)",

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "반주에 백보컬이 유지되어 있습니다 — 클릭해서 이 부분을 들어보세요.",
       "audioInstrumental": "반주",
       "audioInstrumentalBacking": "반주 + 백보컬",
-      "audioInstrumentalClean": "순수 반주"
+      "audioInstrumentalClean": "순수 반주",
+      "audioInstrumentalPillBacking": "반주 (백보컬 포함)",
+      "audioInstrumentalPillClean": "반주 (보컬 없음)"
     },
     "gapNavigator": {
       "previousGap": "이전 공백 (P)",

--- a/frontend/messages/ms.json
+++ b/frontend/messages/ms.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Vokal latar dikekalkan dalam instrumental — klik untuk mendengar bahagian ini.",
       "audioInstrumental": "Instrumental",
       "audioInstrumentalBacking": "Instrumental + vokal latar",
-      "audioInstrumentalClean": "Instrumental bersih"
+      "audioInstrumentalClean": "Instrumental bersih",
+      "audioInstrumentalPillBacking": "Instrumental (dengan vokal latar)",
+      "audioInstrumentalPillClean": "Instrumental (bersih)"
     },
     "gapNavigator": {
       "previousGap": "Jurang sebelumnya (P)",

--- a/frontend/messages/nb.json
+++ b/frontend/messages/nb.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Bakgrunnsvokalen er beholdt i instrumentalen — klikk for å høre denne delen.",
       "audioInstrumental": "Instrumental",
       "audioInstrumentalBacking": "Instrumental + bakgrunnsvokal",
-      "audioInstrumentalClean": "Ren instrumental"
+      "audioInstrumentalClean": "Ren instrumental",
+      "audioInstrumentalPillBacking": "Instrumental (pluss bakgrunnsvokal)",
+      "audioInstrumentalPillClean": "Instrumental (ren)"
     },
     "gapNavigator": {
       "previousGap": "Forrige hull (P)",

--- a/frontend/messages/nl.json
+++ b/frontend/messages/nl.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Achtergrondzang behouden in de instrumentale versie — klik om dit deel te horen.",
       "audioInstrumental": "Instrumentaal",
       "audioInstrumentalBacking": "Instrumentaal + achtergrondzang",
-      "audioInstrumentalClean": "Puur instrumentaal"
+      "audioInstrumentalClean": "Puur instrumentaal",
+      "audioInstrumentalPillBacking": "Instrumentaal (plus achtergrondzang)",
+      "audioInstrumentalPillClean": "Instrumentaal (clean)"
     },
     "gapNavigator": {
       "previousGap": "Vorig gat (P)",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Chórki zachowane w wersji instrumentalnej — kliknij, aby usłyszeć ten fragment.",
       "audioInstrumental": "Wersja instrumentalna",
       "audioInstrumentalBacking": "Wersja instrumentalna + chórki",
-      "audioInstrumentalClean": "Czysta wersja instrumentalna"
+      "audioInstrumentalClean": "Czysta wersja instrumentalna",
+      "audioInstrumentalPillBacking": "Instrumentalny (z chórkami)",
+      "audioInstrumentalPillClean": "Instrumentalny (czysty)"
     },
     "gapNavigator": {
       "previousGap": "Poprzednia luka (P)",

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Vocais de apoio mantidos no instrumental — clique para ouvir esta parte.",
       "audioInstrumental": "Instrumental",
       "audioInstrumentalBacking": "Instrumental + vocais de apoio",
-      "audioInstrumentalClean": "Instrumental limpo"
+      "audioInstrumentalClean": "Instrumental limpo",
+      "audioInstrumentalPillBacking": "Instrumental (com vocais de apoio)",
+      "audioInstrumentalPillClean": "Instrumental (limpo)"
     },
     "gapNavigator": {
       "previousGap": "Lacuna anterior (P)",

--- a/frontend/messages/ro.json
+++ b/frontend/messages/ro.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Vocile de fundal păstrate în instrumental — dă click pentru a asculta această parte.",
       "audioInstrumental": "Instrumental",
       "audioInstrumentalBacking": "Instrumental + voci de fundal",
-      "audioInstrumentalClean": "Instrumental curat"
+      "audioInstrumentalClean": "Instrumental curat",
+      "audioInstrumentalPillBacking": "Instrumental (plus voci de fundal)",
+      "audioInstrumentalPillClean": "Instrumental (curat)"
     },
     "gapNavigator": {
       "previousGap": "Golul anterior (P)",

--- a/frontend/messages/ru.json
+++ b/frontend/messages/ru.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Бэк-вокал сохранен в инструментале — нажми, чтобы послушать эту часть.",
       "audioInstrumental": "Инструментал",
       "audioInstrumentalBacking": "Инструментал + бэк-вокал",
-      "audioInstrumentalClean": "Чистый инструментал"
+      "audioInstrumentalClean": "Чистый инструментал",
+      "audioInstrumentalPillBacking": "Инструментал (с бэк-вокалом)",
+      "audioInstrumentalPillClean": "Инструментал (чистый)"
     },
     "gapNavigator": {
       "previousGap": "Предыдущий пробел (P)",

--- a/frontend/messages/sk.json
+++ b/frontend/messages/sk.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Sprievodné vokály ponechané v inštrumentálnej verzii — klikni a vypočuj si túto časť.",
       "audioInstrumental": "Inštrumentálna",
       "audioInstrumentalBacking": "Inštrumentál + sprievodné vokály",
-      "audioInstrumentalClean": "Čistý inštrumentál"
+      "audioInstrumentalClean": "Čistý inštrumentál",
+      "audioInstrumentalPillBacking": "Inštrumentál (so sprievodnými vokálmi)",
+      "audioInstrumentalPillClean": "Inštrumentál (čistý)"
     },
     "gapNavigator": {
       "previousGap": "Predchádzajúca medzera (P)",

--- a/frontend/messages/sv.json
+++ b/frontend/messages/sv.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Bakgrundssången finns kvar i instrumentalen — klicka för att höra den här delen.",
       "audioInstrumental": "Instrumental",
       "audioInstrumentalBacking": "Instrumental + bakgrundssång",
-      "audioInstrumentalClean": "Ren instrumental"
+      "audioInstrumentalClean": "Ren instrumental",
+      "audioInstrumentalPillBacking": "Instrumental (plus bakgrundssång)",
+      "audioInstrumentalPillClean": "Instrumental (ren)"
     },
     "gapNavigator": {
       "previousGap": "Föregående lucka (P)",

--- a/frontend/messages/th.json
+++ b/frontend/messages/th.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "เสียงร้องประสานยังคงอยู่ในเสียงดนตรี — คลิกเพื่อฟังท่อนนี้",
       "audioInstrumental": "ดนตรีบรรเลง",
       "audioInstrumentalBacking": "ดนตรีบรรเลง + เสียงร้องประสาน",
-      "audioInstrumentalClean": "ดนตรีบรรเลงล้วน"
+      "audioInstrumentalClean": "ดนตรีบรรเลงล้วน",
+      "audioInstrumentalPillBacking": "ดนตรีบรรเลง (พร้อมเสียงร้องประสาน)",
+      "audioInstrumentalPillClean": "ดนตรีบรรเลง (ไม่มีเสียงร้อง)"
     },
     "gapNavigator": {
       "previousGap": "ช่องว่างก่อนหน้า (P)",

--- a/frontend/messages/tl.json
+++ b/frontend/messages/tl.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Pinanatili ang backing vocals sa instrumental — i-click para mapakinggan ang bahaging ito.",
       "audioInstrumental": "Instrumental",
       "audioInstrumentalBacking": "Instrumental + backing vocals",
-      "audioInstrumentalClean": "Malinis na instrumental"
+      "audioInstrumentalClean": "Malinis na instrumental",
+      "audioInstrumentalPillBacking": "Instrumental (may kasamang backing vocals)",
+      "audioInstrumentalPillClean": "Instrumental (malinis)"
     },
     "gapNavigator": {
       "previousGap": "Nakaraang gap (P)",

--- a/frontend/messages/tr.json
+++ b/frontend/messages/tr.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Geri vokaller enstrümantalde bırakıldı — bu kısmı duymak için tıkla.",
       "audioInstrumental": "Enstrümantal",
       "audioInstrumentalBacking": "Enstrümantal + geri vokaller",
-      "audioInstrumentalClean": "Temiz enstrümantal"
+      "audioInstrumentalClean": "Temiz enstrümantal",
+      "audioInstrumentalPillBacking": "Enstrümantal (+ geri vokal)",
+      "audioInstrumentalPillClean": "Enstrümantal (temiz)"
     },
     "gapNavigator": {
       "previousGap": "Önceki boşluk (P)",

--- a/frontend/messages/uk.json
+++ b/frontend/messages/uk.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Бек-вокал збережено в інструменталі — натисни, щоб почути цю частину.",
       "audioInstrumental": "Інструментал",
       "audioInstrumentalBacking": "Інструментал + бек-вокал",
-      "audioInstrumentalClean": "Чистий інструментал"
+      "audioInstrumentalClean": "Чистий інструментал",
+      "audioInstrumentalPillBacking": "Інструментал (з бек-вокалом)",
+      "audioInstrumentalPillClean": "Інструментал (чистий)"
     },
     "gapNavigator": {
       "previousGap": "Попередня прогалина (P)",

--- a/frontend/messages/vi.json
+++ b/frontend/messages/vi.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "Giọng hát bè được giữ lại trong nhạc nền — nhấp để nghe phần này.",
       "audioInstrumental": "Nhạc nền",
       "audioInstrumentalBacking": "Nhạc nền + hát bè",
-      "audioInstrumentalClean": "Nhạc nền thuần"
+      "audioInstrumentalClean": "Nhạc nền thuần",
+      "audioInstrumentalPillBacking": "Nhạc nền (kèm hát bè)",
+      "audioInstrumentalPillClean": "Nhạc nền (không bè)"
     },
     "gapNavigator": {
       "previousGap": "Đoạn trống trước (P)",

--- a/frontend/messages/zh.json
+++ b/frontend/messages/zh.json
@@ -1016,7 +1016,9 @@
       "backingVocalsWaveformHint": "伴奏中保留了伴唱——点击试听此部分。",
       "audioInstrumental": "伴奏",
       "audioInstrumentalBacking": "伴奏 + 伴唱",
-      "audioInstrumentalClean": "纯伴奏"
+      "audioInstrumentalClean": "纯伴奏",
+      "audioInstrumentalPillBacking": "伴奏（含伴唱）",
+      "audioInstrumentalPillClean": "伴奏（纯净）"
     },
     "gapNavigator": {
       "previousGap": "上一个未匹配片段 (P)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.213.0"
+version = "0.213.1"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
Follow-ups to the review-modal audio split (#964), from Andrew's feedback:

1. **Smaller preview video** — the `<video>` height is now capped (`max-h-[45vh]`, aspect ratio preserved, works for portrait too) so the **"🎬 Your karaoke video will use:"** choice is visible without scrolling. Previously the player filled most of the modal and pushed the options off-screen.

2. **Preview pill names the variant** — the "Instrumental" preview pill now reads **"Instrumental (plus backing vocals)"** or **"Instrumental (clean)"** depending on the current final-output selection below, so it's clear which stem you're auditioning (it was ambiguous before — you had to experiment to find out it tracked the radio choice).

## Tests
- `PreviewVideoSection` + `ReviewChangesModal` suites updated (dynamic pill label asserted, incl. live update when `auditionInstrumental` swaps the stem). Full frontend suite: **1237/1237 pass**. ESLint clean.

## i18n
- New keys `previewVideo.audioInstrumentalPillBacking` / `audioInstrumentalPillClean` translated across all 33 locales; full key parity.

Note: local CodeRabbit CLI hit its free-OSS review cap this cycle, so this PR is left open for the GitHub bot to review (no `@coderabbitai ignore`).