### PR TITLE
Admin create/manage tenants: album batch via tenant bulk flow + full theme customisation

### DIFF
--- a/backend/api/routes/tenant_admin.py
+++ b/backend/api/routes/tenant_admin.py
@@ -8,8 +8,9 @@ the tenant can be driven immediately via the admin preview path
 auto-paired mixed/instrumental, resumable uploads, locked theme on every job).
 """
 
+import json
 import logging
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from pydantic import BaseModel, ValidationError
@@ -21,9 +22,13 @@ from backend.services.auth_service import AuthResult
 from backend.services.tenant_admin_service import (
     IMAGE_CONTENT_TYPES,
     TenantConflictError,
+    TenantNotFoundError,
     TenantValidationError,
     create_tenant,
+    get_default_style_params,
+    get_tenant_detail,
     list_tenants,
+    update_tenant,
 )
 
 logger = logging.getLogger(__name__)
@@ -57,12 +62,42 @@ class TenantCreateResponse(BaseModel):
     subdomain_url: str
 
 
+class TenantDetailResponse(BaseModel):
+    tenant: Dict[str, Any]
+    theme_id: str
+    style_params: Dict[str, Any]
+    assets: List[str]
+    preview_url: str
+
+
+class TenantTemplateResponse(BaseModel):
+    style_params: Dict[str, Any]
+
+
+class TenantUpdateResponse(BaseModel):
+    tenant: TenantPublicConfig
+
+
 def _clean(value: Optional[str]) -> Optional[str]:
     """Normalize empty/whitespace form values to None."""
     if value is None:
         return None
     value = value.strip()
     return value or None
+
+
+def _preview_url(tenant_id: str) -> str:
+    return f"{APP_ORIGIN}/en/app?preview_tenant={tenant_id}"
+
+
+def _parse_json_field(raw: Optional[str], label: str) -> Optional[Any]:
+    """Parse an optional JSON string form field, mapping errors to 400."""
+    if raw is None or not raw.strip():
+        return None
+    try:
+        return json.loads(raw)
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(status_code=400, detail=f"{label}: invalid JSON ({exc}).")
 
 
 def _parse_domains(raw: Optional[str]) -> List[str]:
@@ -93,10 +128,105 @@ async def _read_image(upload: Optional[UploadFile], label: str) -> Optional[Tupl
     return data, ext
 
 
+# Assets replaceable in the manage flow: images plus fonts.
+ASSET_EXTENSIONS = set(IMAGE_CONTENT_TYPES) | {"ttf", "otf", "woff", "woff2"}
+
+
+async def _read_asset(upload: Optional[UploadFile], label: str) -> Optional[Tuple[bytes, str]]:
+    """Read+validate an uploaded theme asset (image or font)."""
+    if upload is None or not upload.filename:
+        return None
+    ext = upload.filename.rsplit(".", 1)[-1].lower() if "." in upload.filename else ""
+    if ext not in ASSET_EXTENSIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{label}: unsupported asset type '.{ext}'. Use an image or font file.",
+        )
+    data = await upload.read()
+    if not data:
+        return None
+    if len(data) > MAX_IMAGE_BYTES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{label}: file is too large ({len(data) // (1024 * 1024)}MB). Max 15MB.",
+        )
+    return data, ext
+
+
 @router.get("", response_model=TenantListResponse)
 async def admin_list_tenants(auth_data: AuthResult = Depends(require_admin)):
     """List all white-label tenants."""
     return TenantListResponse(tenants=[TenantSummary(**t) for t in list_tenants()])
+
+
+@router.get("/_template", response_model=TenantTemplateResponse)
+async def admin_tenant_theme_template(auth_data: AuthResult = Depends(require_admin)):
+    """Return the default Nomad theme's full style_params as an editing starting point."""
+    try:
+        return TenantTemplateResponse(style_params=get_default_style_params())
+    except ValueError as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/{tenant_id}", response_model=TenantDetailResponse)
+async def admin_get_tenant(tenant_id: str, auth_data: AuthResult = Depends(require_admin)):
+    """Return a tenant's full config, theme style_params, and asset list for editing."""
+    try:
+        detail = get_tenant_detail(tenant_id)
+    except TenantNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    return TenantDetailResponse(preview_url=_preview_url(tenant_id), **detail)
+
+
+@router.put("/{tenant_id}", response_model=TenantUpdateResponse)
+async def admin_update_tenant(
+    tenant_id: str,
+    auth_data: AuthResult = Depends(require_admin),
+    config: Optional[str] = Form(None),
+    style_params: Optional[str] = Form(None),
+    logo: Optional[UploadFile] = File(None),
+    assets: Optional[List[UploadFile]] = File(None),
+):
+    """
+    Update a tenant: merge config fields (JSON), replace the full theme
+    style_params (JSON), and/or add/replace theme assets (uploaded files keyed
+    by their filename). Re-render jobs to apply an updated theme.
+    """
+    config_updates = _parse_json_field(config, "config")
+    if config_updates is not None and not isinstance(config_updates, dict):
+        raise HTTPException(status_code=400, detail="config must be a JSON object.")
+    style = _parse_json_field(style_params, "style_params")
+
+    asset_map: Dict[str, Tuple[bytes, str]] = {}
+    for upload in assets or []:
+        asset = await _read_asset(upload, f"asset '{upload.filename}'")
+        if asset and upload.filename:
+            asset_map[upload.filename] = asset
+    logo_image = await _read_image(logo, "logo")
+
+    try:
+        updated = update_tenant(
+            tenant_id,
+            config_updates=config_updates,
+            style_params=style,
+            assets=asset_map or None,
+            logo=logo_image,
+        )
+    except TenantNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except TenantValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid config: {exc}")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("Failed to update tenant")
+        raise HTTPException(status_code=500, detail=f"Failed to update tenant: {exc}")
+
+    admin_id = auth_data.user_email or "admin:unknown"
+    logger.info(f"Admin {admin_id} updated tenant '{tenant_id}'")
+    return TenantUpdateResponse(tenant=TenantPublicConfig.from_config(updated))
 
 
 @router.post("", response_model=TenantCreateResponse, status_code=201)
