### PR TITLE
docs: measure human edits across all 3 axes (text + timing + structure)

### DIFF
--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -22,12 +22,21 @@ scorer/gates on edit-log counts:
 
 **Reliable method:** reconstruct the post-AI/pre-human state and diff it against the
 human's final. `apply.build_applied_segments(raw_corrections, suggestions)` gives the
-post-AI segments; `difflib` over word text vs `corrections_updated.json` isolates human
-TEXT edits, and >20 ms start/end deltas on unchanged words isolate TIMING edits.
+post-AI segments; diff vs `corrections_updated.json` across **all three edit axes** —
+measure everything, not just text:
+- **TEXT** — `difflib` over word text (insert/delete/replace).
+- **TIMING** — >20 ms start/end deltas on unchanged words (the axis edit_log is 100% blind
+  to; e.g. Pendulum "The Other Side" = 45 timing edits, 0 text).
+- **STRUCTURE** — line split/merge, via segment membership of untouched words (a flat
+  word-stream diff misses these).
+
 Suggestion source: `corrections_updated.metadata.auto_approval.suggestions` (pre_applied
-jobs) or `auto_correct_cache/<hash>.json` (client-applied). Tool + full write-up:
-workspace `docs/automation-corpus/reconstruct_edits.py` +
-`reconstruction-remeasure-2026-08-30.md`.
+jobs) or `auto_correct_cache/<hash>.json` (client-applied). The tool also has a
+`best_effort` mode (bypasses production safety-aborts so vocalization-heavy jobs still
+measure) and handles correction-disabled jobs (raw IS the post-AI state). Known limit: it
+measures the human's **net** change vs the AI accept-all state — an edit that coincides
+with a suggestion nets to 0. Tool + full write-up: workspace
+`docs/automation-corpus/reconstruct_edits.py` + `reconstruction-remeasure-2026-08-30.md`.
 
 **P8 phantom-parenthetical fixer (v0.212.0):** the re-measure showed deleting phantom
 parentheticals ("(Instrumental break)", "(I'm sorry)", unanchored "(Angel baby)"


### PR DESCRIPTION
## Summary
Docs-only. Refines the `LESSONS-LEARNED.md` reconstruction-measurement note to reflect this session's hardening of `docs/automation-corpus/reconstruct_edits.py`:
- Measures **all three edit axes** now — TEXT + **TIMING** (edit_log's blind spot) + **STRUCTURE** (line split/merge), not just text.
- `best_effort` mode so vocalization-heavy jobs still measure; `tier=none` correction-disabled jobs are now measurable.
- Documents the **net-vs-gross** limitation (an edit coinciding with an AI suggestion nets to 0).

Motivated by a 5-job battery where `edit_count`=0 on all 5 yet each had real edits (e.g. Pendulum "The Other Side" = 45 timing edits). Ensures future agents measure edits thoroughly and never fall back to the retired `edit_log`/`edit_count` metric.

No code change, no version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the reconstruction measurement guidance to cover text, timing, and structure edits.
  * Documented `best_effort` behavior and handling for correction-disabled jobs.
  * Added a note about the limitation when human edits overlap with accepted suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->