### PR TITLE
fix(jobs): atomic dot-path state_data writes (distribution + audio-edit races)

### DIFF
--- a/backend/api/routes/review.py
+++ b/backend/api/routes/review.py
@@ -2585,13 +2585,14 @@ async def apply_audio_edit(
             "timestamp": __import__("datetime").datetime.utcnow().isoformat(),
         })
 
-        # Clear redo stack on new edit
-        updated_state_data = {
-            **state_data,
-            'audio_edit_stack': edit_stack,
-            'audio_edit_redo_stack': [],
-        }
-        job_manager.update_job(job_id, {'state_data': updated_state_data})
+        # Clear redo stack on new edit. Atomic per-field writes so a rapid
+        # follow-up edit/undo — or the idle-reminder scheduler that runs during
+        # the audio-edit phase — can't clobber unrelated state_data keys by
+        # re-persisting a stale copy of the whole map.
+        job_manager.update_job(job_id, {
+            'state_data.audio_edit_stack': edit_stack,
+            'state_data.audio_edit_redo_stack': [],
+        })
 
         return _build_audio_edit_response(
             job_id=job_id,
@@ -2633,12 +2634,13 @@ async def undo_audio_edit(
     undone_edit = edit_stack.pop()
     redo_stack.append(undone_edit)
 
-    updated_state_data = {
-        **state_data,
-        'audio_edit_stack': edit_stack,
-        'audio_edit_redo_stack': redo_stack,
-    }
-    job_manager.update_job(job_id, {'state_data': updated_state_data})
+    # Atomic per-field writes so a rapid undo/redo (or the idle-reminder
+    # scheduler active during audio-edit) can't clobber unrelated state_data
+    # keys by re-persisting a stale copy of the whole map.
+    job_manager.update_job(job_id, {
+        'state_data.audio_edit_stack': edit_stack,
+        'state_data.audio_edit_redo_stack': redo_stack,
+    })
 
     # Get the now-current audio (previous edit or original)
     current_gcs_path = edit_stack[-1]['gcs_path'] if edit_stack else job.input_media_gcs_path
@@ -2680,12 +2682,13 @@ async def redo_audio_edit(
     redone_edit = redo_stack.pop()
     edit_stack.append(redone_edit)
 
-    updated_state_data = {
-        **state_data,
-        'audio_edit_stack': edit_stack,
-        'audio_edit_redo_stack': redo_stack,
-    }
-    job_manager.update_job(job_id, {'state_data': updated_state_data})
+    # Atomic per-field writes so a rapid undo/redo (or the idle-reminder
+    # scheduler active during audio-edit) can't clobber unrelated state_data
+    # keys by re-persisting a stale copy of the whole map.
+    job_manager.update_job(job_id, {
+        'state_data.audio_edit_stack': edit_stack,
+        'state_data.audio_edit_redo_stack': redo_stack,
+    })
 
     current_gcs_path = edit_stack[-1]['gcs_path']
 
@@ -2779,8 +2782,9 @@ async def upload_audio_for_join(
             "duration_seconds": metadata.duration_seconds,
             "filename": filename,
         }
-        updated_state_data = {**state_data, 'audio_edit_uploads': uploads}
-        job_manager.update_job(job_id, {'state_data': updated_state_data})
+        # Atomic write of just the uploads map so a concurrent state_data write
+        # isn't clobbered by re-persisting a stale copy of the whole map.
+        job_manager.update_job(job_id, {'state_data.audio_edit_uploads': uploads})
 
         return {
             "upload_id": upload_id,

--- a/backend/api/routes/review.py
+++ b/backend/api/routes/review.py
@@ -23,6 +23,7 @@ from typing import Dict, Any, List, Literal, Optional, Set, Tuple
 
 from fastapi import APIRouter, HTTPException, Request, Depends, Form, File, UploadFile
 from fastapi.responses import RedirectResponse, Response
+from google.cloud.firestore_v1.field_path import FieldPath
 
 from backend.models.job import JobStatus
 from backend.models.review_session import ReviewSession, ReviewSessionSummary
@@ -2588,7 +2589,11 @@ async def apply_audio_edit(
         # Clear redo stack on new edit. Atomic per-field writes so a rapid
         # follow-up edit/undo — or the idle-reminder scheduler that runs during
         # the audio-edit phase — can't clobber unrelated state_data keys by
-        # re-persisting a stale copy of the whole map.
+        # re-persisting a stale copy of the whole map. NOTE: these two list
+        # fields are still last-write-wins across concurrent edits to the SAME
+        # job (a list can't be dot-path-merged); that's acceptable for the
+        # single-reviewer, sequential audio-editor UI. True multi-writer safety
+        # would need a transaction / optimistic-concurrency CAS.
         job_manager.update_job(job_id, {
             'state_data.audio_edit_stack': edit_stack,
             'state_data.audio_edit_redo_stack': [],
@@ -2636,7 +2641,10 @@ async def undo_audio_edit(
 
     # Atomic per-field writes so a rapid undo/redo (or the idle-reminder
     # scheduler active during audio-edit) can't clobber unrelated state_data
-    # keys by re-persisting a stale copy of the whole map.
+    # keys by re-persisting a stale copy of the whole map. NOTE: the two list
+    # fields remain last-write-wins across concurrent edits to the SAME job —
+    # acceptable for the single-reviewer sequential UI; true multi-writer safety
+    # would need a transaction / optimistic-concurrency CAS.
     job_manager.update_job(job_id, {
         'state_data.audio_edit_stack': edit_stack,
         'state_data.audio_edit_redo_stack': redo_stack,
@@ -2684,7 +2692,10 @@ async def redo_audio_edit(
 
     # Atomic per-field writes so a rapid undo/redo (or the idle-reminder
     # scheduler active during audio-edit) can't clobber unrelated state_data
-    # keys by re-persisting a stale copy of the whole map.
+    # keys by re-persisting a stale copy of the whole map. NOTE: the two list
+    # fields remain last-write-wins across concurrent edits to the SAME job —
+    # acceptable for the single-reviewer sequential UI; true multi-writer safety
+    # would need a transaction / optimistic-concurrency CAS.
     job_manager.update_job(job_id, {
         'state_data.audio_edit_stack': edit_stack,
         'state_data.audio_edit_redo_stack': redo_stack,
@@ -2774,17 +2785,21 @@ async def upload_audio_for_join(
         finally:
             os.unlink(tmp_path)
 
-        # Store upload info in state_data
-        state_data = job.state_data or {}
-        uploads = dict(state_data.get('audio_edit_uploads', {}))
-        uploads[upload_id] = {
-            "gcs_path": gcs_path,
-            "duration_seconds": metadata.duration_seconds,
-            "filename": filename,
-        }
-        # Atomic write of just the uploads map so a concurrent state_data write
-        # isn't clobbered by re-persisting a stale copy of the whole map.
-        job_manager.update_job(job_id, {'state_data.audio_edit_uploads': uploads})
+        # Store upload info in state_data. Write ONLY this upload's entry, keyed
+        # by its uuid. FieldPath.to_api_repr() backtick-escapes the uuid segment
+        # (it contains hyphens, so a raw dotted path would be misparsed) and keeps
+        # the key a string so it doesn't clash with the string 'updated_at' key
+        # update_job appends. Merging at the entry level means two concurrent
+        # uploads no longer drop each other — the old whole-map replace would
+        # orphan a GCS file and 404 later on join_start/join_end.
+        uploads_field = FieldPath("state_data", "audio_edit_uploads", upload_id).to_api_repr()
+        job_manager.update_job(job_id, {
+            uploads_field: {
+                "gcs_path": gcs_path,
+                "duration_seconds": metadata.duration_seconds,
+                "filename": filename,
+            },
+        })
 
         return {
             "upload_id": upload_id,

--- a/backend/tests/emulator/test_state_data_no_clobber.py
+++ b/backend/tests/emulator/test_state_data_no_clobber.py
@@ -26,6 +26,7 @@ pytestmark = pytest.mark.skipif(
 
 if emulators_running():
     from google.cloud.firestore_v1 import DELETE_FIELD, Increment
+    from google.cloud.firestore_v1.field_path import FieldPath
     from backend.models.job import Job, JobStatus
     from backend.services.job_manager import JobManager
     from backend.services.firestore_service import FirestoreService
@@ -111,6 +112,36 @@ class TestDistributionWriteNoClobber:
             sd = firestore_service.get_job(job_id).state_data
             # The full-map write reverted the fence back to the stale value of 1.
             assert sd.get('worker_generation') == 1
+        finally:
+            try:
+                firestore_service.delete_job(job_id)
+            except Exception:
+                pass
+
+    def test_concurrent_audio_edit_uploads_both_survive(self, job_manager, firestore_service):
+        """Two concurrent upload-for-join requests (distinct uuids) must both
+        persist. The audio-edit upload endpoint writes only its own entry via a
+        FieldPath, so neither drops the other (which would orphan a GCS file and
+        404 later on join_start/join_end)."""
+        job_id = f"uploads-{datetime.now(UTC).timestamp()}"
+        try:
+            self._create_job(firestore_service, job_id, {"keep": "me"})
+            id_a = "550e8400-e29b-41d4-a716-446655440000"
+            id_b = "111e8400-e29b-41d4-a716-000000000000"
+
+            job_manager.update_job(job_id, {
+                FieldPath("state_data", "audio_edit_uploads", id_a).to_api_repr(): {"gcs_path": "g/a.flac"},
+            })
+            job_manager.update_job(job_id, {
+                FieldPath("state_data", "audio_edit_uploads", id_b).to_api_repr(): {"gcs_path": "g/b.flac"},
+            })
+
+            sd = firestore_service.get_job(job_id).state_data
+            uploads = sd.get("audio_edit_uploads") or {}
+            assert set(uploads.keys()) == {id_a, id_b}
+            assert uploads[id_a]["gcs_path"] == "g/a.flac"
+            assert uploads[id_b]["gcs_path"] == "g/b.flac"
+            assert sd.get("keep") == "me"
         finally:
             try:
                 firestore_service.delete_job(job_id)

--- a/backend/tests/emulator/test_state_data_no_clobber.py
+++ b/backend/tests/emulator/test_state_data_no_clobber.py
@@ -1,0 +1,118 @@
+"""
+Regression tests for the state_data lost-update race in the distribution path.
+
+The video worker used to write its distribution results by re-persisting the
+WHOLE state_data map from a snapshot. That could clobber a concurrent write —
+most dangerously reverting the ``worker_generation`` supersession fence (an
+atomic Increment) or resurrecting the ``visibility_change_in_progress`` guard,
+which is the "visibility-recycle-dataloss" surface. The fix writes atomic
+dot-path fields (with DELETE_FIELD for the popped guard). These run on the real
+Firestore emulator and assert the invariant the fix guarantees; the final test
+demonstrates why the old full-map write was unsafe.
+
+Run with: scripts/run-emulator-tests.sh
+"""
+
+import pytest
+from copy import deepcopy
+from datetime import datetime, UTC
+
+from backend.tests.emulator.conftest import emulators_running
+
+pytestmark = pytest.mark.skipif(
+    not emulators_running(),
+    reason="GCP emulators not running. Start with: scripts/start-emulators.sh"
+)
+
+if emulators_running():
+    from google.cloud.firestore_v1 import DELETE_FIELD, Increment
+    from backend.models.job import Job, JobStatus
+    from backend.services.job_manager import JobManager
+    from backend.services.firestore_service import FirestoreService
+
+
+class TestDistributionWriteNoClobber:
+    @pytest.fixture
+    def job_manager(self):
+        return JobManager()
+
+    @pytest.fixture
+    def firestore_service(self):
+        return FirestoreService()
+
+    def _create_job(self, firestore_service, job_id, state_data):
+        firestore_service.create_job(Job(
+            job_id=job_id,
+            status=JobStatus.RENDERING_VIDEO,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+            artist="Test",
+            title="Test",
+            state_data=state_data,
+        ))
+
+    def _distribution_write(self, job_manager, job_id):
+        """The dot-path payload the video worker now emits on distribution."""
+        job_manager.update_job(job_id, {
+            'state_data.brand_code': 'NOMAD-1234',
+            'state_data.youtube_url': 'https://youtu.be/abc',
+            'state_data.dropbox_link': 'https://db/x',
+            'state_data.visibility_change_in_progress': DELETE_FIELD,
+        })
+
+    def test_distribution_write_preserves_supersession_fence(self, job_manager, firestore_service):
+        """A supersession bump landing during distribution must survive: the
+        worker_generation Increment is NOT reverted, and unrelated keys stay."""
+        job_id = f"dist-fence-{datetime.now(UTC).timestamp()}"
+        try:
+            self._create_job(firestore_service, job_id, {
+                'worker_generation': 1,
+                'keep_me': 'value',
+                'visibility_change_in_progress': True,
+            })
+
+            # A reset/re-trigger bumps the supersession fence mid-distribution.
+            job_manager.firestore.update_job(job_id, {'state_data.worker_generation': Increment(1)})
+            # The video worker then writes its distribution results.
+            self._distribution_write(job_manager, job_id)
+
+            sd = firestore_service.get_job(job_id).state_data
+            assert sd.get('worker_generation') == 2, "supersession fence was reverted by the distribution write"
+            assert sd.get('keep_me') == 'value', "unrelated sibling key was clobbered"
+            assert sd.get('brand_code') == 'NOMAD-1234'
+            assert sd.get('youtube_url') == 'https://youtu.be/abc'
+            assert 'visibility_change_in_progress' not in sd, "visibility guard was not cleared"
+        finally:
+            try:
+                firestore_service.delete_job(job_id)
+            except Exception:
+                pass
+
+    def test_old_full_map_write_would_have_clobbered(self, job_manager, firestore_service):
+        """Demonstrates the bug: re-persisting the whole state_data map from a
+        stale snapshot reverts the concurrent Increment and resurrects the
+        cleared guard — which is exactly what the dot-path fix avoids."""
+        job_id = f"dist-oldbug-{datetime.now(UTC).timestamp()}"
+        try:
+            self._create_job(firestore_service, job_id, {
+                'worker_generation': 1,
+                'visibility_change_in_progress': True,
+            })
+            stale = deepcopy(firestore_service.get_job(job_id).state_data)
+
+            # Concurrent supersession bump (fence -> 2).
+            job_manager.firestore.update_job(job_id, {'state_data.worker_generation': Increment(1)})
+
+            # OLD pattern: rewrite the whole map from the stale snapshot.
+            stale['brand_code'] = 'NOMAD-1234'
+            stale.pop('visibility_change_in_progress', None)
+            job_manager.update_job(job_id, {'state_data': stale})
+
+            sd = firestore_service.get_job(job_id).state_data
+            # The full-map write reverted the fence back to the stale value of 1.
+            assert sd.get('worker_generation') == 1
+        finally:
+            try:
+                firestore_service.delete_job(job_id)
+            except Exception:
+                pass

--- a/backend/tests/test_audio_edit_routes.py
+++ b/backend/tests/test_audio_edit_routes.py
@@ -402,11 +402,12 @@ class TestUndoAudioEdit:
         assert data["can_undo"] is False
         assert data["can_redo"] is True
 
-        # Verify state_data was updated
-        update_call = mock_job_manager.update_job.call_args[0]
-        state_data = update_call[1]["state_data"]
-        assert len(state_data["audio_edit_stack"]) == 0
-        assert len(state_data["audio_edit_redo_stack"]) == 1
+        # Verify state_data was updated via atomic dot-path writes (not a
+        # full-map rewrite that could clobber a concurrent sibling key).
+        payload = mock_job_manager.update_job.call_args[0][1]
+        assert "state_data" not in payload
+        assert len(payload["state_data.audio_edit_stack"]) == 0
+        assert len(payload["state_data.audio_edit_redo_stack"]) == 1
 
     def test_undo_nothing_to_undo(self, test_client, mock_job_manager, audio_edit_job):
         mock_job_manager.get_job.return_value = audio_edit_job

--- a/backend/tests/test_youtube_queue_processor.py
+++ b/backend/tests/test_youtube_queue_processor.py
@@ -247,7 +247,7 @@ class TestUpdateJobYouTubeUrl:
     """Test updating job state_data with YouTube URL."""
 
     def test_updates_state_data(self):
-        """Should set youtube_url and clear queued flag."""
+        """Should set youtube_url and clear queued flag via atomic dot-path writes."""
         from backend.workers.youtube_queue_processor import _update_job_youtube_url
 
         mock_job = Mock()
@@ -260,9 +260,12 @@ class TestUpdateJobYouTubeUrl:
 
         update_call = mock_job_manager.update_job.call_args[0]
         assert update_call[0] == "job-123"
-        state_data = update_call[1]["state_data"]
-        assert state_data["youtube_url"] == "https://youtube.com/watch?v=abc"
-        assert state_data["youtube_upload_queued"] is False
+        payload = update_call[1]
+        assert payload["state_data.youtube_url"] == "https://youtube.com/watch?v=abc"
+        assert payload["state_data.youtube_upload_queued"] is False
+        # Atomic field writes only — must NOT re-persist the whole state_data map
+        # (which would clobber a concurrently-changed sibling like brand_code).
+        assert "state_data" not in payload
 
     def test_handles_missing_job(self):
         """Should not raise when job not found."""

--- a/backend/workers/video_worker.py
+++ b/backend/workers/video_worker.py
@@ -31,6 +31,8 @@ import json
 from typing import Optional, Dict, Any
 from pathlib import Path
 
+from google.cloud.firestore_v1 import DELETE_FIELD
+
 from backend.models.job import JobStatus
 from backend.exceptions import InvalidStateTransitionError
 from backend.services.job_manager import JobManager
@@ -378,19 +380,23 @@ async def generate_video_orchestrated(job_id: str) -> bool:
             # Store result metadata in job BEFORE transitioning to COMPLETE
             # This ensures youtube_url is available when completion email is sent
             logger.info(f"[job:{job_id}] Video generation complete")
-            state_update = {
-                **job.state_data,
-                'brand_code': result.brand_code,
-                'youtube_url': result.youtube_url,
-                'youtube_upload_queued': result.youtube_upload_queued,
-                'dropbox_link': result.dropbox_link,
-                'gdrive_files': result.gdrive_files,
+            # Atomic per-field writes. Rewriting the whole state_data map from a
+            # snapshot could clobber a concurrent write here — most dangerously the
+            # visibility-change flow or the worker_generation supersession fence
+            # (an Increment reverted by a stale full-map write). Dot-path writes
+            # touch only the distribution-result keys.
+            state_updates: Dict[str, Any] = {
+                'state_data.brand_code': result.brand_code,
+                'state_data.youtube_url': result.youtube_url,
+                'state_data.youtube_upload_queued': result.youtube_upload_queued,
+                'state_data.dropbox_link': result.dropbox_link,
+                'state_data.gdrive_files': result.gdrive_files,
+                # Clear the visibility-change guard flag (previously popped from the map).
+                'state_data.visibility_change_in_progress': DELETE_FIELD,
             }
             if result.distribution_warnings:
-                state_update['distribution_warnings'] = result.distribution_warnings
-            # Clear visibility change guard flag if set (from visibility change flow)
-            state_update.pop('visibility_change_in_progress', None)
-            job_manager.update_job(job_id, {'state_data': state_update})
+                state_updates['state_data.distribution_warnings'] = result.distribution_warnings
+            job_manager.update_job(job_id, state_updates)
 
             # Send Pushbullet alert if any distribution uploads failed
             if result.distribution_warnings:
@@ -627,16 +633,15 @@ async def redistribute_video(job_id: str) -> bool:
             if dropbox_failed:
                 raise RuntimeError("Redistribution failed to upload the Dropbox archive")
 
-        # Update job state_data with new distribution results
-        state_update = dict(job.state_data or {})
-        state_update['brand_code'] = orchestrator.result.brand_code
-        state_update['youtube_url'] = orchestrator.result.youtube_url
-        state_update['dropbox_link'] = orchestrator.result.dropbox_link
-        state_update['gdrive_files'] = orchestrator.result.gdrive_files
-        state_update.pop('visibility_change_in_progress', None)
-
+        # Update job state_data with new distribution results. Atomic per-field
+        # writes so this redistribution can't clobber a concurrent state_data
+        # write (e.g. the visibility-change flow or worker_generation fence).
         job_manager.update_job(job_id, {
-            'state_data': state_update,
+            'state_data.brand_code': orchestrator.result.brand_code,
+            'state_data.youtube_url': orchestrator.result.youtube_url,
+            'state_data.dropbox_link': orchestrator.result.dropbox_link,
+            'state_data.gdrive_files': orchestrator.result.gdrive_files,
+            'state_data.visibility_change_in_progress': DELETE_FIELD,
             'outputs_deleted_at': None,
             'outputs_deleted_by': None,
         })
@@ -1220,15 +1225,16 @@ async def _handle_native_distribution(
     # Update job state_data with brand code and links
     if brand_code or result.get('dropbox_link') or result.get('gdrive_files'):
         try:
-            state_update = {
-                **job.state_data,
-                'brand_code': brand_code,
-                'dropbox_link': result.get('dropbox_link'),
-                'gdrive_files': result.get('gdrive_files'),
+            # Atomic per-field writes so this distribution update can't clobber a
+            # concurrent state_data write from a stale full-map snapshot.
+            state_updates: Dict[str, Any] = {
+                'state_data.brand_code': brand_code,
+                'state_data.dropbox_link': result.get('dropbox_link'),
+                'state_data.gdrive_files': result.get('gdrive_files'),
             }
             if result.get('distribution_warnings'):
-                state_update['distribution_warnings'] = result['distribution_warnings']
-            job_manager.update_job(job_id, {'state_data': state_update})
+                state_updates['state_data.distribution_warnings'] = result['distribution_warnings']
+            job_manager.update_job(job_id, state_updates)
         except Exception as e:
             job_log.warning(f"Failed to update job state_data: {e}")
 

--- a/backend/workers/youtube_queue_processor.py
+++ b/backend/workers/youtube_queue_processor.py
@@ -278,10 +278,13 @@ def _update_job_youtube_url(job_id: str, youtube_url: str) -> None:
         job_manager = JobManager()
         job = job_manager.get_job(job_id)
         if job:
-            state_data = job.state_data or {}
-            state_data["youtube_url"] = youtube_url
-            state_data["youtube_upload_queued"] = False  # No longer queued
-            job_manager.update_job(job_id, {"state_data": state_data})
+            # Atomic per-field writes: this deferred upload can land while other
+            # state_data is being written, so rewriting the whole map from a
+            # snapshot could clobber a sibling key.
+            job_manager.update_job(job_id, {
+                "state_data.youtube_url": youtube_url,
+                "state_data.youtube_upload_queued": False,  # No longer queued
+            })
             logger.info(f"Updated job {job_id} state_data with YouTube URL")
     except Exception as e:
         logger.error(f"Failed to update job {job_id} with YouTube URL: {e}")

--- a/docs/LESSONS-LEARNED.md
+++ b/docs/LESSONS-LEARNED.md
@@ -25,6 +25,18 @@ the path is misread as further nesting. Belt-and-suspenders: `_analyze_backing_v
 now recovers a stem that exists at the conventional GCS path but is unregistered, and
 stores a fallback analysis instead of a silent early-return.
 
+**Follow-up sweep (Sep 2026):** a codebase-wide audit found the same read-copy-mutate-write
+pattern in 8 more sites, now converted to atomic dot-path writes: the video worker's three
+distribution/redistribution writes (`video_worker.py`), the audio-editor undo/redo/apply/
+upload endpoints (`review.py`), and the deferred YouTube-URL write (`youtube_queue_processor.py`).
+The video-worker ones were the most dangerous — they `.pop('visibility_change_in_progress')`
+and rewrote the whole map, so a stale write could **revert the `worker_generation`
+supersession-fence `Increment`** or clobber the visibility flag (the
+"visibility-recycle-dataloss" surface). Clearing a key now uses `DELETE_FIELD` in the same
+dot-path write. When you add a new nested-map write, grep for `{'state_data':` / `{**job.state_data`
+before shipping. (Correct reference pattern: `duration_reconciliation.py` copies state only
+to *read*, and writes via `state_data.<key>`.)
+
 ---
 
 ## Measure Human Edits by RECONSTRUCTION, Not the edit_log (Aug 2026)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karaoke-gen"
-version = "0.218.0"
+version = "0.218.1"
 description = "Generate karaoke videos with synchronized lyrics. Handles the entire process from downloading audio and lyrics to creating the final video with title screens."
 authors = ["Andrew Beveridge <andrew@beveridge.uk>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
Follow-up hardening sweep to the `file_urls`/`state_data` lost-update fix (#970). An audit found the same **read-copy-mutate-write-whole-map** pattern in 8 more sites; this converts them to atomic Firestore dot-path writes so a stale snapshot can't clobber a concurrent sibling key.

## Changes
- **`video_worker` distribution / redistribution / finalize (3 sites)** — the most dangerous: they rewrote the whole `state_data` map and `.pop('visibility_change_in_progress')`, so a stale write could **revert the `worker_generation` supersession fence** (an atomic `Increment`) or resurrect the visibility guard — the "visibility-recycle-dataloss" surface. Now dot-path writes, with `DELETE_FIELD` for the guard.
- **Audio-editor undo / redo / apply (`review.py`)** — full-map rewrites that could race with rapid clicks or the idle-reminder scheduler active during audio-edit → dot-path writes.
- **Audio-editor upload-for-join** — now writes only *this* upload's entry via `FieldPath(...).to_api_repr()` (backtick-escapes the hyphenated uuid, string key), so concurrent uploads **merge** instead of one dropping the other (which orphaned a GCS file and 404'd on join). *(CodeRabbit finding #1.)*
- **Deferred YouTube-URL write (`youtube_queue_processor`)** → dot-path.

## Out of scope (documented)
- The two audio-edit **list** fields (`audio_edit_stack` / `audio_edit_redo_stack`) remain last-write-wins across concurrent edits to the *same* job — a list can't be dot-path-merged. Acceptable for the single-reviewer sequential audio-editor UI; true multi-writer safety needs a transaction/CAS. Documented inline. *(CodeRabbit finding #2 — deliberately deferred.)*
- Two low-risk fresh-dict-*replace* sites (create-from-search / admin re-search) — single-request, early-lifecycle — left as-is.

## Testing
- [x] Full backend unit suite green (4266 passed) + emulator suite green (118 passed).
- [x] New emulator regression tests: distribution write preserves the `worker_generation` fence + clears the visibility guard (with a contrast test showing the old full-map write reverted the fence); concurrent audio-edit uploads both survive.
- [x] Updated the 2 unit tests that asserted the old full-map shape.
- [x] CodeRabbit CLI: finding #1 fixed, finding #2 documented/deferred; no new findings on re-review.

## Review
- [x] Local CodeRabbit review completed (2 cycles); feedback addressed

@coderabbitai ignore

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)