@@ -114,6 +244,7 @@ async def admin_create_tenant(
     distribution_mode: str = Form("download_only"),
     dropbox_path: Optional[str] = Form(None),
     brand_prefix: Optional[str] = Form(None),
+    style_params: Optional[str] = Form(None),
     karaoke_background: Optional[UploadFile] = File(None),
     intro_background: Optional[UploadFile] = File(None),
     end_background: Optional[UploadFile] = File(None),
@@ -146,6 +277,10 @@ async def admin_create_tenant(
     if distribution_mode not in ("all", "download_only", "cloud_only"):
         raise HTTPException(status_code=400, detail="Invalid distribution_mode.")
 
+    style_override = _parse_json_field(style_params, "style_params")
+    if style_override is not None and not isinstance(style_override, dict):
+        raise HTTPException(status_code=400, detail="style_params must be a JSON object.")
+
     try:
         config = create_tenant(
             name=name,
@@ -153,6 +288,7 @@ async def admin_create_tenant(
             subdomain=_clean(subdomain),
             allowed_email_domains=_parse_domains(allowed_email_domains),
             colors=colors,
+            style_params_override=style_override,
             tagline=_clean(tagline),
             distribution_mode=distribution_mode,
             dropbox_path=_clean(dropbox_path),
@@ -175,6 +311,6 @@ async def admin_create_tenant(
 
     return TenantCreateResponse(
         tenant=TenantPublicConfig.from_config(config),
-        preview_url=f"{APP_ORIGIN}/en/app?preview_tenant={config.id}",
+        preview_url=_preview_url(config.id),
         subdomain_url=config.get_frontend_url(),
     )

--- a/backend/api/routes/tenant_admin.py
+++ b/backend/api/routes/tenant_admin.py
@@ -1,0 +1,180 @@
+"""
+Admin API routes for provisioning white-label tenants.
+
+These endpoints let an admin mint a tenant (branded portal + locked theme) from
+the UI, replacing the hand-run ``scripts/setup-*-tenant.py`` recipe. Once created,
+the tenant can be driven immediately via the admin preview path
+``?preview_tenant=<id>`` — including the tenant bulk-upload flow (folder of tracks,
+auto-paired mixed/instrumental, resumable uploads, locked theme on every job).
+"""
+
+import logging
+from typing import List, Optional, Tuple
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from pydantic import BaseModel, ValidationError
+
+from backend.api.dependencies import require_admin
+from backend.models.tenant import TenantPublicConfig
+from backend.models.theme import ColorOverrides
+from backend.services.auth_service import AuthResult
+from backend.services.tenant_admin_service import (
+    IMAGE_CONTENT_TYPES,
+    TenantConflictError,
+    TenantValidationError,
+    create_tenant,
+    list_tenants,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/admin/tenants", tags=["admin", "tenant"])
+
+# Public app origin used to build the admin-preview link.
+APP_ORIGIN = "https://gen.nomadkaraoke.com"
+
+# Reject oversized image uploads (backgrounds/logo).
+MAX_IMAGE_BYTES = 15 * 1024 * 1024
+
+
+class TenantSummary(BaseModel):
+    id: Optional[str] = None
+    name: Optional[str] = None
+    subdomain: Optional[str] = None
+    is_active: bool = True
+    locked_theme: Optional[str] = None
+    dropbox_path: Optional[str] = None
+    created_at: Optional[str] = None
+
+
+class TenantListResponse(BaseModel):
+    tenants: List[TenantSummary]
+
+
+class TenantCreateResponse(BaseModel):
+    tenant: TenantPublicConfig
+    preview_url: str
+    subdomain_url: str
+
+
+def _clean(value: Optional[str]) -> Optional[str]:
+    """Normalize empty/whitespace form values to None."""
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _parse_domains(raw: Optional[str]) -> List[str]:
+    if not raw:
+        return []
+    parts = raw.replace("\n", ",").replace(" ", ",").split(",")
+    return [p.strip().lower() for p in parts if p.strip()]
+
+
+async def _read_image(upload: Optional[UploadFile], label: str) -> Optional[Tuple[bytes, str]]:
+    """Read+validate an uploaded image, returning (bytes, ext) or None."""
+    if upload is None or not upload.filename:
+        return None
+    ext = upload.filename.rsplit(".", 1)[-1].lower() if "." in upload.filename else ""
+    if ext not in IMAGE_CONTENT_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{label}: unsupported image type '.{ext}'. Use PNG, JPG, GIF, or WEBP.",
+        )
+    data = await upload.read()
+    if not data:
+        return None
+    if len(data) > MAX_IMAGE_BYTES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{label}: image is too large ({len(data) // (1024 * 1024)}MB). Max 15MB.",
+        )
+    return data, ext
+
+
+@router.get("", response_model=TenantListResponse)
+async def admin_list_tenants(auth_data: AuthResult = Depends(require_admin)):
+    """List all white-label tenants."""
+    return TenantListResponse(tenants=[TenantSummary(**t) for t in list_tenants()])
+
+
+@router.post("", response_model=TenantCreateResponse, status_code=201)
+async def admin_create_tenant(
+    auth_data: AuthResult = Depends(require_admin),
+    name: str = Form(...),
+    tenant_id: Optional[str] = Form(None),
+    subdomain: Optional[str] = Form(None),
+    allowed_email_domains: Optional[str] = Form(None),
+    artist_color: Optional[str] = Form(None),
+    title_color: Optional[str] = Form(None),
+    sung_lyrics_color: Optional[str] = Form(None),
+    unsung_lyrics_color: Optional[str] = Form(None),
+    tagline: Optional[str] = Form(None),
+    distribution_mode: str = Form("download_only"),
+    dropbox_path: Optional[str] = Form(None),
+    brand_prefix: Optional[str] = Form(None),
+    karaoke_background: Optional[UploadFile] = File(None),
+    intro_background: Optional[UploadFile] = File(None),
+    end_background: Optional[UploadFile] = File(None),
+    logo: Optional[UploadFile] = File(None),
+):
+    """Provision a new white-label tenant (theme + config) from admin form input."""
+    try:
+        colors = ColorOverrides(
+            artist_color=_clean(artist_color),
+            title_color=_clean(title_color),
+            sung_lyrics_color=_clean(sung_lyrics_color),
+            unsung_lyrics_color=_clean(unsung_lyrics_color),
+        )
+    except ValidationError:
+        raise HTTPException(
+            status_code=400, detail="Colors must be hex values like #ff5bb8."
+        )
+
+    backgrounds = {}
+    for field, upload in (
+        ("karaoke_background", karaoke_background),
+        ("intro_background", intro_background),
+        ("end_background", end_background),
+    ):
+        image = await _read_image(upload, field)
+        if image:
+            backgrounds[field] = image
+    logo_image = await _read_image(logo, "logo")
+
+    if distribution_mode not in ("all", "download_only", "cloud_only"):
+        raise HTTPException(status_code=400, detail="Invalid distribution_mode.")
+
+    try:
+        config = create_tenant(
+            name=name,
+            tenant_id=_clean(tenant_id),
+            subdomain=_clean(subdomain),
+            allowed_email_domains=_parse_domains(allowed_email_domains),
+            colors=colors,
+            tagline=_clean(tagline),
+            distribution_mode=distribution_mode,
+            dropbox_path=_clean(dropbox_path),
+            brand_prefix=_clean(brand_prefix),
+            backgrounds=backgrounds,
+            logo=logo_image,
+        )
+    except TenantConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    except TenantValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("Failed to create tenant")
+        raise HTTPException(status_code=500, detail=f"Failed to create tenant: {exc}")
+
+    admin_id = auth_data.user_email or "admin:unknown"
+    logger.info(f"Admin {admin_id} created tenant '{config.id}'")
+
+    return TenantCreateResponse(
+        tenant=TenantPublicConfig.from_config(config),
+        preview_url=f"{APP_ORIGIN}/en/app?preview_tenant={config.id}",
+        subdomain_url=config.get_frontend_url(),
+    )

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from backend.config import settings, validate_production_config
-from backend.api.routes import health, jobs, internal, file_upload, review, auth, audio_search, themes, users, admin, tenant, tenant_bulk, rate_limits, push, catalog, encoding_worker, client_errors, bulk, parse_titles
+from backend.api.routes import health, jobs, internal, file_upload, review, auth, audio_search, themes, users, admin, tenant, tenant_admin, tenant_bulk, rate_limits, push, catalog, encoding_worker, client_errors, bulk, parse_titles
 from backend.services.tracing import setup_tracing, instrument_app, get_current_trace_id
 from backend.services.structured_logging import setup_structured_logging
 from backend.services.spacy_preloader import preload_spacy_model
@@ -203,6 +203,7 @@ app.include_router(parse_titles.router, prefix="/api")  # kjbox karaoke-filename
 app.include_router(bulk.router, prefix="/api")  # Bulk Mode: multi-job submission
 app.include_router(client_errors.router, prefix="/api")  # Frontend crash reports
 app.include_router(tenant.router)  # Tenant/white-label configuration (no /api prefix, router has it)
+app.include_router(tenant_admin.router)  # Admin tenant provisioning (router has /api prefix)
 app.include_router(tenant_bulk.router)  # Tenant bulk-upload filename analysis (router has /api prefix)
 
 

--- a/backend/services/tenant_admin_service.py
+++ b/backend/services/tenant_admin_service.py
@@ -1,0 +1,328 @@
+"""
+Admin-side tenant provisioning.
+
+Turns the hand-run ``scripts/setup-vocalstar-tenant.py`` recipe into a reusable
+function the admin panel can call. Creating a tenant:
+
+1. Derives a self-contained theme from the default Nomad theme:
+   - copies the default theme's assets (fonts, CDG/backgrounds) into the new
+     theme folder so every ``background_image`` basename resolves against the
+     tenant theme's OWN ``assets/`` (this is the fix for the tenant-E2E
+     "background image not found" class of bug),
+   - applies the admin's colour overrides,
+   - overlays any admin-provided background images.
+2. Registers the theme in ``themes/_metadata.json``.
+3. Writes ``tenants/{id}/config.json`` with sensible B2B defaults (create-only,
+   so a concurrent/duplicate create can't clobber an existing tenant).
+
+The tenant can then be driven immediately (no DNS) via the admin preview path
+``?preview_tenant=<id>`` on the main domain; a real subdomain is an optional
+later step (Cloudflare Pages custom domain).
+"""
+
+import copy
+import io
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Tuple
+
+from google.api_core.exceptions import PreconditionFailed
+
+from backend.config import settings
+from backend.middleware.tenant import NON_TENANT_SUBDOMAINS
+from backend.models.tenant import (
+    TenantAuth,
+    TenantBranding,
+    TenantConfig,
+    TenantDefaults,
+    TenantFeatures,
+)
+from backend.models.theme import ColorOverrides
+from backend.services.storage_service import StorageService
+from backend.services.theme_service import METADATA_FILE, THEMES_PREFIX, get_theme_service
+from backend.services.tenant_service import (
+    DEFAULT_SENDER_EMAIL,
+    TENANTS_PREFIX,
+    get_tenant_service,
+)
+
+logger = logging.getLogger(__name__)
+
+BASE_DOMAIN = "nomadkaraoke.com"
+
+# Reserved IDs that must never become tenants (they are real subdomains / paths).
+# Kept in sync with middleware.tenant.NON_TENANT_SUBDOMAINS.
+RESERVED_TENANT_IDS = set(NON_TENANT_SUBDOMAINS)
+
+# form field -> style_params section whose background_image it overrides
+BACKGROUND_SECTIONS = {
+    "karaoke_background": "karaoke",
+    "intro_background": "intro",
+    "end_background": "end",
+}
+
+# allowed image extension -> content type
+IMAGE_CONTENT_TYPES = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif",
+    "webp": "image/webp",
+}
+
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,38}[a-z0-9]$")
+
+
+class TenantValidationError(ValueError):
+    """Raised when tenant inputs are invalid (bad slug, reserved id, etc.)."""
+
+
+class TenantConflictError(ValueError):
+    """Raised when a tenant with the same id already exists."""
+
+
+def slugify_tenant_id(name: str) -> str:
+    """Derive a tenant id slug from a display name."""
+    slug = re.sub(r"[^a-z0-9]+", "-", (name or "").strip().lower()).strip("-")
+    return slug
+
+
+def _validate_tenant_id(tenant_id: str) -> None:
+    if not _SLUG_RE.match(tenant_id):
+        raise TenantValidationError(
+            "Tenant id must be 3-40 chars, lowercase letters/numbers/hyphens, "
+            "and start/end with a letter or number."
+        )
+    if tenant_id in RESERVED_TENANT_IDS:
+        raise TenantValidationError(f"'{tenant_id}' is a reserved subdomain and cannot be used.")
+
+
+def _content_type_for(ext: str) -> str:
+    return IMAGE_CONTENT_TYPES.get(ext.lower(), "application/octet-stream")
+
+
+def _copy_default_theme_assets(storage: StorageService, base_theme_id: str, theme_id: str) -> None:
+    """Copy the default theme's assets into the new theme so it is self-contained."""
+    src_prefix = f"{THEMES_PREFIX}/{base_theme_id}/assets/"
+    dst_prefix = f"{THEMES_PREFIX}/{theme_id}/assets/"
+    for path in storage.list_files(src_prefix):
+        basename = path.rsplit("/", 1)[-1]
+        if not basename:  # skip the folder placeholder
+            continue
+        storage.copy_blob(path, f"{dst_prefix}{basename}")
+
+
+def _register_theme_metadata(storage: StorageService, theme_id: str, name: str) -> None:
+    """Add the new theme to themes/_metadata.json (read-modify-write, idempotent)."""
+    try:
+        registry = storage.download_json(METADATA_FILE)
+    except Exception:
+        registry = {"version": 1, "themes": []}
+
+    themes = registry.setdefault("themes", [])
+    if any(t.get("id") == theme_id for t in themes):
+        return
+    themes.append(
+        {
+            "id": theme_id,
+            "name": name,
+            "description": f"{name} tenant theme",
+            "is_default": False,
+        }
+    )
+    storage.upload_json(METADATA_FILE, registry)
+
+
+def create_tenant(
+    *,
+    name: str,
+    tenant_id: Optional[str] = None,
+    subdomain: Optional[str] = None,
+    allowed_email_domains: Optional[List[str]] = None,
+    colors: Optional[ColorOverrides] = None,
+    tagline: Optional[str] = None,
+    distribution_mode: str = "download_only",
+    dropbox_path: Optional[str] = None,
+    brand_prefix: Optional[str] = None,
+    backgrounds: Optional[Dict[str, Tuple[bytes, str]]] = None,
+    logo: Optional[Tuple[bytes, str]] = None,
+    storage: Optional[StorageService] = None,
+) -> TenantConfig:
+    """
+    Provision a new white-label tenant (theme + config) in GCS.
+
+    Args:
+        name: Display name (e.g. "Randy Vild").
+        tenant_id: Slug id; derived from name if omitted.
+        subdomain: Full subdomain; defaults to ``{id}.nomadkaraoke.com``.
+        allowed_email_domains: Domains permitted to log in (empty = no restriction;
+            admins can always sign in).
+        colors: Lyric/title/artist colour overrides applied to the theme.
+        tagline: Optional portal tagline.
+        distribution_mode: "download_only" (default), "all", or "cloud_only".
+        dropbox_path: If set, outputs are delivered to this Dropbox folder.
+        brand_prefix: Output filename prefix (e.g. "RVILD").
+        backgrounds: {field -> (bytes, ext)} for karaoke/intro/end backgrounds.
+        logo: (bytes, ext) for the portal logo.
+        storage: Injected StorageService (for tests).
+
+    Returns:
+        The persisted TenantConfig.
+
+    Raises:
+        TenantValidationError, TenantConflictError, ValueError.
+    """
+    name = (name or "").strip()
+    if not name:
+        raise TenantValidationError("Tenant name is required.")
+
+    tenant_id = (tenant_id or slugify_tenant_id(name)).strip().lower()
+    _validate_tenant_id(tenant_id)
+
+    subdomain = (subdomain or f"{tenant_id}.{BASE_DOMAIN}").strip().lower()
+
+    storage = storage or StorageService()
+    tenant_service = get_tenant_service()
+    theme_service = get_theme_service()
+
+    if tenant_service.tenant_exists(tenant_id):
+        raise TenantConflictError(f"Tenant '{tenant_id}' already exists.")
+
+    # --- Derive theme from the default Nomad theme ---------------------------
+    base_theme_id = theme_service.get_default_theme_id()
+    if not base_theme_id:
+        raise ValueError("No default theme is configured; cannot derive a tenant theme.")
+    base_style = theme_service.get_theme_style_params(base_theme_id)
+    if base_style is None:
+        raise ValueError(f"Default theme '{base_theme_id}' style params could not be loaded.")
+
+    theme_id = tenant_id  # 1:1 theme per tenant, mirrors the setup scripts
+
+    _copy_default_theme_assets(storage, base_theme_id, theme_id)
+
+    style_params = copy.deepcopy(base_style)
+    if colors and colors.has_overrides():
+        style_params = theme_service.apply_color_overrides(style_params, colors)
+
+    for field, (data, ext) in (backgrounds or {}).items():
+        section = BACKGROUND_SECTIONS.get(field)
+        if not section:
+            continue
+        ext = ext.lower().lstrip(".")
+        filename = f"{field}.{ext}"
+        storage.upload_fileobj(
+            io.BytesIO(data),
+            f"{THEMES_PREFIX}/{theme_id}/assets/{filename}",
+            content_type=_content_type_for(ext),
+        )
+        style_params.setdefault(section, {})["background_image"] = filename
+
+    storage.upload_json(f"{THEMES_PREFIX}/{theme_id}/style_params.json", style_params)
+    _register_theme_metadata(storage, theme_id, name)
+
+    # --- Logo ----------------------------------------------------------------
+    logo_url: Optional[str] = None
+    if logo:
+        logo_data, logo_ext = logo
+        logo_ext = logo_ext.lower().lstrip(".")
+        logo_path = f"{TENANTS_PREFIX}/{tenant_id}/logo.{logo_ext}"
+        storage.upload_fileobj(
+            io.BytesIO(logo_data), logo_path, content_type=_content_type_for(logo_ext)
+        )
+        logo_url = f"gs://{settings.gcs_bucket_name}/{logo_path}"
+
+    # --- Tenant config -------------------------------------------------------
+    domains = sorted({d.strip().lower() for d in (allowed_email_domains or []) if d.strip()})
+    now = datetime.now(timezone.utc)
+
+    branding = TenantBranding(
+        logo_url=logo_url,
+        site_title=f"{name} Karaoke Generator",
+        tagline=tagline or None,
+    )
+    if colors:
+        if colors.title_color:
+            branding.primary_color = colors.title_color
+        if colors.sung_lyrics_color:
+            branding.secondary_color = colors.sung_lyrics_color
+        if colors.artist_color:
+            branding.accent_color = colors.artist_color
+
+    config = TenantConfig(
+        id=tenant_id,
+        name=name,
+        subdomain=subdomain,
+        is_active=True,
+        branding=branding,
+        features=TenantFeatures(
+            audio_search=False,  # tenant provides their own audio
+            file_upload=True,
+            bulk_upload=True,
+            youtube_url=False,
+            youtube_upload=False,  # B2B: never publish to YouTube
+            dropbox_upload=bool(dropbox_path),
+            gdrive_upload=False,
+            theme_selection=False,  # always use the tenant theme
+            color_overrides=False,
+            enable_cdg=True,
+            enable_4k=True,
+            admin_access=False,
+        ),
+        defaults=TenantDefaults(
+            theme_id=theme_id,
+            locked_theme=theme_id,
+            distribution_mode=distribution_mode,
+            brand_prefix=(brand_prefix or None),
+            dropbox_path=(dropbox_path or None),
+            gdrive_folder_id=None,
+        ),
+        auth=TenantAuth(
+            allowed_email_domains=domains,
+            require_email_domain=bool(domains),
+            fixed_token_ids=[],
+            sender_email=DEFAULT_SENDER_EMAIL,
+        ),
+        created_at=now,
+        updated_at=now,
+    )
+
+    config_path = f"{TENANTS_PREFIX}/{tenant_id}/config.json"
+    try:
+        storage.upload_json(config_path, config.model_dump(mode="json"), if_generation_match=0)
+    except PreconditionFailed as exc:
+        raise TenantConflictError(f"Tenant '{tenant_id}' already exists.") from exc
+
+    tenant_service.invalidate_cache(tenant_id)
+    theme_service.invalidate_cache()
+
+    logger.info(f"Created tenant '{tenant_id}' (theme '{theme_id}', subdomain '{subdomain}')")
+    return config
+
+
+def list_tenants(storage: Optional[StorageService] = None) -> List[Dict[str, object]]:
+    """Return a summary list of all tenants for the admin UI."""
+    storage = storage or StorageService()
+    summaries: List[Dict[str, object]] = []
+    for path in storage.list_files(f"{TENANTS_PREFIX}/"):
+        if not path.endswith("/config.json"):
+            continue
+        try:
+            data = storage.download_json(path)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(f"Skipping unreadable tenant config {path}: {exc}")
+            continue
+        defaults = data.get("defaults") or {}
+        summaries.append(
+            {
+                "id": data.get("id"),
+                "name": data.get("name"),
+                "subdomain": data.get("subdomain"),
+                "is_active": data.get("is_active", True),
+                "locked_theme": defaults.get("locked_theme"),
+                "dropbox_path": defaults.get("dropbox_path"),
+                "created_at": data.get("created_at"),
+            }
+        )
+    summaries.sort(key=lambda t: str(t.get("name") or t.get("id") or "").lower())
+    return summaries

--- a/backend/services/tenant_admin_service.py
+++ b/backend/services/tenant_admin_service.py
@@ -233,50 +233,12 @@ def create_tenant(
 
     theme_id = tenant_id  # 1:1 theme per tenant, mirrors the setup scripts
 
-    _copy_default_theme_assets(storage, base_theme_id, theme_id)
-
-    if style_params_override is not None:
-        # Admin supplied a full theme document — it is authoritative. Default
-        # assets are still copied above so any inherited basenames resolve.
-        style_params = copy.deepcopy(_validate_style_params(style_params_override))
-    else:
-        style_params = copy.deepcopy(base_style)
-        if colors and colors.has_overrides():
-            style_params = theme_service.apply_color_overrides(style_params, colors)
-
-    for field, (data, ext) in (backgrounds or {}).items():
-        section = BACKGROUND_SECTIONS.get(field)
-        if not section:
-            continue
-        ext = ext.lower().lstrip(".")
-        filename = f"{field}.{ext}"
-        storage.upload_fileobj(
-            io.BytesIO(data),
-            f"{THEMES_PREFIX}/{theme_id}/assets/{filename}",
-            content_type=_content_type_for(ext),
-        )
-        style_params.setdefault(section, {})["background_image"] = filename
-
-    storage.upload_json(f"{THEMES_PREFIX}/{theme_id}/style_params.json", style_params)
-    _register_theme_metadata(storage, theme_id, name)
-
-    # --- Logo ----------------------------------------------------------------
-    logo_url: Optional[str] = None
-    if logo:
-        logo_data, logo_ext = logo
-        logo_ext = logo_ext.lower().lstrip(".")
-        logo_path = f"{TENANTS_PREFIX}/{tenant_id}/logo.{logo_ext}"
-        storage.upload_fileobj(
-            io.BytesIO(logo_data), logo_path, content_type=_content_type_for(logo_ext)
-        )
-        logo_url = f"gs://{settings.gcs_bucket_name}/{logo_path}"
-
-    # --- Tenant config -------------------------------------------------------
+    # --- Build the tenant config (logo_url filled in after reservation) -------
     domains = sorted({d.strip().lower() for d in (allowed_email_domains or []) if d.strip()})
     now = datetime.now(timezone.utc)
 
     branding = TenantBranding(
-        logo_url=logo_url,
+        logo_url=None,
         site_title=f"{name} Karaoke Generator",
         tagline=tagline or None,
     )
@@ -326,11 +288,63 @@ def create_tenant(
         updated_at=now,
     )
 
+    # --- Reserve the tenant id FIRST (atomic create-only write) --------------
+    # This must happen before any theme/asset/logo write, so a concurrent or
+    # retried create for an existing id fails immediately without clobbering
+    # the live tenant's theme.
     config_path = f"{TENANTS_PREFIX}/{tenant_id}/config.json"
     try:
         storage.upload_json(config_path, config.model_dump(mode="json"), if_generation_match=0)
     except PreconditionFailed as exc:
         raise TenantConflictError(f"Tenant '{tenant_id}' already exists.") from exc
+
+    # --- Build the theme (rollback the reservation if anything fails) --------
+    try:
+        _copy_default_theme_assets(storage, base_theme_id, theme_id)
+
+        if style_params_override is not None:
+            # Admin supplied a full theme document — authoritative. Default
+            # assets are still copied above so any inherited basenames resolve.
+            style_params = copy.deepcopy(_validate_style_params(style_params_override))
+        else:
+            style_params = copy.deepcopy(base_style)
+            if colors and colors.has_overrides():
+                style_params = theme_service.apply_color_overrides(style_params, colors)
+
+        for field, (data, ext) in (backgrounds or {}).items():
+            section = BACKGROUND_SECTIONS.get(field)
+            if not section:
+                continue
+            ext = ext.lower().lstrip(".")
+            filename = f"{field}.{ext}"
+            storage.upload_fileobj(
+                io.BytesIO(data),
+                f"{THEMES_PREFIX}/{theme_id}/assets/{filename}",
+                content_type=_content_type_for(ext),
+            )
+            style_params.setdefault(section, {})["background_image"] = filename
+
+        storage.upload_json(f"{THEMES_PREFIX}/{theme_id}/style_params.json", style_params)
+        _register_theme_metadata(storage, theme_id, name)
+
+        if logo:
+            logo_data, logo_ext = logo
+            logo_ext = logo_ext.lower().lstrip(".")
+            logo_path = f"{TENANTS_PREFIX}/{tenant_id}/logo.{logo_ext}"
+            storage.upload_fileobj(
+                io.BytesIO(logo_data), logo_path, content_type=_content_type_for(logo_ext)
+            )
+            config.branding.logo_url = f"gs://{settings.gcs_bucket_name}/{logo_path}"
+            config.updated_at = datetime.now(timezone.utc)
+            storage.upload_json(config_path, config.model_dump(mode="json"))
+    except Exception:
+        # Roll back the reservation so a failed create doesn't leave a
+        # half-provisioned tenant behind.
+        try:
+            storage.delete_file(config_path, ignore_missing=True)
+        except Exception:  # pragma: no cover - best effort
+            logger.warning(f"Failed to roll back tenant reservation for '{tenant_id}'")
+        raise
 
     tenant_service.invalidate_cache(tenant_id)
     theme_service.invalidate_cache()
@@ -484,6 +498,11 @@ def list_tenants(storage: Optional[StorageService] = None) -> List[Dict[str, obj
             data = storage.download_json(path)
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning(f"Skipping unreadable tenant config {path}: {exc}")
+            continue
+        if not data.get("id"):
+            # A config without an id can't be addressed by the UI (would produce
+            # a null React key and a request to /api/admin/tenants/null) — skip.
+            logger.warning(f"Skipping tenant config without an id: {path}")
             continue
         defaults = data.get("defaults") or {}
         summaries.append(

--- a/backend/services/tenant_admin_service.py
+++ b/backend/services/tenant_admin_service.py
@@ -223,6 +223,17 @@ def create_tenant(
     if tenant_service.tenant_exists(tenant_id):
         raise TenantConflictError(f"Tenant '{tenant_id}' already exists.")
 
+    theme_id = tenant_id  # 1:1 theme per tenant, mirrors the setup scripts
+
+    # The tenant id doubles as the theme id, and theme writes are not create-only.
+    # Guard against an id that collides with an existing theme (e.g. the default
+    # 'nomad' theme) — otherwise provisioning would overwrite that theme's
+    # style_params and break every job/tenant using it.
+    if storage.file_exists(f"{THEMES_PREFIX}/{theme_id}/style_params.json"):
+        raise TenantConflictError(
+            f"A theme named '{theme_id}' already exists; choose a different tenant id."
+        )
+
     # --- Derive theme from the default Nomad theme ---------------------------
     base_theme_id = theme_service.get_default_theme_id()
     if not base_theme_id:
@@ -230,8 +241,6 @@ def create_tenant(
     base_style = theme_service.get_theme_style_params(base_theme_id)
     if base_style is None:
         raise ValueError(f"Default theme '{base_theme_id}' style params could not be loaded.")
-
-    theme_id = tenant_id  # 1:1 theme per tenant, mirrors the setup scripts
 
     # --- Build the tenant config (logo_url filled in after reservation) -------
     domains = sorted({d.strip().lower() for d in (allowed_email_domains or []) if d.strip()})

--- a/backend/services/tenant_admin_service.py
+++ b/backend/services/tenant_admin_service.py
@@ -82,6 +82,14 @@ class TenantConflictError(ValueError):
     """Raised when a tenant with the same id already exists."""
 
 
+class TenantNotFoundError(ValueError):
+    """Raised when the requested tenant does not exist."""
+
+
+# Top-level sections a valid theme style_params document may contain.
+STYLE_PARAM_SECTIONS = {"intro", "karaoke", "end", "cdg"}
+
+
 def slugify_tenant_id(name: str) -> str:
     """Derive a tenant id slug from a display name."""
     slug = re.sub(r"[^a-z0-9]+", "-", (name or "").strip().lower()).strip("-")
@@ -100,6 +108,31 @@ def _validate_tenant_id(tenant_id: str) -> None:
 
 def _content_type_for(ext: str) -> str:
     return IMAGE_CONTENT_TYPES.get(ext.lower(), "application/octet-stream")
+
+
+def _safe_asset_name(name: str) -> str:
+    """Reduce an uploaded filename to a safe bare basename (no path traversal)."""
+    base = name.replace("\\", "/").rsplit("/", 1)[-1].strip()
+    base = re.sub(r"[^A-Za-z0-9._-]", "_", base)
+    return base.lstrip(".") or "asset"
+
+
+def _validate_style_params(style_params: object) -> Dict:
+    """Validate a full theme style_params document supplied by an admin."""
+    if not isinstance(style_params, dict):
+        raise TenantValidationError("Theme style_params must be a JSON object.")
+    if not style_params:
+        raise TenantValidationError("Theme style_params cannot be empty.")
+    unknown = set(style_params) - STYLE_PARAM_SECTIONS
+    if unknown:
+        raise TenantValidationError(
+            f"Unknown theme section(s): {', '.join(sorted(unknown))}. "
+            f"Allowed: {', '.join(sorted(STYLE_PARAM_SECTIONS))}."
+        )
+    for section, value in style_params.items():
+        if not isinstance(value, dict):
+            raise TenantValidationError(f"Theme section '{section}' must be a JSON object.")
+    return style_params
 
 
 def _copy_default_theme_assets(storage: StorageService, base_theme_id: str, theme_id: str) -> None:
@@ -141,6 +174,7 @@ def create_tenant(
     subdomain: Optional[str] = None,
     allowed_email_domains: Optional[List[str]] = None,
     colors: Optional[ColorOverrides] = None,
+    style_params_override: Optional[Dict] = None,
     tagline: Optional[str] = None,
     distribution_mode: str = "download_only",
     dropbox_path: Optional[str] = None,
@@ -201,9 +235,14 @@ def create_tenant(
 
     _copy_default_theme_assets(storage, base_theme_id, theme_id)
 
-    style_params = copy.deepcopy(base_style)
-    if colors and colors.has_overrides():
-        style_params = theme_service.apply_color_overrides(style_params, colors)
+    if style_params_override is not None:
+        # Admin supplied a full theme document — it is authoritative. Default
+        # assets are still copied above so any inherited basenames resolve.
+        style_params = copy.deepcopy(_validate_style_params(style_params_override))
+    else:
+        style_params = copy.deepcopy(base_style)
+        if colors and colors.has_overrides():
+            style_params = theme_service.apply_color_overrides(style_params, colors)
 
     for field, (data, ext) in (backgrounds or {}).items():
         section = BACKGROUND_SECTIONS.get(field)
@@ -297,6 +336,140 @@ def create_tenant(
     theme_service.invalidate_cache()
 
     logger.info(f"Created tenant '{tenant_id}' (theme '{theme_id}', subdomain '{subdomain}')")
+    return config
+
+
+def _theme_id_for(config: TenantConfig) -> str:
+    """The theme id backing a tenant (locked theme, else default theme, else id)."""
+    return config.defaults.locked_theme or config.defaults.theme_id or config.id
+
+
+def get_default_style_params(storage: Optional[StorageService] = None) -> Dict:
+    """Return the default Nomad theme's full style_params (a starting template)."""
+    theme_service = get_theme_service()
+    base_theme_id = theme_service.get_default_theme_id()
+    if not base_theme_id:
+        raise ValueError("No default theme is configured.")
+    style = theme_service.get_theme_style_params(base_theme_id)
+    if style is None:
+        raise ValueError(f"Default theme '{base_theme_id}' style params could not be loaded.")
+    return style
+
+
+def get_tenant_detail(tenant_id: str, storage: Optional[StorageService] = None) -> Dict[str, object]:
+    """Return a tenant's full config, its theme style_params, and its asset list."""
+    storage = storage or StorageService()
+    tenant_service = get_tenant_service()
+    config = tenant_service.get_tenant_config(tenant_id, force_refresh=True)
+    if not config:
+        raise TenantNotFoundError(f"Tenant '{tenant_id}' not found.")
+
+    theme_id = _theme_id_for(config)
+    try:
+        style_params = storage.download_json(f"{THEMES_PREFIX}/{theme_id}/style_params.json")
+    except Exception:
+        style_params = {}
+    assets = sorted(
+        p.rsplit("/", 1)[-1]
+        for p in storage.list_files(f"{THEMES_PREFIX}/{theme_id}/assets/")
+        if p.rsplit("/", 1)[-1]
+    )
+    return {
+        "tenant": config.model_dump(mode="json"),
+        "theme_id": theme_id,
+        "style_params": style_params,
+        "assets": assets,
+    }
+
+
+def _merge_config(config: TenantConfig, updates: Dict) -> TenantConfig:
+    """Merge a partial update dict over an existing TenantConfig (id is immutable)."""
+    base = config.model_dump(mode="json")
+    for key, value in updates.items():
+        if key == "id":
+            continue
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            base[key] = {**base[key], **value}
+        else:
+            base[key] = value
+    base["id"] = config.id  # never allow id to change
+    return TenantConfig(**base)
+
+
+def update_tenant(
+    tenant_id: str,
+    *,
+    config_updates: Optional[Dict] = None,
+    style_params: Optional[Dict] = None,
+    assets: Optional[Dict[str, Tuple[bytes, str]]] = None,
+    logo: Optional[Tuple[bytes, str]] = None,
+    storage: Optional[StorageService] = None,
+) -> TenantConfig:
+    """
+    Update an existing tenant: merge config fields, replace the full theme
+    style_params, and/or add/replace theme assets (backgrounds, fonts).
+
+    Iteration loop for a client: edit the theme JSON here, re-render jobs.
+
+    Args:
+        tenant_id: Tenant to update.
+        config_updates: Partial TenantConfig fields to merge (one-level deep).
+        style_params: Full theme document to write (replaces existing).
+        assets: {target_filename -> (bytes, ext)} written to the theme's assets/.
+        logo: (bytes, ext) -> tenants/{id}/logo.<ext> + branding.logo_url.
+        storage: Injected StorageService (for tests).
+
+    Raises:
+        TenantNotFoundError, TenantValidationError.
+    """
+    storage = storage or StorageService()
+    tenant_service = get_tenant_service()
+    theme_service = get_theme_service()
+
+    config = tenant_service.get_tenant_config(tenant_id, force_refresh=True)
+    if not config:
+        raise TenantNotFoundError(f"Tenant '{tenant_id}' not found.")
+
+    theme_id = _theme_id_for(config)
+
+    # 1. Assets (uploaded files -> theme assets, keyed by their target basename)
+    for name, (data, ext) in (assets or {}).items():
+        safe = _safe_asset_name(name)
+        storage.upload_fileobj(
+            io.BytesIO(data),
+            f"{THEMES_PREFIX}/{theme_id}/assets/{safe}",
+            content_type=_content_type_for(ext),
+        )
+
+    # 2. Full theme style_params replace
+    if style_params is not None:
+        _validate_style_params(style_params)
+        storage.upload_json(f"{THEMES_PREFIX}/{theme_id}/style_params.json", style_params)
+
+    # 3. Logo
+    merged_updates = dict(config_updates or {})
+    if logo:
+        logo_data, logo_ext = logo
+        logo_ext = logo_ext.lower().lstrip(".")
+        logo_path = f"{TENANTS_PREFIX}/{tenant_id}/logo.{logo_ext}"
+        storage.upload_fileobj(
+            io.BytesIO(logo_data), logo_path, content_type=_content_type_for(logo_ext)
+        )
+        branding = dict(merged_updates.get("branding") or {})
+        branding["logo_url"] = f"gs://{settings.gcs_bucket_name}/{logo_path}"
+        merged_updates["branding"] = branding
+
+    # 4. Config merge
+    if merged_updates:
+        config = _merge_config(config, merged_updates)
+
+    config.updated_at = datetime.now(timezone.utc)
+    storage.upload_json(f"{TENANTS_PREFIX}/{tenant_id}/config.json", config.model_dump(mode="json"))
+
+    tenant_service.invalidate_cache(tenant_id)
+    theme_service.invalidate_cache()
+
+    logger.info(f"Updated tenant '{tenant_id}' (theme '{theme_id}')")
     return config
 
 

--- a/backend/tests/test_tenant_admin_route.py
+++ b/backend/tests/test_tenant_admin_route.py
@@ -1,0 +1,137 @@
+"""
+Unit tests for the admin tenant-provisioning routes.
+
+Tests GET/POST /api/admin/tenants. The heavy lifting (GCS writes) lives in
+tenant_admin_service and is tested separately; here we patch the service to
+verify request parsing, validation mapping, and response shaping.
+"""
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.api.routes import tenant_admin
+from backend.api.routes.tenant_admin import router
+from backend.api.dependencies import require_admin
+from backend.services.auth_service import AuthResult, UserType
+from backend.services.tenant_admin_service import TenantConflictError, TenantValidationError
+from backend.models.tenant import TenantConfig, TenantDefaults, TenantFeatures
+
+
+app = FastAPI()
+app.include_router(router)
+
+
+def get_mock_admin():
+    return AuthResult(
+        is_valid=True,
+        user_type=UserType.ADMIN,
+        remaining_uses=-1,
+        message="ok",
+        user_email="admin@nomadkaraoke.com",
+        is_admin=True,
+    )
+
+
+@pytest.fixture
+def client():
+    app.dependency_overrides[require_admin] = get_mock_admin
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _sample_config(tenant_id="randy-vild"):
+    return TenantConfig(
+        id=tenant_id,
+        name="Randy Vild",
+        subdomain=f"{tenant_id}.nomadkaraoke.com",
+        features=TenantFeatures(dropbox_upload=True),
+        defaults=TenantDefaults(theme_id=tenant_id, locked_theme=tenant_id),
+    )
+
+
+def test_create_tenant_happy_path(client, monkeypatch):
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _sample_config()
+
+    monkeypatch.setattr(tenant_admin, "create_tenant", fake_create)
+
+    resp = client.post(
+        "/api/admin/tenants",
+        data={
+            "name": "Randy Vild",
+            "sung_lyrics_color": "#7070f7",
+            "dropbox_path": "/Karaoke/Tracks-RandyVild",
+            "allowed_email_domains": "client.com, label.com",
+        },
+        files={"karaoke_background": ("bg.png", b"imgbytes", "image/png")},
+    )
+
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["tenant"]["id"] == "randy-vild"
+    assert body["preview_url"] == "https://gen.nomadkaraoke.com/en/app?preview_tenant=randy-vild"
+    assert body["subdomain_url"] == "https://randy-vild.nomadkaraoke.com"
+
+    # Service received parsed inputs
+    assert captured["name"] == "Randy Vild"
+    assert captured["colors"].sung_lyrics_color == "#7070f7"
+    assert captured["allowed_email_domains"] == ["client.com", "label.com"]
+    assert "karaoke_background" in captured["backgrounds"]
+    data, ext = captured["backgrounds"]["karaoke_background"]
+    assert data == b"imgbytes" and ext == "png"
+
+
+def test_create_tenant_conflict_maps_to_409(client, monkeypatch):
+    def fake_create(**kwargs):
+        raise TenantConflictError("Tenant 'dup' already exists.")
+
+    monkeypatch.setattr(tenant_admin, "create_tenant", fake_create)
+    resp = client.post("/api/admin/tenants", data={"name": "Dup", "tenant_id": "dup"})
+    assert resp.status_code == 409
+
+
+def test_create_tenant_reserved_maps_to_400(client, monkeypatch):
+    def fake_create(**kwargs):
+        raise TenantValidationError("'admin' is a reserved subdomain and cannot be used.")
+
+    monkeypatch.setattr(tenant_admin, "create_tenant", fake_create)
+    resp = client.post("/api/admin/tenants", data={"name": "Admin", "tenant_id": "admin"})
+    assert resp.status_code == 400
+
+
+def test_create_tenant_bad_color_maps_to_400(client, monkeypatch):
+    monkeypatch.setattr(tenant_admin, "create_tenant", lambda **k: _sample_config())
+    resp = client.post("/api/admin/tenants", data={"name": "X", "artist_color": "not-a-hex"})
+    assert resp.status_code == 400
+
+
+def test_create_tenant_rejects_bad_image_type(client, monkeypatch):
+    monkeypatch.setattr(tenant_admin, "create_tenant", lambda **k: _sample_config())
+    resp = client.post(
+        "/api/admin/tenants",
+        data={"name": "X"},
+        files={"logo": ("evil.svg", b"<svg/>", "image/svg+xml")},
+    )
+    assert resp.status_code == 400
+
+
+def test_create_tenant_rejects_bad_distribution_mode(client, monkeypatch):
+    monkeypatch.setattr(tenant_admin, "create_tenant", lambda **k: _sample_config())
+    resp = client.post("/api/admin/tenants", data={"name": "X", "distribution_mode": "wat"})
+    assert resp.status_code == 400
+
+
+def test_list_tenants(client, monkeypatch):
+    monkeypatch.setattr(
+        tenant_admin,
+        "list_tenants",
+        lambda: [
+            {"id": "a", "name": "Alpha", "subdomain": "a.nomadkaraoke.com", "is_active": True},
+        ],
+    )
+    resp = client.get("/api/admin/tenants")
+    assert resp.status_code == 200
+    assert resp.json()["tenants"][0]["id"] == "a"

--- a/backend/tests/test_tenant_admin_route.py
+++ b/backend/tests/test_tenant_admin_route.py
@@ -13,7 +13,11 @@ from backend.api.routes import tenant_admin
 from backend.api.routes.tenant_admin import router
 from backend.api.dependencies import require_admin
 from backend.services.auth_service import AuthResult, UserType
-from backend.services.tenant_admin_service import TenantConflictError, TenantValidationError
+from backend.services.tenant_admin_service import (
+    TenantConflictError,
+    TenantNotFoundError,
+    TenantValidationError,
+)
 from backend.models.tenant import TenantConfig, TenantDefaults, TenantFeatures
 
 
@@ -121,6 +125,106 @@ def test_create_tenant_rejects_bad_image_type(client, monkeypatch):
 def test_create_tenant_rejects_bad_distribution_mode(client, monkeypatch):
     monkeypatch.setattr(tenant_admin, "create_tenant", lambda **k: _sample_config())
     resp = client.post("/api/admin/tenants", data={"name": "X", "distribution_mode": "wat"})
+    assert resp.status_code == 400
+
+
+def test_create_tenant_with_full_style_params(client, monkeypatch):
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _sample_config()
+
+    monkeypatch.setattr(tenant_admin, "create_tenant", fake_create)
+    resp = client.post(
+        "/api/admin/tenants",
+        data={"name": "Randy Vild", "style_params": '{"intro": {"title_color": "#abcdef"}}'},
+    )
+    assert resp.status_code == 201, resp.text
+    assert captured["style_params_override"] == {"intro": {"title_color": "#abcdef"}}
+
+
+def test_create_tenant_bad_style_params_json(client, monkeypatch):
+    monkeypatch.setattr(tenant_admin, "create_tenant", lambda **k: _sample_config())
+    resp = client.post("/api/admin/tenants", data={"name": "X", "style_params": "{not json"})
+    assert resp.status_code == 400
+
+
+def test_get_tenant_detail(client, monkeypatch):
+    monkeypatch.setattr(
+        tenant_admin,
+        "get_tenant_detail",
+        lambda tid: {
+            "tenant": {"id": tid, "name": "Randy Vild"},
+            "theme_id": tid,
+            "style_params": {"intro": {"title_color": "#fff"}},
+            "assets": ["intro_bg.png"],
+        },
+    )
+    resp = client.get("/api/admin/tenants/randy-vild")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["style_params"]["intro"]["title_color"] == "#fff"
+    assert body["preview_url"].endswith("?preview_tenant=randy-vild")
+
+
+def test_get_tenant_detail_404(client, monkeypatch):
+    def raise_nf(tid):
+        raise TenantNotFoundError("nope")
+
+    monkeypatch.setattr(tenant_admin, "get_tenant_detail", raise_nf)
+    resp = client.get("/api/admin/tenants/ghost")
+    assert resp.status_code == 404
+
+
+def test_theme_template(client, monkeypatch):
+    monkeypatch.setattr(
+        tenant_admin, "get_default_style_params", lambda: {"intro": {}, "karaoke": {}}
+    )
+    resp = client.get("/api/admin/tenants/_template")
+    assert resp.status_code == 200
+    assert "intro" in resp.json()["style_params"]
+
+
+def test_update_tenant(client, monkeypatch):
+    captured = {}
+
+    def fake_update(tid, **kwargs):
+        captured["tid"] = tid
+        captured.update(kwargs)
+        return _sample_config(tid)
+
+    monkeypatch.setattr(tenant_admin, "update_tenant", fake_update)
+    resp = client.put(
+        "/api/admin/tenants/randy-vild",
+        data={
+            "config": '{"name": "Deluxe"}',
+            "style_params": '{"intro": {"title_color": "#123456"}}',
+        },
+        files={"assets": ("kbg.jpg", b"img", "image/jpeg")},
+    )
+    assert resp.status_code == 200, resp.text
+    assert captured["tid"] == "randy-vild"
+    assert captured["config_updates"] == {"name": "Deluxe"}
+    assert captured["style_params"] == {"intro": {"title_color": "#123456"}}
+    assert "kbg.jpg" in captured["assets"]
+
+
+def test_update_tenant_404(client, monkeypatch):
+    def raise_nf(tid, **kwargs):
+        raise TenantNotFoundError("nope")
+
+    monkeypatch.setattr(tenant_admin, "update_tenant", raise_nf)
+    resp = client.put("/api/admin/tenants/ghost", data={"config": "{}"})
+    assert resp.status_code == 404
+
+
+def test_update_tenant_bad_style_params(client, monkeypatch):
+    def raise_val(tid, **kwargs):
+        raise TenantValidationError("bad")
+
+    monkeypatch.setattr(tenant_admin, "update_tenant", raise_val)
+    resp = client.put("/api/admin/tenants/randy-vild", data={"style_params": '{"nope": {}}'})
     assert resp.status_code == 400
 
 

--- a/backend/tests/test_tenant_admin_service.py
+++ b/backend/tests/test_tenant_admin_service.py
@@ -1,0 +1,187 @@
+"""
+Unit tests for tenant_admin_service.create_tenant / list_tenants.
+
+Uses an in-memory fake StorageService so no GCS access is needed. Verifies:
+- slug derivation, reserved-id and duplicate rejection
+- the derived theme copies the default theme's assets (self-contained),
+  applies colour overrides, and points backgrounds at bare basenames
+- the tenant config gets B2B defaults and registers in the theme registry
+"""
+import io
+import json
+
+import pytest
+from google.api_core.exceptions import PreconditionFailed
+
+from backend.models.theme import ColorOverrides, hex_to_rgba
+from backend.services import tenant_admin_service as tas
+from backend.services.theme_service import ThemeService
+from backend.services.tenant_service import TenantService
+
+
+class FakeStorage:
+    """Minimal in-memory stand-in for StorageService."""
+
+    def __init__(self):
+        self.blobs: dict[str, bytes] = {}
+
+    def upload_json(self, path, data, if_generation_match=None):
+        if if_generation_match == 0 and path in self.blobs:
+            raise PreconditionFailed("exists")
+        self.blobs[path] = json.dumps(data).encode()
+        return path
+
+    def download_json(self, path):
+        if path not in self.blobs:
+            raise FileNotFoundError(path)
+        return json.loads(self.blobs[path].decode())
+
+    def file_exists(self, path):
+        return path in self.blobs
+
+    def list_files(self, prefix):
+        return [p for p in self.blobs if p.startswith(prefix)]
+
+    def copy_blob(self, src, dst):
+        self.blobs[dst] = self.blobs.get(src, b"")
+        return dst
+
+    def upload_fileobj(self, fileobj, path, content_type=None):
+        self.blobs[path] = fileobj.read()
+        return path
+
+    def generate_signed_url(self, path, expiration_minutes=60):
+        return f"https://signed/{path}"
+
+
+DEFAULT_STYLE = {
+    "intro": {"artist_color": "#111111", "title_color": "#222222", "background_image": "intro_bg.png"},
+    "karaoke": {"primary_color": "1,1,1,255", "secondary_color": "2,2,2,255", "background_image": "kbg.jpg"},
+    "end": {"artist_color": "#111111", "title_color": "#222222"},
+    "cdg": {"active_fill": "#111111", "inactive_fill": "#222222"},
+}
+
+
+@pytest.fixture
+def fake_storage():
+    s = FakeStorage()
+    s.blobs["themes/_metadata.json"] = json.dumps(
+        {"version": 1, "themes": [{"id": "nomad", "name": "Nomad", "description": "d", "is_default": True}]}
+    ).encode()
+    s.blobs["themes/nomad/style_params.json"] = json.dumps(DEFAULT_STYLE).encode()
+    s.blobs["themes/nomad/assets/intro_bg.png"] = b"introbg"
+    s.blobs["themes/nomad/assets/kbg.jpg"] = b"karaokebg"
+    s.blobs["themes/nomad/assets/Oswald-SemiBold.ttf"] = b"font"
+    return s
+
+
+@pytest.fixture(autouse=True)
+def patch_singletons(fake_storage, monkeypatch):
+    """Point the service's tenant/theme singletons at the fake storage."""
+    monkeypatch.setattr(tas, "get_tenant_service", lambda: TenantService(storage=fake_storage))
+    monkeypatch.setattr(tas, "get_theme_service", lambda: ThemeService(storage=fake_storage))
+    # Ensure logo gs:// url is deterministic
+    monkeypatch.setattr(tas.settings, "gcs_bucket_name", "test-bucket", raising=False)
+    return fake_storage
+
+
+def test_slugify_tenant_id():
+    assert tas.slugify_tenant_id("Randy Vild") == "randy-vild"
+    assert tas.slugify_tenant_id("  Café  Del  Mar! ") == "caf-del-mar"
+
+
+def test_create_tenant_happy_path(fake_storage):
+    colors = ColorOverrides(sung_lyrics_color="#7070f7", title_color="#ffdf6b")
+    config = tas.create_tenant(
+        name="Randy Vild",
+        colors=colors,
+        dropbox_path="/Karaoke/Tracks-RandyVild",
+        brand_prefix="RVILD",
+        backgrounds={"karaoke_background": (b"newbg", "png")},
+        storage=fake_storage,
+    )
+
+    assert config.id == "randy-vild"
+    assert config.subdomain == "randy-vild.nomadkaraoke.com"
+    assert config.defaults.locked_theme == "randy-vild"
+    assert config.defaults.theme_id == "randy-vild"
+    assert config.defaults.brand_prefix == "RVILD"
+
+    # B2B defaults
+    assert config.features.audio_search is False
+    assert config.features.youtube_upload is False
+    assert config.features.gdrive_upload is False
+    assert config.features.bulk_upload is True
+    assert config.features.dropbox_upload is True  # dropbox_path set
+    assert config.features.theme_selection is False
+
+    # Config persisted
+    assert "tenants/randy-vild/config.json" in fake_storage.blobs
+
+    # Theme derived + self-contained (default assets copied in)
+    assert "themes/randy-vild/assets/Oswald-SemiBold.ttf" in fake_storage.blobs
+    assert "themes/randy-vild/assets/intro_bg.png" in fake_storage.blobs
+    # Admin-provided background uploaded + referenced by BARE basename
+    assert fake_storage.blobs["themes/randy-vild/assets/karaoke_background.png"] == b"newbg"
+    style = json.loads(fake_storage.blobs["themes/randy-vild/style_params.json"].decode())
+    assert style["karaoke"]["background_image"] == "karaoke_background.png"
+
+    # Colour overrides applied
+    assert style["karaoke"]["primary_color"] == hex_to_rgba("#7070f7")
+    assert style["intro"]["title_color"] == "#ffdf6b"
+
+    # Registered in theme registry
+    registry = json.loads(fake_storage.blobs["themes/_metadata.json"].decode())
+    assert any(t["id"] == "randy-vild" for t in registry["themes"])
+
+
+def test_create_tenant_download_only_when_no_dropbox(fake_storage):
+    config = tas.create_tenant(name="Solo Client", storage=fake_storage)
+    assert config.features.dropbox_upload is False
+    assert config.defaults.dropbox_path is None
+
+
+def test_allowed_domains_gate_email_restriction(fake_storage):
+    config = tas.create_tenant(
+        name="Domain Client",
+        allowed_email_domains=["client.com", "Client.com", " label.com "],
+        storage=fake_storage,
+    )
+    assert config.auth.allowed_email_domains == ["client.com", "label.com"]
+    assert config.auth.require_email_domain is True
+
+    open_config = tas.create_tenant(name="Open Client", storage=fake_storage)
+    assert open_config.auth.allowed_email_domains == []
+    assert open_config.auth.require_email_domain is False
+
+
+def test_reserved_id_rejected(fake_storage):
+    with pytest.raises(tas.TenantValidationError):
+        tas.create_tenant(name="Admin", tenant_id="admin", storage=fake_storage)
+
+
+def test_short_id_rejected(fake_storage):
+    with pytest.raises(tas.TenantValidationError):
+        tas.create_tenant(name="X", tenant_id="x", storage=fake_storage)
+
+
+def test_duplicate_tenant_rejected(fake_storage):
+    fake_storage.blobs["tenants/dup/config.json"] = json.dumps({"id": "dup"}).encode()
+    with pytest.raises(tas.TenantConflictError):
+        tas.create_tenant(name="Dup", tenant_id="dup", storage=fake_storage)
+
+
+def test_missing_default_theme_errors(fake_storage):
+    # Remove the default flag
+    fake_storage.blobs["themes/_metadata.json"] = json.dumps({"version": 1, "themes": []}).encode()
+    with pytest.raises(ValueError):
+        tas.create_tenant(name="No Theme", storage=fake_storage)
+
+
+def test_list_tenants(fake_storage):
+    tas.create_tenant(name="Bravo", storage=fake_storage)
+    tas.create_tenant(name="Alpha", storage=fake_storage)
+    listed = tas.list_tenants(storage=fake_storage)
+    names = [t["name"] for t in listed]
+    assert names == ["Alpha", "Bravo"]  # sorted by name
+    assert all("id" in t and "subdomain" in t for t in listed)

--- a/backend/tests/test_tenant_admin_service.py
+++ b/backend/tests/test_tenant_admin_service.py
@@ -50,6 +50,13 @@ class FakeStorage:
         self.blobs[path] = fileobj.read()
         return path
 
+    def delete_file(self, path, ignore_missing=False):
+        existed = path in self.blobs
+        self.blobs.pop(path, None)
+        if not existed and not ignore_missing:
+            raise FileNotFoundError(path)
+        return existed
+
     def generate_signed_url(self, path, expiration_minutes=60):
         return f"https://signed/{path}"
 
@@ -169,6 +176,42 @@ def test_duplicate_tenant_rejected(fake_storage):
     fake_storage.blobs["tenants/dup/config.json"] = json.dumps({"id": "dup"}).encode()
     with pytest.raises(tas.TenantConflictError):
         tas.create_tenant(name="Dup", tenant_id="dup", storage=fake_storage)
+
+
+def test_conflict_does_not_clobber_existing_theme(fake_storage):
+    """A create for an existing id must fail before touching the live theme."""
+    tas.create_tenant(name="Existing", colors=ColorOverrides(title_color="#abcabc"), storage=fake_storage)
+    theme_before = fake_storage.blobs["themes/existing/style_params.json"]
+
+    with pytest.raises(tas.TenantConflictError):
+        tas.create_tenant(
+            name="Existing",
+            tenant_id="existing",
+            style_params_override={"intro": {"title_color": "#000000"}},
+            storage=fake_storage,
+        )
+    # Live theme untouched
+    assert fake_storage.blobs["themes/existing/style_params.json"] == theme_before
+
+
+def test_create_rolls_back_reservation_on_theme_failure(fake_storage, monkeypatch):
+    """If theme provisioning fails after reservation, the config is rolled back."""
+    def boom(*args, **kwargs):
+        raise RuntimeError("theme boom")
+
+    monkeypatch.setattr(tas, "_register_theme_metadata", boom)
+    with pytest.raises(RuntimeError):
+        tas.create_tenant(name="Boomer", storage=fake_storage)
+    assert "tenants/boomer/config.json" not in fake_storage.blobs
+
+
+def test_list_tenants_skips_config_without_id(fake_storage):
+    fake_storage.blobs["tenants/broken/config.json"] = json.dumps({"name": "No Id"}).encode()
+    tas.create_tenant(name="Good", storage=fake_storage)
+    listed = tas.list_tenants(storage=fake_storage)
+    ids = [t["id"] for t in listed]
+    assert "good" in ids
+    assert all(t["id"] for t in listed)  # no null-id rows
 
 
 def test_missing_default_theme_errors(fake_storage):

--- a/backend/tests/test_tenant_admin_service.py
+++ b/backend/tests/test_tenant_admin_service.py
@@ -194,6 +194,20 @@ def test_conflict_does_not_clobber_existing_theme(fake_storage):
     assert fake_storage.blobs["themes/existing/style_params.json"] == theme_before
 
 
+def test_id_colliding_with_existing_theme_rejected(fake_storage):
+    """A tenant id that matches an existing theme (e.g. the default) must not clobber it."""
+    theme_before = fake_storage.blobs["themes/nomad/style_params.json"]
+    with pytest.raises(tas.TenantConflictError):
+        tas.create_tenant(
+            name="Nomad",
+            tenant_id="nomad",
+            style_params_override={"intro": {"title_color": "#000000"}},
+            storage=fake_storage,
+        )
+    assert fake_storage.blobs["themes/nomad/style_params.json"] == theme_before
+    assert "tenants/nomad/config.json" not in fake_storage.blobs
+
+
 def test_create_rolls_back_reservation_on_theme_failure(fake_storage, monkeypatch):
     """If theme provisioning fails after reservation, the config is rolled back."""
     def boom(*args, **kwargs):

--- a/backend/tests/test_tenant_admin_service.py
+++ b/backend/tests/test_tenant_admin_service.py
@@ -178,6 +178,80 @@ def test_missing_default_theme_errors(fake_storage):
         tas.create_tenant(name="No Theme", storage=fake_storage)
 
 
+def test_create_with_full_style_params_override(fake_storage):
+    override = {
+        "intro": {"title_color": "#abcdef", "background_image": "custom.png"},
+        "karaoke": {"primary_color": "9,9,9,255"},
+    }
+    tas.create_tenant(name="Override Co", style_params_override=override, storage=fake_storage)
+    style = json.loads(fake_storage.blobs["themes/override-co/style_params.json"].decode())
+    assert style["intro"]["title_color"] == "#abcdef"
+    assert style["karaoke"]["primary_color"] == "9,9,9,255"
+    # default assets still copied so inherited basenames resolve
+    assert "themes/override-co/assets/Oswald-SemiBold.ttf" in fake_storage.blobs
+
+
+def test_create_with_invalid_style_params_override_rejected(fake_storage):
+    with pytest.raises(tas.TenantValidationError):
+        tas.create_tenant(name="Bad", style_params_override={"bogus": {}}, storage=fake_storage)
+
+
+def test_get_tenant_detail(fake_storage):
+    tas.create_tenant(name="Randy Vild", colors=ColorOverrides(title_color="#ffdf6b"), storage=fake_storage)
+    detail = tas.get_tenant_detail("randy-vild", storage=fake_storage)
+    assert detail["tenant"]["id"] == "randy-vild"
+    assert detail["theme_id"] == "randy-vild"
+    assert detail["style_params"]["intro"]["title_color"] == "#ffdf6b"
+    assert "Oswald-SemiBold.ttf" in detail["assets"]
+
+
+def test_get_tenant_detail_missing_raises(fake_storage):
+    with pytest.raises(tas.TenantNotFoundError):
+        tas.get_tenant_detail("nope", storage=fake_storage)
+
+
+def test_update_tenant_full_theme_and_config(fake_storage):
+    tas.create_tenant(name="Randy Vild", storage=fake_storage)
+
+    new_style = {
+        "intro": {"title_color": "#123456", "background_image": "intro_bg.png"},
+        "karaoke": {"primary_color": "5,5,5,255", "background_image": "kbg.jpg"},
+        "end": {},
+        "cdg": {},
+    }
+    updated = tas.update_tenant(
+        "randy-vild",
+        config_updates={"name": "Randy Vild Deluxe", "defaults": {"brand_prefix": "RVD"}},
+        style_params=new_style,
+        assets={"kbg.jpg": (b"replacement", "jpg")},
+        storage=fake_storage,
+    )
+    assert updated.name == "Randy Vild Deluxe"
+    assert updated.defaults.brand_prefix == "RVD"
+    assert updated.id == "randy-vild"  # id immutable
+    # theme replaced
+    style = json.loads(fake_storage.blobs["themes/randy-vild/style_params.json"].decode())
+    assert style["intro"]["title_color"] == "#123456"
+    # asset replaced
+    assert fake_storage.blobs["themes/randy-vild/assets/kbg.jpg"] == b"replacement"
+
+
+def test_update_tenant_rejects_bad_style_params(fake_storage):
+    tas.create_tenant(name="Randy Vild", storage=fake_storage)
+    with pytest.raises(tas.TenantValidationError):
+        tas.update_tenant("randy-vild", style_params={"nope": {}}, storage=fake_storage)
+
+
+def test_update_tenant_missing_raises(fake_storage):
+    with pytest.raises(tas.TenantNotFoundError):
+        tas.update_tenant("ghost", config_updates={"name": "x"}, storage=fake_storage)
+
+
+def test_get_default_style_params(fake_storage):
+    params = tas.get_default_style_params(storage=fake_storage)
+    assert set(params.keys()) == {"intro", "karaoke", "end", "cdg"}
+
+
 def test_list_tenants(fake_storage):
     tas.create_tenant(name="Bravo", storage=fake_storage)
     tas.create_tenant(name="Alpha", storage=fake_storage)

--- a/docs/API.md
+++ b/docs/API.md
@@ -1245,9 +1245,10 @@ Admin-only endpoints (`require_admin`) that mint and manage white-label tenants 
   `preview_url` (for the manage/edit view). 404 if not found.
 - **`PUT /{id}`** (multipart) updates a tenant so a client's feedback can be iterated on: `config`
   (partial TenantConfig JSON, merged one level deep — `id` immutable), `style_params` (full theme
-  JSON, replaces the theme), and repeatable `assets` file uploads (images **or fonts**; each file's
-  name becomes the theme asset name, so uploading `karaoke_background.jpg` replaces it). Re-render
-  jobs to apply an updated theme. Errors: 400 (invalid JSON/theme), 404 (not found).
+  JSON, replaces the theme), an optional `logo` image (updates `branding.logo_url`), and repeatable
+  `assets` file uploads (images **or fonts**; each file's name becomes the theme asset name, so
+  uploading `karaoke_background.jpg` replaces it). Re-render jobs to apply an updated theme.
+  Errors: 400 (invalid JSON/theme), 404 (not found).
 
   Implemented in `backend/services/tenant_admin_service.py` + `backend/api/routes/tenant_admin.py`.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1209,6 +1209,34 @@ The tenant portal's Bulk mode (`TenantBulkFlow.tsx`) renders these rows as an ed
 table, then submits each confirmed row through the standard signed-URL upload flow
 (`upload_mode: "resumable"`, `batch_id` grouping).
 
+#### Tenant Provisioning (Admin Only)
+
+```
+GET  /api/admin/tenants
+POST /api/admin/tenants        (multipart/form-data)
+Authorization: Bearer <admin token>
+```
+
+Admin-only endpoints (`require_admin`) that mint a white-label tenant from the admin panel
+(`/admin/tenants`), replacing the hand-run `scripts/setup-*-tenant.py` recipe.
+
+- **`GET`** returns a summary list of all tenants (`id`, `name`, `subdomain`, `is_active`,
+  `locked_theme`, `dropbox_path`, `created_at`) read from `tenants/*/config.json` in GCS.
+- **`POST`** (multipart) creates a tenant. Form fields: `name` (required), optional `tenant_id`
+  (slug, derived from name if omitted), `subdomain`, `allowed_email_domains` (comma-separated),
+  `artist_color`/`title_color`/`sung_lyrics_color`/`unsung_lyrics_color` (hex), `tagline`,
+  `distribution_mode` (`download_only`|`all`|`cloud_only`), `dropbox_path`, `brand_prefix`; optional
+  image files `karaoke_background`, `intro_background`, `end_background`, `logo` (PNG/JPG/GIF/WEBP,
+  ≤15MB). It derives a **self-contained theme** from the default Nomad theme (copies its assets so
+  every `background_image` basename resolves against the new theme's own `assets/`), applies the
+  colour overrides, overlays any provided backgrounds, registers the theme in
+  `themes/_metadata.json`, and writes `tenants/{id}/config.json` with B2B defaults (audio search off,
+  YouTube/GDrive off, `theme_selection` off, `locked_theme={id}`, jobs private). Returns the public
+  config plus a `preview_url` (`?preview_tenant={id}`) that drives the tenant — including its bulk
+  flow — **without any DNS setup**. Errors: 400 (bad slug/reserved/invalid colour/image),
+  409 (tenant already exists). Implemented in `backend/services/tenant_admin_service.py` +
+  `backend/api/routes/tenant_admin.py`.
+
 ### Internal (Admin Only)
 
 These endpoints are used by workers and require admin tokens.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1213,11 +1213,14 @@ table, then submits each confirmed row through the standard signed-URL upload fl
 
 ```
 GET  /api/admin/tenants
-POST /api/admin/tenants        (multipart/form-data)
+GET  /api/admin/tenants/_template
+GET  /api/admin/tenants/{id}
+POST /api/admin/tenants           (multipart/form-data)
+PUT  /api/admin/tenants/{id}      (multipart/form-data)
 Authorization: Bearer <admin token>
 ```
 
-Admin-only endpoints (`require_admin`) that mint a white-label tenant from the admin panel
+Admin-only endpoints (`require_admin`) that mint and manage white-label tenants from the admin panel
 (`/admin/tenants`), replacing the hand-run `scripts/setup-*-tenant.py` recipe.
 
 - **`GET`** returns a summary list of all tenants (`id`, `name`, `subdomain`, `is_active`,
@@ -1233,9 +1236,20 @@ Admin-only endpoints (`require_admin`) that mint a white-label tenant from the a
   `themes/_metadata.json`, and writes `tenants/{id}/config.json` with B2B defaults (audio search off,
   YouTube/GDrive off, `theme_selection` off, `locked_theme={id}`, jobs private). Returns the public
   config plus a `preview_url` (`?preview_tenant={id}`) that drives the tenant — including its bulk
-  flow — **without any DNS setup**. Errors: 400 (bad slug/reserved/invalid colour/image),
-  409 (tenant already exists). Implemented in `backend/services/tenant_admin_service.py` +
-  `backend/api/routes/tenant_admin.py`.
+  flow — **without any DNS setup**. For **full theme customisation** at create time, pass a
+  `style_params` field (full theme JSON string) — when present it is authoritative and the colour
+  fields are ignored. Errors: 400 (bad slug/reserved/invalid colour/image/JSON), 409 (exists).
+- **`GET /_template`** returns the default Nomad theme's full `style_params` — a starting point for
+  editing a new theme (the admin UI seeds its JSON editor from this).
+- **`GET /{id}`** returns a tenant's full config, its theme `style_params`, its `assets` list, and a
+  `preview_url` (for the manage/edit view). 404 if not found.
+- **`PUT /{id}`** (multipart) updates a tenant so a client's feedback can be iterated on: `config`
+  (partial TenantConfig JSON, merged one level deep — `id` immutable), `style_params` (full theme
+  JSON, replaces the theme), and repeatable `assets` file uploads (images **or fonts**; each file's
+  name becomes the theme asset name, so uploading `karaoke_background.jpg` replaces it). Re-render
+  jobs to apply an updated theme. Errors: 400 (invalid JSON/theme), 404 (not found).
+
+  Implemented in `backend/services/tenant_admin_service.py` + `backend/api/routes/tenant_admin.py`.
 
 ### Internal (Admin Only)
 

--- a/docs/archive/2026-08-31-admin-create-tenant-plan.md
+++ b/docs/archive/2026-08-31-admin-create-tenant-plan.md
@@ -1,0 +1,82 @@
+# Admin "Create Tenant" + Saved Themes — Plan
+
+**Date:** 2026-08-31
+**Worktree:** `karaoke-gen-saved-themes-bulk`
+**Origin (Andrew, verbatim):** Making ~15 tracks (an album) for one client who wants karaoke
+versions of every track. Wants (1) users to save customisation options (colors, background image)
+as their own theme on their profile, selectable from the Custom Video Style dialog (default Nomad
+theme for anyone with none); and (2) a way to handle "a bunch of tracks, audio provided up front,
+same theme/background, client-supplied instrumental per track" — "essentially a tenant use case but
+there's no admin panel mechanism to easily create a new tenant".
+
+## Decisions (Andrew, via AskUserQuestion)
+1. **Build the album batch first.** Saved user themes follows as a second PR (shares the theme core).
+2. **Album batch = admin create-tenant + reuse the existing tenant bulk flow** (not extending
+   consumer Bulk mode).
+
+## Why this is small: the batch pipeline already exists
+The **tenant bulk flow** (`TenantBulkFlow.tsx` + `/api/tenant/bulk/analyze`, shipped v0.200.0 #943)
+already does everything the album needs:
+- Folder pick → LLM pairs each track's **mixed audio ↔ client-supplied instrumental**.
+- Editable review table.
+- GCS-**resumable chunked uploads** (`existing_instrumental` flow → **separation skipped**).
+- The tenant's **locked theme** (colors + background) applied to **every** job.
+- Jobs forced `is_private`, delivered to the tenant's Dropbox, never YouTube/GDrive.
+
+The **only** missing piece is what Andrew named: **no admin UI/API to mint a tenant**. Today a
+tenant is created by hand-running `scripts/setup-vocalstar-tenant.py` (uploads theme assets +
+`themes/{id}/style_params.json`, writes `tenants/{id}/config.json`, registers in
+`themes/_metadata.json`). This PR turns that script into an admin endpoint + form.
+
+## Access without DNS (key finding)
+`lib/tenant.ts::detectTenantFromUrl()` supports **`?preview_tenant=<id>` on any domain for admins**.
+So immediately after creating the tenant, Andrew can drive its bulk flow at
+`https://gen.nomadkaraoke.com/app?preview_tenant=<id>` — **no Cloudflare custom-domain / DNS needed**.
+DNS + Pages custom domain remains a later, optional step if the client ever wants their own portal.
+
+## Backend
+New `backend/services/tenant_admin_service.py`:
+- `slugify_tenant_id(name)` → lowercase `[a-z0-9-]`, reject reserved (`gen,api,www,buy,admin,app,beta`
+  — from `middleware/tenant.py::NON_TENANT_SUBDOMAINS`), reject if `tenant_service.tenant_exists`.
+- `create_tenant(...)`:
+  1. `base = theme_service.get_theme_style_params(get_default_theme_id())` (error if none).
+  2. **Copy default theme's `assets/*` into `themes/{new}/assets/`** so the new theme is
+     self-contained (fonts, CDG backgrounds, default backgrounds all resolve as bare basenames —
+     this is the fix for tenant-E2E bug #6 asset-resolution).
+  3. `apply_color_overrides(base, ColorOverrides(...))`.
+  4. For each provided background (karaoke/intro/end): upload to `themes/{new}/assets/<key>.<ext>`
+     and set `style_params[section]["background_image"] = "<key>.<ext>"` (basename).
+  5. `upload_json("themes/{new}/style_params.json", style_params)`.
+  6. Register `{id,name,description,is_default:false}` in `themes/_metadata.json` (read-modify-write).
+  7. Upload logo (optional) to `tenants/{new}/logo.<ext>`.
+  8. Build `TenantConfig` (B2B defaults: audio_search off, youtube/gdrive off, dropbox if path,
+     theme_selection off, locked_theme={new}, is_private forced downstream, brand_prefix,
+     distribution_mode, allowed_email_domains, sender_email). Write `tenants/{new}/config.json`
+     with `if_generation_match=0` (create-only).
+  9. `tenant_service.invalidate_cache(new)` + `theme_service.invalidate_cache()`.
+
+New `backend/api/routes/tenant_admin.py` (`prefix="/api/admin/tenants"`, `Depends(require_admin)`):
+- `GET /` → list tenants (id/name/subdomain/is_active/created_at) from `list_files("tenants/")`.
+- `POST /` → **multipart** create (fields + optional `karaoke_background`/`intro_background`/
+  `end_background`/`logo` UploadFiles). Returns created public config + the `?preview_tenant=` URL.
+Register in `main.py`.
+
+## Frontend
+- `frontend/app/admin/tenants/page.tsx` — list + "Create tenant" dialog (name→auto slug/subdomain,
+  allowed email domains, 4 color pickers mirroring Custom Video Style, karaoke/intro background
+  uploads, dropbox path / download-only, brand prefix). On success: toast + copyable
+  `?preview_tenant=` link + "Open bulk flow" button.
+- `frontend/components/admin/admin-sidebar.tsx` — add **Tenants** nav item (Building2 icon).
+- `frontend/lib/api.ts` — `adminApi.listTenants()` + `adminApi.createTenant(FormData)`.
+- Admin is English-only (no `[locale]` counterpart) → **no i18n locale files touched**.
+
+## Tests
+- Backend: `test_tenant_admin_service.py` (slug/reserved/duplicate, theme derivation copies assets +
+  applies colors + sets background basename, config B2B defaults, create-only clobber guard) with a
+  fake StorageService; `test_tenant_admin_route.py` (require_admin gate, multipart happy path, 409 on
+  dup, 400 on reserved slug).
+- Frontend: `admin-tenants-page.test.tsx` (render list, submit create, shows preview link).
+
+## Out of scope (this PR) — the follow-up
+Saved **user** themes (profile `saved_themes`, `PUT /users/me`, theme picker in Custom Video Style
+dialog). Reuses the same theme-derivation core built here.

--- a/frontend/__tests__/admin-tenants-page.test.tsx
+++ b/frontend/__tests__/admin-tenants-page.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for the admin Tenants page — listing tenants and creating one.
+ * adminApi is mocked.
+ */
+
+import React from 'react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+
+const listTenants = jest.fn()
+const createTenant = jest.fn()
+
+jest.mock('@/lib/api', () => ({
+  adminApi: {
+    listTenants: (...args: unknown[]) => listTenants(...args),
+    createTenant: (...args: unknown[]) => createTenant(...args),
+  },
+}))
+
+import AdminTenantsPage from '@/app/admin/tenants/page'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  listTenants.mockResolvedValue({
+    tenants: [
+      {
+        id: 'vocalstar',
+        name: 'Vocal Star',
+        subdomain: 'vocalstar.nomadkaraoke.com',
+        is_active: true,
+        dropbox_path: '/Karaoke/Tracks-VocalStar',
+      },
+    ],
+  })
+  createTenant.mockResolvedValue({
+    tenant: { id: 'randy-vild', name: 'Randy Vild', subdomain: 'randy-vild.nomadkaraoke.com', is_active: true },
+    preview_url: 'https://gen.nomadkaraoke.com/en/app?preview_tenant=randy-vild',
+    subdomain_url: 'https://randy-vild.nomadkaraoke.com',
+  })
+})
+
+describe('Admin Tenants page', () => {
+  it('lists existing tenants', async () => {
+    render(<AdminTenantsPage />)
+    expect(await screen.findByText('Vocal Star')).toBeInTheDocument()
+    expect(screen.getByText('vocalstar')).toBeInTheDocument()
+    expect(screen.getByText('vocalstar.nomadkaraoke.com')).toBeInTheDocument()
+  })
+
+  it('auto-derives the tenant id from the name and creates a tenant', async () => {
+    render(<AdminTenantsPage />)
+    await screen.findByText('Vocal Star')
+
+    fireEvent.click(screen.getByRole('button', { name: /create tenant/i }))
+
+    const nameInput = await screen.findByPlaceholderText('Randy Vild')
+    fireEvent.change(nameInput, { target: { value: 'Randy Vild' } })
+
+    // id auto-derived
+    expect(screen.getByPlaceholderText('randy-vild')).toHaveValue('randy-vild')
+
+    // Submit (the dialog's own "Create tenant" button)
+    const submitButtons = screen.getAllByRole('button', { name: /^create tenant$/i })
+    fireEvent.click(submitButtons[submitButtons.length - 1])
+
+    await waitFor(() => expect(createTenant).toHaveBeenCalledTimes(1))
+    const fd = createTenant.mock.calls[0][0] as FormData
+    expect(fd.get('name')).toBe('Randy Vild')
+    expect(fd.get('tenant_id')).toBe('randy-vild')
+
+    // Success view shows the preview link
+    expect(
+      await screen.findByDisplayValue('https://gen.nomadkaraoke.com/en/app?preview_tenant=randy-vild')
+    ).toBeInTheDocument()
+    // List refreshed (initial + post-create)
+    await waitFor(() => expect(listTenants).toHaveBeenCalledTimes(2))
+  })
+})

--- a/frontend/__tests__/admin-tenants-page.test.tsx
+++ b/frontend/__tests__/admin-tenants-page.test.tsx
@@ -10,11 +10,17 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 
 const listTenants = jest.fn()
 const createTenant = jest.fn()
+const getTenant = jest.fn()
+const updateTenant = jest.fn()
+const getThemeTemplate = jest.fn()
 
 jest.mock('@/lib/api', () => ({
   adminApi: {
     listTenants: (...args: unknown[]) => listTenants(...args),
     createTenant: (...args: unknown[]) => createTenant(...args),
+    getTenant: (...args: unknown[]) => getTenant(...args),
+    updateTenant: (...args: unknown[]) => updateTenant(...args),
+    getThemeTemplate: (...args: unknown[]) => getThemeTemplate(...args),
   },
 }))
 
@@ -38,6 +44,23 @@ beforeEach(() => {
     preview_url: 'https://gen.nomadkaraoke.com/en/app?preview_tenant=randy-vild',
     subdomain_url: 'https://randy-vild.nomadkaraoke.com',
   })
+  getTenant.mockResolvedValue({
+    tenant: {
+      id: 'vocalstar',
+      name: 'Vocal Star',
+      subdomain: 'vocalstar.nomadkaraoke.com',
+      is_active: true,
+      branding: { tagline: 'Be a Vocal Star' },
+      defaults: { dropbox_path: '/Karaoke/Tracks-VocalStar', brand_prefix: 'VSTAR', distribution_mode: 'download_only' },
+      auth: { allowed_email_domains: ['vocal-star.com'] },
+    },
+    theme_id: 'vocalstar',
+    style_params: { intro: { title_color: '#ffff00' }, karaoke: {}, end: {}, cdg: {} },
+    assets: ['karaoke_background.jpg', 'Oswald-SemiBold.ttf'],
+    preview_url: 'https://gen.nomadkaraoke.com/en/app?preview_tenant=vocalstar',
+  })
+  updateTenant.mockResolvedValue({ tenant: { id: 'vocalstar', name: 'Vocal Star', subdomain: 'vocalstar.nomadkaraoke.com', is_active: true } })
+  getThemeTemplate.mockResolvedValue({ style_params: { intro: {}, karaoke: {}, end: {}, cdg: {} } })
 })
 
 describe('Admin Tenants page', () => {
@@ -75,5 +98,39 @@ describe('Admin Tenants page', () => {
     ).toBeInTheDocument()
     // List refreshed (initial + post-create)
     await waitFor(() => expect(listTenants).toHaveBeenCalledTimes(2))
+  })
+
+  it('manage loads the full theme JSON and saves config + style_params', async () => {
+    render(<AdminTenantsPage />)
+    await screen.findByText('Vocal Star')
+
+    fireEvent.click(screen.getByRole('button', { name: /manage/i }))
+
+    await waitFor(() => expect(getTenant).toHaveBeenCalledWith('vocalstar'))
+
+    // Theme JSON prefilled into the editor
+    const editor = await screen.findByPlaceholderText(/"intro":/)
+    expect((editor as HTMLTextAreaElement).value).toContain('#ffff00')
+    // Existing assets listed
+    expect(screen.getByText('karaoke_background.jpg')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }))
+
+    await waitFor(() => expect(updateTenant).toHaveBeenCalledTimes(1))
+    const [tid, fd] = updateTenant.mock.calls[0] as [string, FormData]
+    expect(tid).toBe('vocalstar')
+    const config = JSON.parse(fd.get('config') as string)
+    expect(config.name).toBe('Vocal Star')
+    expect(config.defaults.dropbox_path).toBe('/Karaoke/Tracks-VocalStar')
+    expect(JSON.parse(fd.get('style_params') as string).intro.title_color).toBe('#ffff00')
+  })
+
+  it('blocks save when the theme JSON is invalid', async () => {
+    render(<AdminTenantsPage />)
+    await screen.findByText('Vocal Star')
+    fireEvent.click(screen.getByRole('button', { name: /manage/i }))
+    const editor = await screen.findByPlaceholderText(/"intro":/)
+    fireEvent.change(editor, { target: { value: '{ not valid json' } })
+    expect(screen.getByRole('button', { name: /save changes/i })).toBeDisabled()
   })
 })

--- a/frontend/app/admin/tenants/page.tsx
+++ b/frontend/app/admin/tenants/page.tsx
@@ -1,0 +1,360 @@
+"use client"
+
+import { useEffect, useState, useCallback } from "react"
+import { adminApi, TenantSummary, TenantCreateResult } from "@/lib/api"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from "@/components/ui/table"
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
+} from "@/components/ui/dialog"
+import {
+  Building2, Plus, RefreshCw, Loader2, Copy, Check, ExternalLink,
+} from "lucide-react"
+import { useToast } from "@/hooks/use-toast"
+
+// --- Colour field -----------------------------------------------------------
+function ColorField({
+  label, value, onChange, placeholder,
+}: {
+  label: string
+  value: string
+  onChange: (v: string) => void
+  placeholder: string
+}) {
+  return (
+    <div className="space-y-1">
+      <Label className="text-xs text-muted-foreground">{label}</Label>
+      <div className="flex items-center gap-2">
+        <input
+          type="color"
+          aria-label={`${label} swatch`}
+          value={/^#[0-9a-fA-F]{6}$/.test(value) ? value : "#000000"}
+          onChange={(e) => onChange(e.target.value)}
+          className="h-9 w-9 cursor-pointer rounded border border-input bg-transparent p-0.5"
+        />
+        <Input
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          className="font-mono"
+        />
+      </div>
+    </div>
+  )
+}
+
+const EMPTY_FORM = {
+  name: "",
+  tenant_id: "",
+  subdomain: "",
+  allowed_email_domains: "",
+  artist_color: "",
+  title_color: "",
+  sung_lyrics_color: "",
+  unsung_lyrics_color: "",
+  tagline: "",
+  distribution_mode: "download_only",
+  dropbox_path: "",
+  brand_prefix: "",
+}
+
+function slugify(name: string): string {
+  return name.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "")
+}
+
+export default function AdminTenantsPage() {
+  const { toast } = useToast()
+  const [tenants, setTenants] = useState<TenantSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [form, setForm] = useState({ ...EMPTY_FORM })
+  const [idEdited, setIdEdited] = useState(false)
+  const [karaokeBg, setKaraokeBg] = useState<File | null>(null)
+  const [introBg, setIntroBg] = useState<File | null>(null)
+  const [logo, setLogo] = useState<File | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [created, setCreated] = useState<TenantCreateResult | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const loadTenants = useCallback(async () => {
+    try {
+      setLoading(true)
+      const data = await adminApi.listTenants()
+      setTenants(data.tenants)
+    } catch (err: any) {
+      toast({ title: "Error", description: err.message || "Failed to load tenants", variant: "destructive" })
+    } finally {
+      setLoading(false)
+    }
+  }, [toast])
+
+  useEffect(() => { loadTenants() }, [loadTenants])
+
+  const set = (key: keyof typeof EMPTY_FORM, value: string) => {
+    setForm((f) => {
+      const next = { ...f, [key]: value }
+      // Auto-derive the id/subdomain from the name until the admin edits the id
+      if (key === "name" && !idEdited) {
+        const slug = slugify(value)
+        next.tenant_id = slug
+        next.subdomain = slug ? `${slug}.nomadkaraoke.com` : ""
+      }
+      if (key === "tenant_id") {
+        setIdEdited(true)
+        next.subdomain = value ? `${value}.nomadkaraoke.com` : ""
+      }
+      return next
+    })
+  }
+
+  const resetForm = () => {
+    setForm({ ...EMPTY_FORM })
+    setIdEdited(false)
+    setKaraokeBg(null)
+    setIntroBg(null)
+    setLogo(null)
+    setCreated(null)
+  }
+
+  const openCreate = () => {
+    resetForm()
+    setDialogOpen(true)
+  }
+
+  const handleSubmit = async () => {
+    if (!form.name.trim()) {
+      toast({ title: "Name required", description: "Enter a tenant name.", variant: "destructive" })
+      return
+    }
+    setSubmitting(true)
+    try {
+      const fd = new FormData()
+      const fields: (keyof typeof EMPTY_FORM)[] = [
+        "name", "tenant_id", "subdomain", "allowed_email_domains",
+        "artist_color", "title_color", "sung_lyrics_color", "unsung_lyrics_color",
+        "tagline", "distribution_mode", "dropbox_path", "brand_prefix",
+      ]
+      for (const key of fields) {
+        const v = form[key]?.trim?.() ?? form[key]
+        if (v) fd.append(key, v as string)
+      }
+      if (karaokeBg) fd.append("karaoke_background", karaokeBg)
+      if (introBg) fd.append("intro_background", introBg)
+      if (logo) fd.append("logo", logo)
+
+      const result = await adminApi.createTenant(fd)
+      setCreated(result)
+      toast({ title: "Tenant created", description: `${result.tenant.name} is ready.` })
+      loadTenants()
+    } catch (err: any) {
+      toast({ title: "Failed to create tenant", description: err.message || "Unknown error", variant: "destructive" })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const copyPreview = async () => {
+    if (!created) return
+    await navigator.clipboard.writeText(created.preview_url)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Building2 className="h-6 w-6 text-primary" />
+          <div>
+            <h1 className="text-2xl font-semibold">Tenants</h1>
+            <p className="text-sm text-muted-foreground">
+              White-label portals. Create one to batch-produce an album with a shared theme and
+              client-supplied instrumentals.
+            </p>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" size="icon" onClick={loadTenants} disabled={loading}>
+            <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+          </Button>
+          <Button onClick={openCreate}>
+            <Plus className="h-4 w-4 mr-2" /> Create tenant
+          </Button>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>All tenants</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="space-y-2">
+              {[0, 1, 2].map((i) => <Skeleton key={i} className="h-10 w-full" />)}
+            </div>
+          ) : tenants.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-6 text-center">
+              No tenants yet. Create one to get started.
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>ID</TableHead>
+                  <TableHead>Subdomain</TableHead>
+                  <TableHead>Delivery</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {tenants.map((t) => (
+                  <TableRow key={t.id}>
+                    <TableCell className="font-medium">{t.name}</TableCell>
+                    <TableCell className="font-mono text-xs">{t.id}</TableCell>
+                    <TableCell className="text-xs">{t.subdomain}</TableCell>
+                    <TableCell className="text-xs">{t.dropbox_path || "download only"}</TableCell>
+                    <TableCell>
+                      <Badge variant={t.is_active ? "default" : "secondary"}>
+                        {t.is_active ? "active" : "inactive"}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button asChild variant="ghost" size="sm">
+                        <a
+                          href={`https://gen.nomadkaraoke.com/en/app?preview_tenant=${t.id}`}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          Open <ExternalLink className="h-3 w-3 ml-1" />
+                        </a>
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Create tenant</DialogTitle>
+            <DialogDescription>
+              Provisions a branded portal with a locked theme. Jobs are private and delivered to
+              Dropbox (or download only). You can drive it immediately via the preview link — no DNS.
+            </DialogDescription>
+          </DialogHeader>
+
+          {created ? (
+            <div className="space-y-4">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">{created.tenant.name} is ready</CardTitle>
+                  <CardDescription>
+                    Open the preview link, switch to <strong>Bulk</strong>, and drop the album folder.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <div className="flex items-center gap-2">
+                    <Input readOnly value={created.preview_url} className="font-mono text-xs" />
+                    <Button variant="outline" size="icon" onClick={copyPreview}>
+                      {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                    </Button>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button asChild>
+                      <a href={created.preview_url} target="_blank" rel="noreferrer">
+                        Open bulk flow <ExternalLink className="h-4 w-4 ml-2" />
+                      </a>
+                    </Button>
+                    <Button variant="outline" onClick={resetForm}>Create another</Button>
+                    <Button variant="ghost" onClick={() => setDialogOpen(false)}>Done</Button>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1">
+                  <Label>Name</Label>
+                  <Input value={form.name} onChange={(e) => set("name", e.target.value)} placeholder="Randy Vild" />
+                </div>
+                <div className="space-y-1">
+                  <Label>Tenant ID</Label>
+                  <Input value={form.tenant_id} onChange={(e) => set("tenant_id", e.target.value)} placeholder="randy-vild" className="font-mono" />
+                </div>
+              </div>
+              <div className="space-y-1">
+                <Label>Subdomain</Label>
+                <Input value={form.subdomain} onChange={(e) => setForm((f) => ({ ...f, subdomain: e.target.value }))} placeholder="randy-vild.nomadkaraoke.com" className="font-mono text-sm" />
+                <p className="text-xs text-muted-foreground">Only needed for a real client portal (DNS + Cloudflare). The preview link works without it.</p>
+              </div>
+              <div className="space-y-1">
+                <Label>Allowed email domains <span className="text-muted-foreground">(optional)</span></Label>
+                <Input value={form.allowed_email_domains} onChange={(e) => set("allowed_email_domains", e.target.value)} placeholder="client.com, label.com" />
+                <p className="text-xs text-muted-foreground">Comma-separated. Leave blank for no restriction (you can always log in as admin).</p>
+              </div>
+
+              <div>
+                <Label className="mb-2 block">Theme colours <span className="text-muted-foreground">(blank = Nomad default)</span></Label>
+                <div className="grid grid-cols-2 gap-3">
+                  <ColorField label="Artist" value={form.artist_color} onChange={(v) => set("artist_color", v)} placeholder="#ffdf6b" />
+                  <ColorField label="Title" value={form.title_color} onChange={(v) => set("title_color", v)} placeholder="#ffffff" />
+                  <ColorField label="Highlight (sung)" value={form.sung_lyrics_color} onChange={(v) => set("sung_lyrics_color", v)} placeholder="#7070f7" />
+                  <ColorField label="Lyrics (unsung)" value={form.unsung_lyrics_color} onChange={(v) => set("unsung_lyrics_color", v)} placeholder="#ffffff" />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1">
+                  <Label>Karaoke background <span className="text-muted-foreground">(optional)</span></Label>
+                  <Input type="file" accept=".png,.jpg,.jpeg,.gif,.webp" onChange={(e) => setKaraokeBg(e.target.files?.[0] ?? null)} />
+                </div>
+                <div className="space-y-1">
+                  <Label>Title-card background <span className="text-muted-foreground">(optional)</span></Label>
+                  <Input type="file" accept=".png,.jpg,.jpeg,.gif,.webp" onChange={(e) => setIntroBg(e.target.files?.[0] ?? null)} />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1">
+                  <Label>Dropbox path <span className="text-muted-foreground">(optional)</span></Label>
+                  <Input value={form.dropbox_path} onChange={(e) => set("dropbox_path", e.target.value)} placeholder="/MediaUnsynced/Karaoke/Tracks-RandyVild" className="font-mono text-sm" />
+                  <p className="text-xs text-muted-foreground">Set = deliver to Dropbox. Blank = download only.</p>
+                </div>
+                <div className="space-y-1">
+                  <Label>Brand prefix <span className="text-muted-foreground">(optional)</span></Label>
+                  <Input value={form.brand_prefix} onChange={(e) => set("brand_prefix", e.target.value)} placeholder="RVILD" />
+                </div>
+              </div>
+
+              <div className="space-y-1">
+                <Label>Logo <span className="text-muted-foreground">(optional)</span></Label>
+                <Input type="file" accept=".png,.jpg,.jpeg,.gif,.webp" onChange={(e) => setLogo(e.target.files?.[0] ?? null)} />
+              </div>
+
+              <DialogFooter>
+                <Button variant="ghost" onClick={() => setDialogOpen(false)} disabled={submitting}>Cancel</Button>
+                <Button onClick={handleSubmit} disabled={submitting}>
+                  {submitting ? <><Loader2 className="h-4 w-4 mr-2 animate-spin" /> Creating…</> : "Create tenant"}
+                </Button>
+              </DialogFooter>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/frontend/app/admin/tenants/page.tsx
+++ b/frontend/app/admin/tenants/page.tsx
@@ -1,13 +1,14 @@
 "use client"
 
 import { useEffect, useState, useCallback } from "react"
-import { adminApi, TenantSummary, TenantCreateResult } from "@/lib/api"
+import { adminApi, TenantSummary, TenantCreateResult, TenantDetail } from "@/lib/api"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
+import { Switch } from "@/components/ui/switch"
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table"
@@ -15,7 +16,7 @@ import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter,
 } from "@/components/ui/dialog"
 import {
-  Building2, Plus, RefreshCw, Loader2, Copy, Check, ExternalLink,
+  Building2, Plus, RefreshCw, Loader2, Copy, Check, ExternalLink, Settings2, Code2, WandSparkles,
 } from "lucide-react"
 import { useToast } from "@/hooks/use-toast"
 
@@ -39,13 +40,43 @@ function ColorField({
           onChange={(e) => onChange(e.target.value)}
           className="h-9 w-9 cursor-pointer rounded border border-input bg-transparent p-0.5"
         />
-        <Input
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder={placeholder}
-          className="font-mono"
-        />
+        <Input value={value} onChange={(e) => onChange(e.target.value)} placeholder={placeholder} className="font-mono" />
       </div>
+    </div>
+  )
+}
+
+// --- Full theme JSON editor -------------------------------------------------
+function ThemeJsonEditor({
+  value, onChange, error,
+}: {
+  value: string
+  onChange: (v: string) => void
+  error: string | null
+}) {
+  const format = () => {
+    try {
+      onChange(JSON.stringify(JSON.parse(value), null, 2))
+    } catch {
+      /* leave as-is; error surfaced below */
+    }
+  }
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between">
+        <Label className="flex items-center gap-1.5"><Code2 className="h-3.5 w-3.5" /> Theme JSON (full customisation)</Label>
+        <Button type="button" variant="ghost" size="sm" onClick={format} disabled={!value.trim()}>Format</Button>
+      </div>
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        spellCheck={false}
+        className="w-full h-72 rounded-md border border-input bg-background p-3 font-mono text-xs leading-relaxed outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+        placeholder='{ "intro": { ... }, "karaoke": { ... }, "end": { ... }, "cdg": { ... } }'
+      />
+      {error
+        ? <p className="text-xs text-destructive">{error}</p>
+        : <p className="text-xs text-muted-foreground">Edit any theme parameter (fonts, gradients, regions, CDG settings…). Sections: intro, karaoke, end, cdg.</p>}
     </div>
   )
 }
@@ -69,19 +100,44 @@ function slugify(name: string): string {
   return name.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "")
 }
 
+function validateJson(text: string): string | null {
+  if (!text.trim()) return null
+  try { JSON.parse(text); return null } catch (e: any) { return e.message || "Invalid JSON" }
+}
+
 export default function AdminTenantsPage() {
   const { toast } = useToast()
   const [tenants, setTenants] = useState<TenantSummary[]>([])
   const [loading, setLoading] = useState(true)
+
+  // --- Create state ---------------------------------------------------------
   const [dialogOpen, setDialogOpen] = useState(false)
   const [form, setForm] = useState({ ...EMPTY_FORM })
   const [idEdited, setIdEdited] = useState(false)
   const [karaokeBg, setKaraokeBg] = useState<File | null>(null)
   const [introBg, setIntroBg] = useState<File | null>(null)
   const [logo, setLogo] = useState<File | null>(null)
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  const [createStyleText, setCreateStyleText] = useState("")
   const [submitting, setSubmitting] = useState(false)
   const [created, setCreated] = useState<TenantCreateResult | null>(null)
   const [copied, setCopied] = useState(false)
+
+  // --- Manage state ---------------------------------------------------------
+  const [manageOpen, setManageOpen] = useState(false)
+  const [manageId, setManageId] = useState<string | null>(null)
+  const [manageLoading, setManageLoading] = useState(false)
+  const [detail, setDetail] = useState<TenantDetail | null>(null)
+  const [mCfg, setMCfg] = useState({
+    name: "", subdomain: "", tagline: "", allowed_email_domains: "",
+    dropbox_path: "", brand_prefix: "", distribution_mode: "download_only", is_active: true,
+  })
+  const [styleText, setStyleText] = useState("")
+  const [newAssets, setNewAssets] = useState<File[]>([])
+  const [saving, setSaving] = useState(false)
+
+  const styleError = validateJson(styleText)
+  const createStyleError = validateJson(createStyleText)
 
   const loadTenants = useCallback(async () => {
     try {
@@ -100,7 +156,6 @@ export default function AdminTenantsPage() {
   const set = (key: keyof typeof EMPTY_FORM, value: string) => {
     setForm((f) => {
       const next = { ...f, [key]: value }
-      // Auto-derive the id/subdomain from the name until the admin edits the id
       if (key === "name" && !idEdited) {
         const slug = slugify(value)
         next.tenant_id = slug
@@ -120,17 +175,30 @@ export default function AdminTenantsPage() {
     setKaraokeBg(null)
     setIntroBg(null)
     setLogo(null)
+    setShowAdvanced(false)
+    setCreateStyleText("")
     setCreated(null)
   }
 
-  const openCreate = () => {
-    resetForm()
-    setDialogOpen(true)
+  const openCreate = () => { resetForm(); setDialogOpen(true) }
+
+  const loadTemplate = async () => {
+    try {
+      const data = await adminApi.getThemeTemplate()
+      setCreateStyleText(JSON.stringify(data.style_params, null, 2))
+      setShowAdvanced(true)
+    } catch (err: any) {
+      toast({ title: "Failed to load template", description: err.message, variant: "destructive" })
+    }
   }
 
   const handleSubmit = async () => {
     if (!form.name.trim()) {
       toast({ title: "Name required", description: "Enter a tenant name.", variant: "destructive" })
+      return
+    }
+    if (createStyleError) {
+      toast({ title: "Invalid theme JSON", description: createStyleError, variant: "destructive" })
       return
     }
     setSubmitting(true)
@@ -145,6 +213,7 @@ export default function AdminTenantsPage() {
         const v = form[key]?.trim?.() ?? form[key]
         if (v) fd.append(key, v as string)
       }
+      if (createStyleText.trim()) fd.append("style_params", createStyleText)
       if (karaokeBg) fd.append("karaoke_background", karaokeBg)
       if (introBg) fd.append("intro_background", introBg)
       if (logo) fd.append("logo", logo)
@@ -167,6 +236,73 @@ export default function AdminTenantsPage() {
     setTimeout(() => setCopied(false), 1500)
   }
 
+  // --- Manage ---------------------------------------------------------------
+  const openManage = async (tenantId: string) => {
+    setManageId(tenantId)
+    setManageOpen(true)
+    setManageLoading(true)
+    setNewAssets([])
+    try {
+      const d = await adminApi.getTenant(tenantId)
+      setDetail(d)
+      const t = d.tenant
+      setMCfg({
+        name: t.name || "",
+        subdomain: t.subdomain || "",
+        tagline: t.branding?.tagline || "",
+        allowed_email_domains: (t.auth?.allowed_email_domains || []).join(", "),
+        dropbox_path: t.defaults?.dropbox_path || "",
+        brand_prefix: t.defaults?.brand_prefix || "",
+        distribution_mode: t.defaults?.distribution_mode || "download_only",
+        is_active: t.is_active !== false,
+      })
+      setStyleText(JSON.stringify(d.style_params, null, 2))
+    } catch (err: any) {
+      toast({ title: "Failed to load tenant", description: err.message, variant: "destructive" })
+      setManageOpen(false)
+    } finally {
+      setManageLoading(false)
+    }
+  }
+
+  const handleSave = async () => {
+    if (!manageId) return
+    if (styleError) {
+      toast({ title: "Invalid theme JSON", description: styleError, variant: "destructive" })
+      return
+    }
+    setSaving(true)
+    try {
+      const domains = mCfg.allowed_email_domains.split(",").map((s) => s.trim().toLowerCase()).filter(Boolean)
+      const configUpdate: Record<string, any> = {
+        name: mCfg.name.trim(),
+        subdomain: mCfg.subdomain.trim(),
+        is_active: mCfg.is_active,
+        branding: { tagline: mCfg.tagline.trim() || null },
+        defaults: {
+          dropbox_path: mCfg.dropbox_path.trim() || null,
+          brand_prefix: mCfg.brand_prefix.trim() || null,
+          distribution_mode: mCfg.distribution_mode,
+        },
+        features: { dropbox_upload: !!mCfg.dropbox_path.trim() },
+        auth: { allowed_email_domains: domains, require_email_domain: domains.length > 0 },
+      }
+      const fd = new FormData()
+      fd.append("config", JSON.stringify(configUpdate))
+      if (styleText.trim()) fd.append("style_params", styleText)
+      for (const f of newAssets) fd.append("assets", f)
+
+      await adminApi.updateTenant(manageId, fd)
+      toast({ title: "Saved", description: "Re-render jobs to apply the updated theme." })
+      loadTenants()
+      setNewAssets([])
+    } catch (err: any) {
+      toast({ title: "Failed to save", description: err.message || "Unknown error", variant: "destructive" })
+    } finally {
+      setSaving(false)
+    }
+  }
+
   return (
     <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
@@ -176,7 +312,7 @@ export default function AdminTenantsPage() {
             <h1 className="text-2xl font-semibold">Tenants</h1>
             <p className="text-sm text-muted-foreground">
               White-label portals. Create one to batch-produce an album with a shared theme and
-              client-supplied instrumentals.
+              client-supplied instrumentals — then edit the theme and re-render as the client iterates.
             </p>
           </div>
         </div>
@@ -184,25 +320,17 @@ export default function AdminTenantsPage() {
           <Button variant="outline" size="icon" onClick={loadTenants} disabled={loading}>
             <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
           </Button>
-          <Button onClick={openCreate}>
-            <Plus className="h-4 w-4 mr-2" /> Create tenant
-          </Button>
+          <Button onClick={openCreate}><Plus className="h-4 w-4 mr-2" /> Create tenant</Button>
         </div>
       </div>
 
       <Card>
-        <CardHeader>
-          <CardTitle>All tenants</CardTitle>
-        </CardHeader>
+        <CardHeader><CardTitle>All tenants</CardTitle></CardHeader>
         <CardContent>
           {loading ? (
-            <div className="space-y-2">
-              {[0, 1, 2].map((i) => <Skeleton key={i} className="h-10 w-full" />)}
-            </div>
+            <div className="space-y-2">{[0, 1, 2].map((i) => <Skeleton key={i} className="h-10 w-full" />)}</div>
           ) : tenants.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-6 text-center">
-              No tenants yet. Create one to get started.
-            </p>
+            <p className="text-sm text-muted-foreground py-6 text-center">No tenants yet. Create one to get started.</p>
           ) : (
             <Table>
               <TableHeader>
@@ -223,17 +351,14 @@ export default function AdminTenantsPage() {
                     <TableCell className="text-xs">{t.subdomain}</TableCell>
                     <TableCell className="text-xs">{t.dropbox_path || "download only"}</TableCell>
                     <TableCell>
-                      <Badge variant={t.is_active ? "default" : "secondary"}>
-                        {t.is_active ? "active" : "inactive"}
-                      </Badge>
+                      <Badge variant={t.is_active ? "default" : "secondary"}>{t.is_active ? "active" : "inactive"}</Badge>
                     </TableCell>
-                    <TableCell className="text-right">
+                    <TableCell className="text-right whitespace-nowrap">
+                      <Button variant="ghost" size="sm" onClick={() => openManage(t.id)}>
+                        <Settings2 className="h-3.5 w-3.5 mr-1" /> Manage
+                      </Button>
                       <Button asChild variant="ghost" size="sm">
-                        <a
-                          href={`https://gen.nomadkaraoke.com/en/app?preview_tenant=${t.id}`}
-                          target="_blank"
-                          rel="noreferrer"
-                        >
+                        <a href={`https://gen.nomadkaraoke.com/en/app?preview_tenant=${t.id}`} target="_blank" rel="noreferrer">
                           Open <ExternalLink className="h-3 w-3 ml-1" />
                         </a>
                       </Button>
@@ -246,13 +371,14 @@ export default function AdminTenantsPage() {
         </CardContent>
       </Card>
 
+      {/* Create dialog */}
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Create tenant</DialogTitle>
             <DialogDescription>
               Provisions a branded portal with a locked theme. Jobs are private and delivered to
-              Dropbox (or download only). You can drive it immediately via the preview link — no DNS.
+              Dropbox (or download only). Drive it immediately via the preview link — no DNS.
             </DialogDescription>
           </DialogHeader>
 
@@ -261,9 +387,7 @@ export default function AdminTenantsPage() {
               <Card>
                 <CardHeader>
                   <CardTitle className="text-base">{created.tenant.name} is ready</CardTitle>
-                  <CardDescription>
-                    Open the preview link, switch to <strong>Bulk</strong>, and drop the album folder.
-                  </CardDescription>
+                  <CardDescription>Open the preview link, switch to <strong>Bulk</strong>, and drop the album folder.</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-3">
                   <div className="flex items-center gap-2">
@@ -274,9 +398,7 @@ export default function AdminTenantsPage() {
                   </div>
                   <div className="flex gap-2">
                     <Button asChild>
-                      <a href={created.preview_url} target="_blank" rel="noreferrer">
-                        Open bulk flow <ExternalLink className="h-4 w-4 ml-2" />
-                      </a>
+                      <a href={created.preview_url} target="_blank" rel="noreferrer">Open bulk flow <ExternalLink className="h-4 w-4 ml-2" /></a>
                     </Button>
                     <Button variant="outline" onClick={resetForm}>Create another</Button>
                     <Button variant="ghost" onClick={() => setDialogOpen(false)}>Done</Button>
@@ -304,7 +426,7 @@ export default function AdminTenantsPage() {
               <div className="space-y-1">
                 <Label>Allowed email domains <span className="text-muted-foreground">(optional)</span></Label>
                 <Input value={form.allowed_email_domains} onChange={(e) => set("allowed_email_domains", e.target.value)} placeholder="client.com, label.com" />
-                <p className="text-xs text-muted-foreground">Comma-separated. Leave blank for no restriction (you can always log in as admin).</p>
+                <p className="text-xs text-muted-foreground">Comma-separated. Blank = no restriction (you can always log in as admin).</p>
               </div>
 
               <div>
@@ -345,11 +467,116 @@ export default function AdminTenantsPage() {
                 <Input type="file" accept=".png,.jpg,.jpeg,.gif,.webp" onChange={(e) => setLogo(e.target.files?.[0] ?? null)} />
               </div>
 
+              {/* Advanced: full theme JSON */}
+              <div className="rounded-md border border-dashed p-3 space-y-2">
+                <div className="flex items-center justify-between">
+                  <Label className="flex items-center gap-1.5"><Code2 className="h-3.5 w-3.5" /> Advanced: full theme JSON <span className="text-muted-foreground">(optional)</span></Label>
+                  <div className="flex gap-2">
+                    <Button type="button" variant="outline" size="sm" onClick={loadTemplate}>
+                      <WandSparkles className="h-3.5 w-3.5 mr-1" /> Load Nomad template
+                    </Button>
+                    <Button type="button" variant="ghost" size="sm" onClick={() => setShowAdvanced((s) => !s)}>
+                      {showAdvanced ? "Hide" : "Show"}
+                    </Button>
+                  </div>
+                </div>
+                {showAdvanced && (
+                  <>
+                    <ThemeJsonEditor value={createStyleText} onChange={setCreateStyleText} error={createStyleError} />
+                    <p className="text-xs text-muted-foreground">If provided, this full theme JSON is authoritative — colours above are ignored.</p>
+                  </>
+                )}
+              </div>
+
               <DialogFooter>
                 <Button variant="ghost" onClick={() => setDialogOpen(false)} disabled={submitting}>Cancel</Button>
                 <Button onClick={handleSubmit} disabled={submitting}>
                   {submitting ? <><Loader2 className="h-4 w-4 mr-2 animate-spin" /> Creating…</> : "Create tenant"}
                 </Button>
+              </DialogFooter>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Manage dialog */}
+      <Dialog open={manageOpen} onOpenChange={setManageOpen}>
+        <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Manage {manageId}</DialogTitle>
+            <DialogDescription>
+              Edit the tenant config and its full theme. Uploading a file named like an existing
+              asset replaces it. Save, then re-render jobs to apply.
+            </DialogDescription>
+          </DialogHeader>
+
+          {manageLoading || !detail ? (
+            <div className="space-y-2 py-6">{[0, 1, 2, 3].map((i) => <Skeleton key={i} className="h-10 w-full" />)}</div>
+          ) : (
+            <div className="space-y-4">
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1">
+                  <Label>Name</Label>
+                  <Input value={mCfg.name} onChange={(e) => setMCfg((c) => ({ ...c, name: e.target.value }))} />
+                </div>
+                <div className="space-y-1">
+                  <Label>Subdomain</Label>
+                  <Input value={mCfg.subdomain} onChange={(e) => setMCfg((c) => ({ ...c, subdomain: e.target.value }))} className="font-mono text-sm" />
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1">
+                  <Label>Dropbox path</Label>
+                  <Input value={mCfg.dropbox_path} onChange={(e) => setMCfg((c) => ({ ...c, dropbox_path: e.target.value }))} className="font-mono text-sm" placeholder="download only if blank" />
+                </div>
+                <div className="space-y-1">
+                  <Label>Brand prefix</Label>
+                  <Input value={mCfg.brand_prefix} onChange={(e) => setMCfg((c) => ({ ...c, brand_prefix: e.target.value }))} />
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1">
+                  <Label>Allowed email domains</Label>
+                  <Input value={mCfg.allowed_email_domains} onChange={(e) => setMCfg((c) => ({ ...c, allowed_email_domains: e.target.value }))} placeholder="client.com, label.com" />
+                </div>
+                <div className="space-y-1">
+                  <Label>Tagline</Label>
+                  <Input value={mCfg.tagline} onChange={(e) => setMCfg((c) => ({ ...c, tagline: e.target.value }))} />
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <Switch checked={mCfg.is_active} onCheckedChange={(v) => setMCfg((c) => ({ ...c, is_active: v }))} id="active-switch" />
+                <Label htmlFor="active-switch">Active</Label>
+              </div>
+
+              <ThemeJsonEditor value={styleText} onChange={setStyleText} error={styleError} />
+
+              <div className="space-y-1">
+                <Label>Current theme assets</Label>
+                <div className="flex flex-wrap gap-1.5">
+                  {detail.assets.length === 0
+                    ? <span className="text-xs text-muted-foreground">none</span>
+                    : detail.assets.map((a) => <Badge key={a} variant="secondary" className="font-mono text-[11px]">{a}</Badge>)}
+                </div>
+              </div>
+              <div className="space-y-1">
+                <Label>Add / replace assets <span className="text-muted-foreground">(image or font; filename becomes the asset name)</span></Label>
+                <Input type="file" multiple accept=".png,.jpg,.jpeg,.gif,.webp,.ttf,.otf,.woff,.woff2" onChange={(e) => setNewAssets(Array.from(e.target.files ?? []))} />
+                {newAssets.length > 0 && (
+                  <p className="text-xs text-muted-foreground">Uploading: {newAssets.map((f) => f.name).join(", ")}</p>
+                )}
+              </div>
+
+              <DialogFooter className="flex items-center justify-between sm:justify-between">
+                <Button asChild variant="ghost">
+                  <a href={detail.preview_url} target="_blank" rel="noreferrer">Open preview <ExternalLink className="h-4 w-4 ml-2" /></a>
+                </Button>
+                <div className="flex gap-2">
+                  <Button variant="ghost" onClick={() => setManageOpen(false)} disabled={saving}>Close</Button>
+                  <Button onClick={handleSave} disabled={saving || !!styleError}>
+                    {saving ? <><Loader2 className="h-4 w-4 mr-2 animate-spin" /> Saving…</> : "Save changes"}
+                  </Button>
+                </div>
               </DialogFooter>
             </div>
           )}

--- a/frontend/app/admin/tenants/page.tsx
+++ b/frontend/app/admin/tenants/page.tsx
@@ -29,9 +29,10 @@ function ColorField({
   onChange: (v: string) => void
   placeholder: string
 }) {
+  const id = `color-${label.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`
   return (
     <div className="space-y-1">
-      <Label className="text-xs text-muted-foreground">{label}</Label>
+      <Label htmlFor={id} className="text-xs text-muted-foreground">{label}</Label>
       <div className="flex items-center gap-2">
         <input
           type="color"
@@ -40,7 +41,7 @@ function ColorField({
           onChange={(e) => onChange(e.target.value)}
           className="h-9 w-9 cursor-pointer rounded border border-input bg-transparent p-0.5"
         />
-        <Input value={value} onChange={(e) => onChange(e.target.value)} placeholder={placeholder} className="font-mono" />
+        <Input id={id} value={value} onChange={(e) => onChange(e.target.value)} placeholder={placeholder} className="font-mono" />
       </div>
     </div>
   )
@@ -48,8 +49,9 @@ function ColorField({
 
 // --- Full theme JSON editor -------------------------------------------------
 function ThemeJsonEditor({
-  value, onChange, error,
+  id, value, onChange, error,
 }: {
+  id: string
   value: string
   onChange: (v: string) => void
   error: string | null
@@ -64,10 +66,11 @@ function ThemeJsonEditor({
   return (
     <div className="space-y-1">
       <div className="flex items-center justify-between">
-        <Label className="flex items-center gap-1.5"><Code2 className="h-3.5 w-3.5" /> Theme JSON (full customisation)</Label>
+        <Label htmlFor={id} className="flex items-center gap-1.5"><Code2 className="h-3.5 w-3.5" /> Theme JSON (full customisation)</Label>
         <Button type="button" variant="ghost" size="sm" onClick={format} disabled={!value.trim()}>Format</Button>
       </div>
       <textarea
+        id={id}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         spellCheck={false}
@@ -410,22 +413,22 @@ export default function AdminTenantsPage() {
             <div className="space-y-4">
               <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-1">
-                  <Label>Name</Label>
-                  <Input value={form.name} onChange={(e) => set("name", e.target.value)} placeholder="Randy Vild" />
+                  <Label htmlFor="create-name">Name</Label>
+                  <Input id="create-name" value={form.name} onChange={(e) => set("name", e.target.value)} placeholder="Randy Vild" />
                 </div>
                 <div className="space-y-1">
-                  <Label>Tenant ID</Label>
-                  <Input value={form.tenant_id} onChange={(e) => set("tenant_id", e.target.value)} placeholder="randy-vild" className="font-mono" />
+                  <Label htmlFor="create-tenant-id">Tenant ID</Label>
+                  <Input id="create-tenant-id" value={form.tenant_id} onChange={(e) => set("tenant_id", e.target.value)} placeholder="randy-vild" className="font-mono" />
                 </div>
               </div>
               <div className="space-y-1">
-                <Label>Subdomain</Label>
-                <Input value={form.subdomain} onChange={(e) => setForm((f) => ({ ...f, subdomain: e.target.value }))} placeholder="randy-vild.nomadkaraoke.com" className="font-mono text-sm" />
+                <Label htmlFor="create-subdomain">Subdomain</Label>
+                <Input id="create-subdomain" value={form.subdomain} onChange={(e) => setForm((f) => ({ ...f, subdomain: e.target.value }))} placeholder="randy-vild.nomadkaraoke.com" className="font-mono text-sm" />
                 <p className="text-xs text-muted-foreground">Only needed for a real client portal (DNS + Cloudflare). The preview link works without it.</p>
               </div>
               <div className="space-y-1">
-                <Label>Allowed email domains <span className="text-muted-foreground">(optional)</span></Label>
-                <Input value={form.allowed_email_domains} onChange={(e) => set("allowed_email_domains", e.target.value)} placeholder="client.com, label.com" />
+                <Label htmlFor="create-domains">Allowed email domains <span className="text-muted-foreground">(optional)</span></Label>
+                <Input id="create-domains" value={form.allowed_email_domains} onChange={(e) => set("allowed_email_domains", e.target.value)} placeholder="client.com, label.com" />
                 <p className="text-xs text-muted-foreground">Comma-separated. Blank = no restriction (you can always log in as admin).</p>
               </div>
 
@@ -441,30 +444,30 @@ export default function AdminTenantsPage() {
 
               <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-1">
-                  <Label>Karaoke background <span className="text-muted-foreground">(optional)</span></Label>
-                  <Input type="file" accept=".png,.jpg,.jpeg,.gif,.webp" onChange={(e) => setKaraokeBg(e.target.files?.[0] ?? null)} />
+                  <Label htmlFor="create-karaoke-bg">Karaoke background <span className="text-muted-foreground">(optional)</span></Label>
+                  <Input id="create-karaoke-bg" type="file" accept=".png,.jpg,.jpeg,.gif,.webp" onChange={(e) => setKaraokeBg(e.target.files?.[0] ?? null)} />
                 </div>
                 <div className="space-y-1">
-                  <Label>Title-card background <span className="text-muted-foreground">(optional)</span></Label>
-                  <Input type="file" accept=".png,.jpg,.jpeg,.gif,.webp" onChange={(e) => setIntroBg(e.target.files?.[0] ?? null)} />
+                  <Label htmlFor="create-intro-bg">Title-card background <span className="text-muted-foreground">(optional)</span></Label>
+                  <Input id="create-intro-bg" type="file" accept=".png,.jpg,.jpeg,.gif,.webp" onChange={(e) => setIntroBg(e.target.files?.[0] ?? null)} />
                 </div>
               </div>
 
               <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-1">
-                  <Label>Dropbox path <span className="text-muted-foreground">(optional)</span></Label>
-                  <Input value={form.dropbox_path} onChange={(e) => set("dropbox_path", e.target.value)} placeholder="/MediaUnsynced/Karaoke/Tracks-RandyVild" className="font-mono text-sm" />
+                  <Label htmlFor="create-dropbox">Dropbox path <span className="text-muted-foreground">(optional)</span></Label>
+                  <Input id="create-dropbox" value={form.dropbox_path} onChange={(e) => set("dropbox_path", e.target.value)} placeholder="/MediaUnsynced/Karaoke/Tracks-RandyVild" className="font-mono text-sm" />
                   <p className="text-xs text-muted-foreground">Set = deliver to Dropbox. Blank = download only.</p>
                 </div>
                 <div className="space-y-1">
-                  <Label>Brand prefix <span className="text-muted-foreground">(optional)</span></Label>
-                  <Input value={form.brand_prefix} onChange={(e) => set("brand_prefix", e.target.value)} placeholder="RVILD" />
+                  <Label htmlFor="create-brand-prefix">Brand prefix <span className="text-muted-foreground">(optional)</span></Label>
+                  <Input id="create-brand-prefix" value={form.brand_prefix} onChange={(e) => set("brand_prefix", e.target.value)} placeholder="RVILD" />
                 </div>
               </div>
 
               <div className="space-y-1">
-                <Label>Logo <span className="text-muted-foreground">(optional)</span></Label>
-                <Input type="file" accept=".png,.jpg,.jpeg,.gif,.webp" onChange={(e) => setLogo(e.target.files?.[0] ?? null)} />
+                <Label htmlFor="create-logo">Logo <span className="text-muted-foreground">(optional)</span></Label>
+                <Input id="create-logo" type="file" accept=".png,.jpg,.jpeg,.gif,.webp" onChange={(e) => setLogo(e.target.files?.[0] ?? null)} />
               </div>
 
               {/* Advanced: full theme JSON */}
@@ -482,7 +485,7 @@ export default function AdminTenantsPage() {
                 </div>
                 {showAdvanced && (
                   <>
-                    <ThemeJsonEditor value={createStyleText} onChange={setCreateStyleText} error={createStyleError} />
+                    <ThemeJsonEditor id="create-theme-json" value={createStyleText} onChange={setCreateStyleText} error={createStyleError} />
                     <p className="text-xs text-muted-foreground">If provided, this full theme JSON is authoritative — colours above are ignored.</p>
                   </>
                 )}
@@ -516,32 +519,32 @@ export default function AdminTenantsPage() {
             <div className="space-y-4">
               <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-1">
-                  <Label>Name</Label>
-                  <Input value={mCfg.name} onChange={(e) => setMCfg((c) => ({ ...c, name: e.target.value }))} />
+                  <Label htmlFor="manage-name">Name</Label>
+                  <Input id="manage-name" value={mCfg.name} onChange={(e) => setMCfg((c) => ({ ...c, name: e.target.value }))} />
                 </div>
                 <div className="space-y-1">
-                  <Label>Subdomain</Label>
-                  <Input value={mCfg.subdomain} onChange={(e) => setMCfg((c) => ({ ...c, subdomain: e.target.value }))} className="font-mono text-sm" />
-                </div>
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-1">
-                  <Label>Dropbox path</Label>
-                  <Input value={mCfg.dropbox_path} onChange={(e) => setMCfg((c) => ({ ...c, dropbox_path: e.target.value }))} className="font-mono text-sm" placeholder="download only if blank" />
-                </div>
-                <div className="space-y-1">
-                  <Label>Brand prefix</Label>
-                  <Input value={mCfg.brand_prefix} onChange={(e) => setMCfg((c) => ({ ...c, brand_prefix: e.target.value }))} />
+                  <Label htmlFor="manage-subdomain">Subdomain</Label>
+                  <Input id="manage-subdomain" value={mCfg.subdomain} onChange={(e) => setMCfg((c) => ({ ...c, subdomain: e.target.value }))} className="font-mono text-sm" />
                 </div>
               </div>
               <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-1">
-                  <Label>Allowed email domains</Label>
-                  <Input value={mCfg.allowed_email_domains} onChange={(e) => setMCfg((c) => ({ ...c, allowed_email_domains: e.target.value }))} placeholder="client.com, label.com" />
+                  <Label htmlFor="manage-dropbox">Dropbox path</Label>
+                  <Input id="manage-dropbox" value={mCfg.dropbox_path} onChange={(e) => setMCfg((c) => ({ ...c, dropbox_path: e.target.value }))} className="font-mono text-sm" placeholder="download only if blank" />
                 </div>
                 <div className="space-y-1">
-                  <Label>Tagline</Label>
-                  <Input value={mCfg.tagline} onChange={(e) => setMCfg((c) => ({ ...c, tagline: e.target.value }))} />
+                  <Label htmlFor="manage-brand-prefix">Brand prefix</Label>
+                  <Input id="manage-brand-prefix" value={mCfg.brand_prefix} onChange={(e) => setMCfg((c) => ({ ...c, brand_prefix: e.target.value }))} />
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1">
+                  <Label htmlFor="manage-domains">Allowed email domains</Label>
+                  <Input id="manage-domains" value={mCfg.allowed_email_domains} onChange={(e) => setMCfg((c) => ({ ...c, allowed_email_domains: e.target.value }))} placeholder="client.com, label.com" />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="manage-tagline">Tagline</Label>
+                  <Input id="manage-tagline" value={mCfg.tagline} onChange={(e) => setMCfg((c) => ({ ...c, tagline: e.target.value }))} />
                 </div>
               </div>
               <div className="flex items-center gap-2">
@@ -549,7 +552,7 @@ export default function AdminTenantsPage() {
                 <Label htmlFor="active-switch">Active</Label>
               </div>
 
-              <ThemeJsonEditor value={styleText} onChange={setStyleText} error={styleError} />
+              <ThemeJsonEditor id="manage-theme-json" value={styleText} onChange={setStyleText} error={styleError} />
 
               <div className="space-y-1">
                 <Label>Current theme assets</Label>
@@ -560,8 +563,8 @@ export default function AdminTenantsPage() {
                 </div>
               </div>
               <div className="space-y-1">
-                <Label>Add / replace assets <span className="text-muted-foreground">(image or font; filename becomes the asset name)</span></Label>
-                <Input type="file" multiple accept=".png,.jpg,.jpeg,.gif,.webp,.ttf,.otf,.woff,.woff2" onChange={(e) => setNewAssets(Array.from(e.target.files ?? []))} />
+                <Label htmlFor="manage-assets">Add / replace assets <span className="text-muted-foreground">(image or font; filename becomes the asset name)</span></Label>
+                <Input id="manage-assets" type="file" multiple accept=".png,.jpg,.jpeg,.gif,.webp,.ttf,.otf,.woff,.woff2" onChange={(e) => setNewAssets(Array.from(e.target.files ?? []))} />
                 {newAssets.length > 0 && (
                   <p className="text-xs text-muted-foreground">Uploading: {newAssets.map((f) => f.name).join(", ")}</p>
                 )}

--- a/frontend/components/admin/admin-sidebar.tsx
+++ b/frontend/components/admin/admin-sidebar.tsx
@@ -16,6 +16,7 @@ import {
   Fingerprint,
   MessageSquare,
   Share2,
+  Building2,
 } from "lucide-react"
 
 import {
@@ -57,6 +58,11 @@ const navItems = [
     title: "Referrals",
     href: "/admin/referrals",
     icon: Share2,
+  },
+  {
+    title: "Tenants",
+    href: "/admin/tenants",
+    icon: Building2,
   },
   {
     title: "Audio Searches",

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -2537,6 +2537,14 @@ export interface TenantCreateResult {
   subdomain_url: string;
 }
 
+export interface TenantDetail {
+  tenant: Record<string, any>;
+  theme_id: string;
+  style_params: Record<string, any>;
+  assets: string[];
+  preview_url: string;
+}
+
 export const adminApi = {
   /**
    * List all white-label tenants
@@ -2557,6 +2565,38 @@ export const adminApi = {
       method: 'POST',
       headers: getAuthHeaders(),
       body: formData,
+    });
+    return handleResponse(response);
+  },
+
+  /**
+   * Get a tenant's full config, theme style_params, and asset list (for editing).
+   */
+  async getTenant(tenantId: string): Promise<TenantDetail> {
+    const response = await apiFetch(`${API_BASE_URL}/api/admin/tenants/${encodeURIComponent(tenantId)}`, {
+      headers: getAuthHeaders(),
+    });
+    return handleResponse(response);
+  },
+
+  /**
+   * Update a tenant (multipart: optional config JSON, style_params JSON, and asset files).
+   */
+  async updateTenant(tenantId: string, formData: FormData): Promise<{ tenant: TenantCreateResult['tenant'] }> {
+    const response = await apiFetch(`${API_BASE_URL}/api/admin/tenants/${encodeURIComponent(tenantId)}`, {
+      method: 'PUT',
+      headers: getAuthHeaders(),
+      body: formData,
+    });
+    return handleResponse(response);
+  },
+
+  /**
+   * Get the default Nomad theme's full style_params — a starting template for a new theme.
+   */
+  async getThemeTemplate(): Promise<{ style_params: Record<string, any> }> {
+    const response = await apiFetch(`${API_BASE_URL}/api/admin/tenants/_template`, {
+      headers: getAuthHeaders(),
     });
     return handleResponse(response);
   },

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -2516,7 +2516,51 @@ export interface CacheStatsResponse {
 }
 
 // Admin API namespace
+export interface TenantSummary {
+  id: string;
+  name: string;
+  subdomain: string;
+  is_active: boolean;
+  locked_theme?: string | null;
+  dropbox_path?: string | null;
+  created_at?: string | null;
+}
+
+export interface TenantCreateResult {
+  tenant: {
+    id: string;
+    name: string;
+    subdomain: string;
+    is_active: boolean;
+  };
+  preview_url: string;
+  subdomain_url: string;
+}
+
 export const adminApi = {
+  /**
+   * List all white-label tenants
+   */
+  async listTenants(): Promise<{ tenants: TenantSummary[] }> {
+    const response = await apiFetch(`${API_BASE_URL}/api/admin/tenants`, {
+      headers: getAuthHeaders(),
+    });
+    return handleResponse(response);
+  },
+
+  /**
+   * Create a white-label tenant (multipart: fields + optional background/logo images).
+   * Do NOT set Content-Type — the browser sets the multipart boundary.
+   */
+  async createTenant(formData: FormData): Promise<TenantCreateResult> {
+    const response = await apiFetch(`${API_BASE_URL}/api/admin/tenants`, {
+      method: 'POST',
+      headers: getAuthHeaders(),
+      body: formData,
+    });
+    return handleResponse(response);
+  },
+
   /**
    * Get admin dashboard statistics
    */

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.215.0"
+version = "0.216.0"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Why

Enables the "album for one client" use case: a batch of tracks with audio provided up front, a client-supplied instrumental per track, and one shared theme. That pipeline already exists as the **tenant bulk flow** (folder pick → LLM pairs mixed↔instrumental → resumable uploads → skip separation → locked theme on every job) — the only missing piece was an easy way to **mint a tenant** (previously a hand-run `scripts/setup-*-tenant.py`). This adds admin create **and** manage, so a client's feedback can be iterated on (edit theme, re-render).

## What

**Backend** (`backend/services/tenant_admin_service.py` + `backend/api/routes/tenant_admin.py`):
- `POST /api/admin/tenants` (multipart) — mint a tenant: derives a **self-contained theme** from the default Nomad theme (copies its assets so every `background_image` basename resolves), applies colour overrides, overlays uploaded backgrounds, registers the theme, writes `tenants/{id}/config.json` with B2B defaults (private, no YouTube/GDrive, locked theme). Reserves the config **create-only before any theme write**, with rollback on failure.
- `GET /api/admin/tenants` / `GET /api/admin/tenants/{id}` / `GET /api/admin/tenants/_template` — list, full detail (config + theme `style_params` + assets), and the default theme JSON as a template.
- `PUT /api/admin/tenants/{id}` (multipart) — **full theme customisation**: merge config (one level, `id` immutable), replace the entire `style_params.json`, upload/replace assets (images **or fonts**), update logo.
- Full `style_params` override accepted on create too. Theme docs validated to `intro/karaoke/end/cdg`. Guards against a tenant id colliding with an existing theme.

**Frontend** (`/admin/tenants`):
- Tenants list + **Create** dialog (name→auto-slug, colours, backgrounds, Dropbox/delivery, logo, + an "Advanced: full theme JSON" editor seeded from the Nomad template).
- **Manage** dialog: editable config fields + a validated full **theme JSON editor** + asset list & upload.
- New tenants are driveable immediately via **`?preview_tenant=<id>`** — no DNS needed.
- Sidebar "Tenants" entry; `adminApi.listTenants/createTenant/getTenant/updateTenant/getThemeTemplate`.

## Testing
- 36 backend tests (`test_tenant_admin_service.py`, `test_tenant_admin_route.py`) + 4 frontend tests (`admin-tenants-page.test.tsx`), incl. atomic-reservation / conflict-no-clobber / rollback / theme-collision / full-theme-edit.
- Full `make test` green locally (backend + 1245 frontend); typecheck clean.
- Reviewed locally with CodeRabbit (2 cycles, all findings addressed).

## Notes
- Admin is English-only → no i18n locale files touched.
- Follow-up (out of scope): saved **user** themes in the Custom Video Style dialog (reuses this theme-derivation core); and an optional "re-apply theme + re-render existing job" action.

@coderabbitai ignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)