### PR TITLE
Timing-plausibility gate: word timing vs lead-vocal stem (scorer v0.4.0)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -146,6 +146,17 @@ class Settings(BaseSettings):
         "AUTO_APPROVAL_BACKING_KEEP_ENABLED", "true"
     ).lower() in ("true", "1", "yes")
 
+    # Timing-plausibility gate: when the text signals say AUTO, check the word
+    # timing against the lead-vocal stem (backend/services/auto_approval/
+    # timing_check.py) and demote to review when it fires. Only ever ADDS
+    # review (never auto-ships more), so it defaults on. Code-level default for
+    # the same reason as backing_keep above (executor runs in both the backend
+    # service and the audio-separation job). Kill switch: set false in ci.yml
+    # backend deploy env AND the infrastructure audio-separation-job envs.
+    auto_approval_timing_gate_enabled: bool = os.getenv(
+        "AUTO_APPROVAL_TIMING_GATE_ENABLED", "true"
+    ).lower() in ("true", "1", "yes")
+
     # Match judge — artist/title formatting + match-acceptance for the job
     # submission flow. Deterministic + catalog layers always run; the light AI
     # layer (Vertex Gemini Flash) fires only when those aren't confident.

--- a/backend/services/auto_approval/executor.py
+++ b/backend/services/auto_approval/executor.py
@@ -126,6 +126,37 @@ async def maybe_auto_complete_review(job_id: str, trigger: str) -> Dict[str, Any
         stems = (job.file_urls or {}).get("stems", {}) if job.file_urls else {}
 
         verdict = score_job(corrections, backing_analysis, ai_suggestions)
+
+        # Timing-plausibility gate: word timing vs the lead-vocal stem. Audio
+        # IO (~15MB stem + a few seconds of numpy), so it runs only when the
+        # text signals would otherwise let the lyrics auto-ship — the only
+        # case where it can change the outcome. Fail-OPEN on analysis errors
+        # (recorded below; an environmental break must not demote the whole
+        # auto class), fail-CLOSED on pending audio (the audio_worker
+        # second-chance trigger re-scores once stems exist, and the C1 summary
+        # keeps the lyrics screen until then).
+        timing_info: Dict[str, Any] = {"status": "not_needed"}
+        if verdict.lyrics.verdict == LyricsVerdict.AUTO:
+            if not getattr(settings, "auto_approval_timing_gate_enabled", True):
+                timing_info = {"status": "disabled"}
+            elif not audio_complete:
+                timing_info = {"status": "pending_audio"}
+            else:
+                signals = _compute_timing_signals(
+                    job_id, corrections, ai_suggestions, stems, storage
+                )
+                if signals is None:
+                    timing_info = {"status": "no_lead_stem"}
+                elif signals.error:
+                    timing_info = {"status": "error", "error": signals.error}
+                else:
+                    timing_info = {"status": "checked", **signals.to_dict()}
+                    if signals.fired:
+                        verdict = score_job(
+                            corrections, backing_analysis, ai_suggestions,
+                            timing_signals=signals,
+                        )
+
         blockers = _enforcement_blockers(job, settings)
         custom_instrumental = has_custom_instrumental(job)
         backing_preference = getattr(job, "backing_preference", "auto") or "auto"
@@ -184,6 +215,7 @@ async def maybe_auto_complete_review(job_id: str, trigger: str) -> Dict[str, Any
             "resolved_instrumental_selection": decision["selection"],
             "trigger": trigger,
             "enforcement_blockers": blockers,
+            "timing": timing_info,
             "audio_complete_at_scoring": audio_complete,
             "backing_analysis_available": backing_analysis is not None,
             "ai_suggestions_available": ai_suggestions is not None,
@@ -290,6 +322,52 @@ async def maybe_auto_complete_review(job_id: str, trigger: str) -> Dict[str, Any
         except Exception:
             pass
         return {"outcome": "error", "error": str(e)}
+
+
+def _compute_timing_signals(job_id, corrections, ai_suggestions, stems, storage):
+    """Download the lead-vocal stem and run the timing-plausibility analysis
+    on the POST-AI word stream (the state auto-ship would publish).
+
+    Returns ``None`` when no lead/vocals stem is registered, else a
+    ``TimingSignals`` (whose ``.error`` is set on analysis failure — caller
+    decides fail-open). Never raises.
+    """
+    import os
+    import tempfile
+
+    from backend.services.auto_approval.apply import build_applied_segments
+    from backend.services.auto_approval.timing_check import (
+        TimingSignals,
+        compute_timing_signals,
+    )
+
+    stem_path = stems.get("lead_vocals") or stems.get("vocals_clean")
+    if not stem_path:
+        return None
+    try:
+        # The published state is raw + auto-applied suggestions; on an apply
+        # abort the executor falls back to human review anyway, so analyzing
+        # the raw segments there is only shadow data.
+        segments = corrections.get("corrected_segments") or []
+        if ai_suggestions:
+            applied = build_applied_segments(corrections, ai_suggestions)
+            if not applied.get("aborted"):
+                segments = applied["segments"]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            local = os.path.join(temp_dir, "lead_vocals.flac")
+            storage.download_file(stem_path, local)
+            signals = compute_timing_signals(segments, local)
+        logger.info(
+            f"[job:{job_id}] timing check: fired={signals.fired or 'no'} "
+            f"shadow={signals.shadow_fired or 'no'} "
+            f"(start_inactive={signals.pct_start_inactive}% "
+            f"suspect_bad={signals.n_suspect_bad} "
+            f"unclaimed_run={signals.max_unclaimed_run_s}s error={signals.error})"
+        )
+        return signals
+    except Exception as e:  # noqa: BLE001 — gate is best-effort by design
+        logger.warning(f"[job:{job_id}] timing check failed non-fatally: {e}")
+        return TimingSignals(error=str(e))
 
 
 def _build_auto_corrections(

--- a/backend/services/auto_approval/instrumental.py
+++ b/backend/services/auto_approval/instrumental.py
@@ -147,7 +147,10 @@ def auto_approval_summary(job, settings) -> Dict[str, Any]:
     # audio_worker re-score clears that "pending_audio" marker, the lyrics half
     # is not confident enough to skip its screen — otherwise a job with
     # machine-mistimed words could bypass the lyrics review via the C1 skip.
-    timing_pending = (aa.get("timing") or {}).get("status") == "pending_audio"
+    timing_pending = (
+        bool(getattr(settings, "auto_approval_timing_gate_enabled", True))
+        and (aa.get("timing") or {}).get("status") == "pending_audio"
+    )
     return {
         "backing": {
             "verdict": backing.get("verdict"),

--- a/backend/services/auto_approval/instrumental.py
+++ b/backend/services/auto_approval/instrumental.py
@@ -142,6 +142,12 @@ def auto_approval_summary(job, settings) -> Dict[str, Any]:
         custom_instrumental=custom,
     )
     selection = _selection_with_stem_check(job, decision["selection"])
+    # A lyrics verdict scored before audio separation finished could not run
+    # the timing-plausibility check (it needs the lead-vocal stem). Until the
+    # audio_worker re-score clears that "pending_audio" marker, the lyrics half
+    # is not confident enough to skip its screen — otherwise a job with
+    # machine-mistimed words could bypass the lyrics review via the C1 skip.
+    timing_pending = (aa.get("timing") or {}).get("status") == "pending_audio"
     return {
         "backing": {
             "verdict": backing.get("verdict"),
@@ -150,7 +156,7 @@ def auto_approval_summary(job, settings) -> Dict[str, Any]:
         },
         "lyrics": {
             "verdict": lyrics.get("verdict"),
-            "confident": lyrics.get("verdict") == "auto",
+            "confident": lyrics.get("verdict") == "auto" and not timing_pending,
         },
         "custom_instrumental": custom,
         "verdict_present": bool(aa),

--- a/backend/services/auto_approval/scorer.py
+++ b/backend/services/auto_approval/scorer.py
@@ -41,7 +41,7 @@ from backend.services.auto_approval.models import (
     LyricsVerdict,
 )
 
-SCORER_VERSION = "0.3.0"
+SCORER_VERSION = "0.4.0"
 
 # --- Lyrics thresholds (deliberately conservative; the safe intersection first) ---
 # The AUTO tier requires a synced reference the transcription matches with ZERO
@@ -376,8 +376,17 @@ def extract_lyrics_signals(
 def score_lyrics(
     correction_data: Dict[str, Any],
     ai_suggestions: Optional[List[Dict[str, Any]]] = None,
+    timing_signals: Optional[Any] = None,
 ) -> LyricsResult:
-    """Decide whether the lyrics look safe to auto-approve."""
+    """Decide whether the lyrics look safe to auto-approve.
+
+    ``timing_signals`` (a ``timing_check.TimingSignals``) is optional because
+    computing it needs the lead-vocal stem (audio IO the executor performs only
+    when the text signals would otherwise be AUTO). When provided and fired,
+    it is a never-auto gate: word timing that contradicts the vocal audio is a
+    quality problem no text signal can see (corpus: timing is the dominant
+    residual human-edit class, median retime 0.70s).
+    """
     s = extract_lyrics_signals(correction_data, ai_suggestions)
     reasons: List[str] = []
 
@@ -406,6 +415,17 @@ def score_lyrics(
             f"{s.suspicious_parenthetical_count} multi-second short parenthetical lines"
         )
         return LyricsResult(LyricsVerdict.REVIEW, "phantom-gate", s, reasons)
+
+    if timing_signals is not None and getattr(timing_signals, "fired", None):
+        sig = timing_signals
+        reasons.append(
+            f"timing-plausibility gate fired ({', '.join(sig.fired)}): "
+            f"{sig.pct_start_inactive:.1f}% of word starts in vocal silence, "
+            f"{sig.n_suspect_bad} structurally-suspect words contradicted by the "
+            f"audio, longest unclaimed vocal run {sig.max_unclaimed_run_s:.1f}s — "
+            "word timing likely needs human retiming"
+        )
+        return LyricsResult(LyricsVerdict.REVIEW, "timing-gate", s, reasons)
 
     if not s.accepted_reference_sources:
         reasons.append("no reference lyrics survived the relevance filter")
@@ -614,13 +634,14 @@ def score_job(
     correction_data: Dict[str, Any],
     backing_analysis: Optional[Dict[str, Any]],
     ai_suggestions: Optional[List[Dict[str, Any]]] = None,
+    timing_signals: Optional[Any] = None,
 ) -> AutoApprovabilityVerdict:
     """Produce the combined shadow verdict for a job.
 
     ``overall_auto`` is the narrow safe intersection: confident lyrics AND a
     non-subjective (no-audible-backing) backing decision.
     """
-    lyrics = score_lyrics(correction_data, ai_suggestions)
+    lyrics = score_lyrics(correction_data, ai_suggestions, timing_signals)
     backing = score_backing(backing_analysis)
     overall_auto = lyrics.verdict == LyricsVerdict.AUTO and backing.non_subjective
     return AutoApprovabilityVerdict(

--- a/backend/services/auto_approval/timing_check.py
+++ b/backend/services/auto_approval/timing_check.py
@@ -1,0 +1,335 @@
+"""Timing-plausibility gate signals: word times vs the lead-vocal stem.
+
+WHY: reconstruction-based measurement of real reviews (2026-08-30/31, private
+corpus) showed TIMING is the dominant residual human-edit class — present in
+14/25 measurable corpus jobs, median human retime 0.70s (72% > 0.3s = clearly
+audible), and 100% invisible to every text-based signal the scorer has. One
+corpus job (f986dfe5) reaches the AUTO ai-resolved tier while carrying +3-4s
+held-note timing errors — the exact leak this gate closes.
+
+WHAT: three signals computed from the POST-AI word stream (the state auto-ship
+would publish) + the job's already-separated ``lead_vocals`` stem:
+
+- G1 ``start-silence``: fraction of words whose claimed start sits in vocal
+  silence. Catches hand-retimed *section shifts* (corpus 1d45b286: 62 retimes,
+  63% of words started in silence).
+- G2 ``suspect-mistimed``: count of *structurally suspect* words (inside an
+  equal-duration run — the signature of machine-DISTRIBUTED timing — or a
+  repeated-phrase run) that the audio contradicts (start in silence, mostly
+  silent span, or no spectral-flux onset near the claimed start). Catches
+  repetitive-phrase mistiming ("waves and waves and waves", "come on x4").
+- G3 ``unclaimed-vocal`` (SHADOW-ONLY): longest contiguous run of vocal energy
+  claimed by NO word. Catches held-note under-extension and missing words
+  (f986dfe5: 8.2s) — but the 2026-08-31 out-of-sample run found a semantic
+  false-positive mode: vocal content deliberately absent from the lyrics
+  (ad-libs / DnB vocal samples; e34f1782 shipped zero-touch with a 17.6s
+  unclaimed run, and run-adjacency does not separate the two). So G3 is
+  recorded in the signals + logged for calibration but never gates.
+
+Thresholds calibrated on the 25-job reconstruction corpus and validated
+out-of-sample on ~50 recent prod jobs (docs/automation-corpus/
+timing-gate-2026-08-31.md + validate_timing_gate.py, private): G1+G2 catch
+every corpus job with >=8 human timing edits and change the outcome of ZERO
+currently-auto jobs in either sample. Keep the private validator green after
+ANY change here — the exact algorithm is mirrored there as
+timing_check_proto.py.
+
+Dependencies: numpy + pydub only (ffmpeg is in every worker image). The onset
+detector is a dependency-free spectral-flux stand-in for librosa's, validated
+against it on the corpus. Runtime ~2-4s for a typical track (22kHz mono).
+"""
+from __future__ import annotations
+
+import logging
+import math
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# ---- analysis parameters -------------------------------------------------
+FRAME_S = 0.02  # 20ms RMS frames — fine enough for the 90ms start window
+FLOOR_PCTL = 20  # noise floor: max(p20 * 3, peak * 0.02) of linear frame RMS
+EQDUR_EPS_S = 0.005  # equal-duration run tolerance
+EQDUR_MIN_RUN = 3
+START_WIN = (-0.03, 0.06)  # window around a claimed start checked for energy
+START_ACTIVE_MIN = 0.3  # fraction of that window that must be vocal-active
+WORD_ACTIVE_MIN = 0.5  # word-span active fraction below which it's "dead"
+ONSET_SR = 22050
+ONSET_NFFT = 1024
+ONSET_HOP = 256  # ~11.6ms
+ONSET_MAX_DIST_S = 0.15  # start farther than this from any onset = suspect
+
+# ---- gate thresholds (v0 — 25-job corpus calibration 2026-08-31) ---------
+G1_PCT_START_INACTIVE = 8.0
+G2_N_SUSPECT_BAD = 15
+G3_MAX_UNCLAIMED_RUN_S = 4.0  # shadow-only (see module docstring)
+
+
+@dataclass
+class TimingSignals:
+    """JSON-serializable timing-plausibility signals for one job."""
+
+    n_words: int = 0
+    pct_start_inactive: float = 0.0
+    n_suspect: int = 0
+    n_suspect_bad: int = 0
+    max_unclaimed_run_s: float = 0.0
+    unclaimed_fraction: float = 0.0
+    n_eqdur_words: int = 0
+    n_repetition_words: int = 0
+    fired: List[str] = field(default_factory=list)
+    # Rules that would fire but are calibration-only (never gate): currently
+    # G3 unclaimed-vocal. Recorded so prod shadow data accumulates.
+    shadow_fired: List[str] = field(default_factory=list)
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+# ---------------------------------------------------------------- audio
+
+def _load_mono(path: str) -> Tuple[np.ndarray, int]:
+    from pydub import AudioSegment
+
+    audio = AudioSegment.from_file(path)
+    if audio.channels > 1:
+        audio = audio.set_channels(1)
+    if audio.frame_rate != ONSET_SR:
+        audio = audio.set_frame_rate(ONSET_SR)
+    samples = np.asarray(audio.get_array_of_samples(), dtype=np.float64)
+    peak = float(1 << (8 * audio.sample_width - 1))
+    return samples / peak, audio.frame_rate
+
+
+def _rms_activity(samples: np.ndarray, sr: int) -> Tuple[np.ndarray, float]:
+    """(vocal-active bool array at FRAME_S resolution, frame seconds)."""
+    frame_len = max(1, int(sr * FRAME_S))
+    n_frames = len(samples) // frame_len
+    if n_frames == 0:
+        return np.zeros(0, dtype=bool), FRAME_S
+    trimmed = samples[: n_frames * frame_len].reshape(n_frames, frame_len)
+    rms = np.sqrt((trimmed**2).mean(axis=1))
+    # Vocal stems are near-silent between phrases; the floor sits well above
+    # residual separation bleed but scales with the track's own level.
+    floor = max(np.percentile(rms, FLOOR_PCTL) * 3.0, rms.max() * 0.02)
+    return rms > floor, FRAME_S
+
+
+def _detect_onsets(samples: np.ndarray, sr: int) -> np.ndarray:
+    """Vocal onset times (s) via numpy spectral flux + adaptive peak-picking.
+
+    Log-magnitude STFT positive flux; peaks must be local maxima exceeding a
+    moving average by a fixed delta and sit >=35ms apart. A dependency-free
+    stand-in for librosa.onset.onset_detect, validated against it on the
+    private corpus (both catch the same gate outcomes).
+    """
+    n = (len(samples) - ONSET_NFFT) // ONSET_HOP
+    if n < 3:
+        return np.zeros(0)
+    idx = np.arange(n)[:, None] * ONSET_HOP + np.arange(ONSET_NFFT)[None, :]
+    frames = samples[idx] * np.hanning(ONSET_NFFT)[None, :]
+    mag = np.abs(np.fft.rfft(frames, axis=1))
+    logmag = np.log1p(1000.0 * mag)
+    flux = np.maximum(0.0, np.diff(logmag, axis=0)).sum(axis=1)
+    if not flux.size or flux.max() <= 0:
+        return np.zeros(0)
+    flux = flux / flux.max()
+    win = 21  # moving average over ~±0.12s
+    avg = np.convolve(flux, np.ones(win) / win, mode="same")
+    delta = 0.07
+    peaks = []
+    last = -10
+    for i in range(1, len(flux) - 1):
+        if (
+            flux[i] >= flux[i - 1]
+            and flux[i] >= flux[i + 1]
+            and flux[i] > avg[i] + delta
+            and i - last >= 3
+        ):
+            peaks.append(i)
+            last = i
+    return (np.asarray(peaks, dtype=float) * ONSET_HOP + ONSET_NFFT // 2) / sr
+
+
+# ---------------------------------------------------------------- words
+
+_NORM_RE = re.compile(r"[^a-z']+")
+
+
+def _norm(text: str) -> str:
+    return _NORM_RE.sub("", (text or "").lower())
+
+
+def _flatten_words(segments: List[dict]) -> List[dict]:
+    out = []
+    for si, seg in enumerate(segments):
+        for w in seg.get("words") or []:
+            out.append(
+                {
+                    "seg": si,
+                    "text": (w.get("text") or "").strip(),
+                    "start": float(w.get("start_time") or 0.0),
+                    "end": float(w.get("end_time") or 0.0),
+                }
+            )
+    return out
+
+
+def _repetition_run_flags(tokens: List[str]) -> List[bool]:
+    """Words inside a consecutive repetition of a 1-4 token phrase
+    (>=3 reps for single tokens, >=2 for multi-token phrases)."""
+    n = len(tokens)
+    flags = [False] * n
+    i = 0
+    while i < n:
+        best_span = 0
+        for plen in range(1, 5):
+            if i + 2 * plen > n or not all(tokens[i + j] for j in range(plen)):
+                continue
+            reps = 1
+            while (
+                i + (reps + 1) * plen <= n
+                and tokens[i + reps * plen : i + (reps + 1) * plen]
+                == tokens[i : i + plen]
+            ):
+                reps += 1
+            if reps >= (3 if plen == 1 else 2):
+                best_span = max(best_span, reps * plen)
+        if best_span:
+            for k in range(i, i + best_span):
+                flags[k] = True
+            i += best_span
+        else:
+            i += 1
+    return flags
+
+
+def _eqdur_run_flags(words: List[dict]) -> List[bool]:
+    """Words inside >=3 consecutive same-segment words with identical
+    durations (±EQDUR_EPS_S) — the machine-distributed-timing signature
+    (humans retime exactly these blocks; corpus 1d45b286 = 49/62)."""
+    n = len(words)
+    flags = [False] * n
+    durs = [max(0.0, w["end"] - w["start"]) for w in words]
+    i = 0
+    while i < n:
+        j = i
+        while (
+            j + 1 < n
+            and words[j + 1]["seg"] == words[i]["seg"]
+            and abs(durs[j + 1] - durs[i]) < EQDUR_EPS_S
+        ):
+            j += 1
+        if j - i + 1 >= EQDUR_MIN_RUN and durs[i] > 0.01:
+            for k in range(i, j + 1):
+                flags[k] = True
+        i = j + 1
+    return flags
+
+
+# ---------------------------------------------------------------- signals
+
+def _frac_active(active: np.ndarray, frame_s: float, t0: float, t1: float) -> float:
+    i0 = max(0, int(math.floor(t0 / frame_s)))
+    i1 = min(len(active), int(math.ceil(t1 / frame_s)))
+    if i1 <= i0:
+        return 0.0
+    return float(active[i0:i1].mean())
+
+
+def compute_timing_signals(
+    segments: List[dict], lead_vocals_path: str
+) -> TimingSignals:
+    """Compute gate signals for the given (post-AI) segments + lead stem.
+
+    Never raises: failures return ``TimingSignals(error=...)`` so callers
+    record an explicit "analysis unavailable" marker (the fail-open/-closed
+    choice belongs to the caller, not here).
+    """
+    try:
+        words = _flatten_words(segments)
+        if not words:
+            raise ValueError("no words")
+        samples, sr = _load_mono(lead_vocals_path)
+        active, frame_s = _rms_activity(samples, sr)
+        if not len(active):
+            raise ValueError("empty audio")
+        onsets = _detect_onsets(samples, sr)
+
+        rep = _repetition_run_flags([_norm(w["text"]) for w in words])
+        eqd = _eqdur_run_flags(words)
+
+        n = len(words)
+        start_inactive = 0
+        n_suspect = n_suspect_bad = 0
+        claimed = np.zeros_like(active)
+        for i, w in enumerate(words):
+            s, e = w["start"], w["end"]
+            start_ok = (
+                _frac_active(active, frame_s, s + START_WIN[0], s + START_WIN[1])
+                >= START_ACTIVE_MIN
+            )
+            if not start_ok:
+                start_inactive += 1
+            if rep[i] or eqd[i]:
+                n_suspect += 1
+                dead = _frac_active(active, frame_s, s, e) < WORD_ACTIVE_MIN
+                far = (
+                    float(np.min(np.abs(onsets - s))) > ONSET_MAX_DIST_S
+                    if len(onsets)
+                    else False
+                )
+                if (not start_ok) or dead or far:
+                    n_suspect_bad += 1
+            i0 = max(0, int(math.floor(s / frame_s)))
+            i1 = min(len(claimed), int(math.ceil(e / frame_s)))
+            claimed[i0:i1] = True
+
+        orphan = active & ~claimed
+        n_active = int(active.sum())
+        best = run = 0
+        for a in orphan:
+            run = run + 1 if a else 0
+            best = max(best, run)
+
+        sig = TimingSignals(
+            n_words=n,
+            pct_start_inactive=round(100.0 * start_inactive / n, 1),
+            n_suspect=n_suspect,
+            n_suspect_bad=n_suspect_bad,
+            max_unclaimed_run_s=round(best * frame_s, 2),
+            unclaimed_fraction=round(
+                float(orphan.sum()) / n_active if n_active else 0.0, 4
+            ),
+            n_eqdur_words=sum(eqd),
+            n_repetition_words=sum(rep),
+        )
+        sig.fired = gate_fired(sig)
+        sig.shadow_fired = shadow_fired(sig)
+        return sig
+    except Exception as e:  # noqa: BLE001 — analysis is best-effort by design
+        logger.warning("timing check failed: %s", e, exc_info=True)
+        return TimingSignals(error=str(e))
+
+
+def gate_fired(sig: TimingSignals) -> List[str]:
+    """Which GATING rules the signals trip (empty = timing looks plausible)."""
+    fired = []
+    if sig.pct_start_inactive >= G1_PCT_START_INACTIVE:
+        fired.append("start-silence")
+    if sig.n_suspect_bad >= G2_N_SUSPECT_BAD:
+        fired.append("suspect-mistimed")
+    return fired
+
+
+def shadow_fired(sig: TimingSignals) -> List[str]:
+    """Calibration-only rules (recorded + logged, never gate)."""
+    shadow = []
+    if sig.max_unclaimed_run_s >= G3_MAX_UNCLAIMED_RUN_S:
+        shadow.append("unclaimed-vocal")
+    return shadow

--- a/backend/services/auto_approval/timing_check.py
+++ b/backend/services/auto_approval/timing_check.py
@@ -131,11 +131,25 @@ def _detect_onsets(samples: np.ndarray, sr: int) -> np.ndarray:
     n = (len(samples) - ONSET_NFFT) // ONSET_HOP
     if n < 3:
         return np.zeros(0)
-    idx = np.arange(n)[:, None] * ONSET_HOP + np.arange(ONSET_NFFT)[None, :]
-    frames = samples[idx] * np.hanning(ONSET_NFFT)[None, :]
-    mag = np.abs(np.fft.rfft(frames, axis=1))
-    logmag = np.log1p(1000.0 * mag)
-    flux = np.maximum(0.0, np.diff(logmag, axis=0)).sum(axis=1)
+    # Batched STFT flux: a full-track frame matrix would be O(minutes * 60MB)
+    # and can OOM a worker on long inputs. Each batch re-computes one overlap
+    # frame so the flux diff is continuous across batch boundaries.
+    window = np.hanning(ONSET_NFFT)
+    batch = 4096
+    flux_parts = []
+    prev_last_logmag = None
+    for b0 in range(0, n, batch):
+        b1 = min(n, b0 + batch)
+        idx = (
+            np.arange(b0, b1)[:, None] * ONSET_HOP
+            + np.arange(ONSET_NFFT)[None, :]
+        )
+        logmag = np.log1p(1000.0 * np.abs(np.fft.rfft(samples[idx] * window, axis=1)))
+        if prev_last_logmag is not None:
+            logmag = np.vstack([prev_last_logmag, logmag])
+        flux_parts.append(np.maximum(0.0, np.diff(logmag, axis=0)).sum(axis=1))
+        prev_last_logmag = logmag[-1]
+    flux = np.concatenate(flux_parts)
     if not flux.size or flux.max() <= 0:
         return np.zeros(0)
     flux = flux / flux.max()
@@ -257,8 +271,10 @@ def compute_timing_signals(
             raise ValueError("no words")
         samples, sr = _load_mono(lead_vocals_path)
         active, frame_s = _rms_activity(samples, sr)
-        if not len(active):
-            raise ValueError("empty audio")
+        if not len(active) or not active.any():
+            # A silent/failed separation output would mark every word start
+            # inactive and falsely fire — treat as analysis-unavailable.
+            raise ValueError("empty or silent audio")
         onsets = _detect_onsets(samples, sr)
 
         rep = _repetition_run_flags([_norm(w["text"]) for w in words])

--- a/backend/tests/services/auto_approval/test_executor.py
+++ b/backend/tests/services/auto_approval/test_executor.py
@@ -362,3 +362,113 @@ async def test_backing_preference_review_blocks_even_confident_clean() -> None:
     assert result["outcome"] == "review"
     jm.transition_to_state.assert_not_called()
     ws.trigger_render_video_worker.assert_not_awaited()
+
+
+# ---- timing-plausibility gate wiring ----------------------------------------
+
+def _timing_signals(fired):
+    from backend.services.auto_approval.timing_check import TimingSignals
+
+    return TimingSignals(
+        n_words=100,
+        pct_start_inactive=40.0 if fired else 0.0,
+        n_suspect_bad=30 if fired else 0,
+        max_unclaimed_run_s=5.0 if fired else 0.5,
+        fired=["start-silence", "suspect-mistimed"] if fired else [],
+    )
+
+
+def _job_with_lead_stem(**kwargs):
+    kwargs.setdefault("backing", _clean_backing())
+    job = _job(**kwargs)
+    job.file_urls["stems"]["lead_vocals"] = "jobs/j1/stems/lead_vocals.flac"
+    return job
+
+
+@pytest.mark.asyncio
+async def test_fired_timing_gate_demotes_to_review() -> None:
+    with patch(
+        "backend.services.auto_approval.executor._compute_timing_signals",
+        return_value=_timing_signals(fired=True),
+    ):
+        result, job_manager, _, worker = await _run(_job_with_lead_stem())
+    assert result["outcome"] == "review"
+    payload = job_manager.update_processing_metadata.call_args[0][2]
+    assert payload["timing"]["status"] == "checked"
+    assert payload["timing"]["fired"] == ["start-silence", "suspect-mistimed"]
+    assert payload["lyrics"]["tier"] == "timing-gate"
+    worker.trigger_render_video_worker.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_clean_timing_signals_allow_auto_completion() -> None:
+    with patch(
+        "backend.services.auto_approval.executor._compute_timing_signals",
+        return_value=_timing_signals(fired=False),
+    ):
+        result, job_manager, _, _ = await _run(_job_with_lead_stem())
+    assert result["outcome"] == "auto_completed"
+    payload = job_manager.update_processing_metadata.call_args[0][2]
+    assert payload["timing"]["status"] == "checked"
+    assert payload["timing"]["fired"] == []
+
+
+@pytest.mark.asyncio
+async def test_incomplete_audio_records_timing_pending() -> None:
+    result, job_manager, _, _ = await _run(_job_with_lead_stem(audio_complete=False))
+    assert result["outcome"] == "review"  # blocked by audio_incomplete
+    payload = job_manager.update_processing_metadata.call_args[0][2]
+    assert payload["timing"]["status"] == "pending_audio"
+
+
+@pytest.mark.asyncio
+async def test_timing_gate_flag_disabled_fails_open() -> None:
+    settings = SimpleNamespace(
+        auto_approval_enforce_enabled=True,
+        auto_approval_timing_gate_enabled=False,
+    )
+    result, job_manager, _, _ = await _run(_job_with_lead_stem(), settings=settings)
+    assert result["outcome"] == "auto_completed"
+    payload = job_manager.update_processing_metadata.call_args[0][2]
+    assert payload["timing"]["status"] == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_missing_lead_stem_fails_open() -> None:
+    with patch(
+        "backend.services.auto_approval.executor._compute_timing_signals",
+        return_value=None,
+    ):
+        result, job_manager, _, _ = await _run(_job_with_lead_stem())
+    assert result["outcome"] == "auto_completed"
+    payload = job_manager.update_processing_metadata.call_args[0][2]
+    assert payload["timing"]["status"] == "no_lead_stem"
+
+
+@pytest.mark.asyncio
+async def test_timing_analysis_error_fails_open() -> None:
+    from backend.services.auto_approval.timing_check import TimingSignals
+
+    with patch(
+        "backend.services.auto_approval.executor._compute_timing_signals",
+        return_value=TimingSignals(error="boom"),
+    ):
+        result, job_manager, _, _ = await _run(_job_with_lead_stem())
+    assert result["outcome"] == "auto_completed"
+    payload = job_manager.update_processing_metadata.call_args[0][2]
+    assert payload["timing"]["status"] == "error"
+    assert payload["timing"]["error"] == "boom"
+
+
+@pytest.mark.asyncio
+async def test_gated_lyrics_skip_timing_compute() -> None:
+    # Lyrics already gated (no reference sources) -> no audio work needed.
+    data = _confident_corrections()
+    data["reference_lyrics"] = {}
+    with patch(
+        "backend.services.auto_approval.executor._compute_timing_signals"
+    ) as compute:
+        result, job_manager, _, _ = await _run(_job_with_lead_stem(), corrections=data)
+    compute.assert_not_called()
+    payload = job_manager.update_processing_metadata.call_args[0][2]
+    assert payload["timing"]["status"] == "not_needed"

--- a/backend/tests/services/auto_approval/test_instrumental.py
+++ b/backend/tests/services/auto_approval/test_instrumental.py
@@ -294,3 +294,16 @@ def test_summary_lyrics_confident_without_timing_block():
     # their confidence semantics are unchanged.
     s = auto_approval_summary(_job_with_verdict("clean", True), _settings())
     assert s["lyrics"]["confident"] is True
+
+
+def test_summary_timing_pending_ignored_when_gate_disabled():
+    # Kill switch consistency: with the timing gate disabled the executor can
+    # auto-complete, so the C1 summary must not hold the lyrics screen either.
+    job = _job_with_verdict("clean", True)
+    job.processing_metadata["auto_approval"]["timing"] = {"status": "pending_audio"}
+    settings = SimpleNamespace(
+        auto_approval_backing_keep_enabled=True,
+        auto_approval_timing_gate_enabled=False,
+    )
+    s = auto_approval_summary(job, settings)
+    assert s["lyrics"]["confident"] is True

--- a/backend/tests/services/auto_approval/test_instrumental.py
+++ b/backend/tests/services/auto_approval/test_instrumental.py
@@ -268,3 +268,29 @@ def test_jobcreate_coerces_out_of_set_preferences():
     assert JobCreate(review_mode="typo").review_mode == "always_review"
     assert JobCreate(review_mode="auto").review_mode == "auto"
     assert JobCreate().backing_preference == "auto" and JobCreate().review_mode == "auto"
+
+
+# ---- timing gate interaction with the C1 lyrics-skip ------------------------
+
+def test_summary_lyrics_not_confident_while_timing_pending_audio():
+    # A verdict scored before audio separation finished could not run the
+    # timing check; the lyrics screen must not be skipped until the
+    # audio_worker re-score clears the pending marker.
+    job = _job_with_verdict("clean", True)
+    job.processing_metadata["auto_approval"]["timing"] = {"status": "pending_audio"}
+    s = auto_approval_summary(job, _settings())
+    assert s["lyrics"]["confident"] is False
+
+
+def test_summary_lyrics_confident_when_timing_checked():
+    job = _job_with_verdict("clean", True)
+    job.processing_metadata["auto_approval"]["timing"] = {"status": "checked", "fired": []}
+    s = auto_approval_summary(job, _settings())
+    assert s["lyrics"]["confident"] is True
+
+
+def test_summary_lyrics_confident_without_timing_block():
+    # Jobs scored before the timing gate existed have no timing block at all —
+    # their confidence semantics are unchanged.
+    s = auto_approval_summary(_job_with_verdict("clean", True), _settings())
+    assert s["lyrics"]["confident"] is True

--- a/backend/tests/services/auto_approval/test_scorer.py
+++ b/backend/tests/services/auto_approval/test_scorer.py
@@ -408,3 +408,40 @@ def test_overall_not_auto_when_backing_subjective() -> None:
     )
     assert v.lyrics.verdict == LyricsVerdict.AUTO
     assert v.overall_auto is False
+
+
+# --- Timing-plausibility gate (never-auto; signals computed by the executor) ---
+
+def test_fired_timing_signals_gate_confident_lyrics() -> None:
+    from backend.services.auto_approval.timing_check import TimingSignals
+
+    sig = TimingSignals(
+        n_words=100, pct_start_inactive=40.0, n_suspect_bad=30,
+        max_unclaimed_run_s=4.9, fired=["start-silence", "suspect-mistimed"],
+    )
+    res = score_lyrics(_corrections_json(), timing_signals=sig)
+    assert res.verdict == LyricsVerdict.REVIEW
+    assert res.tier == "timing-gate"
+    assert "timing-plausibility gate fired" in res.reasons[0]
+
+
+def test_unfired_timing_signals_leave_auto_untouched() -> None:
+    from backend.services.auto_approval.timing_check import TimingSignals
+
+    res = score_lyrics(_corrections_json(), timing_signals=TimingSignals(n_words=100))
+    assert res.verdict == LyricsVerdict.AUTO
+    assert res.tier == "synced-perfect"
+
+
+def test_absent_timing_signals_leave_auto_untouched() -> None:
+    res = score_lyrics(_corrections_json(), timing_signals=None)
+    assert res.verdict == LyricsVerdict.AUTO
+
+
+def test_timing_gate_flows_through_score_job() -> None:
+    from backend.services.auto_approval.timing_check import TimingSignals
+
+    sig = TimingSignals(n_words=50, pct_start_inactive=40.0, fired=["start-silence"])
+    verdict = score_job(_corrections_json(), None, None, timing_signals=sig)
+    assert verdict.lyrics.tier == "timing-gate"
+    assert verdict.overall_auto is False

--- a/backend/tests/services/auto_approval/test_timing_check.py
+++ b/backend/tests/services/auto_approval/test_timing_check.py
@@ -1,0 +1,187 @@
+"""Tests for the timing-plausibility gate signals (timing_check.py).
+
+The acoustic behavior is validated on real jobs by the private corpus
+harness (docs/automation-corpus/validate_timing_gate.py); these tests pin the
+algorithm's building blocks and end-to-end behavior on synthesized audio where
+the ground truth is constructed: words aligned with sung regions must not
+fire, words claimed in silence / long unclaimed sung regions must.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from backend.services.auto_approval.timing_check import (
+    G1_PCT_START_INACTIVE,
+    G2_N_SUSPECT_BAD,
+    G3_MAX_UNCLAIMED_RUN_S,
+    TimingSignals,
+    _eqdur_run_flags,
+    _repetition_run_flags,
+    compute_timing_signals,
+    gate_fired,
+    shadow_fired,
+)
+
+
+# ---------------------------------------------------------------- structural
+
+def _w(seg: int, text: str, start: float, end: float) -> dict:
+    return {"seg": seg, "text": text, "start": start, "end": end}
+
+
+class TestEqualDurationRuns:
+    def test_three_identical_durations_flagged(self):
+        words = [_w(0, "a", 0.0, 1.0), _w(0, "b", 1.0, 2.0), _w(0, "c", 2.0, 3.0)]
+        assert _eqdur_run_flags(words) == [True, True, True]
+
+    def test_two_identical_durations_not_flagged(self):
+        words = [_w(0, "a", 0.0, 1.0), _w(0, "b", 1.0, 2.0), _w(0, "c", 2.0, 2.5)]
+        assert _eqdur_run_flags(words) == [False, False, False]
+
+    def test_segment_boundary_breaks_run(self):
+        words = [_w(0, "a", 0.0, 1.0), _w(0, "b", 1.0, 2.0), _w(1, "c", 2.0, 3.0)]
+        assert _eqdur_run_flags(words) == [False, False, False]
+
+    def test_varied_durations_not_flagged(self):
+        words = [_w(0, "a", 0.0, 0.3), _w(0, "b", 0.3, 0.9), _w(0, "c", 0.9, 1.1)]
+        assert _eqdur_run_flags(words) == [False, False, False]
+
+    def test_zero_duration_words_not_flagged(self):
+        words = [_w(0, "a", 1.0, 1.0), _w(0, "b", 2.0, 2.0), _w(0, "c", 3.0, 3.0)]
+        assert _eqdur_run_flags(words) == [False, False, False]
+
+
+class TestRepetitionRuns:
+    def test_single_token_needs_three_reps(self):
+        assert _repetition_run_flags(["come", "come"]) == [False, False]
+        assert _repetition_run_flags(["come", "come", "come"]) == [True] * 3
+
+    def test_phrase_repetition_two_reps(self):
+        toks = ["come", "on", "come", "on"]
+        assert _repetition_run_flags(toks) == [True] * 4
+
+    def test_pendulum_come_on_x4(self):
+        toks = ["come", "on", "come", "on", "come", "on", "come", "on"]
+        assert _repetition_run_flags(toks) == [True] * 8
+
+    def test_no_repetition(self):
+        toks = ["under", "the", "waves", "tonight"]
+        assert _repetition_run_flags(toks) == [False] * 4
+
+    def test_empty_tokens_never_flagged(self):
+        assert _repetition_run_flags(["", "", ""]) == [False, False, False]
+
+
+# ---------------------------------------------------------------- gate rules
+
+class TestGateRules:
+    def test_no_fire_on_clean_signals(self):
+        assert gate_fired(TimingSignals(n_words=100)) == []
+
+    def test_g1_start_silence(self):
+        sig = TimingSignals(pct_start_inactive=G1_PCT_START_INACTIVE)
+        assert gate_fired(sig) == ["start-silence"]
+
+    def test_g2_suspect_mistimed(self):
+        sig = TimingSignals(n_suspect_bad=G2_N_SUSPECT_BAD)
+        assert gate_fired(sig) == ["suspect-mistimed"]
+
+    def test_g3_unclaimed_vocal_is_shadow_only(self):
+        # G3 has a known semantic FP mode (ad-libs / vocal samples absent from
+        # the lyrics, e.g. e34f1782's zero-touch 17.6s run) — it is recorded
+        # for calibration but must never gate.
+        sig = TimingSignals(max_unclaimed_run_s=G3_MAX_UNCLAIMED_RUN_S)
+        assert gate_fired(sig) == []
+        assert shadow_fired(sig) == ["unclaimed-vocal"]
+
+    def test_below_thresholds_no_fire(self):
+        sig = TimingSignals(
+            pct_start_inactive=G1_PCT_START_INACTIVE - 0.1,
+            n_suspect_bad=G2_N_SUSPECT_BAD - 1,
+            max_unclaimed_run_s=G3_MAX_UNCLAIMED_RUN_S - 0.1,
+        )
+        assert gate_fired(sig) == []
+
+
+# ---------------------------------------------------------------- end-to-end
+
+def _synth_stem(tmp_path, sung_regions, duration_s=30.0):
+    """Write a WAV 'vocal stem': silence with 440Hz tone over sung_regions."""
+    from pydub import AudioSegment
+    from pydub.generators import Sine
+
+    audio = AudioSegment.silent(duration=int(duration_s * 1000), frame_rate=22050)
+    for start_s, end_s in sung_regions:
+        tone = Sine(440, sample_rate=22050).to_audio_segment(
+            duration=int((end_s - start_s) * 1000)
+        ).apply_gain(-6)
+        audio = audio.overlay(tone, position=int(start_s * 1000))
+    path = os.path.join(str(tmp_path), "lead_vocals.wav")
+    audio.export(path, format="wav")
+    return path
+
+
+def _segments(words):
+    return [{
+        "id": "s0",
+        "words": [
+            {"id": f"w{i}", "text": t, "start_time": s, "end_time": e}
+            for i, (t, s, e) in enumerate(words)
+        ],
+    }]
+
+
+class TestComputeTimingSignals:
+    def test_aligned_words_do_not_fire(self, tmp_path):
+        # Words exactly covering the sung regions -> plausible timing.
+        words = [(f"word{i}", 1.0 + i * 2.0, 2.4 + i * 2.0) for i in range(10)]
+        stem = _synth_stem(tmp_path, [(s, e) for _, s, e in words])
+        sig = compute_timing_signals(_segments(words), stem)
+        assert sig.error is None
+        assert sig.fired == []
+        assert sig.n_words == 10
+        assert sig.pct_start_inactive < G1_PCT_START_INACTIVE
+
+    def test_words_claimed_in_silence_fire_start_silence(self, tmp_path):
+        # Singing happens 20-28s but every word is claimed at 1-11s (silence):
+        # the hand-retimed-section signature (corpus 1d45b286).
+        words = [(f"word{i}", 1.0 + i, 1.8 + i) for i in range(10)]
+        stem = _synth_stem(tmp_path, [(20.0, 28.0)])
+        sig = compute_timing_signals(_segments(words), stem)
+        assert sig.error is None
+        assert "start-silence" in sig.fired
+        assert sig.pct_start_inactive > 50
+
+    def test_long_unclaimed_sung_region_recorded_as_shadow(self, tmp_path):
+        # Words cover 1-3s; 10 further seconds of singing claimed by nothing
+        # (held-note under-extension / missing words; corpus f986dfe5 = 8.2s).
+        # Recorded as shadow only — must NOT gate (ad-lib FP mode).
+        words = [("hello", 1.0, 2.0), ("there", 2.0, 3.0)]
+        stem = _synth_stem(tmp_path, [(1.0, 3.0), (10.0, 20.0)])
+        sig = compute_timing_signals(_segments(words), stem)
+        assert sig.error is None
+        assert "unclaimed-vocal" not in sig.fired
+        assert "unclaimed-vocal" in sig.shadow_fired
+        assert sig.max_unclaimed_run_s >= G3_MAX_UNCLAIMED_RUN_S
+
+    def test_missing_file_returns_error_not_raise(self):
+        sig = compute_timing_signals(
+            _segments([("a", 0.0, 1.0)]), "/nonexistent/stem.flac"
+        )
+        assert sig.error is not None
+        assert sig.fired == []
+
+    def test_no_words_returns_error(self, tmp_path):
+        stem = _synth_stem(tmp_path, [(1.0, 2.0)], duration_s=5.0)
+        sig = compute_timing_signals([], stem)
+        assert sig.error is not None
+
+    def test_to_dict_is_json_serializable(self, tmp_path):
+        import json
+
+        words = [("hey", 1.0, 1.5)]
+        stem = _synth_stem(tmp_path, [(1.0, 1.5)], duration_s=5.0)
+        sig = compute_timing_signals(_segments(words), stem)
+        json.dumps(sig.to_dict())  # must not raise

--- a/backend/tests/services/auto_approval/test_timing_check.py
+++ b/backend/tests/services/auto_approval/test_timing_check.py
@@ -185,3 +185,12 @@ class TestComputeTimingSignals:
         stem = _synth_stem(tmp_path, [(1.0, 1.5)], duration_s=5.0)
         sig = compute_timing_signals(_segments(words), stem)
         json.dumps(sig.to_dict())  # must not raise
+
+    def test_silent_stem_is_analysis_unavailable(self, tmp_path):
+        # A silent (failed-separation) stem must NOT mark every word start
+        # inactive and fire — it goes down the fail-open error path.
+        words = [(f"word{i}", 1.0 + i, 1.8 + i) for i in range(10)]
+        stem = _synth_stem(tmp_path, [])  # no sung regions at all
+        sig = compute_timing_signals(_segments(words), stem)
+        assert sig.error is not None
+        assert sig.fired == []

--- a/docs/archive/2026-08-31-timing-gate.md
+++ b/docs/archive/2026-08-31-timing-gate.md
@@ -1,0 +1,69 @@
+# Timing-plausibility gate (scorer v0.4.0, app v0.216.0)
+
+## Why
+
+Reconstruction-based measurement of real reviews (2026-08-30/31, private
+corpus at the workspace root) proved TIMING is the dominant residual
+human-edit class in the full-auto initiative: present in 14/25 measurable
+corpus jobs and ~21% of a recent-58 prod sample, median human retime 0.70s
+(72% > 0.3s — clearly audible), and 100% invisible to every text-based signal
+the scorer has. As the auto tiers widen toward the >50% goal, jobs with
+machine-mistimed words would silently auto-ship. This gate is the seatbelt.
+
+## What
+
+`backend/services/auto_approval/timing_check.py` — numpy+pydub analysis of the
+POST-AI word stream against the job's separated `lead_vocals` stem:
+
+- **G1 start-silence** (gates): ≥8% of words start in vocal silence — the
+  hand-retimed *section shift* signature.
+- **G2 suspect-mistimed** (gates): ≥15 structurally suspect words (equal-
+  duration runs = machine-distributed timing; repeated-phrase runs)
+  contradicted by the audio (silent start, dead span, or no spectral-flux
+  onset near the claimed start) — the *repetitive-phrase mistiming* signature
+  ("come on ×4" all 0.39s each).
+- **G3 unclaimed-vocal** (shadow-only): ≥4s of continuous vocal energy no word
+  claims — held-note under-extension / missing words. Not gating because
+  out-of-sample it also fires on vocal content deliberately absent from
+  lyrics (ad-libs / DnB vocal samples; a zero-touch auto job had a 17.6s run).
+  Recorded + logged on every checked job for future refinement.
+
+Wiring: the executor computes signals only when the text signals would
+otherwise let the lyrics auto-ship (audio IO costs a few seconds; any other
+verdict can't change). Fired ⇒ `score_lyrics` returns REVIEW tier
+`timing-gate` (a never-auto gate). The payload records
+`auto_approval.timing.{status, signals, fired, shadow_fired}`:
+`checked | pending_audio | no_lead_stem | error | disabled | not_needed`.
+Fail-open on analysis errors (an environmental break must not demote the whole
+auto class — the error is recorded and logged); fail-closed on `pending_audio`
+(the audio_worker second-chance re-score runs the check once stems exist, and
+the C1 summary keeps the lyrics screen until then). Kill switch:
+`AUTO_APPROVAL_TIMING_GATE_ENABLED` (code default true, same both-envs pattern
+as the backing-keep flag).
+
+## Validation
+
+- **Calibration corpus (25 jobs, reconstruction ground truth):** G1+G2 catch
+  6/6 jobs with ≥8 human timing edits; zero fires on clean jobs (the only
+  false fires are vocalization-gated jobs that never auto-ship anyway);
+  f986dfe5 (the +4s held-note AUTO leak) appears in G3 shadow.
+- **Out-of-sample (65 recent prod jobs, not used for tuning):** G1+G2 change
+  the outcome of ZERO of the 14 currently-auto (ai-resolved) jobs — no
+  auto-rate cost — and catch 6/11 jobs with ≥8 human timing edits
+  (41/41/30/19/15/11-edit jobs; the misses have no structural/silence
+  signature and are all review-bound today anyway). Private harness:
+  `docs/automation-corpus/validate_timing_gate.py` (workspace root) imports
+  this exact module — keep it green after any change here.
+
+## Known limitations
+
+- **Partial recall by design:** subtle per-word boundary tweaks inside
+  continuous singing (no structural signature, no silence violation) are not
+  detectable by these signals — out-of-sample, ai-resolved jobs with 7 and 9
+  net timing edits pass the gate, as does a 79-edit needs-review job. Catching
+  those needs localized forced alignment (the planned FIXER direction), not
+  looser thresholds.
+- Thresholds are calibrated on the corpus; re-run the private validator after
+  ANY change to `timing_check.py`.
+- The vocal-stem quality bounds everything: separation bleed inflates the
+  activity floor; ad-libs/samples inflate unclaimed energy (why G3 is shadow).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.215.0"
+version = "0.216.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Reconstruction-based measurement of real reviews proved **timing is the dominant residual human-edit class** in the full-auto initiative (14/25 measurable corpus jobs, median human retime 0.70s, 72% > 0.3s = clearly audible) — and it is 100% invisible to every text-based signal the scorer has. This PR adds the timing seatbelt so the auto class can keep widening without silently shipping mistimed karaoke.

## Changes

- **New `backend/services/auto_approval/timing_check.py`** — analyzes the POST-AI word stream against the job's separated `lead_vocals` stem (numpy + pydub only; batched numpy spectral-flux onset detection, no librosa):
  - **G1 start-silence** (gates): ≥8% of words start in vocal silence — hand-retimed section-shift signature
  - **G2 suspect-mistimed** (gates): ≥15 structurally suspect words (equal-duration runs = machine-distributed timing; repeated-phrase runs) contradicted by the audio
  - **G3 unclaimed-vocal** (shadow-only): long sung region no word claims — recorded + logged, never gates (out-of-sample FP mode: ad-libs/vocal samples deliberately absent from lyrics)
- **Scorer v0.4.0**: `score_lyrics`/`score_job` accept optional timing signals; fired ⇒ REVIEW tier `timing-gate` (never-auto gate)
- **Executor**: computes signals only when the text signals would otherwise let lyrics auto-ship (the only case that can change the outcome); records `auto_approval.timing.{status, signals, fired, shadow_fired}`; fail-open on analysis error, `pending_audio` until the audio-worker re-score
- **C1 summary**: lyrics half not confident while timing is `pending_audio` (kill-switch-aware) — a pre-audio verdict can't skip the lyrics screen
- **Kill switch**: `AUTO_APPROVAL_TIMING_GATE_ENABLED` (code default true, both-envs pattern)

## Validation

- **25-job reconstruction corpus**: 6/6 jobs with ≥8 human timing edits caught; 0 fires on clean jobs; f986dfe5 (the +4s held-note AUTO leak) in G3 shadow. Private harness `docs/automation-corpus/validate_timing_gate.py` imports this exact module — PASS.
- **Out-of-sample, 65 recent prod jobs (not used for tuning)**: G1+G2 fire on **zero of the 14 currently-auto (ai-resolved) jobs** — enforcement costs no auto-rate — and catch 6/11 jobs with ≥8 timing edits. Known partial recall (subtle boundary tweaks inside continuous singing need forced alignment — the planned fixer direction).

## Testing

- 158 auto-approval unit tests pass (23 new: structural detectors, synthesized-audio end-to-end incl. silent-stem regression, scorer gate tier, executor wiring incl. fail-open paths, C1 summary interactions)
- Full `make test` green (backend + 1241 frontend)
- CodeRabbit review: 3 findings (OOM-bounded onset batching, silent-stem fail-open, C1 kill-switch consistency) — all fixed + regression-tested

Docs: `docs/archive/2026-08-31-timing-gate.md`

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)